### PR TITLE
[HipDNN][SDPA] Fix incorrect variable name in tests

### DIFF
--- a/dnn-providers/sdpa-kernel-provider/cmake/Dependencies.cmake
+++ b/dnn-providers/sdpa-kernel-provider/cmake/Dependencies.cmake
@@ -3,7 +3,7 @@
 
 cmake_minimum_required(VERSION 3.25.2)
 
-if(SDPAKERNELPROVIDER_ENABLE_TESTS)
+if(NOT SDPAKERNELPROVIDER_SKIP_TESTS)
     include(FetchContent)
 
     # Try to find GTest first


### PR DESCRIPTION
## Motivation

Correct test building error

## Technical Details

Change `SDPAKERNELPROVIDER_ENABLE_TESTS` to `SDPAKERNELPROVIDER_SKIP_TESTS`