### PR TITLE
[tensilelite] Reference CPU GEMM infra update

### DIFF
--- a/projects/hipblaslt/tensilelite/client/cpu_gemm_driver.cpp
+++ b/projects/hipblaslt/tensilelite/client/cpu_gemm_driver.cpp
@@ -384,7 +384,7 @@ int main(int argc, char* argv[])
         "N", po::value<size_t>()->default_value(128), "Matrix N dimension")(
         "K", po::value<size_t>()->default_value(128), "Matrix K dimension")(
         "transA", po::value<bool>()->default_value(false), "Transpose A")(
-        "transB", po::value<bool>()->default_value(true), "Transpose B")(
+        "transB", po::value<bool>()->default_value(false), "Transpose B")(
         "alpha", po::value<float>()->default_value(1.0f), "Alpha scalar")(
         "beta", po::value<float>()->default_value(0.0f), "Beta scalar")(
         "type", po::value<std::string>()->default_value("f32"), "Data type (f32, f16, bf16)")(

--- a/projects/hipblaslt/tensilelite/client/cpu_gemm_driver.cpp
+++ b/projects/hipblaslt/tensilelite/client/cpu_gemm_driver.cpp
@@ -34,6 +34,7 @@
 #include "ProgramOptions.hpp"
 #include "Reference.hpp"
 #include "rocisa/include/enum.hpp"
+#include <Tensile/Activation.hpp>
 
 /*
  * CPU GEMM Driver and Validator
@@ -92,21 +93,25 @@ namespace
 
     // A naive, slow, golden reference implementation of GEMM.
     // Used strictly for validating the correctness of the optimized path.
-    // Calculates D = alpha * (A * B) + beta * C
-    //
-    // We can all the various bells and whistles that tensile supports
-    // (activations, etc) as needed.
-    void columnMajorGemm(const float* a,
-                         const float* b,
-                         const float* c,
-                         float*       d,
-                         size_t       m,
-                         size_t       n,
-                         size_t       k,
-                         bool         transA,
-                         bool         transB,
-                         float        alpha,
-                         float        beta)
+    // Calculates D = activation(alpha * scaleA[i] * scaleB[j] * scaleAlphaVec[d] * (A * B) + beta * C + bias[i])
+    // where d = i (row/M) when factorDim==0, or d = j (col/N) when factorDim==1.
+    void columnMajorGemm(const float*   a,
+                         const float*   b,
+                         const float*   c,
+                         float*         d,
+                         size_t         m,
+                         size_t         n,
+                         size_t         k,
+                         bool           transA,
+                         bool           transB,
+                         float          alpha,
+                         float          beta,
+                         const float*   biasVec       = nullptr,
+                         const float*   scaleAlphaVec = nullptr,
+                         ActivationType activation    = ActivationType::None,
+                         const float*   scaleAVec     = nullptr,
+                         const float*   scaleBVec     = nullptr,
+                         int            factorDim     = 0)
     {
         size_t strideAK = transA ? 1 : m;
         size_t strideAM = transA ? k : 1;
@@ -124,7 +129,23 @@ namespace
                     float bVal = b[l * strideBK + j * strideBN];
                     sum += aVal * bVal;
                 }
-                d[i + j * m] = alpha * sum + beta * c[i + j * m];
+                float effectiveAlpha = alpha;
+                if(scaleAVec)
+                    effectiveAlpha *= scaleAVec[i];
+                if(scaleBVec)
+                    effectiveAlpha *= scaleBVec[j];
+                if(scaleAlphaVec)
+                    effectiveAlpha *= scaleAlphaVec[factorDim == 0 ? i : j];
+
+                float result = effectiveAlpha * sum + beta * c[i + j * m];
+
+                if(biasVec)
+                    result += biasVec[i];
+
+                if(activation == ActivationType::Relu)
+                    result = std::max(0.0f, result);
+
+                d[i + j * m] = result;
             }
         }
     }
@@ -138,15 +159,20 @@ namespace
  * AccumulateT: The type used for accumulation (currently restricted to float).
  */
 template <typename InputT, typename AccumulateT = float>
-int runGemm(size_t m,
-            size_t n,
-            size_t k,
-            bool   transA,
-            bool   transB,
-            float  alpha,
-            float  beta,
-            bool   validate,
-            bool   tryFastPath)
+int runGemm(size_t         m,
+            size_t         n,
+            size_t         k,
+            bool           transA,
+            bool           transB,
+            float          alpha,
+            float          beta,
+            bool           validate,
+            bool           tryFastPath,
+            bool           useBias,
+            ActivationType activation,
+            bool               useScaleAlphaVec,
+            const std::string& useScaleAB,
+            int                factorDim)
 {
     constexpr rocisa::DataType dtypeEnum = TypeTraits<InputT>::value;
     static_assert(std::is_same<AccumulateT, float>::value,
@@ -182,6 +208,8 @@ int runGemm(size_t m,
 
     contraction.setComputeInputTypeA(dtypeEnum);
     contraction.setComputeInputTypeB(dtypeEnum);
+    contraction.setAlphaType(rocisa::DataType::Float);
+    contraction.setBetaType(rocisa::DataType::Float);
 
     // Allocate host memory for inputs and outputs
     std::vector<InputT> a(m * k);
@@ -200,7 +228,72 @@ int runGemm(size_t m,
     std::generate(b.begin(), b.end(), [&]() { return static_cast<InputT>(randomGen()); });
     std::generate(c.begin(), c.end(), [&]() { return static_cast<float>(randomGen()); });
 
+    // Optional feature buffers
+    std::vector<float> biasVec;
+    std::vector<float> scaleAlphaVecBuf;
+
+    if(useBias)
+    {
+        biasVec.resize(m);
+        std::generate(biasVec.begin(), biasVec.end(), randomGen);
+        contraction.setUseBias(1);
+        contraction.setBias(rocisa::DataType::Float, m, m);
+    }
+
+    if(useScaleAlphaVec)
+    {
+        size_t scaleAlphaVecLen = (factorDim == 0) ? m : n;
+        scaleAlphaVecBuf.resize(scaleAlphaVecLen);
+        std::generate(scaleAlphaVecBuf.begin(), scaleAlphaVecBuf.end(), randomGen);
+        contraction.setUseScaleAlphaVec(1);
+        contraction.setScaleAlphaVec(rocisa::DataType::Float, scaleAlphaVecLen, factorDim);
+    }
+
+    // Random scale generator: magnitude in [1.1, 100], sign random.
+    // Excludes 0 and ±1 so missing/incorrect scaling is never masked.
+    std::uniform_real_distribution<float> scaleDis(1.1f, 100.0f);
+    auto scaleGen = [&]() {
+        float sign = dis(gen) ? 1.0f : -1.0f;
+        float mag  = scaleDis(gen);
+        return sign * mag;
+    };
+
+    std::vector<float> scaleABuf;
+    std::vector<float> scaleBBuf;
+
+    if(useScaleAB == "Scalar")
+    {
+        scaleABuf = {scaleGen()};
+        scaleBBuf = {scaleGen()};
+        // setUseScaleAB must be called before setScaleA/setScaleB,
+        // because setScaleA/B silently skips tensor registration when
+        // m_useScaleAB is still empty.
+        contraction.setUseScaleAB("Scalar");
+        contraction.setScaleA(rocisa::DataType::Float, 1);
+        contraction.setScaleB(rocisa::DataType::Float, 1);
+    }
+    else if(useScaleAB == "Vector")
+    {
+        scaleABuf.resize(m);
+        scaleBBuf.resize(n);
+        std::generate(scaleABuf.begin(), scaleABuf.end(), scaleGen);
+        std::generate(scaleBBuf.begin(), scaleBBuf.end(), scaleGen);
+        contraction.setUseScaleAB("Vector");
+        contraction.setScaleA(rocisa::DataType::Float, m);
+        contraction.setScaleB(rocisa::DataType::Float, n);
+    }
+
+    if(activation != ActivationType::None)
+    {
+        contraction.setActivationType(ActivationType::All);
+        contraction.setParams().setActivationEnum(activation);
+    }
+
     ContractionInputs inputs(a.data(), b.data(), c.data(), d.data(), alpha, beta);
+    inputs.bias          = useBias ? biasVec.data() : nullptr;
+    inputs.scaleAlphaVec = useScaleAlphaVec ? scaleAlphaVecBuf.data() : nullptr;
+    inputs.scaleA        = (useScaleAB != "none") ? scaleABuf.data() : nullptr;
+    inputs.scaleB        = (useScaleAB != "none") ? scaleBBuf.data() : nullptr;
 
     auto start = std::chrono::high_resolution_clock::now();
 
@@ -234,8 +327,14 @@ int runGemm(size_t m,
                         k,
                         transA,
                         transB,
-                        alpha,
-                        beta);
+                        (useScaleAB == "Scalar") ? alpha * scaleABuf[0] * scaleBBuf[0] : alpha,
+                        beta,
+                        useBias ? biasVec.data() : nullptr,
+                        useScaleAlphaVec ? scaleAlphaVecBuf.data() : nullptr,
+                        activation,
+                        (useScaleAB == "Vector") ? scaleABuf.data() : nullptr,
+                        (useScaleAB == "Vector") ? scaleBBuf.data() : nullptr,
+                        factorDim);
 
         // Compare results
         bool  allClose = true;
@@ -274,6 +373,8 @@ int runGemm(size_t m,
 
 int main(int argc, char* argv[])
 {
+    using namespace TensileLite;
+
     po::options_description desc("Allowed options");
     desc.add_options()("help,h", "Produce help message")(
         "M", po::value<size_t>()->default_value(128), "Matrix M dimension")(
@@ -285,7 +386,12 @@ int main(int argc, char* argv[])
         "beta", po::value<float>()->default_value(0.0f), "Beta scalar")(
         "type", po::value<std::string>()->default_value("f32"), "Data type (f32, f16, bf16)")(
         "validate", po::value<bool>()->default_value(true), "Run validation against ref")(
-        "tryFastPath", po::value<bool>()->default_value(true), "Use optimized path");
+        "tryFastPath", po::value<bool>()->default_value(false), "Use optimized path")(
+        "bias", po::value<bool>()->default_value(false), "Enable bias vector")(
+        "activation", po::value<std::string>()->default_value("none"), "Activation (none, relu)")(
+        "scaleAlphaVec", po::value<bool>()->default_value(false), "Enable per-row alpha scaling")(
+        "factorDim", po::value<int>()->default_value(0), "ScaleAlphaVec dimension: 0=row(M), 1=col(N)")(
+        "useScaleAB", po::value<std::string>()->default_value("none"), "ScaleAB mode (none, Scalar, Vector)");
 
     po::variables_map vm;
     try
@@ -305,16 +411,42 @@ int main(int argc, char* argv[])
         return 0;
     }
 
-    size_t      m           = vm["M"].as<size_t>();
-    size_t      n           = vm["N"].as<size_t>();
-    size_t      k           = vm["K"].as<size_t>();
-    bool        transA      = vm["transA"].as<bool>();
-    bool        transB      = vm["transB"].as<bool>();
-    float       alpha       = vm["alpha"].as<float>();
-    float       beta        = vm["beta"].as<float>();
-    std::string typeStr     = vm["type"].as<std::string>();
-    bool        validate    = vm["validate"].as<bool>();
-    bool        tryFastPath = vm["tryFastPath"].as<bool>();
+    size_t      m                = vm["M"].as<size_t>();
+    size_t      n                = vm["N"].as<size_t>();
+    size_t      k                = vm["K"].as<size_t>();
+    bool        transA           = vm["transA"].as<bool>();
+    bool        transB           = vm["transB"].as<bool>();
+    float       alpha            = vm["alpha"].as<float>();
+    float       beta             = vm["beta"].as<float>();
+    std::string typeStr          = vm["type"].as<std::string>();
+    bool        validate         = vm["validate"].as<bool>();
+    bool        tryFastPath      = vm["tryFastPath"].as<bool>();
+    bool        useBias          = vm["bias"].as<bool>();
+    std::string activationStr    = vm["activation"].as<std::string>();
+    bool        useScaleAlphaVec = vm["scaleAlphaVec"].as<bool>();
+    int         factorDim        = vm["factorDim"].as<int>();
+    std::string useScaleAB       = vm["useScaleAB"].as<std::string>();
+
+    if(useScaleAB != "none" && useScaleAB != "Scalar" && useScaleAB != "Vector")
+    {
+        std::cerr << "Unknown useScaleAB mode: " << useScaleAB << std::endl;
+        return 1;
+    }
+
+    if(factorDim != 0 && factorDim != 1)
+    {
+        std::cerr << "Invalid factorDim: " << factorDim << " (must be 0 or 1)" << std::endl;
+        return 1;
+    }
+
+    ActivationType activation = ActivationType::None;
+    if(activationStr == "relu")
+        activation = ActivationType::Relu;
+    else if(activationStr != "none")
+    {
+        std::cerr << "Unknown activation: " << activationStr << std::endl;
+        return 1;
+    }
 
     std::cout << "Running GEMM with: M=" << m << " N=" << n << " K=" << k << " Type=" << typeStr
               << " FastPath=" << tryFastPath << std::endl;
@@ -323,17 +455,21 @@ int main(int argc, char* argv[])
     {
         if(typeStr == "f32")
         {
-            return runGemm<float>(m, n, k, transA, transB, alpha, beta, validate, tryFastPath);
+            return runGemm<float>(
+                m, n, k, transA, transB, alpha, beta, validate, tryFastPath,
+                useBias, activation, useScaleAlphaVec, useScaleAB, factorDim);
         }
         else if(typeStr == "bf16")
         {
-            return runGemm<TensileLite::BFloat16>(
-                m, n, k, transA, transB, alpha, beta, validate, tryFastPath);
+            return runGemm<BFloat16>(
+                m, n, k, transA, transB, alpha, beta, validate, tryFastPath,
+                useBias, activation, useScaleAlphaVec, useScaleAB, factorDim);
         }
         else if(typeStr == "f16")
         {
-            return runGemm<TensileLite::Half>(
-                m, n, k, transA, transB, alpha, beta, validate, tryFastPath);
+            return runGemm<Half>(
+                m, n, k, transA, transB, alpha, beta, validate, tryFastPath,
+                useBias, activation, useScaleAlphaVec, useScaleAB, factorDim);
         }
         else
         {

--- a/projects/hipblaslt/tensilelite/client/cpu_gemm_driver.cpp
+++ b/projects/hipblaslt/tensilelite/client/cpu_gemm_driver.cpp
@@ -142,9 +142,12 @@ namespace
                 if(biasVec)
                     result += biasVec[i];
 
-                if(activation == ActivationType::Relu) {
+                if(activation == ActivationType::Relu)
+                {
                     result = std::max(0.0f, result);
-                } else {
+                }
+                else
+                {
                     assert(activation == ActivationType::None);
                 }
 

--- a/projects/hipblaslt/tensilelite/client/cpu_gemm_driver.cpp
+++ b/projects/hipblaslt/tensilelite/client/cpu_gemm_driver.cpp
@@ -142,8 +142,11 @@ namespace
                 if(biasVec)
                     result += biasVec[i];
 
-                if(activation == ActivationType::Relu)
+                if(activation == ActivationType::Relu) {
                     result = std::max(0.0f, result);
+                } else {
+                    assert(activation == ActivationType::None);
+                }
 
                 d[i + j * m] = result;
             }
@@ -220,9 +223,9 @@ int runGemm(size_t         m,
     // Initialize inputs with random values in {-1.0, 1.0}
     size_t                          seed = 42;
     std::mt19937                    gen(seed);
-    std::uniform_int_distribution<> dis(0, 1);
+    std::uniform_int_distribution<> binary_distribution(0, 1);
 
-    auto randomGen = [&]() { return dis(gen) ? 1.0f : -1.0f; };
+    auto randomGen = [&]() { return binary_distribution(gen) ? 1.0f : -1.0f; };
 
     std::generate(a.begin(), a.end(), [&]() { return static_cast<InputT>(randomGen()); });
     std::generate(b.begin(), b.end(), [&]() { return static_cast<InputT>(randomGen()); });
@@ -249,13 +252,13 @@ int runGemm(size_t         m,
         contraction.setScaleAlphaVec(rocisa::DataType::Float, scaleAlphaVecLen, factorDim);
     }
 
-    // Random scale generator: magnitude in [1.1, 100], sign random.
+    // Random scale generator: magnitude in (1, 100], integer values to avoid rounding issues, sign random.
     // Excludes 0 and ±1 so missing/incorrect scaling is never masked.
-    std::uniform_real_distribution<float> scaleDis(1.1f, 100.0f);
+    std::uniform_int_distribution<int> scaleDis(2, 100);
     auto scaleGen = [&]() {
-        float sign = dis(gen) ? 1.0f : -1.0f;
-        float mag  = scaleDis(gen);
-        return sign * mag;
+        float sign = binary_distribution(gen) ? 1.0f : -1.0f;
+        int mag    = scaleDis(gen);
+        return sign * static_cast<float>(mag);
     };
 
     std::vector<float> scaleABuf;

--- a/projects/hipblaslt/tensilelite/tests/CMakeLists.txt
+++ b/projects/hipblaslt/tensilelite/tests/CMakeLists.txt
@@ -68,42 +68,109 @@ function(add_cpu_gemm_test TEST_NAME)
     )
 endfunction()
 
-# 2. Basic Sanity Check (F32)
-add_cpu_gemm_test(F32_Sanity
-    ARGS --M 31 --N 41 --K 51 --type f32 --validate 1
-)
+# Default test sizes. Non-tile-aligned to stress remainder handling.
+# f32 and f16/bf16 use different sizes to increase coverage diversity.
+set(F32_SIZES -M 133 -N 147 -K 165)
+set(ALT_SIZES -M 131 -N 141 -K 151)
+set(ODD_SIZES -M 102 -N 103 -K 105)
 
-# 3. Transpose Combinations (T/N, N/T, T/T)
-add_cpu_gemm_test(F32_TransA
-    ARGS --M 31 --N 41 --K 51 --transA 1 --transB 0 --type f32 --validate 1
-)
-add_cpu_gemm_test(F32_TransB
-    ARGS --M 31 --N 41 --K 51 --transA 0 --transB 1 --type f32 --validate 1
-)
-add_cpu_gemm_test(F32_TransAB
-    ARGS --M 31 --N 41 --K 51 --transA 1 --transB 1 --type f32 --validate 1
-)
+macro(get_test_sizes TYPE OUT_SIZES)
+    if("${TYPE}" STREQUAL "f32")
+        set(${OUT_SIZES} ${F32_SIZES})
+    else()
+        set(${OUT_SIZES} ${ALT_SIZES})
+    endif()
+endmacro()
 
-# 4. Small sizes
-add_cpu_gemm_test(F32_Odd_Sizes
-    ARGS --M 2 --N 3 --K 5 --type f32 --validate 1
-)
+# Helper: convert transpose tag (NN/TN/NT/TT) to flags
+macro(get_trans_flags TRANS OUT_FLAGS)
+    set(${OUT_FLAGS} "")
+    if("${TRANS}" MATCHES "^T")
+        list(APPEND ${OUT_FLAGS} --transA)
+    endif()
+    if("${TRANS}" MATCHES "T$")
+        list(APPEND ${OUT_FLAGS} --transB)
+    endif()
+endmacro()
 
-# 5. BFloat16 Tests
-# These verify your "cast to f32 -> compute -> cast back" logic
-add_cpu_gemm_test(BF16_Standard
-    ARGS --M 128 --N 128 --K 128 --type bf16 --validate 1
-)
+# Run all tests against both fast and slow paths
+foreach(PATH fast slow)
+    if("${PATH}" STREQUAL "fast")
+        set(PATH_FLAGS --tryFastPath)
+    else()
+        set(PATH_FLAGS "")
+    endif()
 
-# 6. FP16 Tests
-add_cpu_gemm_test(F16_Standard
-    ARGS --M 128 --N 128 --K 128 --type f16 --validate 1
-)
+    # Basic sanity, transpose combos, odd sizes, type coverage
+    add_cpu_gemm_test(${PATH}_F32_Sanity
+        ARGS ${F32_SIZES} --type f32 --validate ${PATH_FLAGS}
+    )
+    add_cpu_gemm_test(${PATH}_F32_Odd_Sizes
+        ARGS ${ODD_SIZES} --type f32 --validate ${PATH_FLAGS}
+    )
+    foreach(TYPE f32 f16 bf16)
+        get_test_sizes(${TYPE} SIZES)
+        foreach(TRANS NN TN NT TT)
+            get_trans_flags(${TRANS} TFLAGS)
+            add_cpu_gemm_test(${PATH}_${TYPE}_${TRANS}
+                ARGS ${SIZES} ${TFLAGS} --type ${TYPE} --validate ${PATH_FLAGS}
+            )
+        endforeach()
+    endforeach()
 
-# 7. Verify fast flag on / off works
-add_cpu_gemm_test(FastPath_On
-    ARGS --M 256 --N 256 --K 256 --tryFastPath 1 --validate 1 --type f32
-)
-add_cpu_gemm_test(FastPath_Off
-    ARGS --M 256 --N 256 --K 256 --tryFastPath 0 --validate 1 --type f32
-)
+    # Cross-validate: features per type
+    foreach(TYPE f32 f16 bf16)
+        get_test_sizes(${TYPE} SIZES)
+        add_cpu_gemm_test(${PATH}_${TYPE}_Beta
+            ARGS ${SIZES} --type ${TYPE} --beta 1.0 --validate ${PATH_FLAGS}
+        )
+        add_cpu_gemm_test(${PATH}_${TYPE}_Bias
+            ARGS ${SIZES} --type ${TYPE} --validate --bias ${PATH_FLAGS}
+        )
+        add_cpu_gemm_test(${PATH}_${TYPE}_AllFeatures
+            ARGS ${SIZES} --type ${TYPE} --validate --bias --activation relu --scaleAlphaVec ${PATH_FLAGS}
+        )
+        add_cpu_gemm_test(${PATH}_${TYPE}_TN_AllFeatures
+            ARGS ${SIZES} --transA --type ${TYPE} --validate --bias --activation relu --scaleAlphaVec ${PATH_FLAGS}
+        )
+    endforeach()
+
+    # F32-only individual feature tests
+    add_cpu_gemm_test(${PATH}_f32_Relu
+        ARGS ${F32_SIZES} --type f32 --validate --activation relu ${PATH_FLAGS}
+    )
+    add_cpu_gemm_test(${PATH}_f32_ScaleAlphaVec
+        ARGS ${F32_SIZES} --type f32 --validate --scaleAlphaVec ${PATH_FLAGS}
+    )
+    add_cpu_gemm_test(${PATH}_f32_Beta_AllFeatures
+        ARGS ${F32_SIZES} --type f32 --beta 0.5 --validate --bias --activation relu --scaleAlphaVec ${PATH_FLAGS}
+    )
+    add_cpu_gemm_test(${PATH}_f32_ScaleAlphaVec_ColN
+        ARGS ${F32_SIZES} --type f32 --validate --scaleAlphaVec --factorDim 1 ${PATH_FLAGS}
+    )
+
+    # Edge cases: dimensions at or below tile size (BLOCK_M=32, BLOCK_N=32, BLOCK_K=8)
+    foreach(CASE "M1;1;147;165" "N1;133;1;165" "K1;133;147;1" "1x1;1;1;1" "ExactBlock;32;32;8")
+        list(GET CASE 0 NAME)
+        list(GET CASE 1 EM)
+        list(GET CASE 2 EN)
+        list(GET CASE 3 EK)
+        add_cpu_gemm_test(${PATH}_f32_${NAME}
+            ARGS -M ${EM} -N ${EN} -K ${EK} --type f32 --validate ${PATH_FLAGS}
+        )
+    endforeach()
+
+endforeach()
+
+# ScaleAB tests (slow path only — fast path does not yet support useScaleAB)
+foreach(MODE Scalar Vector)
+    foreach(TYPE f32 f16 bf16)
+        get_test_sizes(${TYPE} SIZES)
+        add_cpu_gemm_test(slow_${TYPE}_ScaleAB_${MODE}
+            ARGS ${SIZES} --type ${TYPE} --validate --useScaleAB ${MODE}
+        )
+    endforeach()
+    add_cpu_gemm_test(slow_f32_ScaleAB_${MODE}_AllFeatures
+        ARGS ${F32_SIZES} --type f32 --beta 0.5 --validate --useScaleAB ${MODE} --bias --activation relu --scaleAlphaVec
+    )
+endforeach()

--- a/projects/hipblaslt/tensilelite/tests/CMakeLists.txt
+++ b/projects/hipblaslt/tensilelite/tests/CMakeLists.txt
@@ -71,14 +71,14 @@ endfunction()
 # Default test sizes. Non-tile-aligned to stress remainder handling.
 # f32 and f16/bf16 use different sizes to increase coverage diversity.
 set(F32_SIZES -M 133 -N 147 -K 165)
-set(ALT_SIZES -M 131 -N 141 -K 151)
-set(ODD_SIZES -M 102 -N 103 -K 105)
+set(F16_SIZES -M 131 -N 141 -K 151)
+set(ADDITIONAL_SIZES -M 102 -N 103 -K 105)
 
 macro(get_test_sizes TYPE OUT_SIZES)
     if("${TYPE}" STREQUAL "f32")
         set(${OUT_SIZES} ${F32_SIZES})
     else()
-        set(${OUT_SIZES} ${ALT_SIZES})
+        set(${OUT_SIZES} ${F16_SIZES})
     endif()
 endmacro()
 
@@ -105,8 +105,8 @@ foreach(PATH fast slow)
     add_cpu_gemm_test(${PATH}_F32_Sanity
         ARGS ${F32_SIZES} --type f32 --validate ${PATH_FLAGS}
     )
-    add_cpu_gemm_test(${PATH}_F32_Odd_Sizes
-        ARGS ${ODD_SIZES} --type f32 --validate ${PATH_FLAGS}
+    add_cpu_gemm_test(${PATH}_F32_ADDITIONAL_SIZES
+        ARGS ${ADDITIONAL_SIZES} --type f32 --validate ${PATH_FLAGS}
     )
     foreach(TYPE f32 f16 bf16)
         get_test_sizes(${TYPE} SIZES)


### PR DESCRIPTION
## Motivation

The CPU GEMM reference path lacked test coverage for features like bias, activation, scaleAlphaVec, and scaleAB, and the existing CTest definitions were repetitive. Timing instrumentation was also incomplete, making it difficult to profile fast vs slow path performance. This PR improves the testing infrastructure and debugging tooling for the CPU GEMM reference implementation.

## Technical Details

- cpu_gemm_driver extensions: Extend the golden reference GEMM (`columnMajorGemm`) to support bias vectors, activation (relu), per-row/col `scaleAlphaVec` with `factorDim`, and `ScaleAB` in both Scalar and Vector modes. Add corresponding CLI flags for all new features.
- Parameterized CTests: Replace individual test definitions with parameterized loops over types (f32/f16/bf16), transposes (NN/TN/NT/TT), and feature combinations. All tests run against both fast and slow paths. Add edge case tests (M=1, N=1, K=1, 1x1x1, exact block-aligned). ScaleAB tests are slow-path-only in this PR.

## Test Plan

90 CTests via `ctest -R CPUGemm` covering:
- All type/transpose combinations for both fast and slow paths
- Feature cross-validation (bias, relu, scaleAlphaVec, scaleAB) per type
- Edge cases (degenerate dimensions, exact block-aligned sizes)
- Beta != 0, combined feature tests, factorDim=1 (column-dimension scaleAlphaVec)

## Test Result

90/90 tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.