### PR TITLE
Revert "[MIOpen] Message buffer for logging (#3669)"

### DIFF
--- a/projects/miopen/CHANGELOG.md
+++ b/projects/miopen/CHANGELOG.md
@@ -6,7 +6,6 @@ Full documentation for MIOpen is available [here](https://rocm.docs.amd.com/proj
 ### Added
 * [Conv] Enabled CK wrw and bwd solvers with split-k disabled in deterministic mode.
 * [Conv] Added `ConvDepthwiseFwd2D` solver for optimizing specific depthwise convolutions.
-* Recent logs dumped to file (`/tmp/miopen_error_<pid>`) on error log or MIOpen throw.
 
 ## MIOpen 3.5.1 for ROCm 7.11.0
 ### Added

--- a/projects/miopen/docs/how-to/debug-log.rst
+++ b/projects/miopen/docs/how-to/debug-log.rst
@@ -48,12 +48,6 @@ environmental variables to control logging. Both variables are disabled by defau
 
 * ``MIOPEN_WARN_SEARCH``: Elevate log messages for Search to warnings.
 
-* ``MIOPEN_LOG_BUFFER_SIZE``: Message length of the Info2 buffer.
-  If ``MIOPEN_LOG_LEVEL`` is less than 6, then log messages will be buffered.
-  The buffered logs will be dumped to a log file when MIOpen logs an error message,
-  or an error is thrown by MIOpen.
-  This log can be found in ``/tmp/miopen_error_<pid>``.
-
 .. note::
 
   If you require technical support, include the console log that is produced from these settings:

--- a/projects/miopen/src/include/miopen/errors.hpp
+++ b/projects/miopen/src/include/miopen/errors.hpp
@@ -28,7 +28,6 @@
 
 #include <exception>
 #include <iostream>
-#include <miopen/logger.hpp>
 #include <miopen/miopen.h>
 #include <miopen/object.hpp>
 #include <miopen/returns.hpp>
@@ -64,9 +63,7 @@ MIOPEN_EXPORT std::string HIPErrorMessage(int error, const std::string& msg = ""
 template <class... Params>
 [[noreturn]] void MIOpenThrow(const std::string& file, int line, Params&&... args)
 {
-    auto exe = miopen::Exception(std::forward<Params>(args)...);
-    MIOPEN_LOG_E_FROM(file + ":" + std::to_string(line), exe.message);
-    throw exe.SetContext(file, line);
+    throw miopen::Exception(std::forward<Params>(args)...).SetContext(file, line);
 }
 
 #define MIOPEN_THROW(...)                                     \

--- a/projects/miopen/src/include/miopen/logger.hpp
+++ b/projects/miopen/src/include/miopen/logger.hpp
@@ -34,15 +34,12 @@
 #include <type_traits>
 #include <chrono>
 
+#include <miopen/each_args.hpp>
 #include <miopen/object.hpp>
 #include <miopen/config.hpp>
 
 #if MIOPEN_USE_ROCTRACER
 #include <roctracer/roctx.h>
-#endif
-
-#ifdef _WIN32
-#include <process.h> // for getpid
 #endif
 
 // See https://github.com/pfultz2/Cloak/wiki/C-Preprocessor-tricks,-tips,-and-idioms
@@ -367,33 +364,16 @@ constexpr std::string_view LoggingParseFunction(const std::string_view func,
 #define MIOPEN_GET_FN_NAME miopen::LoggingParseFunction(__func__, __PRETTY_FUNCTION__)
 #endif
 
-MIOPEN_INTERNALS_EXPORT void ClearBufferLog();
-
-MIOPEN_INTERNALS_EXPORT void BufferLog(std::string line);
-
-MIOPEN_INTERNALS_EXPORT void OutputBufferedLogs();
-
-#define MIOPEN_LOG_XQ_CUSTOM(level, disableQuieting, category, fn_name, ...)            \
-    do                                                                                  \
-    {                                                                                   \
-        std::ostringstream miopen_log_ss;                                               \
-        miopen_log_ss << miopen::LoggingPrefix() << category << " [" << fn_name << "] " \
-                      << __VA_ARGS__ << std::endl;                                      \
-        if(miopen::IsLogging(level, disableQuieting))                                   \
-        {                                                                               \
-            std::cerr << miopen_log_ss.str();                                           \
-        }                                                                               \
-        if(!miopen::IsLogging(miopen::LoggingLevel::Info2, disableQuieting))            \
-        {                                                                               \
-            if(level < miopen::LoggingLevel::Trace)                                     \
-            {                                                                           \
-                miopen::BufferLog(miopen_log_ss.str());                                 \
-            }                                                                           \
-            if(level == miopen::LoggingLevel::Error)                                    \
-            {                                                                           \
-                miopen::OutputBufferedLogs();                                           \
-            }                                                                           \
-        }                                                                               \
+#define MIOPEN_LOG_XQ_CUSTOM(level, disableQuieting, category, fn_name, ...)                \
+    do                                                                                      \
+    {                                                                                       \
+        if(miopen::IsLogging(level, disableQuieting))                                       \
+        {                                                                                   \
+            std::ostringstream miopen_log_ss;                                               \
+            miopen_log_ss << miopen::LoggingPrefix() << category << " [" << fn_name << "] " \
+                          << __VA_ARGS__ << std::endl;                                      \
+            std::cerr << miopen_log_ss.str();                                               \
+        }                                                                                   \
     } while(false)
 
 #define MIOPEN_LOG_XQ_(level, disableQuieting, fn_name, ...) \

--- a/projects/miopen/src/logger.cpp
+++ b/projects/miopen/src/logger.cpp
@@ -24,14 +24,12 @@
  *
  *******************************************************************************/
 #include <miopen/env.hpp>
-#include <miopen/filesystem.hpp>
 #include <miopen/logger.hpp>
 #include <miopen/config.h>
 #include <miopen/sysinfo_utils.hpp>
 
 #include <cstdlib>
 #include <chrono>
-#include <fstream>
 #include <ios>
 #include <iomanip>
 #include <sstream>
@@ -70,47 +68,7 @@ MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_ENABLE_LOGGING_ROCTX)
 /// Disable logging quieting.
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_LOGGING_QUIETING_DISABLE)
 
-MIOPEN_DECLARE_ENV_VAR_UINT64(MIOPEN_LOG_BUFFER_SIZE, 128);
-
 namespace miopen {
-
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, cert-err58-cpp)
-static thread_local size_t log_buffer_size = env::value(MIOPEN_LOG_BUFFER_SIZE);
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, cert-err58-cpp)
-static thread_local size_t log_buffer_i = 0;
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, cert-err58-cpp)
-static thread_local std::vector<std::string> log_buffer(log_buffer_size, "");
-
-void ClearBufferLog()
-{
-    log_buffer_i = 0;
-    log_buffer   = std::vector<std::string>(miopen::log_buffer_size, "");
-}
-
-void BufferLog(std::string line)
-{
-    log_buffer[log_buffer_i] = line;
-    log_buffer_i             = (log_buffer_i + 1) % log_buffer_size;
-}
-
-void OutputBufferedLogs()
-{
-    auto buffer_size = (log_buffer[log_buffer_size - 1] == "") ? log_buffer_i : log_buffer_size;
-    auto filename =
-        fs::temp_directory_path() / ("miopen_error_" + std::to_string(::getpid()) + ".log");
-    std::cerr << "Buffered " << buffer_size << " messages to file: " << sysinfo::GetSystemHostname()
-              << ":" << filename.string() << std::endl;
-    auto err_file = std::ofstream{filename};
-    size_t i      = log_buffer_i;
-    do
-    {
-        if(log_buffer[i] != "")
-        {
-            err_file << log_buffer[i];
-        }
-        i = (i + 1) % log_buffer_size;
-    } while(i != log_buffer_i);
-}
 
 namespace debug {
 

--- a/projects/miopen/test/gtest/log.cpp
+++ b/projects/miopen/test/gtest/log.cpp
@@ -31,10 +31,8 @@
 #include "get_handle.hpp"
 #include "../lib_env_var.hpp"
 
-#include <gtest/gtest_common.hpp>
 #include <miopen/config.h>
 #include <miopen/fusion_plan.hpp>
-#include <miopen/logger.hpp>
 #include "../random.hpp"
 
 #if MIOPEN_BACKEND_OPENCL
@@ -345,91 +343,4 @@ void TestLogCmdBNormFusion(std::function<void(const miopenFusionPlanDescriptor_t
         ASSERT_TRUE(isSubStr(str, sub_str)) << "str     : " << str << "str_sub : " << sub_str;
     else
         ASSERT_FALSE(isSubStr(str, sub_str)) << "str     : " << str << "str_sub : " << sub_str;
-}
-
-void TestLogBufferOn()
-{
-    auto filename =
-        fs::temp_directory_path() / ("miopen_error_" + std::to_string(getpid()) + ".log");
-    size_t line_i = 0;
-    std::string line;
-
-    fs::remove(filename);
-
-    ScopedEnvironment<std::string> log_level_env(MIOPEN_LOG_LEVEL,
-                                                 "5"); // miopen::LoggingLevel::Info
-    // test log dump after error
-    miopen::ClearBufferLog();
-    MIOPEN_LOG_W("warn");
-    MIOPEN_LOG_I("info");
-    MIOPEN_LOG_I2("info2");
-    MIOPEN_LOG_T("trace");
-    MIOPEN_LOG_E("error");
-
-    ASSERT_TRUE(fs::exists(filename));
-    {
-        auto log_file = std::ifstream{filename};
-        while(std::getline(log_file, line))
-        {
-            switch(line_i)
-            {
-            case 0: ASSERT_TRUE(isSubStr(line, "warn")); break;
-            case 1: ASSERT_TRUE(isSubStr(line, "info")); break;
-            case 2: ASSERT_TRUE(isSubStr(line, "info2")); break;
-            case 3:
-                ASSERT_FALSE(isSubStr(line, "trace"));
-                ASSERT_TRUE(isSubStr(line, "error"));
-                break;
-            }
-            line_i++;
-        }
-    }
-    fs::remove(filename);
-
-    // test log dump after throw
-    miopen::ClearBufferLog();
-    MIOPEN_LOG_W("warn");
-    MIOPEN_LOG_I("info");
-    MIOPEN_LOG_I2("info2");
-    MIOPEN_LOG_T("trace");
-    EXPECT_ANY_THROW({ MIOPEN_THROW("throw"); });
-
-    EXPECT_TRUE(fs::exists(filename));
-    {
-        auto log_file = std::ifstream{filename};
-        line_i        = 0;
-        while(std::getline(log_file, line))
-        {
-            switch(line_i)
-            {
-            case 0: ASSERT_TRUE(isSubStr(line, "warn")); break;
-            case 1: ASSERT_TRUE(isSubStr(line, "info")); break;
-            case 2: ASSERT_TRUE(isSubStr(line, "info2")); break;
-            case 3: ASSERT_TRUE(isSubStr(line, "throw")); break;
-            }
-            line_i++;
-        }
-    }
-    fs::remove(filename);
-}
-
-void TestLogBufferOff()
-{
-    auto filename =
-        fs::temp_directory_path() / ("miopen_error_" + std::to_string(getpid()) + ".log");
-
-    fs::remove(filename);
-
-    ScopedEnvironment<std::string> log_level_env(MIOPEN_LOG_LEVEL,
-                                                 "6"); // miopen::LoggingLevel::Info2
-
-    miopen::ClearBufferLog();
-    // log messages
-    MIOPEN_LOG_W("warn");
-    MIOPEN_LOG_I("info");
-    MIOPEN_LOG_I2("info2");
-    MIOPEN_LOG_T("trace");
-    // test log dump after error
-    MIOPEN_LOG_E("error");
-    ASSERT_FALSE(fs::exists(filename));
 }

--- a/projects/miopen/test/gtest/log.hpp
+++ b/projects/miopen/test/gtest/log.hpp
@@ -82,7 +82,3 @@ void TestLogCmdCBAFusion(std::function<void(const miopenFusionPlanDescriptor_t)>
 void TestLogCmdBNormFusion(std::function<void(const miopenFusionPlanDescriptor_t)> const& func,
                            std::string sub_str,
                            bool set_env);
-
-void TestLogBufferOn();
-
-void TestLogBufferOff();

--- a/projects/miopen/test/gtest/log_test.cpp
+++ b/projects/miopen/test/gtest/log_test.cpp
@@ -38,10 +38,6 @@ TEST(CPU_LOG_TEST_ASSERT_NONE, AssertLogFindCmdOutput)
     TestLogFun(miopen::debug::LogCmdFindConvolution, logFindConv, true);
 }
 
-TEST(CPU_LOG_TEST_ASSERT_NONE, AssertLogBufferOn) { TestLogBufferOn(); }
-
-TEST(CPU_LOG_TEST_ASSERT_NONE, AssertLogBufferOff) { TestLogBufferOff(); }
-
 TEST(CPU_LOG_TEST_FUSION_NONE, AssertTestLogCmdCBAFusionOutput)
 {
     TestLogCmdCBAFusion(miopen::debug::LogCmdFusion, logFusionConvBiasActiv, true);


### PR DESCRIPTION
This reverts commit 54303f2f5966b1a519c3003287f6b876b3e4613e.

## Motivation

The message buffer logging was adding extra CPU overhead, which caused a performance degradation in certain pytorch tests.

## Technical Details

The original PR #3669 will be reverted for 7.12.0.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
