### PR TITLE
[rocthrust] Fix a couple of compilation warnings

### DIFF
--- a/projects/rocthrust/test/generate_resource_spec.cpp
+++ b/projects/rocthrust/test/generate_resource_spec.cpp
@@ -97,8 +97,8 @@ int main(int argc, char* argv[])
   out_file.open(argv[1]);
 
   // Figure out how many devices are in the system.
-  int dev_count = 0;
-  hipGetDeviceCount(&dev_count);
+  int dev_count;
+  HIP_CHECK(hipGetDeviceCount(&dev_count));
 
   // There could be more than one device of each type.
   // Build a mapping of gfxID (string) to a vector of device IDs (unsigned ints).

--- a/projects/rocthrust/thrust/system/hip/detail/future.inl
+++ b/projects/rocthrust/thrust/system/hip/detail/future.inl
@@ -698,7 +698,7 @@ public:
     thrust::hip_rocprim::throw_on_error(hipGetDevice(&device_));
   }
 
-  THRUST_HOST virtual ~unique_eager_event()
+  THRUST_HOST ~unique_eager_event()
   {
     // FIXME: If we could asynchronously handle destruction of keep alives, we
     // could avoid doing this.


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This PR fixes a couple of compilation warnings for rocThrust.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
At the normal warning level of rocThrust, `-Wall -Wextra`, a couple of compiler warnings were generated. They are fixed by this PR.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Build rucThrust on both Linux and Windows. No compilation warnings should be generated.

## Test Result

<!-- Briefly summarize test outcomes. -->
Verified that the build logs do not contain warnings.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
