### PR TITLE
Add SDPA support to fusilli hipDNN plugin

### DIFF
--- a/dnn-providers/fusilli-provider/include/custom_ops.h
+++ b/dnn-providers/fusilli-provider/include/custom_ops.h
@@ -1,0 +1,218 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===----------------------------------------------------------------------===//
+//
+// Custom op definitions for hipDNN operations that map to fusilli CustomOp
+// nodes. Each struct provides:
+//
+//   validateTemplate() — Check if the hipDNN attributes use only features
+//                        supported by the MLIR template. Returns NotImplemented
+//                        for unsupported configurations.
+//
+//   validateInputs()   — Check tensor dimension constraints (rank, matching
+//                        dims).
+//
+//   buildMLIR()        — Construct the MLIR template string for the CustomOp.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FUSILLI_PLUGIN_CUSTOM_OPS_H
+#define FUSILLI_PLUGIN_CUSTOM_OPS_H
+
+#include <fusilli.h>
+#include <hipdnn_data_sdk/data_objects/sdpa_attributes_generated.h>
+
+#include <format>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+
+// SDPA MLIR templates for torch.aten.scaled_dot_product_attention.
+//
+// Templates are stored as R-string literals so the MLIR structure is
+// directly readable in source. Standard CustomOp placeholders
+// ({FUNC_NAME}, {IN<i>_DTYPE}, {OUT0_DTYPE}) are resolved by
+// CustomOpNode::resolveMlirPlaceholders(). Scalar placeholders
+// ({DROPOUT_P}, {IS_CAUSAL}, {SCALE_CONST}, {SCALE_TYPE}, {ENABLE_GQA})
+// are resolved by SdpaImport::buildMLIR().
+//
+// Tensor rank is hardcoded to 4 ([batch, heads, seq_len, head_dim]).
+
+// SDPA template: 3 tensor inputs (Q, K, V), attention mask is none.
+// Positional args: {0}=DROPOUT_P, {1}=IS_CAUSAL, {2}=SCALE_CONST,
+//                  {3}=SCALE_TYPE, {4}=ENABLE_GQA
+// clang-format off
+static constexpr std::string_view kSdpaNoMask = R"mlir(
+  func.func private @{{FUNC_NAME}}(
+      %arg0: !torch.vtensor<[?,?,?,?],{{IN0_DTYPE}}>,
+      %arg1: !torch.vtensor<[?,?,?,?],{{IN1_DTYPE}}>,
+      %arg2: !torch.vtensor<[?,?,?,?],{{IN2_DTYPE}}>)
+      -> !torch.vtensor<[?,?,?,?],{{OUT0_DTYPE}}> {{
+    %none_mask = torch.constant.none
+    %dropout = torch.constant.float {0}
+    %is_causal = torch.constant.bool {1}
+    %scale = {2}
+    %enable_gqa = torch.constant.bool {4}
+    %0 = torch.aten.scaled_dot_product_attention %arg0, %arg1, %arg2,
+        %none_mask, %dropout, %is_causal, %scale, %enable_gqa :
+        !torch.vtensor<[?,?,?,?],{{IN0_DTYPE}}>, !torch.vtensor<[?,?,?,?],{{IN1_DTYPE}}>,
+        !torch.vtensor<[?,?,?,?],{{IN2_DTYPE}}>, !torch.none, !torch.float, !torch.bool,
+        {3}, !torch.bool -> !torch.vtensor<[?,?,?,?],{{OUT0_DTYPE}}>
+    return %0 : !torch.vtensor<[?,?,?,?],{{OUT0_DTYPE}}>
+  }}
+)mlir";
+
+// SDPA template: 4 tensor inputs (Q, K, V, attn_mask).
+// Positional args: same as kSdpaNoMask.
+static constexpr std::string_view kSdpaWithMask = R"mlir(
+  func.func private @{{FUNC_NAME}}(
+      %arg0: !torch.vtensor<[?,?,?,?],{{IN0_DTYPE}}>,
+      %arg1: !torch.vtensor<[?,?,?,?],{{IN1_DTYPE}}>,
+      %arg2: !torch.vtensor<[?,?,?,?],{{IN2_DTYPE}}>,
+      %arg3: !torch.vtensor<[?,?,?,?],{{IN3_DTYPE}}>)
+      -> !torch.vtensor<[?,?,?,?],{{OUT0_DTYPE}}> {{
+    %dropout = torch.constant.float {0}
+    %is_causal = torch.constant.bool {1}
+    %scale = {2}
+    %enable_gqa = torch.constant.bool {4}
+    %0 = torch.aten.scaled_dot_product_attention %arg0, %arg1, %arg2,
+        %arg3, %dropout, %is_causal, %scale, %enable_gqa :
+        !torch.vtensor<[?,?,?,?],{{IN0_DTYPE}}>, !torch.vtensor<[?,?,?,?],{{IN1_DTYPE}}>,
+        !torch.vtensor<[?,?,?,?],{{IN2_DTYPE}}>, !torch.vtensor<[?,?,?,?],{{IN3_DTYPE}}>,
+        !torch.float, !torch.bool,
+        {3}, !torch.bool -> !torch.vtensor<[?,?,?,?],{{OUT0_DTYPE}}>
+    return %0 : !torch.vtensor<[?,?,?,?],{{OUT0_DTYPE}}>
+  }}
+)mlir";
+// clang-format on
+
+struct SdpaImport {
+  // Check if the SDPA attributes use only features supported by the MLIR
+  // template. Returns NotImplemented for unsupported configurations.
+  static fusilli::ErrorObject
+  validateTemplate(const hipdnn_data_sdk::data_objects::SdpaAttributes *attrs) {
+    if (attrs->dropout_probability().has_value() &&
+        *attrs->dropout_probability() > 0.0f)
+      return fusilli::error(fusilli::ErrorCode::NotImplemented,
+                            "SDPA with dropout not supported.");
+    if (attrs->alibi_mask())
+      return fusilli::error(fusilli::ErrorCode::NotImplemented,
+                            "SDPA with alibi mask not supported.");
+    if (attrs->padding_mask())
+      return fusilli::error(fusilli::ErrorCode::NotImplemented,
+                            "SDPA with padding mask not supported.");
+    if (attrs->stats_tensor_uid().has_value())
+      return fusilli::error(fusilli::ErrorCode::NotImplemented,
+                            "SDPA with stats output not supported.");
+    if (attrs->seed_tensor_uid().has_value() ||
+        attrs->offset_tensor_uid().has_value() ||
+        attrs->dropout_mask_tensor_uid().has_value() ||
+        attrs->dropout_scale_tensor_uid().has_value())
+      return fusilli::error(fusilli::ErrorCode::NotImplemented,
+                            "SDPA with dropout tensors not supported.");
+    if (attrs->page_table_k_tensor_uid().has_value() ||
+        attrs->page_table_v_tensor_uid().has_value())
+      return fusilli::error(fusilli::ErrorCode::NotImplemented,
+                            "SDPA with paged attention not supported.");
+    if (attrs->block_mask_tensor_uid().has_value() ||
+        attrs->sink_token_tensor_uid().has_value())
+      return fusilli::error(fusilli::ErrorCode::NotImplemented,
+                            "SDPA with block mask not supported.");
+    if (attrs->left_bound().has_value() || attrs->right_bound().has_value())
+      return fusilli::error(fusilli::ErrorCode::NotImplemented,
+                            "SDPA with sliding window not supported.");
+    if (attrs->descale_q_tensor_uid().has_value() ||
+        attrs->descale_k_tensor_uid().has_value() ||
+        attrs->descale_v_tensor_uid().has_value() ||
+        attrs->descale_s_tensor_uid().has_value() ||
+        attrs->scale_s_tensor_uid().has_value() ||
+        attrs->scale_o_tensor_uid().has_value() ||
+        attrs->amax_s_tensor_uid().has_value() ||
+        attrs->amax_o_tensor_uid().has_value())
+      return fusilli::error(fusilli::ErrorCode::NotImplemented,
+                            "SDPA with FP8 quantization not supported.");
+
+    // Causal attention has an explicit attn_mask, torch will reject causal with
+    // additional attn_mask.
+    if (attrs->causal_mask() && attrs->attn_mask_tensor_uid().has_value())
+      return fusilli::error(
+          fusilli::ErrorCode::NotImplemented,
+          "SDPA with both causal mask and attention mask not supported.");
+
+    return fusilli::ok();
+  }
+
+  // Validate tensor dimension constraints for SDPA.
+  // Expected layout: Q[B,H,S,D], K[B,H_kv,S,D], V[B,H_kv,S,D] where H is a
+  // multiple of H_kv (equal for standard MHA and > 1 for GQA).
+  static fusilli::ErrorObject
+  validateInputs(const std::shared_ptr<fusilli::TensorAttr> &q,
+                 const std::shared_ptr<fusilli::TensorAttr> &k,
+                 const std::shared_ptr<fusilli::TensorAttr> &v) {
+    const auto &qDim = q->getDim();
+    const auto &kDim = k->getDim();
+    const auto &vDim = v->getDim();
+
+    constexpr size_t kRequiredRank = 4;
+    if (qDim.size() != kRequiredRank || kDim.size() != kRequiredRank ||
+        vDim.size() != kRequiredRank)
+      return fusilli::error(fusilli::ErrorCode::InvalidAttribute,
+                            "SDPA tensors must be rank 4 [B, H, S, D].");
+    if (qDim[0] != kDim[0] || qDim[0] != vDim[0])
+      return fusilli::error(fusilli::ErrorCode::InvalidAttribute,
+                            "SDPA batch dimensions must match.");
+    if (kDim[1] != vDim[1])
+      return fusilli::error(fusilli::ErrorCode::InvalidAttribute,
+                            "SDPA K and V num_heads must match.");
+    // GQA: query heads must be a multiple of KV heads.
+    if (qDim[1] % kDim[1] != 0)
+      return fusilli::error(fusilli::ErrorCode::InvalidAttribute,
+                            "SDPA Q num_heads must be a multiple of "
+                            "K/V num_heads for GQA.");
+    if (kDim[2] != vDim[2])
+      return fusilli::error(fusilli::ErrorCode::InvalidAttribute,
+                            "SDPA K and V seq_len must match.");
+    if (qDim[3] != kDim[3])
+      return fusilli::error(fusilli::ErrorCode::InvalidAttribute,
+                            "SDPA Q and K head_dim must match.");
+
+    // #TODO(iree/issues/21858) GQA with f32 triggers an IREE distribution
+    // failure.
+    bool isGqa = qDim[1] != kDim[1];
+    if (isGqa && q->getDataType() == fusilli::DataType::Float)
+      return fusilli::error(fusilli::ErrorCode::NotImplemented,
+                            "SDPA GQA with f32 not supported.");
+
+    return fusilli::ok();
+  }
+
+  // Build the MLIR template string for the CustomOp by selecting the
+  // appropriate R-string template and resolving scalar placeholders.
+  static std::string buildMLIR(bool hasAttnMask, float dropoutP, bool isCausal,
+                               std::optional<float> scale = std::nullopt,
+                               bool enableGqa = false) {
+    std::string dropoutStr = std::format("{:e}", dropoutP);
+    std::string isCausalStr = isCausal ? "true" : "false";
+    std::string scaleConstStr =
+        scale.has_value() ? std::format("torch.constant.float {:e}", *scale)
+                          : "torch.constant.none";
+    std::string scaleTypeStr =
+        scale.has_value() ? "!torch.float" : "!torch.none";
+    std::string enableGqaStr = enableGqa ? "true" : "false";
+
+    return std::vformat(hasAttnMask ? kSdpaWithMask : kSdpaNoMask,
+                        std::make_format_args(dropoutStr,    // {0} DROPOUT_P
+                                              isCausalStr,   // {1} IS_CAUSAL
+                                              scaleConstStr, // {2} SCALE_CONST
+                                              scaleTypeStr,  // {3} SCALE_TYPE
+                                              enableGqaStr   // {4} ENABLE_GQA
+                                              ));
+  }
+};
+
+#endif // FUSILLI_PLUGIN_CUSTOM_OPS_H

--- a/dnn-providers/fusilli-provider/include/custom_ops.h
+++ b/dnn-providers/fusilli-provider/include/custom_ops.h
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 //
 // Custom op definitions for hipDNN operations that map to fusilli CustomOp
-// nodes. Each struct provides:
+// nodes. Each namespace provides:
 //
 //   validateTemplate() — Check if the hipDNN attributes use only features
 //                        supported by the MLIR template. Returns NotImplemented
@@ -91,128 +91,139 @@ static constexpr std::string_view kSdpaWithMask = R"mlir(
 )mlir";
 // clang-format on
 
-struct SdpaImport {
-  // Check if the SDPA attributes use only features supported by the MLIR
-  // template. Returns NotImplemented for unsupported configurations.
-  static fusilli::ErrorObject
-  validateTemplate(const hipdnn_data_sdk::data_objects::SdpaAttributes *attrs) {
-    if (attrs->dropout_probability().has_value() &&
-        *attrs->dropout_probability() > 0.0f)
-      return fusilli::error(fusilli::ErrorCode::NotImplemented,
-                            "SDPA with dropout not supported.");
-    if (attrs->alibi_mask())
-      return fusilli::error(fusilli::ErrorCode::NotImplemented,
-                            "SDPA with alibi mask not supported.");
-    if (attrs->padding_mask())
-      return fusilli::error(fusilli::ErrorCode::NotImplemented,
-                            "SDPA with padding mask not supported.");
-    if (attrs->stats_tensor_uid().has_value())
-      return fusilli::error(fusilli::ErrorCode::NotImplemented,
-                            "SDPA with stats output not supported.");
-    if (attrs->seed_tensor_uid().has_value() ||
-        attrs->offset_tensor_uid().has_value() ||
-        attrs->dropout_mask_tensor_uid().has_value() ||
-        attrs->dropout_scale_tensor_uid().has_value())
-      return fusilli::error(fusilli::ErrorCode::NotImplemented,
-                            "SDPA with dropout tensors not supported.");
-    if (attrs->page_table_k_tensor_uid().has_value() ||
-        attrs->page_table_v_tensor_uid().has_value())
-      return fusilli::error(fusilli::ErrorCode::NotImplemented,
-                            "SDPA with paged attention not supported.");
-    if (attrs->block_mask_tensor_uid().has_value() ||
-        attrs->sink_token_tensor_uid().has_value())
-      return fusilli::error(fusilli::ErrorCode::NotImplemented,
-                            "SDPA with block mask not supported.");
-    if (attrs->left_bound().has_value() || attrs->right_bound().has_value())
-      return fusilli::error(fusilli::ErrorCode::NotImplemented,
-                            "SDPA with sliding window not supported.");
-    if (attrs->descale_q_tensor_uid().has_value() ||
-        attrs->descale_k_tensor_uid().has_value() ||
-        attrs->descale_v_tensor_uid().has_value() ||
-        attrs->descale_s_tensor_uid().has_value() ||
-        attrs->scale_s_tensor_uid().has_value() ||
-        attrs->scale_o_tensor_uid().has_value() ||
-        attrs->amax_s_tensor_uid().has_value() ||
-        attrs->amax_o_tensor_uid().has_value())
-      return fusilli::error(fusilli::ErrorCode::NotImplemented,
-                            "SDPA with FP8 quantization not supported.");
+namespace SdpaImport {
+// Check if the SDPA attributes use only features supported by the MLIR
+// template. Returns NotImplemented for unsupported configurations.
+inline fusilli::ErrorObject
+validateTemplate(const hipdnn_data_sdk::data_objects::SdpaAttributes *attrs) {
+  if (attrs->dropout_probability().has_value() &&
+      *attrs->dropout_probability() > 0.0f)
+    return fusilli::error(fusilli::ErrorCode::NotImplemented,
+                          "SDPA with dropout not supported.");
+  if (attrs->alibi_mask())
+    return fusilli::error(fusilli::ErrorCode::NotImplemented,
+                          "SDPA with alibi mask not supported.");
+  if (attrs->padding_mask())
+    return fusilli::error(fusilli::ErrorCode::NotImplemented,
+                          "SDPA with padding mask not supported.");
+  if (attrs->stats_tensor_uid().has_value())
+    return fusilli::error(fusilli::ErrorCode::NotImplemented,
+                          "SDPA with stats output not supported.");
+  if (attrs->seed_tensor_uid().has_value() ||
+      attrs->offset_tensor_uid().has_value() ||
+      attrs->dropout_mask_tensor_uid().has_value() ||
+      attrs->dropout_scale_tensor_uid().has_value())
+    return fusilli::error(fusilli::ErrorCode::NotImplemented,
+                          "SDPA with dropout tensors not supported.");
+  if (attrs->page_table_k_tensor_uid().has_value() ||
+      attrs->page_table_v_tensor_uid().has_value())
+    return fusilli::error(fusilli::ErrorCode::NotImplemented,
+                          "SDPA with paged attention not supported.");
+  if (attrs->block_mask_tensor_uid().has_value() ||
+      attrs->sink_token_tensor_uid().has_value())
+    return fusilli::error(fusilli::ErrorCode::NotImplemented,
+                          "SDPA with block mask not supported.");
+  if (attrs->left_bound().has_value() || attrs->right_bound().has_value())
+    return fusilli::error(fusilli::ErrorCode::NotImplemented,
+                          "SDPA with sliding window not supported.");
+  if (attrs->descale_q_tensor_uid().has_value() ||
+      attrs->descale_k_tensor_uid().has_value() ||
+      attrs->descale_v_tensor_uid().has_value() ||
+      attrs->descale_s_tensor_uid().has_value() ||
+      attrs->scale_s_tensor_uid().has_value() ||
+      attrs->scale_o_tensor_uid().has_value() ||
+      attrs->amax_s_tensor_uid().has_value() ||
+      attrs->amax_o_tensor_uid().has_value())
+    return fusilli::error(fusilli::ErrorCode::NotImplemented,
+                          "SDPA with FP8 quantization not supported.");
+  if (attrs->diagonal_alignment() !=
+      hipdnn_data_sdk::data_objects::DiagonalAlignment::TOP_LEFT)
+    return fusilli::error(
+        fusilli::ErrorCode::NotImplemented,
+        "SDPA with non-TOP_LEFT diagonal alignment not supported.");
+  // This is out of an over-abundance of caution, IREE doesn't need a backend
+  // implementation hit.
+  if (attrs->implementation() !=
+      hipdnn_data_sdk::data_objects::AttentionImplementation::AUTO)
+    return fusilli::error(
+        fusilli::ErrorCode::NotImplemented,
+        "SDPA with explicit implementation strategy not supported.");
 
-    // Causal attention has an explicit attn_mask, torch will reject causal with
-    // additional attn_mask.
-    if (attrs->causal_mask() && attrs->attn_mask_tensor_uid().has_value())
-      return fusilli::error(
-          fusilli::ErrorCode::NotImplemented,
-          "SDPA with both causal mask and attention mask not supported.");
+  // Causal attention has an explicit attn_mask, torch will reject causal with
+  // additional attn_mask.
+  if (attrs->causal_mask() && attrs->attn_mask_tensor_uid().has_value())
+    return fusilli::error(
+        fusilli::ErrorCode::NotImplemented,
+        "SDPA with both causal mask and attention mask not supported.");
 
-    return fusilli::ok();
-  }
+  return fusilli::ok();
+}
 
-  // Validate tensor dimension constraints for SDPA.
-  // Expected layout: Q[B,H,S,D], K[B,H_kv,S,D], V[B,H_kv,S,D] where H is a
-  // multiple of H_kv (equal for standard MHA and > 1 for GQA).
-  static fusilli::ErrorObject
-  validateInputs(const std::shared_ptr<fusilli::TensorAttr> &q,
-                 const std::shared_ptr<fusilli::TensorAttr> &k,
-                 const std::shared_ptr<fusilli::TensorAttr> &v) {
-    const auto &qDim = q->getDim();
-    const auto &kDim = k->getDim();
-    const auto &vDim = v->getDim();
+// Validate tensor dimension constraints for SDPA.
+// Expected layout: Q[B,H,S,D], K[B,H_kv,S,D], V[B,H_kv,S,D] where H is a
+// multiple of H_kv (equal for standard MHA and > 1 for GQA).
+inline fusilli::ErrorObject
+validateInputs(const std::shared_ptr<fusilli::TensorAttr> &q,
+               const std::shared_ptr<fusilli::TensorAttr> &k,
+               const std::shared_ptr<fusilli::TensorAttr> &v) {
+  const auto &qDim = q->getDim();
+  const auto &kDim = k->getDim();
+  const auto &vDim = v->getDim();
 
-    constexpr size_t kRequiredRank = 4;
-    if (qDim.size() != kRequiredRank || kDim.size() != kRequiredRank ||
-        vDim.size() != kRequiredRank)
-      return fusilli::error(fusilli::ErrorCode::InvalidAttribute,
-                            "SDPA tensors must be rank 4 [B, H, S, D].");
-    if (qDim[0] != kDim[0] || qDim[0] != vDim[0])
-      return fusilli::error(fusilli::ErrorCode::InvalidAttribute,
-                            "SDPA batch dimensions must match.");
-    if (kDim[1] != vDim[1])
-      return fusilli::error(fusilli::ErrorCode::InvalidAttribute,
-                            "SDPA K and V num_heads must match.");
-    // GQA: query heads must be a multiple of KV heads.
-    if (qDim[1] % kDim[1] != 0)
-      return fusilli::error(fusilli::ErrorCode::InvalidAttribute,
-                            "SDPA Q num_heads must be a multiple of "
-                            "K/V num_heads for GQA.");
-    if (kDim[2] != vDim[2])
-      return fusilli::error(fusilli::ErrorCode::InvalidAttribute,
-                            "SDPA K and V seq_len must match.");
-    if (qDim[3] != kDim[3])
-      return fusilli::error(fusilli::ErrorCode::InvalidAttribute,
-                            "SDPA Q and K head_dim must match.");
+  constexpr size_t kRequiredRank = 4;
+  if (qDim.size() != kRequiredRank || kDim.size() != kRequiredRank ||
+      vDim.size() != kRequiredRank)
+    return fusilli::error(fusilli::ErrorCode::InvalidAttribute,
+                          "SDPA tensors must be rank 4 [B, H, S, D].");
+  if (qDim[0] != kDim[0] || qDim[0] != vDim[0])
+    return fusilli::error(fusilli::ErrorCode::InvalidAttribute,
+                          "SDPA batch dimensions must match.");
+  if (kDim[1] != vDim[1])
+    return fusilli::error(fusilli::ErrorCode::InvalidAttribute,
+                          "SDPA K and V num_heads must match.");
+  // GQA: query heads must be a multiple of KV heads.
+  if (qDim[1] % kDim[1] != 0)
+    return fusilli::error(fusilli::ErrorCode::InvalidAttribute,
+                          "SDPA Q num_heads must be a multiple of "
+                          "K/V num_heads for GQA.");
+  if (kDim[2] != vDim[2])
+    return fusilli::error(fusilli::ErrorCode::InvalidAttribute,
+                          "SDPA K and V seq_len must match.");
+  if (qDim[3] != kDim[3])
+    return fusilli::error(fusilli::ErrorCode::InvalidAttribute,
+                          "SDPA Q and K head_dim must match.");
 
-    // #TODO(iree/issues/21858) GQA with f32 triggers an IREE distribution
-    // failure.
-    bool isGqa = qDim[1] != kDim[1];
-    if (isGqa && q->getDataType() == fusilli::DataType::Float)
-      return fusilli::error(fusilli::ErrorCode::NotImplemented,
-                            "SDPA GQA with f32 not supported.");
+  // #TODO(iree/issues/21858) GQA with f32 triggers an IREE distribution
+  // failure.
+  bool isGqa = qDim[1] != kDim[1];
+  if (isGqa && q->getDataType() == fusilli::DataType::Float)
+    return fusilli::error(fusilli::ErrorCode::NotImplemented,
+                          "SDPA GQA with f32 not supported.");
 
-    return fusilli::ok();
-  }
+  return fusilli::ok();
+}
 
-  // Build the MLIR template string for the CustomOp by selecting the
-  // appropriate R-string template and resolving scalar placeholders.
-  static std::string buildMLIR(bool hasAttnMask, float dropoutP, bool isCausal,
-                               std::optional<float> scale = std::nullopt,
-                               bool enableGqa = false) {
-    std::string dropoutStr = std::format("{:e}", dropoutP);
-    std::string isCausalStr = isCausal ? "true" : "false";
-    std::string scaleConstStr =
-        scale.has_value() ? std::format("torch.constant.float {:e}", *scale)
-                          : "torch.constant.none";
-    std::string scaleTypeStr =
-        scale.has_value() ? "!torch.float" : "!torch.none";
-    std::string enableGqaStr = enableGqa ? "true" : "false";
+// Build the MLIR template string for the CustomOp by selecting the
+// appropriate R-string template and resolving scalar placeholders.
+inline std::string buildMLIR(bool hasAttnMask, float dropoutP, bool isCausal,
+                             std::optional<float> scale = std::nullopt,
+                             bool enableGqa = false) {
+  std::string dropoutStr = std::format("{:e}", dropoutP);
+  std::string isCausalStr = isCausal ? "true" : "false";
+  std::string scaleConstStr =
+      scale.has_value() ? std::format("torch.constant.float {:e}", *scale)
+                        : "torch.constant.none";
+  std::string scaleTypeStr = scale.has_value() ? "!torch.float" : "!torch.none";
+  std::string enableGqaStr = enableGqa ? "true" : "false";
 
-    return std::vformat(hasAttnMask ? kSdpaWithMask : kSdpaNoMask,
-                        std::make_format_args(dropoutStr,    // {0} DROPOUT_P
-                                              isCausalStr,   // {1} IS_CAUSAL
-                                              scaleConstStr, // {2} SCALE_CONST
-                                              scaleTypeStr,  // {3} SCALE_TYPE
-                                              enableGqaStr   // {4} ENABLE_GQA
-                                              ));
-  }
-};
+  return std::vformat(hasAttnMask ? kSdpaWithMask : kSdpaNoMask,
+                      std::make_format_args(dropoutStr,    // {0} DROPOUT_P
+                                            isCausalStr,   // {1} IS_CAUSAL
+                                            scaleConstStr, // {2} SCALE_CONST
+                                            scaleTypeStr,  // {3} SCALE_TYPE
+                                            enableGqaStr   // {4} ENABLE_GQA
+                                            ));
+}
+} // namespace SdpaImport
 
 #endif // FUSILLI_PLUGIN_CUSTOM_OPS_H

--- a/dnn-providers/fusilli-provider/include/graph_import.h
+++ b/dnn-providers/fusilli-provider/include/graph_import.h
@@ -20,14 +20,17 @@
 #include <hipdnn_data_sdk/data_objects/data_types_generated.h>
 #include <hipdnn_data_sdk/data_objects/matmul_attributes_generated.h>
 #include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
+#include <hipdnn_data_sdk/data_objects/sdpa_attributes_generated.h>
 #include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
 #include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
 
 #include <format>
 #include <memory>
+#include <optional>
 #include <unordered_map>
 
+#include "custom_ops.h"
 #include "hipdnn_engine_plugin_execution_context.h"
 
 // Convert from hipDNN DataType to fusilli DataType.
@@ -168,6 +171,9 @@ private:
     case hipdnn_data_sdk::data_objects::NodeAttributes::MatmulAttributes:
       FUSILLI_CHECK_ERROR(
           importMatmulAttr(node.attributes_as_MatmulAttributes()));
+      break;
+    case hipdnn_data_sdk::data_objects::NodeAttributes::SdpaAttributes:
+      FUSILLI_CHECK_ERROR(importSdpaAttr(node.attributes_as_SdpaAttributes()));
       break;
     default:
       return fusilli::error(fusilli::ErrorCode::NotImplemented,
@@ -336,6 +342,78 @@ private:
     // Import node output.
     FUSILLI_CHECK_ERROR(
         importNodeOutput(hipDnnMatmulAttr->c_tensor_uid(), "c", c));
+
+    return fusilli::ok();
+  }
+
+  fusilli::ErrorObject importSdpaAttr(
+      const hipdnn_data_sdk::data_objects::SdpaAttributes *hipDnnSdpaAttr) {
+    // Are available SDPA templates applicable?
+    FUSILLI_CHECK_ERROR(SdpaImport::validateTemplate(hipDnnSdpaAttr));
+
+    bool hasAttnMask = hipDnnSdpaAttr->attn_mask_tensor_uid().has_value();
+    bool isCausal = hipDnnSdpaAttr->causal_mask();
+
+    // Import required tensor inputs.
+    FUSILLI_ASSIGN_OR_RETURN(
+        std::shared_ptr<fusilli::TensorAttr> q,
+        importNodeInput(hipDnnSdpaAttr->q_tensor_uid(), "q"));
+    FUSILLI_ASSIGN_OR_RETURN(
+        std::shared_ptr<fusilli::TensorAttr> k,
+        importNodeInput(hipDnnSdpaAttr->k_tensor_uid(), "k"));
+    FUSILLI_ASSIGN_OR_RETURN(
+        std::shared_ptr<fusilli::TensorAttr> v,
+        importNodeInput(hipDnnSdpaAttr->v_tensor_uid(), "v"));
+
+    // Validate inputs to graph
+    FUSILLI_CHECK_ERROR(SdpaImport::validateInputs(q, k, v));
+
+    std::vector<std::shared_ptr<fusilli::TensorAttr>> inputs = {q, k, v};
+
+    // Import optional attn_mask tensor.
+    if (hasAttnMask) {
+      FUSILLI_ASSIGN_OR_RETURN(
+          std::shared_ptr<fusilli::TensorAttr> mask,
+          importNodeInput(*hipDnnSdpaAttr->attn_mask_tensor_uid(),
+                          "attn_mask"));
+      inputs.push_back(mask);
+    }
+
+    // Read optional attention scale.
+    std::optional<float> scaleValue;
+    if (hipDnnSdpaAttr->attn_scale_value().has_value()) {
+      // Scalar float attribute set directly on the SDPA node.
+      scaleValue = *hipDnnSdpaAttr->attn_scale_value();
+    } else if (hipDnnSdpaAttr->scale_tensor_uid().has_value()) {
+      // Scale provided as a tensor UID — only pass-by-value scalars are
+      // supported since the scale must be a compile-time constant.
+      const auto *scaleTensor =
+          opGraphWrapper.getTensorMap().at(*hipDnnSdpaAttr->scale_tensor_uid());
+      if (!isPassByValue(scaleTensor))
+        return fusilli::error(fusilli::ErrorCode::NotImplemented,
+                              "SDPA scale must be a pass-by-value scalar, "
+                              "not a device tensor.");
+      if (scaleTensor->value_type() !=
+          hipdnn_data_sdk::data_objects::TensorValue::Float32Value)
+        return fusilli::error(fusilli::ErrorCode::NotImplemented,
+                              "SDPA scale tensor must be Float32.");
+      scaleValue = scaleTensor->value_as_Float32Value()->value();
+    }
+
+    // GQA: enable when Q has more heads than K/V.
+    bool enableGqa = q->getDim()[1] != k->getDim()[1];
+
+    // Build MLIR template and create CustomOp.
+    std::string mlir = SdpaImport::buildMLIR(hasAttnMask, /*dropoutP=*/0.0f,
+                                             isCausal, scaleValue, enableGqa);
+    fusilli::CustomOpAttr sdpaAttr;
+    sdpaAttr.setName("sdpa_fprop").setMlir(mlir).setNumOutputs(1);
+    auto outs = fusilliGraph.customOp(inputs, sdpaAttr);
+
+    // Import output tensor. importNodeOutput sets dim/stride/dtype from the
+    // flatbuffer tensor attributes.
+    FUSILLI_CHECK_ERROR(
+        importNodeOutput(hipDnnSdpaAttr->o_tensor_uid(), "o", outs[0]));
 
     return fusilli::ok();
   }

--- a/dnn-providers/fusilli-provider/include/graph_import.h
+++ b/dnn-providers/fusilli-provider/include/graph_import.h
@@ -351,6 +351,20 @@ private:
     // Are available SDPA templates applicable?
     FUSILLI_CHECK_ERROR(SdpaImport::validateTemplate(hipDnnSdpaAttr));
 
+    // mma_core_mode requests a specific accumulator precision. Our MLIR path
+    // accumulates in the query element type, so reject if the requested mode
+    // doesn't match. UNSET (the default) is always fine.
+    auto mmaCoreMode = hipDnnSdpaAttr->mma_core_mode();
+    if (mmaCoreMode != hipdnn_data_sdk::data_objects::DataType::UNSET) {
+      auto qDataType = opGraphWrapper.getTensorMap()
+                           .at(hipDnnSdpaAttr->q_tensor_uid())
+                           ->data_type();
+      if (mmaCoreMode != qDataType)
+        return fusilli::error(
+            fusilli::ErrorCode::NotImplemented,
+            "SDPA mma_core_mode must match query tensor dtype.");
+    }
+
     bool hasAttnMask = hipDnnSdpaAttr->attn_mask_tensor_uid().has_value();
     bool isCausal = hipDnnSdpaAttr->causal_mask();
 

--- a/dnn-providers/fusilli-provider/test/integration/CMakeLists.txt
+++ b/dnn-providers/fusilli-provider/test/integration/CMakeLists.txt
@@ -169,3 +169,18 @@ add_fusilli_plugin_test(
   COMPILE_DEFS
     FUSILLI_PLUGIN_PATH="../${FUSILLI_PLUGIN_RELATIVE_PATH}"
 )
+
+add_fusilli_plugin_test(
+  NAME fusilli_plugin_simple_sdpa_test
+  SRCS sdpa/simple_sdpa.cpp
+  DEPS
+    GTest::gtest_main
+    hip::host
+    hipdnn_frontend
+    hipdnn_plugin_sdk
+    hipdnn_data_sdk
+    hipdnn_test_sdk
+    Threads::Threads
+  COMPILE_DEFS
+    FUSILLI_PLUGIN_PATH="../${FUSILLI_PLUGIN_RELATIVE_PATH}"
+)

--- a/dnn-providers/fusilli-provider/test/integration/sdpa/simple_sdpa.cpp
+++ b/dnn-providers/fusilli-provider/test/integration/sdpa/simple_sdpa.cpp
@@ -1,0 +1,249 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <gtest/gtest.h>
+#include <hip/hip_runtime.h>
+#include <hipdnn_backend.h>
+#include <hipdnn_data_sdk/types.hpp>
+#include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_frontend/Graph.hpp>
+#include <hipdnn_frontend/attributes/SdpaAttributes.hpp>
+#include <hipdnn_frontend/attributes/TensorAttributes.hpp>
+#include <hipdnn_test_sdk/utilities/CpuFpReferenceSdpa.hpp>
+#include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
+#include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
+
+#include <cstdint>
+#include <memory>
+
+using namespace hipdnn_frontend;
+using namespace hipdnn_data_sdk::utilities;
+using namespace hipdnn_test_sdk::utilities;
+using hipdnn_data_sdk::types::half;
+
+// Test: Simple scaled dot-product attention
+// Q[B,H,S,D] x K[B,H,S,D] x V[B,H,S,D] -> O[B,H,S,D]
+TEST(SdpaIntegrationTest, SimpleSdpa) {
+  // Initialize HIP.
+  ASSERT_EQ(hipInit(0), hipSuccess);
+  ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+  hipStream_t stream = nullptr;
+  ASSERT_EQ(hipStreamCreate(&stream), hipSuccess);
+
+  // Set plugin paths.
+  auto pluginPath = std::filesystem::canonical(getCurrentExecutableDirectory() /
+                                               FUSILLI_PLUGIN_PATH);
+  const std::array<const char *, 1> paths = {pluginPath.c_str()};
+  ASSERT_EQ(hipdnnSetEnginePluginPaths_ext(paths.size(), paths.data(),
+                                           HIPDNN_PLUGIN_LOADING_ABSOLUTE),
+            HIPDNN_STATUS_SUCCESS);
+
+  // Create handle.
+  hipdnnHandle_t handle;
+  ASSERT_EQ(hipdnnCreate(&handle), HIPDNN_STATUS_SUCCESS);
+  ASSERT_EQ(hipdnnSetStream(handle, stream), HIPDNN_STATUS_SUCCESS);
+
+  // Dimensions: [batch=2, heads=4, seq_len=8, head_dim=16]
+  const int64_t B = 2;
+  const int64_t H = 4;
+  const int64_t S = 8;
+  const int64_t D = 16;
+
+  // UIDs.
+  const int64_t qUID = 0;
+  const int64_t kUID = 1;
+  const int64_t vUID = 2;
+  const int64_t oUID = 3;
+
+  // Initialize tensors.
+  PinnedTensor<float> qTensor({B, H, S, D});
+  PinnedTensor<float> kTensor({B, H, S, D});
+  PinnedTensor<float> vTensor({B, H, S, D});
+  PinnedTensor<float> oTensor({B, H, S, D});
+  qTensor.fillWithValue(0.1f);
+  kTensor.fillWithValue(0.1f);
+  vTensor.fillWithValue(0.1f);
+  oTensor.fillWithValue(-100.0f);
+
+  // Compute expected output using CPU reference.
+  PinnedTensor<float> expectedOutput({B, H, S, D});
+  CpuFpReferenceSdpa::forward(qTensor, kTensor, vTensor, expectedOutput);
+
+  // Create graph.
+  auto graph = std::make_shared<graph::Graph>();
+  graph->set_name("simple_sdpa_test");
+  graph->set_io_data_type(DataType_t::FLOAT)
+      .set_intermediate_data_type(DataType_t::FLOAT)
+      .set_compute_data_type(DataType_t::FLOAT);
+
+  // Create tensor attributes.
+  auto qAttr = std::make_shared<graph::TensorAttributes>(
+      graph::makeTensorAttributes("Q", DataType_t::FLOAT, qTensor));
+  qAttr->set_uid(qUID);
+  auto kAttr = std::make_shared<graph::TensorAttributes>(
+      graph::makeTensorAttributes("K", DataType_t::FLOAT, kTensor));
+  kAttr->set_uid(kUID);
+  auto vAttr = std::make_shared<graph::TensorAttributes>(
+      graph::makeTensorAttributes("V", DataType_t::FLOAT, vTensor));
+  vAttr->set_uid(vUID);
+
+  // Create SDPA node.
+  graph::SdpaAttributes sdpaAttr;
+  sdpaAttr.set_name("sdpa");
+  auto [oAttr, statsAttr] = graph->sdpa(qAttr, kAttr, vAttr, sdpaAttr);
+  oAttr->set_uid(oUID);
+  oAttr->set_dim(oTensor.dims()).set_stride(oTensor.strides()).set_output(true);
+
+  // Build + validate + build plans for graph.
+  auto result = graph->validate();
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+
+  result = graph->build_operation_graph(handle);
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+
+  result = graph->create_execution_plans();
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+
+  result = graph->check_support();
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+
+  result = graph->build_plans();
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+
+  // Create variant pack.
+  std::unordered_map<int64_t, void *> variantPack;
+  variantPack[qUID] = qTensor.memory().deviceData();
+  variantPack[kUID] = kTensor.memory().deviceData();
+  variantPack[vUID] = vTensor.memory().deviceData();
+  variantPack[oUID] = oTensor.memory().deviceData();
+
+  // Execute graph.
+  result = graph->execute(handle, variantPack, nullptr);
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+  oTensor.memory().markDeviceModified();
+
+  // Check results.
+  CpuFpReferenceValidation<float> validator(1e-6f, 1e-6f);
+  EXPECT_TRUE(validator.allClose(expectedOutput, oTensor));
+
+  // Clean up.
+  ASSERT_EQ(hipStreamDestroy(stream), HIPDNN_STATUS_SUCCESS);
+  ASSERT_EQ(hipdnnDestroy(handle), HIPDNN_STATUS_SUCCESS);
+}
+
+// Test: Grouped query attention (GQA)
+// Q has more heads than K/V: Q[B,H,S,D] x K[B,Hkv,S,D] x V[B,Hkv,S,D]
+// where H is a multiple of Hkv.
+TEST(SdpaIntegrationTest, SdpaGqa) {
+  // Initialize HIP.
+  ASSERT_EQ(hipInit(0), hipSuccess);
+  ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+  hipStream_t stream = nullptr;
+  ASSERT_EQ(hipStreamCreate(&stream), hipSuccess);
+
+  // Set plugin paths.
+  auto pluginPath = std::filesystem::canonical(getCurrentExecutableDirectory() /
+                                               FUSILLI_PLUGIN_PATH);
+  const std::array<const char *, 1> paths = {pluginPath.c_str()};
+  ASSERT_EQ(hipdnnSetEnginePluginPaths_ext(paths.size(), paths.data(),
+                                           HIPDNN_PLUGIN_LOADING_ABSOLUTE),
+            HIPDNN_STATUS_SUCCESS);
+
+  // Create handle.
+  hipdnnHandle_t handle;
+  ASSERT_EQ(hipdnnCreate(&handle), HIPDNN_STATUS_SUCCESS);
+  ASSERT_EQ(hipdnnSetStream(handle, stream), HIPDNN_STATUS_SUCCESS);
+
+  // Dimensions matching fusilli SDPA GQA sample.
+  const int64_t B = 1;
+  const int64_t H = 8;
+  const int64_t Hkv = 2;
+  const int64_t S = 64;
+  const int64_t D = 64;
+
+  // UIDs.
+  const int64_t qUID = 0;
+  const int64_t kUID = 1;
+  const int64_t vUID = 2;
+  const int64_t oUID = 3;
+
+  // Initialize tensors (f16 to match fusilli GQA sample).
+  PinnedTensor<half> qTensor({B, H, S, D});
+  PinnedTensor<half> kTensor({B, Hkv, S, D});
+  PinnedTensor<half> vTensor({B, Hkv, S, D});
+  PinnedTensor<half> oTensor({B, H, S, D});
+  qTensor.fillWithValue(half(0.01f));
+  kTensor.fillWithValue(half(0.01f));
+  vTensor.fillWithValue(half(0.01f));
+  oTensor.fillWithValue(half(-100.0f));
+
+  // Compute expected output using CPU reference (supports GQA natively).
+  PinnedTensor<half> expectedOutput({B, H, S, D});
+  CpuFpReferenceSdpa::forward(qTensor, kTensor, vTensor, expectedOutput);
+
+  // Create graph.
+  auto graph = std::make_shared<graph::Graph>();
+  graph->set_name("sdpa_gqa_test");
+  graph->set_io_data_type(DataType_t::HALF)
+      .set_intermediate_data_type(DataType_t::HALF)
+      .set_compute_data_type(DataType_t::FLOAT);
+
+  // Create tensor attributes.
+  auto qAttr = std::make_shared<graph::TensorAttributes>(
+      graph::makeTensorAttributes("Q", DataType_t::HALF, qTensor));
+  qAttr->set_uid(qUID);
+  auto kAttr = std::make_shared<graph::TensorAttributes>(
+      graph::makeTensorAttributes("K", DataType_t::HALF, kTensor));
+  kAttr->set_uid(kUID);
+  auto vAttr = std::make_shared<graph::TensorAttributes>(
+      graph::makeTensorAttributes("V", DataType_t::HALF, vTensor));
+  vAttr->set_uid(vUID);
+
+  // Create SDPA node.
+  graph::SdpaAttributes sdpaAttr;
+  sdpaAttr.set_name("sdpa_gqa");
+  auto [oAttr, statsAttr] = graph->sdpa(qAttr, kAttr, vAttr, sdpaAttr);
+  oAttr->set_uid(oUID);
+  oAttr->set_dim(oTensor.dims()).set_stride(oTensor.strides()).set_output(true);
+
+  // Build + validate + build plans for graph.
+  auto result = graph->validate();
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+
+  result = graph->build_operation_graph(handle);
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+
+  result = graph->create_execution_plans();
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+
+  result = graph->check_support();
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+
+  result = graph->build_plans();
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+
+  // Create variant pack.
+  std::unordered_map<int64_t, void *> variantPack;
+  variantPack[qUID] = qTensor.memory().deviceData();
+  variantPack[kUID] = kTensor.memory().deviceData();
+  variantPack[vUID] = vTensor.memory().deviceData();
+  variantPack[oUID] = oTensor.memory().deviceData();
+
+  // Execute graph.
+  result = graph->execute(handle, variantPack, nullptr);
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+  oTensor.memory().markDeviceModified();
+
+  // Check results (relaxed tolerance for f16 accumulation error).
+  CpuFpReferenceValidation<half> validator(1e-2f, 1e-2f);
+  EXPECT_TRUE(validator.allClose(expectedOutput, oTensor));
+
+  // Clean up.
+  ASSERT_EQ(hipStreamDestroy(stream), HIPDNN_STATUS_SUCCESS);
+  ASSERT_EQ(hipdnnDestroy(handle), HIPDNN_STATUS_SUCCESS);
+}

--- a/dnn-providers/fusilli-provider/test/test_fusilli_plugin_api.cpp
+++ b/dnn-providers/fusilli-provider/test/test_fusilli_plugin_api.cpp
@@ -581,3 +581,59 @@ TEST(TestFusilliPluginApi, SetStreamNullHandle) {
   // Clean up.
   EXPECT_EQ(hipStreamDestroy(stream), hipSuccess);
 }
+
+TEST(TestFusilliPluginApi, GetApplicableEngineIdsSdpa) {
+  hipdnnEnginePluginHandle_t handle = nullptr;
+  ASSERT_EQ(hipdnnEnginePluginCreate(&handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+  ASSERT_NE(handle, nullptr);
+
+  std::array<int64_t, 5> engineIDs;
+  uint32_t numEngines = 0;
+
+  const std::vector<int64_t> qkvDims = {2, 8, 16, 64};
+  const std::vector<int64_t> qkvStrides = {qkvDims[1] * qkvDims[2] * qkvDims[3],
+                                           qkvDims[2] * qkvDims[3], qkvDims[3],
+                                           1};
+
+  // Basic SDPA (Q, K, V -> O) should be supported.
+  auto builder = hipdnn_test_sdk::utilities::createValidSdpaFpropGraph(
+      qkvDims, qkvStrides, qkvDims, qkvStrides, qkvDims, qkvStrides, qkvDims,
+      qkvStrides);
+  hipdnnPluginConstData_t opGraph;
+  opGraph.ptr = builder.GetBufferPointer();
+  opGraph.size = builder.GetSize();
+
+  ASSERT_EQ(hipdnnEnginePluginGetApplicableEngineIds(
+                handle, &opGraph, engineIDs.data(), 5, &numEngines),
+            HIPDNN_PLUGIN_STATUS_SUCCESS);
+  ASSERT_EQ(numEngines, 1);
+  ASSERT_EQ(engineIDs[0], hipdnn_data_sdk::utilities::FUSILLI_ENGINE_ID);
+
+  // SDPA with attn_mask should be supported.
+  builder = hipdnn_test_sdk::utilities::createValidSdpaFpropGraph(
+      qkvDims, qkvStrides, qkvDims, qkvStrides, qkvDims, qkvStrides, qkvDims,
+      qkvStrides, hipdnn_data_sdk::data_objects::DataType::HALF,
+      /*withAttnMask=*/true);
+  opGraph.ptr = builder.GetBufferPointer();
+  opGraph.size = builder.GetSize();
+
+  ASSERT_EQ(hipdnnEnginePluginGetApplicableEngineIds(
+                handle, &opGraph, engineIDs.data(), 5, &numEngines),
+            HIPDNN_PLUGIN_STATUS_SUCCESS);
+  ASSERT_EQ(numEngines, 1);
+
+  // SDPA with stats output is NOT supported (yet).
+  builder = hipdnn_test_sdk::utilities::createValidSdpaFpropGraph(
+      qkvDims, qkvStrides, qkvDims, qkvStrides, qkvDims, qkvStrides, qkvDims,
+      qkvStrides, hipdnn_data_sdk::data_objects::DataType::HALF,
+      /*withAttnMask=*/false, /*withScale=*/false, /*withStats=*/true);
+  opGraph.ptr = builder.GetBufferPointer();
+  opGraph.size = builder.GetSize();
+
+  ASSERT_EQ(hipdnnEnginePluginGetApplicableEngineIds(
+                handle, &opGraph, engineIDs.data(), 5, &numEngines),
+            HIPDNN_PLUGIN_STATUS_SUCCESS);
+  ASSERT_EQ(numEngines, 0);
+
+  EXPECT_EQ(hipdnnEnginePluginDestroy(handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+}


### PR DESCRIPTION
. Supports basic SDPA, causal masking, attention mask, custom scale, and grouped query attention (GQA).


## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Map hipDNN SDPA (Scaled Dot-Product Attention) graphs to fusilli `CustomOp` nodes using `torch.aten.scaled_dot_product_attention` MLIR template.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

- Add custom_ops.h with SdpaImport struct (validateTemplate, validateInputs, buildMLIR) and MLIR R-string templates
- Add SdpaAttributes case to importNode() switch in graph_import.h
- Add importSdpaAttr() orchestrator in graph_import.h
- Add GetApplicableEngineIdsSdpa plugin API test
- Add SimpleSdpa (f32) and SdpaGqa (f16) integration tests
- Gate unsupported features: dropout, FP8, paged attention, etc.
- Gate GQA with f32 (https://github.com/iree-org/iree/issues/21858)

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Tests added.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
