### PR TITLE
[hipblaslt] Fix hipblaslt-test failure caused by hipModuleLoad failure

### DIFF
--- a/projects/hipblaslt/clients/common/include/d_vector.hpp
+++ b/projects/hipblaslt/clients/common/include/d_vector.hpp
@@ -151,14 +151,19 @@ public:
                 m_size = m_capacity = 0;
             }
         }
-        else if(hipMalloc(&d, capacity) != hipSuccess)
+        else
         {
+            // Reserve some memory for the code object file(module) loading
+            size_t reserve_for_module = 10 * 1024 * 1024; // 10MB (largest code object file size can be 6MB)
             size_t free_device_mem, total_device_mem;
             (void)hipMemGetInfo(&free_device_mem, &total_device_mem);
-            hipblaslt_cerr << "Insufficient device memory to allocate (" << (m_size >> 30) << " GB) as the available device memory is (" << (free_device_mem >> 30) << " GB) "
-                           << std::endl;
-            d      = nullptr;
-            m_size = m_capacity = 0;
+            if(free_device_mem < (capacity + reserve_for_module) || hipMalloc(&d, capacity) != hipSuccess)
+            {
+                hipblaslt_cerr << "Insufficient device memory to allocate (" << (m_size >> 30) << " GB) as the available device memory is (" << (free_device_mem >> 30) << " GB) "
+                               << std::endl;
+                d      = nullptr;
+                m_size = m_capacity = 0;
+            }
         }
         m_d.reset(d);
     }

--- a/projects/hipblaslt/clients/common/include/d_vector.hpp
+++ b/projects/hipblaslt/clients/common/include/d_vector.hpp
@@ -154,7 +154,8 @@ public:
         else
         {
             // Reserve some memory for the code object file(module) loading
-            size_t reserve_for_module = 10 * 1024 * 1024; // 10MB (largest code object file size can be 6MB)
+            // 15MB (largest code object file size can be 6MB + 6MB for helper kernels)
+            size_t reserve_for_module = 15 * 1024 * 1024;
             size_t free_device_mem, total_device_mem;
             (void)hipMemGetInfo(&free_device_mem, &total_device_mem);
             if(free_device_mem < (capacity + reserve_for_module) || hipMalloc(&d, capacity) != hipSuccess)

--- a/projects/hipblaslt/clients/common/include/d_vector.hpp
+++ b/projects/hipblaslt/clients/common/include/d_vector.hpp
@@ -151,20 +151,14 @@ public:
                 m_size = m_capacity = 0;
             }
         }
-        else
+        else if(hipMalloc(&d, capacity) != hipSuccess)
         {
-            // Reserve some memory for the code object file(module) loading
-            // 15MB (largest code object file size can be 6MB + 6MB for helper kernels)
-            size_t reserve_for_module = 15 * 1024 * 1024;
             size_t free_device_mem, total_device_mem;
             (void)hipMemGetInfo(&free_device_mem, &total_device_mem);
-            if(free_device_mem < (capacity + reserve_for_module) || hipMalloc(&d, capacity) != hipSuccess)
-            {
-                hipblaslt_cerr << "Insufficient device memory to allocate (" << (m_size >> 30) << " GB) as the available device memory is (" << (free_device_mem >> 30) << " GB) "
-                               << std::endl;
-                d      = nullptr;
-                m_size = m_capacity = 0;
-            }
+            hipblaslt_cerr << "Insufficient device memory to allocate (" << (m_size >> 30) << " GB) as the available device memory is (" << (free_device_mem >> 30) << " GB) "
+                           << std::endl;
+            d      = nullptr;
+            m_size = m_capacity = 0;
         }
         m_d.reset(d);
     }

--- a/projects/hipblaslt/tensilelite/include/Tensile/hip/HipSolutionAdapter.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/hip/HipSolutionAdapter.hpp
@@ -104,6 +104,9 @@ namespace TensileLite
             std::vector<std::string>        m_loadedModuleNames;
             std::unordered_set<std::string> m_loadedCOFiles;
 
+            // Record for module reload
+            std::string m_lazyLoadArchitecture;
+
             friend std::ostream& operator<<(std::ostream& stream, SolutionAdapter const& adapter);
         };
 

--- a/projects/hipblaslt/tensilelite/src/hip/HipSolutionAdapter.cpp
+++ b/projects/hipblaslt/tensilelite/src/hip/HipSolutionAdapter.cpp
@@ -109,10 +109,23 @@ namespace TensileLite
                     );
                 }
                 // Need to clean up all these old modules' data structures, otherwise next problem will getKernel failed
+                m_access.lock();
                 m_modules.clear();
                 m_loadedModuleNames.clear();
                 m_loadedCOFiles.clear();
                 m_kernels.clear();
+                m_access.unlock();
+                // Need to re-run lazy-loading for hsaco(helper kernels) module reload
+                std::string lazyArch;
+                std::string lazyDir;
+                lazyArch = m_lazyLoadArchitecture;
+                lazyDir  = m_codeObjectDirectory;
+                HIP_CHECK_RETURN_WITH_LOG(initializeLazyLoading(lazyArch, lazyDir),
+                    [&](hipError_t error_t) {
+                        std::cerr << "initializeLazyLoading after module clear failed: " << std::endl
+                                  << " error: " << hipGetErrorString(error_t) << std::endl;
+                    }
+                );
                 HIP_CHECK_RETURN_WITH_LOG(hipModuleLoad(&module, path.c_str()),
                     [&](hipError_t error_t) {
                         std::cerr << "hipModuleLoad failed: " << path.c_str() << std::endl
@@ -347,7 +360,10 @@ namespace TensileLite
             std::string helperKernelName = std::string("Kernels.so-000-") + arch;
 
             m_access.lock();
-            m_codeObjectDirectory = codeObjDir;
+
+            // Record for module reload
+            m_lazyLoadArchitecture = arch;
+            m_codeObjectDirectory  = codeObjDir;
 
             //If required code object file hasn't yet been loaded, load it now
             bool loaded = m_loadedCOFiles.find(removeXnack(helperKernelName) + ".hsaco")

--- a/projects/hipblaslt/tensilelite/src/hip/HipSolutionAdapter.cpp
+++ b/projects/hipblaslt/tensilelite/src/hip/HipSolutionAdapter.cpp
@@ -108,7 +108,11 @@ namespace TensileLite
                         }
                     );
                 }
+                // Need to clean up all these old modules' data structures, otherwise next problem will getKernel failed
                 m_modules.clear();
+                m_loadedModuleNames.clear();
+                m_loadedCOFiles.clear();
+                m_kernels.clear();
                 HIP_CHECK_RETURN_WITH_LOG(hipModuleLoad(&module, path.c_str()),
                     [&](hipError_t error_t) {
                         std::cerr << "hipModuleLoad failed: " << path.c_str() << std::endl

--- a/projects/hipblaslt/tensilelite/src/hip/HipSolutionAdapter.cpp
+++ b/projects/hipblaslt/tensilelite/src/hip/HipSolutionAdapter.cpp
@@ -91,12 +91,37 @@ namespace TensileLite
             Debug::Instance().markerStart("loadCodeObjectFile", path);
             hipModule_t module;
 
-            HIP_CHECK_RETURN_WITH_LOG(hipModuleLoad(&module, path.c_str()),
-                [&](hipError_t error) {
-                    std::cerr << "hipModuleLoad failed: " << path.c_str() << std::endl
-                            << " error: " << hipGetErrorString(error) << std::endl;
+            hipError_t error = hipModuleLoad(&module, path.c_str());
+            // Large problem sizes may cause global memory to run out of space 
+            // when loading the module, which can lead to hipErrorLaunchFailure or hipErrorNoBinaryForGpu.
+            if(error == hipErrorLaunchFailure || error == hipErrorNoBinaryForGpu)
+            {        
+                // Reset the error code from previous hipModuleLoad failure
+                (void)hipGetLastError();
+                std::cout << "Clearing modules and retrying hipModuleLoad" << std::endl;
+                for(auto m_module : m_modules)
+                {
+                    HIP_CHECK_PRINT(hipModuleUnload(m_module),
+                        [&](hipError_t error_t) {
+                            std::cerr << "hipModuleUnload failed: " << std::endl
+                                      << " error: " << hipGetErrorString(error_t) << std::endl;
+                        }
+                    );
                 }
-            );
+                m_modules.clear();
+                HIP_CHECK_RETURN_WITH_LOG(hipModuleLoad(&module, path.c_str()),
+                    [&](hipError_t error_t) {
+                        std::cerr << "hipModuleLoad failed: " << path.c_str() << std::endl
+                                  << " error: " << hipGetErrorString(error_t) << std::endl;
+                    }
+                );
+            }
+            else if(error)
+            {
+                std::cerr << "hipModuleLoad failed: " << path.c_str() << std::endl
+                          << " error: " << hipGetErrorString(error) << std::endl;
+                return error;
+            }
 
             if(m_debug)
                 std::cout << "loaded code object " << path << std::endl;


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
According to [ROCM-2593](https://amd-hub.atlassian.net/browse/ROCM-2593), the gtest failure occurs when hipModuleLoad fails. The detailed log shows that the HSA error code returned is "HSA_STATUS_ERROR_OUT_OF_RESOURCES", which confirms that global (device) memory does not have enough space to load the code object file.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
1. This commit introduces the flow that cleans old modules and reloads the current module into the hipModuleLoad phase. This helps handle cases where the required module cannot be loaded due to insufficient global memory.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
1. Perform the gtest on the machine with the issue‑reported architecture (gfx1200).

## Test Result

<!-- Briefly summarize test outcomes. -->
<img width="969" height="120" alt="image" src="https://github.com/user-attachments/assets/41d995e8-65df-444d-9511-a809c7d3370c" />

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


[ROCM-2593]: https://amd-hub.atlassian.net/browse/ROCM-2593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ