### PR TITLE
[rocBLAS] defeat get_all_solutions solution validity testing for now

### DIFF
--- a/projects/rocblas/clients/gtest/get_solutions_gtest.yaml
+++ b/projects/rocblas/clients/gtest/get_solutions_gtest.yaml
@@ -78,27 +78,28 @@ Tests:
   gpu_arch: ['90a','942','12??']
 
 # special form of get_solutions testing via gemm_ex harness
-- name: gemm_ex_get_solutions_custom
-  category: pre_checkin
-  function:
-  - gemm_ex
-  - gemm_batched_ex
-  - gemm_strided_batched_ex
-  M: 16
-  N: 16
-  K: 1
-  lda: 16
-  ldb: 16
-  ldc: 16
-  ldd: 16
-  batch_count: 2
-  alpha_beta: { alpha:  1, beta:  1 }
-  transA: N
-  transB: T
-  precision : *real_precisions
-  solution_index: *c_gemm_test_all_solutions_returned
-  algo: 1
-  pointer_mode_device: false
-  gpu_arch: ['90a','942','950','12??']
+# TODO solution guarantees need additional work before re-adding this test
+# - name: gemm_ex_get_solutions_custom
+#   category: pre_checkin
+#   function:
+#   - gemm_ex
+#   - gemm_batched_ex
+#   - gemm_strided_batched_ex
+#   M: 16
+#   N: 16
+#   K: 1
+#   lda: 16
+#   ldb: 16
+#   ldc: 16
+#   ldd: 16
+#   batch_count: 2
+#   alpha_beta: { alpha:  1, beta:  1 }
+#   transA: N
+#   transB: T
+#   precision : *real_precisions
+#   solution_index: *c_gemm_test_all_solutions_returned
+#   algo: 1
+#   pointer_mode_device: false
+#   gpu_arch: ['90a','942','950','12??']
 
 ...

--- a/projects/rocblas/clients/include/blas_ex/testing_gemm_batched_ex.hpp
+++ b/projects/rocblas/clients/include/blas_ex/testing_gemm_batched_ex.hpp
@@ -670,6 +670,7 @@ void testing_gemm_batched_ex(const Arguments& arg)
     rocblas_gemm_algo algo = rocblas_gemm_algo(arg.algo);
 
 #ifdef BUILD_WITH_TENSILE // tensile or hipblaslt only for now
+/* TODO requires full data for query otherwise no solution guarantees
     if(compare_solutions && algo == rocblas_gemm_algo_solution_index)
     {
         arguments = &run_arg; // override
@@ -713,6 +714,7 @@ void testing_gemm_batched_ex(const Arguments& arg)
             GTEST_SKIP() << "Backend returning 0 valid solutions";
         }
     }
+*/
 #endif
 
     for(auto sol : solutions_that_solve)

--- a/projects/rocblas/clients/include/blas_ex/testing_gemm_ex.hpp
+++ b/projects/rocblas/clients/include/blas_ex/testing_gemm_ex.hpp
@@ -813,6 +813,7 @@ void testing_gemm_ex(const Arguments& arg)
     rocblas_gemm_algo algo = rocblas_gemm_algo(arg.algo);
 
 #ifdef BUILD_WITH_TENSILE // tensile or hipblaslt only for now
+/* TODO requires full data for query otherwise no solution guarantees
     if(compare_solutions && algo == rocblas_gemm_algo_solution_index)
     {
         arguments = &run_arg; // override
@@ -856,6 +857,7 @@ void testing_gemm_ex(const Arguments& arg)
             GTEST_SKIP() << "Backend returning 0 valid solutions";
         }
     }
+*/
 #endif
 
     for(auto sol : solutions_that_solve)

--- a/projects/rocblas/clients/include/blas_ex/testing_gemm_strided_batched_ex.hpp
+++ b/projects/rocblas/clients/include/blas_ex/testing_gemm_strided_batched_ex.hpp
@@ -694,6 +694,7 @@ void testing_gemm_strided_batched_ex(const Arguments& arg)
     rocblas_gemm_algo algo = rocblas_gemm_algo(arg.algo);
 
 #ifdef BUILD_WITH_TENSILE // tensile or hipblaslt only for now
+/* TODO requires full data for query otherwise no solution guarantees
     if(compare_solutions && algo == rocblas_gemm_algo_solution_index)
     {
         arguments = &run_arg; // override
@@ -740,6 +741,7 @@ void testing_gemm_strided_batched_ex(const Arguments& arg)
             GTEST_SKIP() << "Backend returning 0 valid solutions";
         }
     }
+*/
 #endif
 
     for(auto sol : solutions_that_solve)


### PR DESCRIPTION
This pull request temporarily disables a the testing of all soutions returned by get_solutions due to incomplete solution guarantees and invalid batched queries.  The intent is to prevent false test failures until the solution guarantee logic is improved.  These were causing local test failures not seen in CI.
