### PR TITLE
[hipDNN] Fix bugprone-multi-level-implicit-pointer-conversion clang-tidy errors

### DIFF
--- a/projects/hipdnn/backend/tests/descriptors/TestBatchnormOperationDescriptor.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestBatchnormOperationDescriptor.cpp
@@ -582,8 +582,8 @@ TEST_P(TestBatchnormOperationDescriptorGetTensor, GetAttributeTensorDescriptorRe
     // Ownership is transferred to the caller - delete after use.
     HipdnnBackendDescriptor* retrieved = nullptr;
     int64_t elementCount = 0;
-    ASSERT_NO_THROW(
-        desc->getAttribute(tc.attr, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &elementCount, &retrieved));
+    ASSERT_NO_THROW(desc->getAttribute(
+        tc.attr, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &elementCount, static_cast<void*>(&retrieved)));
 
     ASSERT_EQ(elementCount, 1);
     ASSERT_NE(retrieved, nullptr);
@@ -915,7 +915,7 @@ TEST_F(TestBatchnormOperationDescriptor, SetPeerStatsTensorArray)
     ASSERT_NO_THROW(desc->setAttribute(HIPDNN_ATTR_OPERATION_BATCHNORM_PEER_STATS_EXT,
                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                        2,
-                                       descs.data()));
+                                       static_cast<const void*>(descs.data())));
 
     auto& data = desc->getData();
     ASSERT_EQ(data.peer_stats_tensor_uid.size(), 2u);
@@ -930,7 +930,7 @@ TEST_F(TestBatchnormOperationDescriptor, GetPeerStatsTensorArray)
     desc->setAttribute(HIPDNN_ATTR_OPERATION_BATCHNORM_PEER_STATS_EXT,
                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                        2,
-                       descs.data());
+                       static_cast<const void*>(descs.data()));
     setAllAttributesExcept();
     desc->finalize();
 
@@ -940,7 +940,7 @@ TEST_F(TestBatchnormOperationDescriptor, GetPeerStatsTensorArray)
                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                        2,
                                        &elementCount,
-                                       retrieved.data()));
+                                       static_cast<void*>(retrieved.data())));
 
     ASSERT_EQ(elementCount, 2);
     ASSERT_NE(retrieved[0], nullptr);

--- a/projects/hipdnn/backend/tests/descriptors/TestGraphDescriptorBatchnorm.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestGraphDescriptorBatchnorm.cpp
@@ -53,65 +53,75 @@ inline std::unique_ptr<HipdnnBackendDescriptor>
     auto wrapper = createDescriptor<BatchnormOperationDescriptor>();
     auto desc = wrapper->asDescriptor<BatchnormOperationDescriptor>();
 
-    desc->setAttribute(
-        HIPDNN_ATTR_OPERATION_BATCHNORM_X_EXT, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &xDesc);
-    desc->setAttribute(
-        HIPDNN_ATTR_OPERATION_BATCHNORM_SCALE_EXT, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &scaleDesc);
-    desc->setAttribute(
-        HIPDNN_ATTR_OPERATION_BATCHNORM_BIAS_EXT, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &biasDesc);
+    desc->setAttribute(HIPDNN_ATTR_OPERATION_BATCHNORM_X_EXT,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       static_cast<const void*>(&xDesc));
+    desc->setAttribute(HIPDNN_ATTR_OPERATION_BATCHNORM_SCALE_EXT,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       static_cast<const void*>(&scaleDesc));
+    desc->setAttribute(HIPDNN_ATTR_OPERATION_BATCHNORM_BIAS_EXT,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       static_cast<const void*>(&biasDesc));
     desc->setAttribute(HIPDNN_ATTR_OPERATION_BATCHNORM_EPSILON_EXT,
                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                        1,
-                       &epsilonDesc);
-    desc->setAttribute(
-        HIPDNN_ATTR_OPERATION_BATCHNORM_Y_EXT, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &yDesc);
+                       static_cast<const void*>(&epsilonDesc));
+    desc->setAttribute(HIPDNN_ATTR_OPERATION_BATCHNORM_Y_EXT,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       static_cast<const void*>(&yDesc));
 
     if(meanDesc != nullptr)
     {
-        desc->setAttribute(
-            HIPDNN_ATTR_OPERATION_BATCHNORM_MEAN_EXT, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &meanDesc);
+        desc->setAttribute(HIPDNN_ATTR_OPERATION_BATCHNORM_MEAN_EXT,
+                           HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                           1,
+                           static_cast<const void*>(&meanDesc));
     }
     if(invVarianceDesc != nullptr)
     {
         desc->setAttribute(HIPDNN_ATTR_OPERATION_BATCHNORM_INV_VARIANCE_EXT,
                            HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                            1,
-                           &invVarianceDesc);
+                           static_cast<const void*>(&invVarianceDesc));
     }
     if(prevRunningMeanDesc != nullptr)
     {
         desc->setAttribute(HIPDNN_ATTR_OPERATION_BATCHNORM_PREV_RUNNING_MEAN_EXT,
                            HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                            1,
-                           &prevRunningMeanDesc);
+                           static_cast<const void*>(&prevRunningMeanDesc));
     }
     if(prevRunningVarianceDesc != nullptr)
     {
         desc->setAttribute(HIPDNN_ATTR_OPERATION_BATCHNORM_PREV_RUNNING_VARIANCE_EXT,
                            HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                            1,
-                           &prevRunningVarianceDesc);
+                           static_cast<const void*>(&prevRunningVarianceDesc));
     }
     if(momentumDesc != nullptr)
     {
         desc->setAttribute(HIPDNN_ATTR_OPERATION_BATCHNORM_MOMENTUM_EXT,
                            HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                            1,
-                           &momentumDesc);
+                           static_cast<const void*>(&momentumDesc));
     }
     if(nextRunningMeanDesc != nullptr)
     {
         desc->setAttribute(HIPDNN_ATTR_OPERATION_BATCHNORM_NEXT_RUNNING_MEAN_EXT,
                            HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                            1,
-                           &nextRunningMeanDesc);
+                           static_cast<const void*>(&nextRunningMeanDesc));
     }
     if(nextRunningVarianceDesc != nullptr)
     {
         desc->setAttribute(HIPDNN_ATTR_OPERATION_BATCHNORM_NEXT_RUNNING_VARIANCE_EXT,
                            HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                            1,
-                           &nextRunningVarianceDesc);
+                           static_cast<const void*>(&nextRunningVarianceDesc));
     }
 
     desc->setAttribute(HIPDNN_ATTR_BATCHNORM_MATH_PREC_EXT, HIPDNN_TYPE_DATA_TYPE, 1, &computeType);
@@ -121,7 +131,7 @@ inline std::unique_ptr<HipdnnBackendDescriptor>
         desc->setAttribute(HIPDNN_ATTR_OPERATION_BATCHNORM_PEER_STATS_EXT,
                            HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                            static_cast<int64_t>(peerStatsDescs.size()),
-                           peerStatsDescs.data());
+                           static_cast<const void*>(peerStatsDescs.data()));
     }
 
     desc->finalize();
@@ -140,7 +150,10 @@ public:
     {
         auto desc = getDescriptor();
         hipdnnHandle_t handle = &_mockHandle;
-        desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle);
+        desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE,
+                           HIPDNN_TYPE_HANDLE,
+                           1,
+                           static_cast<const void*>(&handle));
     }
 
     // Creates a finalized op using the standard fixture tensors, with optional overrides
@@ -241,8 +254,10 @@ TEST_F(TestGraphDescriptorBatchnorm, BuildFromSingleOperationWithOptionals)
     setHandle();
 
     std::array<HipdnnBackendDescriptor*, 1> ops = {opDesc.get()};
-    ASSERT_NO_THROW(desc->setAttribute(
-        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data()));
+    ASSERT_NO_THROW(desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                       1,
+                                       static_cast<const void*>(ops.data())));
     ASSERT_NO_THROW(desc->finalize());
 
     auto serialized = desc->getSerializedGraph();
@@ -284,8 +299,10 @@ TEST_F(TestGraphDescriptorBatchnorm, ComputeDataTypePreserved)
     setHandle();
 
     std::array<HipdnnBackendDescriptor*, 1> ops = {opDesc.get()};
-    desc->setAttribute(
-        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data());
+    desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       static_cast<const void*>(ops.data()));
     desc->finalize();
 
     auto serialized = desc->getSerializedGraph();
@@ -306,8 +323,10 @@ TEST_F(TestGraphDescriptorBatchnorm, BuildWithPeerStatsTensorArray)
     setHandle();
 
     std::array<HipdnnBackendDescriptor*, 1> ops = {opDesc.get()};
-    ASSERT_NO_THROW(desc->setAttribute(
-        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data()));
+    ASSERT_NO_THROW(desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                       1,
+                                       static_cast<const void*>(ops.data())));
     ASSERT_NO_THROW(desc->finalize());
 
     auto serialized = desc->getSerializedGraph();


### PR DESCRIPTION
## Motivation

A newly enabled clang-tidy check — `bugprone-multi-level-implicit-pointer-conversion` — treats implicit conversions from multilevel pointer types (e.g. `T**`) to `void*` or `const void*` as errors. This caused the batchnorm descriptor PR (#5399) to break the build, as its tests passed `HipdnnBackendDescriptor**` and `hipdnnHandle_t*` implicitly to `setAttribute` / `getAttribute`, which take `const void*` / `void*`.

## Technical Details

`setAttribute` and `getAttribute` accept `const void*` / `void*` for their data parameter. When passing `&desc` where `desc` is `HipdnnBackendDescriptor*`, or `.data()` on a `std::array<HipdnnBackendDescriptor*, N>`, the result is a two-level pointer (`T**`) being implicitly narrowed to `void*`. Clang-tidy now rejects this.

The fix adds explicit `static_cast<const void*>` at every `setAttribute` call site and `static_cast<void*>` at every `getAttribute` output-buffer call site in the two affected test files:

- `backend/tests/descriptors/TestGraphDescriptorBatchnorm.cpp` — `&xDesc`, `&scaleDesc`, `&biasDesc`, `&epsilonDesc`, `&yDesc`, `&meanDesc`, `&invVarianceDesc`, `&prevRunningMeanDesc`, `&prevRunningVarianceDesc`, `&momentumDesc`, `&nextRunningMeanDesc`, `&nextRunningVarianceDesc`, `&handle`, `peerStatsDescs.data()`, and all `ops.data()` calls.
- `backend/tests/descriptors/TestBatchnormOperationDescriptor.cpp` — `&retrieved` (output buffer), `descs.data()` for set and get.

Single-level pointer conversions (e.g. `int64_t*` → `const void*`) are unaffected and require no changes.

## Test Plan

- [x] `cmake -GNinja .. && ninja` — clean build, zero clang-tidy errors
- [x] `ninja check`

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.