### PR TITLE
Fix the handling of nested lists in the test_categories.yaml parser

### DIFF
--- a/shared/ctest/parse_test_categories.py
+++ b/shared/ctest/parse_test_categories.py
@@ -243,7 +243,11 @@ def main():
                 if gpu_arch_matches(gpu_arch, config_arch):
                     patterns = gpu_config.get("test_patterns", [])
                     if patterns:
-                        all_applicable_patterns.extend(patterns)
+                        for p in patterns:
+                            if isinstance(p, list):
+                                all_applicable_patterns.extend(p)
+                            else:
+                                all_applicable_patterns.append(p)
 
                     # Collect applicable categories from this config
                     gpu_labels = gpu_config.get("labels", [])


### PR DESCRIPTION
## Motivation

The parse_test_categories.py script throws errors on encountering nested lists in test patterns. This PR fixes it.

## Technical Details

The script throws errors on adding additional tests under test lists, like in:

```
    test_patterns: 
      - *gfx11_common_patterns
      - "*/GPU_MIOpenDriver*"
      - "Smoke/CPU_Handle_NONE*"
      - "Full/GPU_reduce_custom_fp32*"
```

where gfx11_common_patterns itself is a list. 
This change fixes it.

