### PR TITLE
Pass dynamic TheRock ref to CI workflows for release branches

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -13,6 +13,9 @@ on:
         type: string
       test_runs_on:
         type: string
+      therock_ref:
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -43,7 +46,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 2d9260c2b1c87175539a9fc45a2e9513ed36aff6 # 2026-04-16
+          ref: ${{ inputs.therock_ref }}
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -158,4 +158,5 @@ jobs:
       test_runs_on: ${{ inputs.test_runs_on }}
       platform: "linux"
       test_type: ${{ inputs.test_type }}
+      therock_ref: ${{ inputs.therock_ref }}
     secrets: inherit

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -179,4 +179,5 @@ jobs:
       test_runs_on: ${{ inputs.test_runs_on }}
       platform: "windows"
       test_type: ${{ inputs.test_type }}
+      therock_ref: ${{ inputs.therock_ref }}
     secrets: inherit

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -13,6 +13,9 @@ on:
         type: string
       test_runs_on:
         type: string
+      therock_ref:
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -47,7 +50,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 2d9260c2b1c87175539a9fc45a2e9513ed36aff6 # 2026-04-16
+          ref: ${{ inputs.therock_ref }}
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -61,7 +61,7 @@ jobs:
           if [[ "${GITHUB_REF}" == refs/heads/release/therock-* ]]; then
             echo "ref=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
           else
-            echo "ref=1408a826dc2c3446a0295c0ef0c71c4d92f0f4f9" >> $GITHUB_OUTPUT
+            echo "ref=2d9260c2b1c87175539a9fc45a2e9513ed36aff6" >> $GITHUB_OUTPUT
           fi
 
       - name: Checkout TheRock repository

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -46,6 +46,7 @@ jobs:
       test_type: ${{ steps.linux_projects.outputs.test_type }}
       linux_package_targets: ${{ steps.configure_linux.outputs.package_targets }}
       windows_package_targets: ${{ steps.configure_windows.outputs.package_targets }}
+      therock_ref: ${{ steps.therock_ref.outputs.ref }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -54,12 +55,21 @@ jobs:
           sparse-checkout-cone-mode: true
           fetch-depth: 2
 
+      - name: Determine TheRock ref
+        id: therock_ref
+        run: |
+          if [[ "${GITHUB_REF}" == refs/heads/release/therock-* ]]; then
+            echo "ref=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+          else
+            echo "ref=1408a826dc2c3446a0295c0ef0c71c4d92f0f4f9" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout TheRock repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 2d9260c2b1c87175539a9fc45a2e9513ed36aff6 # 2026-04-16
+          ref: ${{ steps.therock_ref.outputs.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -141,6 +151,7 @@ jobs:
       test_type: ${{ needs.setup.outputs.test_type }}
       amdgpu_families: ${{ matrix.target_bundle.amdgpu_family }}
       test_runs_on: ${{ matrix.target_bundle.test_machine }}
+      therock_ref: ${{ needs.setup.outputs.therock_ref }}
 
   therock-ci-windows:
     name: Windows (${{ matrix.projects.projects_to_test }} | ${{ matrix.target_bundle.amdgpu_family }})
@@ -162,6 +173,7 @@ jobs:
       test_type: ${{ needs.setup.outputs.test_type }}
       amdgpu_families: ${{ matrix.target_bundle.amdgpu_family }}
       test_runs_on: ${{ matrix.target_bundle.test_machine }}
+      therock_ref: ${{ needs.setup.outputs.therock_ref }}
 
   therock_ci_summary:
     name: TheRock CI Summary

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -14,6 +14,9 @@ on:
         type: string
       component:
         type: string
+      therock_ref:
+        type: string
+        required: true
 
 
 permissions:
@@ -57,6 +60,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
+          ref: ${{ inputs.therock_ref }}
           sparse-checkout: build_tools
           path: "prejob"
 
@@ -70,7 +74,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: 2d9260c2b1c87175539a9fc45a2e9513ed36aff6 # 2026-04-16
+          ref: ${{ inputs.therock_ref }}
 
       - name: Configure git for long paths on Windows
         if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -13,6 +13,9 @@ on:
         type: string
       test_type:
         type: string
+      therock_ref:
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -43,8 +46,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: 2d9260c2b1c87175539a9fc45a2e9513ed36aff6 # 2026-04-16
-
+          ref: ${{ inputs.therock_ref }}
+          
       - name: Setting up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -74,4 +77,5 @@ jobs:
       test_runs_on: ${{ inputs.test_runs_on }}
       platform: ${{ inputs.platform }}
       component: ${{ toJSON(matrix.components) }}
+      therock_ref: ${{ inputs.therock_ref }}
     secrets: inherit


### PR DESCRIPTION
This change removes the need to manually update the pinned TheRock ref for each release branch.

- Adds a therock_ref input propagated from the top-level CI workflow
- Dynamically sets the ref based on the triggering branch:
- release/therock-* → uses matching release branch
- otherwise → falls back to pinned SHA (stable CI)

Updates leaf workflows (therock-ci-linux / therock-ci-windows) to consume this input instead of hardcoding the ref

Benefits:

-  Eliminates repeated ref updates for every release
- Ensures release branches test against the correct TheRock branch
- Keeps PR CI stable and reproducible