### PR TITLE
[hipDNN] Fix clang-tidy const-correctness errors

### DIFF
--- a/projects/hipdnn/backend/src/logging/GraphLogger.cpp
+++ b/projects/hipdnn/backend/src/logging/GraphLogger.cpp
@@ -48,13 +48,13 @@ std::filesystem::path GraphLogger::getOutputDirectory()
 
     // Slow path: another thread may have initialized while we waited for the
     // lock, so check again.
-    std::lock_guard<std::mutex> lock(cacheMutex);
+    const std::lock_guard<std::mutex> lock(cacheMutex);
     if(cacheInitialized.load(std::memory_order_acquire))
     {
         return cachedPath;
     }
 
-    std::string dirPath = hipdnn_data_sdk::utilities::trim(
+    const std::string dirPath = hipdnn_data_sdk::utilities::trim(
         hipdnn_data_sdk::utilities::getEnv("HIPDNN_LOG_GRAPH_DIR", ""));
 
     if(dirPath.empty())
@@ -109,7 +109,7 @@ void GraphLogger::logGraph(const uint8_t* serializedGraph, size_t size)
     }
 
     auto* graph = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Graph>(serializedGraph);
-    nlohmann::json j = *graph;
+    const nlohmann::json j = *graph;
 
     std::ofstream file(fullPath);
     if(file.is_open())

--- a/projects/hipdnn/backend/tests/TestGraphLogger.cpp
+++ b/projects/hipdnn/backend/tests/TestGraphLogger.cpp
@@ -154,9 +154,9 @@ TEST_F(TestGraphLogger, DifferentGraphsLoggedSeparately)
     // Create a second graph with different data types
     {
         flatbuffers::FlatBufferBuilder builder;
-        std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        const std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
             tensorAttributes;
-        std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+        const std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
         auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
             builder,
             "different_graph",
@@ -186,7 +186,7 @@ TEST_F(TestGraphLogger, OutputDirectoryUsesEnvVar)
 {
     // Create a subdirectory and point HIPDNN_LOG_GRAPH_DIR there
     auto subDir = _tempDir / "graphs";
-    std::string subDirStr = subDir.string();
+    const std::string subDirStr = subDir.string();
     std::filesystem::create_directories(subDir);
     hipdnn_data_sdk::utilities::setEnv("HIPDNN_LOG_GRAPH_DIR", subDirStr.c_str());
     hipdnn_backend::logging::loggerShutdown();
@@ -205,7 +205,7 @@ TEST_F(TestGraphLogger, OutputDirectoryUsesEnvVar)
 TEST_F(TestGraphLogger, OutputDirectoryCreatedIfMissing)
 {
     auto newDir = _tempDir / "new_subdir" / "graphs";
-    std::string newDirStr = newDir.string();
+    const std::string newDirStr = newDir.string();
 
     ASSERT_FALSE(std::filesystem::exists(newDir));
 

--- a/projects/hipdnn/data_sdk/tests/utilities/TestJson.cpp
+++ b/projects/hipdnn/data_sdk/tests/utilities/TestJson.cpp
@@ -232,7 +232,7 @@ TEST(TestJson, FlatbufferStringToJsonImplicit)
 
     auto sv = flatbuffers::GetRoot<StringValue>(builder.GetBufferPointer());
 
-    nlohmann::json j = sv->value();
+    const nlohmann::json j = sv->value();
     EXPECT_TRUE(j.is_string());
     EXPECT_EQ(j.get<std::string>(), "implicit_test");
 }
@@ -292,7 +292,7 @@ TEST(TestJson, FlatbufferStringVectorToJson)
 TEST(TestJson, FlatbufferEmptyStringVectorToJson)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<flatbuffers::Offset<flatbuffers::String>> emptyOffsets;
+    const std::vector<flatbuffers::Offset<flatbuffers::String>> emptyOffsets;
     auto vecOffset = builder.CreateVector(emptyOffsets);
 
     auto scOffset = CreateStringConstraint(builder, 0, vecOffset);


### PR DESCRIPTION
## Motivation

The `ninja check` target fails with 10 `misc-const-correctness` clang-tidy errors across hipDNN source and test files. These variables are assigned once and never modified, so they should be declared `const`.

## Technical Details

Added `const` qualifiers to 10 variables flagged by clang-tidy's `misc-const-correctness` rule:

- `backend/src/logging/GraphLogger.cpp`: `lock` (`std::lock_guard`), `dirPath`, and `j` (`nlohmann::json`) are never mutated after initialization.
- `backend/tests/TestGraphLogger.cpp`: `tensorAttributes`, `nodes`, `subDirStr`, and `newDirStr` are built once and passed as const references.
- `data_sdk/tests/utilities/TestJson.cpp`: `j` (`nlohmann::json`) and `emptyOffsets` are read-only after construction.

## Test Plan

- [x] `ninja check` passes with no clang-tidy errors

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.