### PR TITLE
Fix `THEROCK_DIR` path resolution in TheRock test scripts

### DIFF
--- a/test/therock/test_hipblas.py
+++ b/test/therock/test_hipblas.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
 
 # Importing is_asan from github_actions_api.py
 sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))

--- a/test/therock/test_hipblas.py
+++ b/test/therock/test_hipblas.py
@@ -10,7 +10,9 @@ from pathlib import Path
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
+THEROCK_DIR = Path(
+    os.environ.get("THEROCK_DIR") or SCRIPT_DIR.parent.parent.parent
+).resolve()
 
 # Importing is_asan from github_actions_api.py
 sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))

--- a/test/therock/test_hipblaslt.py
+++ b/test/therock/test_hipblaslt.py
@@ -12,7 +12,9 @@ THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
 platform = os.getenv("RUNNER_OS").lower()
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
+THEROCK_DIR = Path(
+    os.environ.get("THEROCK_DIR") or SCRIPT_DIR.parent.parent.parent
+).resolve()
 
 # Importing is_asan from github_actions_api.py
 sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))

--- a/test/therock/test_hipblaslt.py
+++ b/test/therock/test_hipblaslt.py
@@ -12,7 +12,7 @@ THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
 platform = os.getenv("RUNNER_OS").lower()
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
 
 # Importing is_asan from github_actions_api.py
 sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))

--- a/test/therock/test_hipcub.py
+++ b/test/therock/test_hipcub.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
 
 logging.basicConfig(level=logging.INFO)
 

--- a/test/therock/test_hipcub.py
+++ b/test/therock/test_hipcub.py
@@ -10,7 +10,9 @@ from pathlib import Path
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
+THEROCK_DIR = Path(
+    os.environ.get("THEROCK_DIR") or SCRIPT_DIR.parent.parent.parent
+).resolve()
 
 logging.basicConfig(level=logging.INFO)
 

--- a/test/therock/test_hipdnn.py
+++ b/test/therock/test_hipdnn.py
@@ -9,7 +9,9 @@ from pathlib import Path
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
+THEROCK_DIR = Path(
+    os.environ.get("THEROCK_DIR") or SCRIPT_DIR.parent.parent.parent
+).resolve()
 AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
 
 logging.basicConfig(level=logging.INFO)

--- a/test/therock/test_hipdnn.py
+++ b/test/therock/test_hipdnn.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
 AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
 
 logging.basicConfig(level=logging.INFO)

--- a/test/therock/test_hipdnn_install.py
+++ b/test/therock/test_hipdnn_install.py
@@ -21,7 +21,9 @@ from pathlib import Path
 
 OUTPUT_ARTIFACTS_DIR = os.getenv("OUTPUT_ARTIFACTS_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
+THEROCK_DIR = Path(
+    os.environ.get("THEROCK_DIR") or SCRIPT_DIR.parent.parent.parent
+).resolve()
 TEST_PROJECT_DIR = SCRIPT_DIR / "hipdnn_install_tests"
 
 logging.basicConfig(level=logging.INFO)

--- a/test/therock/test_hipdnn_install.py
+++ b/test/therock/test_hipdnn_install.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 OUTPUT_ARTIFACTS_DIR = os.getenv("OUTPUT_ARTIFACTS_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
 TEST_PROJECT_DIR = SCRIPT_DIR / "hipdnn_install_tests"
 
 logging.basicConfig(level=logging.INFO)

--- a/test/therock/test_hipdnn_samples.py
+++ b/test/therock/test_hipdnn_samples.py
@@ -9,7 +9,9 @@ from pathlib import Path
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
+THEROCK_DIR = Path(
+    os.environ.get("THEROCK_DIR") or SCRIPT_DIR.parent.parent.parent
+).resolve()
 
 logging.basicConfig(level=logging.INFO)
 

--- a/test/therock/test_hipdnn_samples.py
+++ b/test/therock/test_hipdnn_samples.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
 
 logging.basicConfig(level=logging.INFO)
 

--- a/test/therock/test_hipfft.py
+++ b/test/therock/test_hipfft.py
@@ -9,7 +9,9 @@ from pathlib import Path
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
+THEROCK_DIR = Path(
+    os.environ.get("THEROCK_DIR") or SCRIPT_DIR.parent.parent.parent
+).resolve()
 
 logging.basicConfig(level=logging.INFO)
 

--- a/test/therock/test_hipfft.py
+++ b/test/therock/test_hipfft.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
 
 logging.basicConfig(level=logging.INFO)
 

--- a/test/therock/test_hiprand.py
+++ b/test/therock/test_hiprand.py
@@ -9,7 +9,9 @@ from pathlib import Path
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
+THEROCK_DIR = Path(
+    os.environ.get("THEROCK_DIR") or SCRIPT_DIR.parent.parent.parent
+).resolve()
 
 logging.basicConfig(level=logging.INFO)
 

--- a/test/therock/test_hiprand.py
+++ b/test/therock/test_hiprand.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
 
 logging.basicConfig(level=logging.INFO)
 

--- a/test/therock/test_hipsolver.py
+++ b/test/therock/test_hipsolver.py
@@ -9,7 +9,9 @@ from pathlib import Path
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
+THEROCK_DIR = Path(
+    os.environ.get("THEROCK_DIR") or SCRIPT_DIR.parent.parent.parent
+).resolve()
 
 PLATFORM = os.getenv("PLATFORM")
 AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")

--- a/test/therock/test_hipsolver.py
+++ b/test/therock/test_hipsolver.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
 
 PLATFORM = os.getenv("PLATFORM")
 AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")

--- a/test/therock/test_hipsparse.py
+++ b/test/therock/test_hipsparse.py
@@ -11,7 +11,7 @@ import platform
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 OUTPUT_ARTIFACTS_DIR = os.getenv("OUTPUT_ARTIFACTS_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
 AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
 os_type = platform.system().lower()
 

--- a/test/therock/test_hipsparse.py
+++ b/test/therock/test_hipsparse.py
@@ -11,7 +11,9 @@ import platform
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 OUTPUT_ARTIFACTS_DIR = os.getenv("OUTPUT_ARTIFACTS_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
+THEROCK_DIR = Path(
+    os.environ.get("THEROCK_DIR") or SCRIPT_DIR.parent.parent.parent
+).resolve()
 AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
 os_type = platform.system().lower()
 

--- a/test/therock/test_hipsparselt.py
+++ b/test/therock/test_hipsparselt.py
@@ -10,7 +10,7 @@ from pathlib import Path
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 OUTPUT_ARTIFACTS_DIR = os.getenv("OUTPUT_ARTIFACTS_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
 
 logging.basicConfig(level=logging.INFO)
 

--- a/test/therock/test_hipsparselt.py
+++ b/test/therock/test_hipsparselt.py
@@ -10,7 +10,9 @@ from pathlib import Path
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 OUTPUT_ARTIFACTS_DIR = os.getenv("OUTPUT_ARTIFACTS_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
+THEROCK_DIR = Path(
+    os.environ.get("THEROCK_DIR") or SCRIPT_DIR.parent.parent.parent
+).resolve()
 
 logging.basicConfig(level=logging.INFO)
 

--- a/test/therock/test_miopen.py
+++ b/test/therock/test_miopen.py
@@ -10,7 +10,9 @@ import platform
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
+THEROCK_DIR = Path(
+    os.environ.get("THEROCK_DIR") or SCRIPT_DIR.parent.parent.parent
+).resolve()
 
 AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
 os_type = platform.system().lower()

--- a/test/therock/test_miopen.py
+++ b/test/therock/test_miopen.py
@@ -10,7 +10,7 @@ import platform
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
 
 AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
 os_type = platform.system().lower()

--- a/test/therock/test_rocblas.py
+++ b/test/therock/test_rocblas.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
 
 # Importing is_asan from github_actions_api.py
 sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))

--- a/test/therock/test_rocblas.py
+++ b/test/therock/test_rocblas.py
@@ -10,7 +10,9 @@ from pathlib import Path
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
+THEROCK_DIR = Path(
+    os.environ.get("THEROCK_DIR") or SCRIPT_DIR.parent.parent.parent
+).resolve()
 
 # Importing is_asan from github_actions_api.py
 sys.path.append(str(THEROCK_DIR / "build_tools" / "github_actions"))

--- a/test/therock/test_rocfft.py
+++ b/test/therock/test_rocfft.py
@@ -9,7 +9,9 @@ from pathlib import Path
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
+THEROCK_DIR = Path(
+    os.environ.get("THEROCK_DIR") or SCRIPT_DIR.parent.parent.parent
+).resolve()
 
 logging.basicConfig(level=logging.INFO)
 

--- a/test/therock/test_rocfft.py
+++ b/test/therock/test_rocfft.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
 
 logging.basicConfig(level=logging.INFO)
 

--- a/test/therock/test_rocprim.py
+++ b/test/therock/test_rocprim.py
@@ -10,7 +10,9 @@ import platform
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
+THEROCK_DIR = Path(
+    os.environ.get("THEROCK_DIR") or SCRIPT_DIR.parent.parent.parent
+).resolve()
 
 AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
 os_type = platform.system().lower()

--- a/test/therock/test_rocprim.py
+++ b/test/therock/test_rocprim.py
@@ -10,7 +10,7 @@ import platform
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
 
 AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
 os_type = platform.system().lower()

--- a/test/therock/test_rocrand.py
+++ b/test/therock/test_rocrand.py
@@ -9,7 +9,9 @@ from pathlib import Path
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
+THEROCK_DIR = Path(
+    os.environ.get("THEROCK_DIR") or SCRIPT_DIR.parent.parent.parent
+).resolve()
 
 logging.basicConfig(level=logging.INFO)
 

--- a/test/therock/test_rocrand.py
+++ b/test/therock/test_rocrand.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
 
 logging.basicConfig(level=logging.INFO)
 

--- a/test/therock/test_rocroller.py
+++ b/test/therock/test_rocroller.py
@@ -12,7 +12,9 @@ logging.basicConfig(level=logging.INFO, format="%(message)s")
 
 # repo + dirs
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
+THEROCK_DIR = Path(
+    os.environ.get("THEROCK_DIR") or SCRIPT_DIR.parent.parent.parent
+).resolve()
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR", "")
 platform = os.getenv("RUNNER_OS", "linux").lower()
 

--- a/test/therock/test_rocroller.py
+++ b/test/therock/test_rocroller.py
@@ -12,7 +12,7 @@ logging.basicConfig(level=logging.INFO, format="%(message)s")
 
 # repo + dirs
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR", "")
 platform = os.getenv("RUNNER_OS", "linux").lower()
 

--- a/test/therock/test_rocsolver.py
+++ b/test/therock/test_rocsolver.py
@@ -10,7 +10,7 @@ from pathlib import Path
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 OUTPUT_ARTIFACTS_DIR = os.getenv("OUTPUT_ARTIFACTS_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
 
 logging.basicConfig(level=logging.INFO)
 

--- a/test/therock/test_rocsolver.py
+++ b/test/therock/test_rocsolver.py
@@ -10,7 +10,9 @@ from pathlib import Path
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 OUTPUT_ARTIFACTS_DIR = os.getenv("OUTPUT_ARTIFACTS_DIR")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
+THEROCK_DIR = Path(
+    os.environ.get("THEROCK_DIR") or SCRIPT_DIR.parent.parent.parent
+).resolve()
 
 logging.basicConfig(level=logging.INFO)
 

--- a/test/therock/test_rocsparse.py
+++ b/test/therock/test_rocsparse.py
@@ -10,7 +10,7 @@ from pathlib import Path
 THEROCK_BIN_DIR = Path(os.getenv("THEROCK_BIN_DIR")).resolve()
 OUTPUT_ARTIFACTS_DIR = Path(os.getenv("OUTPUT_ARTIFACTS_DIR")).resolve()
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = SCRIPT_DIR.parent.parent.parent.resolve()
+THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
 
 logging.basicConfig(level=logging.INFO)
 

--- a/test/therock/test_rocsparse.py
+++ b/test/therock/test_rocsparse.py
@@ -10,7 +10,9 @@ from pathlib import Path
 THEROCK_BIN_DIR = Path(os.getenv("THEROCK_BIN_DIR")).resolve()
 OUTPUT_ARTIFACTS_DIR = Path(os.getenv("OUTPUT_ARTIFACTS_DIR")).resolve()
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
+THEROCK_DIR = Path(
+    os.environ.get("THEROCK_DIR") or SCRIPT_DIR.parent.parent.parent
+).resolve()
 
 logging.basicConfig(level=logging.INFO)
 

--- a/test/therock/test_rocthrust.py
+++ b/test/therock/test_rocthrust.py
@@ -11,7 +11,7 @@ from pathlib import Path
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
 
 logging.basicConfig(level=logging.INFO)
 

--- a/test/therock/test_rocthrust.py
+++ b/test/therock/test_rocthrust.py
@@ -11,7 +11,9 @@ from pathlib import Path
 THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
+THEROCK_DIR = Path(
+    os.environ.get("THEROCK_DIR") or SCRIPT_DIR.parent.parent.parent
+).resolve()
 
 logging.basicConfig(level=logging.INFO)
 

--- a/test/therock/test_rocwmma.py
+++ b/test/therock/test_rocwmma.py
@@ -11,7 +11,9 @@ THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
 platform = os.getenv("RUNNER_OS").lower()
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
+THEROCK_DIR = Path(
+    os.environ.get("THEROCK_DIR") or SCRIPT_DIR.parent.parent.parent
+).resolve()
 
 # GTest sharding
 SHARD_INDEX = os.getenv("SHARD_INDEX", 1)

--- a/test/therock/test_rocwmma.py
+++ b/test/therock/test_rocwmma.py
@@ -11,7 +11,7 @@ THEROCK_BIN_DIR = os.getenv("THEROCK_BIN_DIR")
 AMDGPU_FAMILIES = os.getenv("AMDGPU_FAMILIES")
 platform = os.getenv("RUNNER_OS").lower()
 SCRIPT_DIR = Path(__file__).resolve().parent
-THEROCK_DIR = SCRIPT_DIR.parent.parent.parent
+THEROCK_DIR = Path(os.getenv("THEROCK_DIR", SCRIPT_DIR.parent.parent.parent)).resolve()
 
 # GTest sharding
 SHARD_INDEX = os.getenv("SHARD_INDEX", 1)


### PR DESCRIPTION
Part of the TheRock test script migration (RFC0010).

Fixes `THEROCK_DIR` resolution in the scripts seeded under `test/therock/`
so they work in both execution contexts:

- **Via TheRock submodule**: `SCRIPT_DIR.parent.parent.parent` fallback
  navigates up 3 levels to the TheRock root (same depth as the old
  `test_executable_scripts/` location).
- **Standalone from this repo**: `THEROCK_DIR` env var points to a
  checked-out TheRock installation.

Scripts with no TheRock-specific path assumptions are left unchanged.

Note: these scripts are not yet wired into CI from their new locations.
That will be addressed in a follow-on step once validated.

RFC: https://github.com/ROCm/TheRock/blob/main/docs/rfcs/RFC0010-Test-Scripts-Migration.md