### PR TITLE
[Origami] Add option to select with formocast

### DIFF
--- a/projects/hipblaslt/docs/reference/env-variables.rst
+++ b/projects/hipblaslt/docs/reference/env-variables.rst
@@ -125,6 +125,11 @@ For more information, see :doc:`Use Stream-K with hipBLASLt <../how-to/how-to-us
         | Example: 32 (limits GEMM kernels to 32 compute units)
         | Default: All available compute units
 
+    * - | ``ANALYTICAL_GEMM_PREDICTION_MODE``
+        | Controls the prediction model used by Origami for kernel selection.
+      - | 0: Estimation mode (fast analytical estimation, default)
+        | 1: Simulation mode (uses Formocast for more accurate performance prediction)
+
 Type overrides
 ======================
 

--- a/projects/hipblaslt/tensilelite/include/Tensile/Serialization/PredictionLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/Serialization/PredictionLibrary.hpp
@@ -30,10 +30,22 @@
 
 #include <Tensile/PredictionLibrary.hpp>
 
+#include <cstdlib>
+#include <cstring>
+
 namespace TensileLite
 {
     namespace Serialization
     {
+        inline origami::prediction_modes_t getPredictionModeFromEnv()
+        {
+            const char* env = std::getenv("ANALYTICAL_GEMM_PREDICTION_MODE");
+            if(env && std::strcmp(env, "1") == 0)
+            {
+                return origami::prediction_modes_t::simulation;
+            }
+            return origami::prediction_modes_t::estimation;
+        }
 
         template <typename MyProblem, typename MySolution, typename IO>
         struct MappingTraits<ProblemPredictionLibrary<MyProblem, MySolution>, IO>
@@ -116,8 +128,36 @@ namespace TensileLite
                                 .cache_hints_b             = solution->sizeMapping.nonTemporalB,
                                 .workspace_size            = std::numeric_limits<size_t>::max(),
                                 .workspace_size_per_elem_c = std::numeric_limits<size_t>::max(),
+                                .prediction_mode           = getPredictionModeFromEnv(),
                                 .index                     = local_index,
+                                .grvw_a                    = solution->sizeMapping.grvwA,
+                                .grvw_b                    = solution->sizeMapping.grvwB,
+                                .gwvw_d                    = solution->sizeMapping.gwvwD,
+                                .vector_width_a            = solution->sizeMapping.VectorWidthA,
+                                .vector_width_b            = solution->sizeMapping.VectorWidthB,
                             };
+
+                            // Populate tensile_params_t for Formocast simulation mode
+                            auto& tensile_params = origami_config.tensile();
+                            tensile_params.depth_u = solution->sizeMapping.depthU;
+                            tensile_params.global_split_u = solution->sizeMapping.globalSplitU;
+                            tensile_params.global_accumulation = solution->sizeMapping.globalAccumulation;
+                            tensile_params.local_split_u = solution->sizeMapping.LocalSplitU;
+                            tensile_params.direct_to_vgpr_a = solution->sizeMapping.DirectToVgprA;
+                            tensile_params.direct_to_vgpr_b = solution->sizeMapping.DirectToVgprB;
+                            tensile_params.direct_to_lds_a = solution->sizeMapping.DirectToLdsA;
+                            tensile_params.direct_to_lds_b = solution->sizeMapping.DirectToLdsB;
+                            tensile_params.num_loads_coalesced_a = solution->sizeMapping.NumLoadsCoalescedA;
+                            tensile_params.num_loads_coalesced_b = solution->sizeMapping.NumLoadsCoalescedB;
+                            tensile_params.wave_num = solution->sizeMapping.waveNum;
+                            tensile_params.wave_group_m = solution->sizeMapping.waveGroup[0];
+                            tensile_params.wave_group_n = solution->sizeMapping.waveGroup[1];
+                            tensile_params.prefetch_global_read = solution->sizeMapping.PrefetchGlobalRead;
+                            tensile_params.math_clocks_unrolled_loop = solution->sizeMapping.MathClocksUnrolledLoop;
+                            tensile_params.workgroup_mapping_xcc = solution->sizeMapping.workGroupMappingXCC;
+                            tensile_params.workgroup_mapping_xcc_group = solution->sizeMapping.workGroupMappingXCCGroup;
+                            tensile_params.global_split_u_coalesced = solution->sizeMapping.globalSplitUCoalesced;
+                            tensile_params.global_split_u_wgm_round_robin = solution->sizeMapping.globalSplitUWorkGroupMappingRoundRobin;
 
                             lib.origami_config_list.emplace_back(origami_config);
                         }

--- a/shared/origami/src/origami/gemm.cpp
+++ b/shared/origami/src/origami/gemm.cpp
@@ -1046,7 +1046,7 @@ static double compute_formocast_latency(const problem_t& problem,
   // Use depth_u if set, otherwise use mt.k
   size_mapping.depthU = (config.tensile().depth_u > 0) ? config.tensile().depth_u : config.mt.k;
 
-  size_mapping.globalSplitU = config.tensile().global_split_u;
+  size_mapping.globalSplitU = std::max(static_cast<int16_t>(1), config.tensile().global_split_u);
   size_mapping.globalAccumulation = config.tensile().global_accumulation;
   size_mapping.LocalSplitU = config.tensile().local_split_u;
 

--- a/shared/origami/src/origami/gemm.cpp
+++ b/shared/origami/src/origami/gemm.cpp
@@ -915,6 +915,11 @@ double compute_total_latency(const problem_t& problem,
   assert(config.is_valid());
   bool debug = runtime_options::get().debug_enabled;
 
+  // Use Formocast simulation model if prediction_mode is set to simulation
+  if (config.prediction_mode == prediction_modes_t::simulation) {
+    return compute_formocast_latency(problem, hardware, config);
+  }
+
   // Extract parameters from structured types
   size_t M     = problem.size.m;
   size_t N     = problem.size.n;
@@ -968,12 +973,6 @@ double compute_total_latency(const problem_t& problem,
     } else if (config.cache_hints_a || config.cache_hints_b) {
       return std::numeric_limits<double>::max();
     }
-  }
-
-  // Use Formocast simulation model if prediction_mode is set to simulation
-  // (placed after short-circuit filters so known-bad configs are rejected first)
-  if (config.prediction_mode == prediction_modes_t::simulation) {
-    return compute_formocast_latency(problem, hardware, config);
   }
 
   if(debug)

--- a/shared/origami/src/origami/gemm.cpp
+++ b/shared/origami/src/origami/gemm.cpp
@@ -915,11 +915,6 @@ double compute_total_latency(const problem_t& problem,
   assert(config.is_valid());
   bool debug = runtime_options::get().debug_enabled;
 
-  // Use Formocast simulation model if prediction_mode is set to simulation
-  if (config.prediction_mode == prediction_modes_t::simulation) {
-    return compute_formocast_latency(problem, hardware, config);
-  }
-
   // Extract parameters from structured types
   size_t M     = problem.size.m;
   size_t N     = problem.size.n;
@@ -974,6 +969,13 @@ double compute_total_latency(const problem_t& problem,
       return std::numeric_limits<double>::max();
     }
   }
+
+  // Use Formocast simulation model if prediction_mode is set to simulation
+  // (placed after short-circuit filters so known-bad configs are rejected first)
+  if (config.prediction_mode == prediction_modes_t::simulation) {
+    return compute_formocast_latency(problem, hardware, config);
+  }
+
   if(debug)
   {
     OLOG_DEBUG("======== Origami Debug Info ========");


### PR DESCRIPTION
## Motivation

Adds an environment variable that can be used to enable kernel selection with formocast.

## Technical Details

   | ``ANALYTICAL_GEMM_PREDICTION_MODE``
   | Controls the prediction model used by Origami for kernel selection.
   | 0: Estimation mode (fast analytical estimation, default)
   | 1: Simulation mode (uses Formocast for more accurate performance prediction)

## Test Plan

Benchmarking is currently being done to see the performance impact of using formocast for selection.

[AIGESOLSEL-36](https://amd-hub.atlassian.net/browse/AIGESOLSEL-36)

[AIGESOLSEL-36]: https://amd-hub.atlassian.net/browse/AIGESOLSEL-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ