### PR TITLE
[hipBLASLt] Fix failed rocRoller test

### DIFF
--- a/projects/hipblaslt/clients/CMakeLists.txt
+++ b/projects/hipblaslt/clients/CMakeLists.txt
@@ -37,7 +37,7 @@ if(HIPBLASLT_ENABLE_MXDATAGENERATOR AND NOT ROCM_LIBS_SUPERBUILD)
 endif()
 target_compile_features(hipblaslt-clients-common PRIVATE cxx_std_20)
 if(HIPBLASLT_ENABLE_MXDATAGENERATOR)
-    target_compile_definitions(hipblaslt-clients-common PRIVATE HIPBLASLT_ENABLE_MXDATAGENERATOR)
+    target_compile_definitions(hipblaslt-clients-common PUBLIC HIPBLASLT_ENABLE_MXDATAGENERATOR)
     target_link_libraries(hipblaslt-clients-common PRIVATE roc::mxDataGenerator)
 endif()
 


### PR DESCRIPTION
## Motivation

Fix the rocRoller failed test in precheckin stage:



> [  FAILED  ] 1 test, listed below:
> [  FAILED  ] _/rocroller_predicate_test.unrollXYK/pre_checkin_rocroller_predicate_f8_rf8_rf32_rf32_rf32_r_TN_128_128_96_1p5_96_96_2_128_128_1_SAMX_32_UE8M0_SBMX_32_UE8M0, where GetParam() = { function: "rocroller_predicate", name: "rocroller_predicate", category: "pre_checkin", known_bug_platforms: "", alpha: 1.5, beta: 2, stride_a: 0x9ec9018, stride_b: 0x9ec9118, stride_c: 0x9ec9218, stride_d: 0x9ec9318, stride_e: 0x9ec9418, user_allocated_workspace: 134217728, M: 0x9ec9520, N: 0x9ec9620, K: 0x9ec9720, lda: 0x9ec9820, ldb: 0x9ec9920, ldc: 0x9ec9a20, ldd: 0x9ec9b20, lde: 0x9ec9c20, batch_count: 1, iters: 10, cold_iters: 2, algo: 0, solution_index: -1, requested_solution_num: 1, a_type: f8_r, b_type: f8_r, c_type: f32_r, d_type: f32_r, compute_type: f32_r, compute_input_typeA: non-supported type, compute_input_typeB: non-supported type, scale_type: f32_r, initialization: "hpl", gpu_arch: "950", gpu_arch_exclude: "", pad: 4096, grouped_gemm: 0, threads: 0, streams: 0, devices: 



## Technical Details

Change visibility of macro `HIPBLASLT_ENABLE_MXDATAGENERATOR` to make it visible (defined) to the files that use it.

## Test Plan

Manually run the failed test:

`./clients/hipblaslt-test  --gtest_filter=*pre_checkin_rocroller_predicate_f8_rf8_rf32_rf32_rf32_r_TN_128_128_96_1p5_96_96_2_128_128_1_SAMX_32_UE8M0_SBMX_32_UE8M0*`

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
