### PR TITLE
[hipDNN] Add TheRock developer bootstrap script for Linux

### DIFF
--- a/projects/hipdnn/scripts/linux/README.md
+++ b/projects/hipdnn/scripts/linux/README.md
@@ -1,0 +1,73 @@
+# TheRock Developer Bootstrap Scripts (Linux)
+
+Scripts for building hipDNN and its DNN provider plugins from source using
+[TheRock](https://github.com/ROCm/TheRock) build infrastructure. TheRock
+downloads prebuilt CI artifacts for the full ROCm stack and lets you
+selectively rebuild individual components from source.
+
+## Prerequisites
+
+- A clone of [TheRock](https://github.com/ROCm/TheRock)
+- Python 3.9+
+- CMake and Ninja
+- `pip install meson` (or install it in TheRock's `.venv` — see below)
+
+## Quick Start
+
+Copy `rock_dev_bootstrap.sh` into your TheRock checkout, then:
+
+```bash
+cd /path/to/TheRock
+
+# 1. Download prebuilt CI artifacts (one-time setup)
+./rock_dev_bootstrap.sh bootstrap --gpu gfx90a
+
+# 2. Activate the Python venv (meson must be on PATH for cmake)
+source .venv/bin/activate
+
+# 3. Configure hipDNN + providers for source build
+./rock_dev_bootstrap.sh configure --gpu gfx90a hipdnn miopenprovider hipkernelprovider hipblasltprovider
+
+# 4. Build
+./rock_dev_bootstrap.sh build --gpu gfx90a
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `bootstrap [run-id]` | Download prebuilt CI artifacts. Auto-detects the latest nightly if no run ID is given. |
+| `configure [components...]` | Remove `.prebuilt` markers for the listed components and run cmake. Defaults to all components if none specified. |
+| `build [components...]` | Build configured components with ninja. |
+| `rebuild [components...]` | Expunge (full clean) then rebuild components. |
+
+## Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--gpu <family>` | `gfx94X-dcgpu` | GPU architecture family (e.g. `gfx90a`, `gfx94X-dcgpu`). |
+| `--build-dir <dir>` | `~/therock-build-<gpu>` | Build output directory. |
+| `--workflow <file>` | `ci_nightly.yml` | GitHub Actions workflow to search for artifacts. |
+
+## Available Components
+
+| Component | Description |
+|-----------|-------------|
+| `hipdnn` | Core hipDNN library |
+| `miopenprovider` | MIOpen backend DNN provider plugin |
+| `hipblasltprovider` | hipBLASLt backend DNN provider plugin |
+| `hipkernelprovider` | HIP kernel backend DNN provider plugin |
+
+## Notes
+
+- **Python venv:** The `bootstrap` command creates a `.venv` in the TheRock
+  repo and installs dependencies (including `meson`). You must activate this
+  venv before running `configure` so that cmake can find `meson` on PATH.
+- **GitHub auth:** Without `gh auth` or a `GITHUB_TOKEN`, artifact search
+  requests are unauthenticated and may be rate-limited. Set up authentication
+  for faster, more reliable bootstrapping.
+- **Build directory:** Each GPU family gets its own build directory
+  (`~/therock-build-gfx90a`, `~/therock-build-gfx94X`, etc.). You can
+  override this with `--build-dir`.
+- **Incremental builds:** After the initial build, re-running `build` only
+  recompiles changed files. Use `rebuild` for a full clean rebuild.

--- a/projects/hipdnn/scripts/linux/README.md
+++ b/projects/hipdnn/scripts/linux/README.md
@@ -1,22 +1,22 @@
-# TheRock Developer Bootstrap Scripts (Linux)
+# hipDNN Linux Scripts
 
-Scripts for building hipDNN and its DNN provider plugins from source using
-[TheRock](https://github.com/ROCm/TheRock) build infrastructure. TheRock
-downloads prebuilt CI artifacts for the full ROCm stack and lets you
-selectively rebuild individual components from source.
+Developer scripts for building, testing, and working with hipDNN on Linux.
 
-## Prerequisites
+## Scripts
 
-- A clone of [TheRock](https://github.com/ROCm/TheRock)
-- Python 3.9+
-- CMake and Ninja
-- `pip install meson` (or install it in TheRock's `.venv` — see below)
+### `rock_dev_bootstrap.sh`
 
-## Quick Start
+Automates building hipDNN and its DNN provider plugins from source using
+[TheRock](https://github.com/ROCm/TheRock) build infrastructure. Downloads
+prebuilt CI artifacts for the full ROCm stack and lets you selectively rebuild
+individual components from source.
 
-Copy `rock_dev_bootstrap.sh` into your TheRock checkout, then:
+**Prerequisites:** A TheRock clone, Python 3.9+, CMake, Ninja.
+
+**Quick start:**
 
 ```bash
+# Copy the script into your TheRock checkout, then:
 cd /path/to/TheRock
 
 # 1. Download prebuilt CI artifacts (one-time setup)
@@ -32,42 +32,6 @@ source .venv/bin/activate
 ./rock_dev_bootstrap.sh build --gpu gfx90a
 ```
 
-## Commands
-
-| Command | Description |
-|---------|-------------|
-| `bootstrap [run-id]` | Download prebuilt CI artifacts. Auto-detects the latest nightly if no run ID is given. |
-| `configure [components...]` | Remove `.prebuilt` markers for the listed components and run cmake. Defaults to all components if none specified. |
-| `build [components...]` | Build configured components with ninja. |
-| `rebuild [components...]` | Expunge (full clean) then rebuild components. |
-
-## Options
-
-| Option | Default | Description |
-|--------|---------|-------------|
-| `--gpu <family>` | `gfx94X-dcgpu` | GPU architecture family (e.g. `gfx90a`, `gfx94X-dcgpu`). |
-| `--build-dir <dir>` | `~/therock-build-<gpu>` | Build output directory. |
-| `--workflow <file>` | `ci_nightly.yml` | GitHub Actions workflow to search for artifacts. |
-
-## Available Components
-
-| Component | Description |
-|-----------|-------------|
-| `hipdnn` | Core hipDNN library |
-| `miopenprovider` | MIOpen backend DNN provider plugin |
-| `hipblasltprovider` | hipBLASLt backend DNN provider plugin |
-| `hipkernelprovider` | HIP kernel backend DNN provider plugin |
-
-## Notes
-
-- **Python venv:** The `bootstrap` command creates a `.venv` in the TheRock
-  repo and installs dependencies (including `meson`). You must activate this
-  venv before running `configure` so that cmake can find `meson` on PATH.
-- **GitHub auth:** Without `gh auth` or a `GITHUB_TOKEN`, artifact search
-  requests are unauthenticated and may be rate-limited. Set up authentication
-  for faster, more reliable bootstrapping.
-- **Build directory:** Each GPU family gets its own build directory
-  (`~/therock-build-gfx90a`, `~/therock-build-gfx94X`, etc.). You can
-  override this with `--build-dir`.
-- **Incremental builds:** After the initial build, re-running `build` only
-  recompiles changed files. Use `rebuild` for a full clean rebuild.
+Run `./rock_dev_bootstrap.sh --help` for full usage details including
+available commands (`bootstrap`, `configure`, `build`, `rebuild`), GPU family
+options, and component list.

--- a/projects/hipdnn/scripts/linux/rock_dev_bootstrap.sh
+++ b/projects/hipdnn/scripts/linux/rock_dev_bootstrap.sh
@@ -1,0 +1,515 @@
+#!/bin/bash
+# TheRock developer bootstrap and build tool.
+#
+# Downloads prebuilt CI artifacts and lets you selectively build
+# ml-libs components (hipdnn, hipkernelprovider, etc.) from source
+# while everything else uses prebuilt binaries.
+#
+# Usage:
+#   ./dev_bootstrap.sh <command> [options] [components...]
+#
+# Commands:
+#   bootstrap [run-id]                  Download CI artifacts (auto-detects latest if omitted)
+#   configure [components...]           Remove .prebuilt markers + run cmake
+#   build [components...]               Build components with ninja
+#   rebuild [components...]             Expunge + rebuild components
+#
+# Examples:
+#   # One-time setup (auto-detect latest nightly):
+#   ./dev_bootstrap.sh bootstrap
+#
+#   # One-time setup with specific run:
+#   ./dev_bootstrap.sh bootstrap 22884930750
+#
+#   # Configure to build hipdnn + miopenprovider from source:
+#   ./dev_bootstrap.sh configure hipdnn miopenprovider
+#
+#   # Configure all default components from source:
+#   ./dev_bootstrap.sh configure
+#
+#   # Build everything that was configured:
+#   ./dev_bootstrap.sh build
+#
+#   # Build just one component:
+#   ./dev_bootstrap.sh build miopenprovider
+#
+#   # Clean rebuild of a component:
+#   ./dev_bootstrap.sh rebuild hipkernelprovider
+#
+# Global options (work with any command):
+#   --gpu <family>      GPU family (default: gfx94X-dcgpu)
+#   --build-dir <dir>   Build directory (default: ~/therock-build-<gpu>)
+#   --workflow <file>    Workflow for auto-detect (default: ci_nightly.yml)
+#   -h, --help          Show this help
+#
+# Available components:
+#   hipdnn, hipkernelprovider, miopenprovider, hipblasltprovider
+#
+# Per-component ninja targets (for manual use):
+#   component+configure  - Run cmake configure
+#   component+build      - Incremental build
+#   component+stage      - Install to stage dir
+#   component+expunge    - Full clean (build/, stage/, stamp/, dist/)
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# All known components that can be built from source
+ALL_COMPONENTS=(hipdnn hipkernelprovider miopenprovider hipblasltprovider)
+
+# Ninja target names (must match cmake subproject names exactly)
+declare -A NINJA_TARGETS=(
+    [hipdnn]="hipDNN"
+    [hipkernelprovider]="hipkernelprovider"
+    [miopenprovider]="miopenprovider"
+    [hipblasltprovider]="hipblasltprovider"
+)
+
+# ---- Defaults ----
+GPU_FAMILY="gfx94X-dcgpu"
+BUILD_DIR=""
+WORKFLOW="ci_nightly.yml"
+COMMAND=""
+RUN_ID=""
+COMPONENTS=()
+
+# ---- Helpers ----
+
+# Convert component name to cmake enable flag name (e.g., hipdnn -> HIPDNN)
+component_to_flag() {
+    echo "$1" | tr '[:lower:]-' '[:upper:]_'
+}
+
+# Convert component name to ninja target name (e.g., hipdnn -> hipDNN)
+component_to_ninja_target() {
+    echo "${NINJA_TARGETS[$1]:-$1}"
+}
+
+# Validate that a component name is known
+validate_component() {
+    local comp="$1"
+    for known in "${ALL_COMPONENTS[@]}"; do
+        if [[ "$comp" == "$known" ]]; then
+            return 0
+        fi
+    done
+    echo "ERROR: Unknown component '$comp'"
+    echo "Available components: ${ALL_COMPONENTS[*]}"
+    exit 1
+}
+
+# Config file in build dir to remember settings between commands
+config_file() {
+    echo "$BUILD_DIR/.dev_bootstrap_config"
+}
+
+save_config() {
+    local cfg
+    cfg=$(config_file)
+    mkdir -p "$BUILD_DIR"
+    cat > "$cfg" <<EOF
+GPU_FAMILY=$GPU_FAMILY
+COMPONENTS=(${COMPONENTS[*]})
+EOF
+}
+
+load_config() {
+    local cfg
+    cfg=$(config_file)
+    if [ -f "$cfg" ]; then
+        source "$cfg"
+    fi
+}
+
+# ---- Usage ----
+usage() {
+    echo "Usage: $0 <command> [options] [components...]"
+    echo ""
+    echo "Commands:"
+    echo "  bootstrap [run-id]       Download CI artifacts (auto-detects latest if omitted)"
+    echo "  configure [components]   Remove .prebuilt markers + run cmake"
+    echo "  build [components]       Build with ninja"
+    echo "  rebuild [components]     Expunge + rebuild"
+    echo ""
+    echo "Options:"
+    echo "  --gpu <family>           GPU family (default: gfx94X-dcgpu)"
+    echo "  --build-dir <dir>        Build directory (default: ~/therock-build-<gpu>)"
+    echo "  --workflow <file>        Workflow for auto-detect (default: ci_nightly.yml)"
+    echo "  -h, --help               Show this help"
+    echo ""
+    echo "Components (default: all):"
+    for comp in "${ALL_COMPONENTS[@]}"; do
+        echo "  - $comp"
+    done
+    echo ""
+    echo "Examples:"
+    echo "  $0 bootstrap                          # download latest nightly artifacts"
+    echo "  $0 configure hipdnn miopenprovider     # configure those two for source build"
+    echo "  $0 build                               # build all configured components"
+    echo "  $0 rebuild miopenprovider               # expunge + rebuild one component"
+    exit "${1:-0}"
+}
+
+# ---- Parse arguments ----
+
+# Need at least one arg (the command)
+if [ $# -lt 1 ]; then
+    usage 0
+fi
+
+# Parse global options and command
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --gpu)
+            GPU_FAMILY="$2"
+            shift 2
+            ;;
+        --build-dir)
+            BUILD_DIR="$2"
+            shift 2
+            ;;
+        --workflow)
+            WORKFLOW="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage 0
+            ;;
+        bootstrap|configure|build|rebuild)
+            COMMAND="$1"
+            shift
+            break  # remaining args are command-specific
+            ;;
+        -*)
+            echo "ERROR: Unknown option: $1"
+            usage 1
+            ;;
+        *)
+            echo "ERROR: Unknown command: $1"
+            usage 1
+            ;;
+    esac
+done
+
+if [ -z "$COMMAND" ]; then
+    echo "ERROR: No command specified"
+    usage 1
+fi
+
+# Parse command-specific args (remaining after break)
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --gpu|--build-dir|--workflow)
+            # Allow global options after command too
+            if [ "$1" = "--gpu" ]; then GPU_FAMILY="$2"; fi
+            if [ "$1" = "--build-dir" ]; then BUILD_DIR="$2"; fi
+            if [ "$1" = "--workflow" ]; then WORKFLOW="$2"; fi
+            shift 2
+            ;;
+        -h|--help)
+            usage 0
+            ;;
+        -*)
+            echo "ERROR: Unknown option: $1"
+            usage 1
+            ;;
+        *)
+            # For bootstrap: first positional is run ID (numeric)
+            if [[ "$COMMAND" == "bootstrap" ]] && [[ "$1" =~ ^[0-9]+$ ]] && [ -z "$RUN_ID" ]; then
+                RUN_ID="$1"
+            else
+                # Component name
+                validate_component "$1"
+                COMPONENTS+=("$1")
+            fi
+            shift
+            ;;
+    esac
+done
+
+# Derive build dir from GPU family if not set
+GPU_SHORT="${GPU_FAMILY%%-*}"
+if [ -z "$BUILD_DIR" ]; then
+    BUILD_DIR="$HOME/therock-build-${GPU_SHORT}"
+fi
+
+# Validate script location
+if [ ! -f "$SCRIPT_DIR/build_tools/artifact_manager.py" ]; then
+    echo "ERROR: This script must be run from the TheRock repo root"
+    exit 1
+fi
+
+# ---- Setup Python environment ----
+setup_python() {
+    cd "$SCRIPT_DIR"
+    if [ ! -d ".venv" ]; then
+        echo "Creating Python virtual environment..."
+        python3 -m venv .venv
+    fi
+    source .venv/bin/activate
+    pip install -q --upgrade pip
+    pip install -q -r requirements.txt
+    export PYTHONWARNINGS="ignore:Unverified HTTPS request"
+}
+
+# ---- Remove .prebuilt markers for given components ----
+remove_prebuilt_markers() {
+    local comps=("$@")
+    echo ""
+    echo "Removing .prebuilt markers for source-build components..."
+    echo ""
+
+    for comp in "${comps[@]}"; do
+        PREBUILT_FILES=$(find "$BUILD_DIR" -ipath "*/${comp}/stage.prebuilt" -o -ipath "*/${comp}/*/stage.prebuilt" 2>/dev/null || true)
+        if [ -n "$PREBUILT_FILES" ]; then
+            echo "  $comp: removing .prebuilt marker"
+            for f in $PREBUILT_FILES; do
+                rm -f "$f"
+                rm -rf "${f%.prebuilt}"
+            done
+        else
+            echo "  $comp: no .prebuilt marker (will build from source)"
+        fi
+    done
+    echo ""
+}
+
+# ========================================
+# COMMAND: bootstrap
+# ========================================
+do_bootstrap() {
+    setup_python
+
+    # Fetch sources if needed
+    if [ ! -f "short-hip-runtime/hip/VERSION" ] && [ ! -f "rocm-systems/projects/hip/VERSION" ]; then
+        echo "Fetching submodule sources..."
+        python3 build_tools/fetch_sources.py
+        echo ""
+    fi
+
+    # Find latest run ID if not specified
+    if [ -z "$RUN_ID" ]; then
+        echo "=========================================="
+        echo "Finding latest CI run with artifacts"
+        echo "=========================================="
+        echo ""
+        echo "Searching $WORKFLOW for $GPU_FAMILY artifacts..."
+        echo ""
+
+        FIND_OUTPUT=$(python build_tools/find_latest_artifacts.py \
+            --artifact-group "$GPU_FAMILY" \
+            --workflow "$WORKFLOW" \
+            --verbose 2>&1)
+
+        if [ $? -ne 0 ]; then
+            echo "$FIND_OUTPUT"
+            echo ""
+            echo "ERROR: Could not find a recent CI run with artifacts for $GPU_FAMILY"
+            echo ""
+            echo "Try specifying a run ID manually:"
+            echo "  $0 bootstrap <run-id>"
+            echo ""
+            echo "Find run IDs at:"
+            echo "  https://github.com/ROCm/TheRock/actions/workflows/$WORKFLOW"
+            exit 1
+        fi
+
+        RUN_ID=$(echo "$FIND_OUTPUT" | grep "Workflow run ID:" | head -1 | awk '{print $NF}')
+
+        if [ -z "$RUN_ID" ]; then
+            echo "$FIND_OUTPUT"
+            echo "ERROR: Could not parse run ID from output"
+            exit 1
+        fi
+
+        echo "$FIND_OUTPUT"
+        echo ""
+        echo "Using run ID: $RUN_ID"
+    fi
+
+    echo ""
+    echo "=========================================="
+    echo "Fetching all artifacts from run $RUN_ID"
+    echo "=========================================="
+    echo ""
+    echo "GPU Family: $GPU_FAMILY"
+    echo "Build Dir:  $BUILD_DIR"
+    echo ""
+
+    python build_tools/artifact_manager.py fetch \
+        --stage all \
+        --run-id "$RUN_ID" \
+        --amdgpu-families "$GPU_FAMILY" \
+        --output-dir "$BUILD_DIR" \
+        --bootstrap
+
+    echo ""
+    echo "=========================================="
+    echo "Bootstrap complete!"
+    echo "=========================================="
+    PREBUILT_COUNT=$(find "$BUILD_DIR" -name "*.prebuilt" 2>/dev/null | wc -l)
+    echo ""
+    echo "  $PREBUILT_COUNT components marked as prebuilt"
+    echo ""
+    echo "Next: $0 configure [components...]"
+    echo ""
+}
+
+# ========================================
+# COMMAND: configure
+# ========================================
+do_configure() {
+    setup_python
+
+    # Default to all components if none specified
+    if [ ${#COMPONENTS[@]} -eq 0 ]; then
+        COMPONENTS=("${ALL_COMPONENTS[@]}")
+    fi
+
+    echo "=========================================="
+    echo "Configuring TheRock build"
+    echo "=========================================="
+    echo ""
+    echo "GPU Family: $GPU_FAMILY"
+    echo "Build Dir:  $BUILD_DIR"
+    echo ""
+    echo "Building from source:"
+    for comp in "${COMPONENTS[@]}"; do
+        echo "  - $comp"
+    done
+
+    # Remove .prebuilt markers
+    remove_prebuilt_markers "${COMPONENTS[@]}"
+
+    # Save config for build/rebuild commands
+    save_config
+
+    # Build cmake args
+    CMAKE_ARGS=(
+        -B "$BUILD_DIR"
+        -GNinja
+        -DTHEROCK_ENABLE_ALL=OFF
+        -DTHEROCK_AMDGPU_FAMILIES="$GPU_FAMILY"
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo
+    )
+
+    for comp in "${COMPONENTS[@]}"; do
+        flag=$(component_to_flag "$comp")
+        CMAKE_ARGS+=("-DTHEROCK_ENABLE_${flag}=ON")
+    done
+
+    echo "Running cmake..."
+    echo "  cmake ${CMAKE_ARGS[*]} ."
+    echo ""
+
+    cd "$SCRIPT_DIR"
+    cmake "${CMAKE_ARGS[@]}" .
+
+    echo ""
+    echo "=========================================="
+    echo "Configure complete!"
+    echo "=========================================="
+    echo ""
+    echo "Next: $0 build [components...]"
+    echo ""
+}
+
+# ========================================
+# COMMAND: build
+# ========================================
+do_build() {
+    # Load saved config if no components specified
+    if [ ${#COMPONENTS[@]} -eq 0 ]; then
+        load_config
+    fi
+
+    if [ ${#COMPONENTS[@]} -eq 0 ]; then
+        echo "ERROR: No components specified and no saved config found."
+        echo "Run '$0 configure [components...]' first."
+        exit 1
+    fi
+
+    # Resolve to ninja target names
+    local TARGETS=()
+    for comp in "${COMPONENTS[@]}"; do
+        TARGETS+=("$(component_to_ninja_target "$comp")")
+    done
+
+    echo "=========================================="
+    echo "Building components"
+    echo "=========================================="
+    echo ""
+    echo "Build Dir: $BUILD_DIR"
+    echo "Targets:   ${TARGETS[*]}"
+    echo ""
+
+    ninja -C "$BUILD_DIR" "${TARGETS[@]}"
+
+    echo ""
+    echo "Build complete!"
+    echo ""
+}
+
+# ========================================
+# COMMAND: rebuild
+# ========================================
+do_rebuild() {
+    # Load saved config if no components specified
+    if [ ${#COMPONENTS[@]} -eq 0 ]; then
+        load_config
+    fi
+
+    if [ ${#COMPONENTS[@]} -eq 0 ]; then
+        echo "ERROR: No components specified and no saved config found."
+        echo "Run '$0 configure [components...]' first."
+        exit 1
+    fi
+
+    # Resolve to ninja target names
+    local TARGETS=()
+    for comp in "${COMPONENTS[@]}"; do
+        TARGETS+=("$(component_to_ninja_target "$comp")")
+    done
+
+    echo "=========================================="
+    echo "Rebuilding components (expunge + build)"
+    echo "=========================================="
+    echo ""
+    echo "Build Dir: $BUILD_DIR"
+    echo "Targets:   ${TARGETS[*]}"
+    echo ""
+
+    # Expunge each component
+    EXPUNGE_TARGETS=()
+    for t in "${TARGETS[@]}"; do
+        EXPUNGE_TARGETS+=("${t}+expunge")
+    done
+
+    echo "Expunging: ${EXPUNGE_TARGETS[*]}"
+    ninja -C "$BUILD_DIR" "${EXPUNGE_TARGETS[@]}"
+
+    echo ""
+    echo "Building: ${TARGETS[*]}"
+    ninja -C "$BUILD_DIR" "${TARGETS[@]}"
+
+    echo ""
+    echo "Rebuild complete!"
+    echo ""
+}
+
+# ---- Dispatch command ----
+case "$COMMAND" in
+    bootstrap)
+        do_bootstrap
+        ;;
+    configure)
+        do_configure
+        ;;
+    build)
+        do_build
+        ;;
+    rebuild)
+        do_rebuild
+        ;;
+esac


### PR DESCRIPTION
## Motivation

Add rock_dev_bootstrap.sh and README to projects/hipdnn/scripts/linux/. The script automates building hipDNN and its DNN provider plugins (miopenprovider, hipblasltprovider, hipkernelprovider) from source using TheRock's prebuilt CI artifacts for all other dependencies.

## Technical Details

Changes:
- Add rock_dev_bootstrap.sh with bootstrap, configure, build, and rebuild commands
- Fix: activate Python venv during configure so cmake can find meson
- Add README.md documenting prerequisites, usage, and available components

## Test Plan

Can build our projects via TheRock using this script.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
