### PR TITLE
Fix use-after-free in hipstdpar with correct memory allocator

### DIFF
--- a/projects/rocthrust/thrust/system/hip/detail/parallel_for.h
+++ b/projects/rocthrust/thrust/system/hip/detail/parallel_for.h
@@ -43,10 +43,6 @@
 
 #  include <thrust/system/hip/detail/util.h>
 
-#  include <new>
-#  include <type_traits>
-#  include <utility>
-
 THRUST_NAMESPACE_BEGIN
 
 namespace hip_rocprim
@@ -136,49 +132,6 @@ hipError_t THRUST_HIP_RUNTIME_FUNCTION parallel_for(Size num_items, F f, hipStre
   return hipSuccess;
 }
 
-template <class F>
-class managed_callable_guard
-{
-public:
-  explicit managed_callable_guard(F&& f)
-  {
-    hipError_t status = ::hipMallocManaged(reinterpret_cast<void**>(&f_ptr_), sizeof(F));
-    hip_rocprim::throw_on_error(status, "parallel_for: failed to allocate managed callable");
-    ::new (static_cast<void*>(f_ptr_)) F(::std::move(f));
-  }
-
-  managed_callable_guard(const managed_callable_guard&)            = delete;
-  managed_callable_guard& operator=(const managed_callable_guard&) = delete;
-
-  ~managed_callable_guard()
-  {
-    if (f_ptr_ != nullptr)
-    {
-      f_ptr_->~F();
-      (void) ::hipFree(f_ptr_);
-    }
-  }
-
-  F* get() const noexcept
-  {
-    return f_ptr_;
-  }
-
-private:
-  F* f_ptr_ = nullptr;
-};
-
-template <class F>
-struct callable_proxy
-{
-  F* f_ptr;
-
-  template <class... Args>
-  THRUST_HIP_FUNCTION auto operator()(Args&&... args) const -> decltype((*f_ptr)(::std::forward<Args>(args)...))
-  {
-    return (*f_ptr)(::std::forward<Args>(args)...);
-  }
-};
 } // namespace __parallel_for
 
 THRUST_EXEC_CHECK_DISABLE
@@ -197,17 +150,7 @@ void THRUST_HOST_DEVICE parallel_for(execution_policy<Derived>& policy, F f, Siz
     THRUST_HOST static void par(execution_policy<Derived>& policy, F f, Size count)
     {
       hipStream_t stream = hip_rocprim::stream(policy);
-      if constexpr (!::std::is_trivially_destructible_v<F>)
-      {
-        __parallel_for::managed_callable_guard<F> guard(::std::move(f));
-        hipError_t status = __parallel_for::parallel_for(count, __parallel_for::callable_proxy<F>{guard.get()}, stream);
-        hip_rocprim::throw_on_error(status, "parallel_for failed");
-        status = hip_rocprim::synchronize_optional(policy);
-        hip_rocprim::throw_on_error(status, "parallel_for: failed to synchronize");
-        return;
-      }
-
-      hipError_t status = __parallel_for::parallel_for(count, f, stream);
+      hipError_t status  = __parallel_for::parallel_for(count, f, stream);
       hip_rocprim::throw_on_error(status, "parallel_for failed");
       status = hip_rocprim::synchronize_optional(policy);
       hip_rocprim::throw_on_error(status, "parallel_for: failed to synchronize");

--- a/projects/rocthrust/thrust/system/hip/hipstdpar/impl/batch.hpp
+++ b/projects/rocthrust/thrust/system/hip/hipstdpar/impl/batch.hpp
@@ -45,6 +45,7 @@
 
 #  include <algorithm>
 #  include <execution>
+#  include <type_traits>
 #  include <utility>
 
 #  include "hipstd.hpp"
@@ -57,7 +58,27 @@ template <typename I,
           enable_if_t<::hipstd::is_offloadable_iterator<I>() && ::hipstd::is_offloadable_callable<F>()>* = nullptr>
 inline void for_each(execution::parallel_unsequenced_policy, I f, I l, F fn)
 {
-  ::thrust::for_each(::thrust::device, f, l, ::std::move(fn));
+  using fn_t = ::std::decay_t<F>;
+
+  if constexpr (::std::is_trivially_destructible_v<fn_t>)
+  {
+    ::thrust::for_each(::thrust::device, f, l, ::std::move(fn));
+  }
+  else
+  {
+    ::hipstd::detail::device_callable_guard<fn_t> guard(::std::move(fn));
+    try
+    {
+      ::thrust::for_each(::thrust::device, f, l, ::hipstd::detail::callable_proxy<fn_t>{guard.get()});
+    }
+    catch (...)
+    {
+      (void) ::hipDeviceSynchronize();
+      throw;
+    }
+    ::thrust::hip_rocprim::throw_on_error(::hipDeviceSynchronize(), "hipstdpar for_each: failed to synchronize");
+    guard.destroy_and_free();
+  }
 }
 
 template <typename I,
@@ -85,7 +106,29 @@ template <typename I,
           enable_if_t<::hipstd::is_offloadable_iterator<I>() && ::hipstd::is_offloadable_callable<F>()>* = nullptr>
 inline I for_each_n(execution::parallel_unsequenced_policy, I f, N n, F fn)
 {
-  return ::thrust::for_each_n(::thrust::device, f, n, ::std::move(fn));
+  using fn_t = ::std::decay_t<F>;
+
+  if constexpr (::std::is_trivially_destructible_v<fn_t>)
+  {
+    return ::thrust::for_each_n(::thrust::device, f, n, ::std::move(fn));
+  }
+  else
+  {
+    ::hipstd::detail::device_callable_guard<fn_t> guard(::std::move(fn));
+    I result;
+    try
+    {
+      result = ::thrust::for_each_n(::thrust::device, f, n, ::hipstd::detail::callable_proxy<fn_t>{guard.get()});
+    }
+    catch (...)
+    {
+      (void) ::hipDeviceSynchronize();
+      throw;
+    }
+    ::thrust::hip_rocprim::throw_on_error(::hipDeviceSynchronize(), "hipstdpar for_each_n: failed to synchronize");
+    guard.destroy_and_free();
+    return result;
+  }
 }
 
 template <typename I,

--- a/projects/rocthrust/thrust/system/hip/hipstdpar/impl/generation.hpp
+++ b/projects/rocthrust/thrust/system/hip/hipstdpar/impl/generation.hpp
@@ -46,6 +46,7 @@
 
 #  include <algorithm>
 #  include <execution>
+#  include <type_traits>
 #  include <utility>
 
 #  include "hipstd.hpp"
@@ -90,7 +91,27 @@ template <typename I,
           enable_if_t<::hipstd::is_offloadable_iterator<I>() && ::hipstd::is_offloadable_callable<G>()>* = nullptr>
 inline void generate(execution::parallel_unsequenced_policy, I f, I l, G g)
 {
-  return ::thrust::generate(::thrust::device, f, l, ::std::move(g));
+  using g_t = ::std::decay_t<G>;
+
+  if constexpr (::std::is_trivially_destructible_v<g_t>)
+  {
+    ::thrust::generate(::thrust::device, f, l, ::std::move(g));
+  }
+  else
+  {
+    ::hipstd::detail::device_callable_guard<g_t> guard(::std::move(g));
+    try
+    {
+      ::thrust::generate(::thrust::device, f, l, ::hipstd::detail::callable_proxy<g_t>{guard.get()});
+    }
+    catch (...)
+    {
+      (void) ::hipDeviceSynchronize();
+      throw;
+    }
+    ::thrust::hip_rocprim::throw_on_error(::hipDeviceSynchronize(), "hipstdpar generate: failed to synchronize");
+    guard.destroy_and_free();
+  }
 }
 
 template <typename I,
@@ -118,7 +139,27 @@ template <typename I,
           enable_if_t<::hipstd::is_offloadable_iterator<I>() && ::hipstd::is_offloadable_callable<G>()>* = nullptr>
 inline void generate_n(execution::parallel_unsequenced_policy, I f, N n, G g)
 {
-  return ::thrust::generate_n(::thrust::device, f, n, ::std::move(g));
+  using g_t = ::std::decay_t<G>;
+
+  if constexpr (::std::is_trivially_destructible_v<g_t>)
+  {
+    ::thrust::generate_n(::thrust::device, f, n, ::std::move(g));
+  }
+  else
+  {
+    ::hipstd::detail::device_callable_guard<g_t> guard(::std::move(g));
+    try
+    {
+      ::thrust::generate_n(::thrust::device, f, n, ::hipstd::detail::callable_proxy<g_t>{guard.get()});
+    }
+    catch (...)
+    {
+      (void) ::hipDeviceSynchronize();
+      throw;
+    }
+    ::thrust::hip_rocprim::throw_on_error(::hipDeviceSynchronize(), "hipstdpar generate_n: failed to synchronize");
+    guard.destroy_and_free();
+  }
 }
 
 template <typename I,

--- a/projects/rocthrust/thrust/system/hip/hipstdpar/impl/hipstd.hpp
+++ b/projects/rocthrust/thrust/system/hip/hipstdpar/impl/hipstd.hpp
@@ -45,8 +45,12 @@
 
 #  include <cstddef>
 #  include <iterator>
+#  include <new>
 #  include <type_traits>
 #  include <utility>
+
+#  include <hip/hip_runtime_api.h>
+#  include <thrust/system/hip/detail/util.h>
 
 namespace hipstd
 {
@@ -96,6 +100,81 @@ inline constexpr
                              "warning"))) void
   unsupported_iterator_category() noexcept
 {}
+
+namespace detail
+{
+
+// Ensures a non-trivially-destructible callable outlives any asynchronous
+// kernel that references it.  The callable is placement-new'd into GPU-
+// accessible memory whose lifetime is controlled by this guard.
+//
+//   * When --hipstdpar-interpose-alloc is active (no XNACK / no transparent
+//     paging) hipMallocManaged is used so that both host and device can
+//     access the callable.
+//
+//   * Otherwise hipMalloc is used, which is faster; XNACK guarantees that
+//     the host can still access device memory directly.
+template <typename Fn>
+class device_callable_guard
+{
+public:
+  explicit device_callable_guard(Fn&& fn)
+  {
+#  if defined(__HIPSTDPAR_INTERPOSE_ALLOC__) || defined(__HIPSTDPAR_INTERPOSE_ALLOC_V1__)
+    hipError_t status = ::hipMallocManaged(reinterpret_cast<void**>(&fn_ptr_), sizeof(Fn));
+#  else
+    hipError_t status = ::hipMalloc(reinterpret_cast<void**>(&fn_ptr_), sizeof(Fn));
+#  endif
+    ::thrust::hip_rocprim::throw_on_error(status, "hipstdpar: failed to allocate device callable");
+    ::new (static_cast<void*>(fn_ptr_)) Fn(::std::move(fn));
+  }
+
+  device_callable_guard(const device_callable_guard&)            = delete;
+  device_callable_guard& operator=(const device_callable_guard&) = delete;
+
+  ~device_callable_guard()
+  {
+    if (fn_ptr_ != nullptr)
+    {
+      fn_ptr_->~Fn();
+      (void) ::hipFree(fn_ptr_);
+    }
+  }
+
+  Fn* get() const noexcept
+  {
+    return fn_ptr_;
+  }
+
+  void destroy_and_free()
+  {
+    if (fn_ptr_ == nullptr)
+    {
+      return;
+    }
+    fn_ptr_->~Fn();
+    hipError_t status = ::hipFree(fn_ptr_);
+    fn_ptr_           = nullptr;
+    ::thrust::hip_rocprim::throw_on_error(status, "hipstdpar: failed to free device callable");
+  }
+
+private:
+  Fn* fn_ptr_ = nullptr;
+};
+
+template <typename Fn>
+struct callable_proxy
+{
+  Fn* fn_ptr;
+
+  template <typename... Args>
+  THRUST_HIP_FUNCTION void operator()(Args&&... args) const
+  {
+    (*fn_ptr)(::std::forward<Args>(args)...);
+  }
+};
+
+} // namespace detail
 } // namespace hipstd
 #else // __HIPSTDPAR__
 #  error "__HIPSTDPAR__ should be defined. Please use the '--hipstdpar' compile option."

--- a/projects/rocthrust/thrust/system/hip/hipstdpar/impl/numeric.hpp
+++ b/projects/rocthrust/thrust/system/hip/hipstdpar/impl/numeric.hpp
@@ -51,6 +51,7 @@
 
 #  include <algorithm>
 #  include <execution>
+#  include <type_traits>
 #  include <utility>
 
 #  include "hipstd.hpp"
@@ -265,9 +266,32 @@ inline O inclusive_scan(execution::parallel_unsequenced_policy, I fi, I li, O fo
 
   auto lo = ::thrust::inclusive_scan(::thrust::device, fi, li, fo, op);
 
-  return ::thrust::transform(::thrust::device, fo, lo, fo, [op = ::std::move(op), x = ::std::move(x)](auto&& y) {
-    return op(x, y);
-  });
+  auto fn   = [op = ::std::move(op), x = ::std::move(x)](auto&& y) { return op(x, y); };
+  using fn_t = decltype(fn);
+
+  if constexpr (::std::is_trivially_destructible_v<fn_t>)
+  {
+    return ::thrust::transform(::thrust::device, fo, lo, fo, ::std::move(fn));
+  }
+  else
+  {
+    ::hipstd::detail::device_callable_guard<fn_t> guard(::std::move(fn));
+    O result;
+    try
+    {
+      result = ::thrust::transform(
+        ::thrust::device, fo, lo, fo, ::hipstd::detail::callable_proxy<fn_t>{guard.get()});
+    }
+    catch (...)
+    {
+      (void) ::hipDeviceSynchronize();
+      throw;
+    }
+    ::thrust::hip_rocprim::throw_on_error(
+      ::hipDeviceSynchronize(), "hipstdpar inclusive_scan: failed to synchronize");
+    guard.destroy_and_free();
+    return result;
+  }
 }
 
 template <typename I,
@@ -459,9 +483,32 @@ inline O transform_inclusive_scan(execution::parallel_unsequenced_policy, I fi, 
 
   auto lo = ::thrust::transform_inclusive_scan(::thrust::device, fi, li, fo, ::std::move(op1), op0);
 
-  return ::thrust::transform(::thrust::device, fo, lo, fo, [op0 = ::std::move(op0), x = ::std::move(x)](auto&& y) {
-    return op0(x, y);
-  });
+  auto fn    = [op0 = ::std::move(op0), x = ::std::move(x)](auto&& y) { return op0(x, y); };
+  using fn_t = decltype(fn);
+
+  if constexpr (::std::is_trivially_destructible_v<fn_t>)
+  {
+    return ::thrust::transform(::thrust::device, fo, lo, fo, ::std::move(fn));
+  }
+  else
+  {
+    ::hipstd::detail::device_callable_guard<fn_t> guard(::std::move(fn));
+    O result;
+    try
+    {
+      result = ::thrust::transform(
+        ::thrust::device, fo, lo, fo, ::hipstd::detail::callable_proxy<fn_t>{guard.get()});
+    }
+    catch (...)
+    {
+      (void) ::hipDeviceSynchronize();
+      throw;
+    }
+    ::thrust::hip_rocprim::throw_on_error(
+      ::hipDeviceSynchronize(), "hipstdpar transform_inclusive_scan: failed to synchronize");
+    guard.destroy_and_free();
+    return result;
+  }
 }
 
 template <

--- a/projects/rocthrust/thrust/system/hip/hipstdpar/impl/transformation.hpp
+++ b/projects/rocthrust/thrust/system/hip/hipstdpar/impl/transformation.hpp
@@ -46,6 +46,7 @@
 
 #  include <algorithm>
 #  include <execution>
+#  include <type_traits>
 #  include <utility>
 
 #  include "hipstd.hpp"
@@ -59,7 +60,29 @@ template <typename I,
           enable_if_t<::hipstd::is_offloadable_iterator<I, O>() && ::hipstd::is_offloadable_callable<F>()>* = nullptr>
 inline O transform(execution::parallel_unsequenced_policy, I fi, I li, O fo, F fn)
 {
-  return ::thrust::transform(::thrust::device, fi, li, fo, ::std::move(fn));
+  using fn_t = ::std::decay_t<F>;
+
+  if constexpr (::std::is_trivially_destructible_v<fn_t>)
+  {
+    return ::thrust::transform(::thrust::device, fi, li, fo, ::std::move(fn));
+  }
+  else
+  {
+    ::hipstd::detail::device_callable_guard<fn_t> guard(::std::move(fn));
+    O result;
+    try
+    {
+      result = ::thrust::transform(::thrust::device, fi, li, fo, ::hipstd::detail::callable_proxy<fn_t>{guard.get()});
+    }
+    catch (...)
+    {
+      (void) ::hipDeviceSynchronize();
+      throw;
+    }
+    ::thrust::hip_rocprim::throw_on_error(::hipDeviceSynchronize(), "hipstdpar transform: failed to synchronize");
+    guard.destroy_and_free();
+    return result;
+  }
 }
 
 template <typename I,
@@ -89,7 +112,30 @@ template <
   enable_if_t<::hipstd::is_offloadable_iterator<I0, I1, O>() && ::hipstd::is_offloadable_callable<F>()>* = nullptr>
 inline O transform(execution::parallel_unsequenced_policy, I0 fi0, I0 li0, I1 fi1, O fo, F fn)
 {
-  return ::thrust::transform(::thrust::device, fi0, li0, fi1, fo, ::std::move(fn));
+  using fn_t = ::std::decay_t<F>;
+
+  if constexpr (::std::is_trivially_destructible_v<fn_t>)
+  {
+    return ::thrust::transform(::thrust::device, fi0, li0, fi1, fo, ::std::move(fn));
+  }
+  else
+  {
+    ::hipstd::detail::device_callable_guard<fn_t> guard(::std::move(fn));
+    O result;
+    try
+    {
+      result =
+        ::thrust::transform(::thrust::device, fi0, li0, fi1, fo, ::hipstd::detail::callable_proxy<fn_t>{guard.get()});
+    }
+    catch (...)
+    {
+      (void) ::hipDeviceSynchronize();
+      throw;
+    }
+    ::thrust::hip_rocprim::throw_on_error(::hipDeviceSynchronize(), "hipstdpar transform: failed to synchronize");
+    guard.destroy_and_free();
+    return result;
+  }
 }
 
 template <
@@ -138,7 +184,27 @@ template <typename I,
           enable_if_t<::hipstd::is_offloadable_iterator<I>() && ::hipstd::is_offloadable_callable<P>()>* = nullptr>
 inline void replace_if(execution::parallel_unsequenced_policy, I f, I l, P p, const T& x)
 {
-  return ::thrust::replace_if(::thrust::device, f, l, ::std::move(p), x);
+  using p_t = ::std::decay_t<P>;
+
+  if constexpr (::std::is_trivially_destructible_v<p_t>)
+  {
+    ::thrust::replace_if(::thrust::device, f, l, ::std::move(p), x);
+  }
+  else
+  {
+    ::hipstd::detail::device_callable_guard<p_t> guard(::std::move(p));
+    try
+    {
+      ::thrust::replace_if(::thrust::device, f, l, ::hipstd::detail::callable_proxy<p_t>{guard.get()}, x);
+    }
+    catch (...)
+    {
+      (void) ::hipDeviceSynchronize();
+      throw;
+    }
+    ::thrust::hip_rocprim::throw_on_error(::hipDeviceSynchronize(), "hipstdpar replace_if: failed to synchronize");
+    guard.destroy_and_free();
+  }
 }
 
 template <typename I,
@@ -185,7 +251,29 @@ template <typename I,
           enable_if_t<::hipstd::is_offloadable_iterator<I, O>() && ::hipstd::is_offloadable_callable<P>()>* = nullptr>
 inline void replace_copy_if(execution::parallel_unsequenced_policy, I fi, I li, O fo, P p, const T& x)
 {
-  return ::thrust::replace_copy_if(::thrust::device, fi, li, fo, ::std::move(p), x);
+  using p_t = ::std::decay_t<P>;
+
+  if constexpr (::std::is_trivially_destructible_v<p_t>)
+  {
+    ::thrust::replace_copy_if(::thrust::device, fi, li, fo, ::std::move(p), x);
+  }
+  else
+  {
+    ::hipstd::detail::device_callable_guard<p_t> guard(::std::move(p));
+    try
+    {
+      ::thrust::replace_copy_if(
+        ::thrust::device, fi, li, fo, ::hipstd::detail::callable_proxy<p_t>{guard.get()}, x);
+    }
+    catch (...)
+    {
+      (void) ::hipDeviceSynchronize();
+      throw;
+    }
+    ::thrust::hip_rocprim::throw_on_error(
+      ::hipDeviceSynchronize(), "hipstdpar replace_copy_if: failed to synchronize");
+    guard.destroy_and_free();
+  }
 }
 
 template <typename I,


### PR DESCRIPTION
## Motivation

Performance improvement over https://github.com/ROCm/rocm-libraries/pull/5014 and https://github.com/ROCm/rocm-libraries/pull/5434

## Technical Details

Memory allocated via hipMalloc is generally faster than hipMallocManaged. This PR checks whether interpose model for HIPSTDPAR is used, and if that's the case it uses hipMallocManaged. Otherwise, it used hipMalloc.

## Test Plan

Ran all tests in rocThrust + HIPSTDPAR

## Test Result

100% tests passed, 0 tests failed out of 350

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
