### PR TITLE
Adjusting workflow files to support release/therock-7.12

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -95,11 +95,8 @@ jobs:
         run: |
           python3 TheRock/build_tools/github_actions/build_configure.py
 
-      - name: Build therock-dist
-        run: cmake --build TheRock/build --target therock-dist
-
-      - name: Build therock-archives
-        run: cmake --build TheRock/build --target therock-archives
+      - name: Build therock-archives and therock-dist
+        run: cmake --build TheRock/build --target therock-archives therock-dist -- -k 0
 
       - name: Report
         if: ${{ !cancelled() }}

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 085571a87f8050f94c77eb90454995b6d1b75658 # 2026-02-26
+          ref: release/therock-7.12
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -109,11 +109,8 @@ jobs:
           ccache -z
           python3 TheRock/build_tools/github_actions/build_configure.py
 
-      - name: Build therock-dist
-        run: cmake --build "${{ env.BUILD_DIR }}" --target therock-dist
-
-      - name: Build therock-archives
-        run: cmake --build "${{ env.BUILD_DIR }}" --target therock-archives
+      - name: Build therock-archives and therock-dist
+        run: cmake --build "${{ env.BUILD_DIR }}" --target therock-archives therock-dist -- -k 0
 
       - name: Report
         if: ${{ !cancelled() }}

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 085571a87f8050f94c77eb90454995b6d1b75658 # 2026-02-26
+          ref: release/therock-7.12
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -3,8 +3,7 @@ name: TheRock CI
 on:
   push:
     branches:
-      - develop
-      - release/therock-*
+      - release/therock-7.12
   pull_request:
     types:
       - opened


### PR DESCRIPTION
Adjusting workflow files to support release/therock-7.12

1. Add workflow updates for pinning to release branch

2. Update .github/workflows/therock-ci.yml

3. Cherry-pick [3d58a508d9cc5f5e5fa5a9c961b9f977fc375658 ](https://github.com/ROCm/rocm-libraries/commit/3d58a508d9cc5f5e5fa5a9c961b9f977fc375658) to fix linux build failures

https://github.com/ROCm/rocm-libraries/actions/runs/23243818368/job/67566880908?pr=5551#step:14:352