### PR TITLE
[rocroller] Fix PrefetchScales

### DIFF
--- a/shared/rocroller/lib/source/KernelGraph/Transformations/PrefetchScale.cpp
+++ b/shared/rocroller/lib/source/KernelGraph/Transformations/PrefetchScale.cpp
@@ -463,11 +463,10 @@ namespace rocRoller
          *                     pre-loop loads from K loop body loads)
          * @return PrefetchPositions indexed by sub-iteration
          */
-        PrefetchPositions
-            DeterminePrefetchPositions(KernelGraph const&               graph,
-                                      UnrollColouring const&           colouring,
-                                      std::vector<int> const&          nonSwizzleLoads,
-                                      std::unordered_set<int> const&   kLoopLoadSet)
+        PrefetchPositions DeterminePrefetchPositions(KernelGraph const&             graph,
+                                                     UnrollColouring const&         colouring,
+                                                     std::vector<int> const&        nonSwizzleLoads,
+                                                     std::unordered_set<int> const& kLoopLoadSet)
         {
             std::vector<int>   prefetchPosition;
             std::vector<int>   exchangePosition;

--- a/shared/rocroller/lib/source/KernelGraph/Transformations/PrefetchScale.cpp
+++ b/shared/rocroller/lib/source/KernelGraph/Transformations/PrefetchScale.cpp
@@ -459,11 +459,15 @@ namespace rocRoller
          * @param graph Kernel graph containing the loads
          * @param colouring Maps operations to unroll values
          * @param nonSwizzleLoads Non-WAVE_SWIZZLE loads used as position anchors
+         * @param kLoopLoadSet Loads that are inside the K loop (used to distinguish
+         *                     pre-loop loads from K loop body loads)
          * @return PrefetchPositions indexed by sub-iteration
          */
-        PrefetchPositions DeterminePrefetchPositions(KernelGraph const&      graph,
-                                                     UnrollColouring const&  colouring,
-                                                     std::vector<int> const& nonSwizzleLoads)
+        PrefetchPositions
+            DeterminePrefetchPositions(KernelGraph const&               graph,
+                                      UnrollColouring const&           colouring,
+                                      std::vector<int> const&          nonSwizzleLoads,
+                                      std::unordered_set<int> const&   kLoopLoadSet)
         {
             std::vector<int>   prefetchPosition;
             std::vector<int>   exchangePosition;
@@ -477,11 +481,10 @@ namespace rocRoller
                 auto unrollKDim = graph.mapper.get<Unroll>(loadTag, rocRoller::KLOOP_UNROLL);
                 auto subiter    = unrollMap.at(unrollKDim);
 
-                // Detect if we've entered the K loop
+                // Detect if we've entered the K loop (not just any ForLoopOp)
                 if(!isInsideLoop)
                 {
-                    auto maybeForLoop = findContainingOperation<ForLoopOp>(loadTag, graph);
-                    if(maybeForLoop)
+                    if(kLoopLoadSet.contains(loadTag))
                         isInsideLoop = true;
                 }
 
@@ -606,8 +609,10 @@ namespace rocRoller
             if(swizzleLoads.empty())
                 return;
 
+            std::unordered_set<int> kLoopLoadSet(loopLoads.begin(), loopLoads.end());
+
             auto [prefetchPosition, exchangePosition]
-                = DeterminePrefetchPositions(graph, colouring, nonSwizzleLoads);
+                = DeterminePrefetchPositions(graph, colouring, nonSwizzleLoads, kLoopLoadSet);
 
             for(auto const loadTag : swizzleLoads)
             {

--- a/shared/rocroller/scripts/lib/rrperf/rrsuites.py
+++ b/shared/rocroller/scripts/lib/rrperf/rrsuites.py
@@ -1850,11 +1850,7 @@ def fp4_kernels_wgm():
 
 
 def fp4_kernels_wgm_streamk():
-    # TODO: simplify to addStreamK(fp4_kernels_wgm()) once all tests are working
-    yield from addStreamK(fp4_target_d2lds_mi32x32x64_pf2x1_wgm())
-    # yield from addStreamK(fp4_target_d2lds_mi32x32x64_pf4x1_wgm())
-    # yield from addStreamK(fp4_target_d2lds_mi16x16x128_pf4x1_wgm())
-    yield from addStreamK(fp4_single_scale_target_d2lds_mi16x16x128_pf4x1_wgm())
+    yield from addStreamK(fp4_kernels_wgm())
 
 
 def fp4_16x16x128_scale_options():

--- a/shared/rocroller/test/catch/CMakeLists.txt
+++ b/shared/rocroller/test/catch/CMakeLists.txt
@@ -87,6 +87,7 @@ target_sources(rocroller-tests-catch
         "${CMAKE_CURRENT_SOURCE_DIR}/NaryExpressionTest.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/NodeSchedulingUtilsTest.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/OrderMultiplyNodesTest.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/PrefetchScaleTest.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/RandomNumberExpressionTest.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/RandomNumberGenerationTest.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/RegisterTagManagerTest.cpp"

--- a/shared/rocroller/test/catch/PrefetchScaleTest.cpp
+++ b/shared/rocroller/test/catch/PrefetchScaleTest.cpp
@@ -79,7 +79,7 @@ namespace PrefetchScaleTest
         graph = transform<AddPrefetch>(graph, params, context.get());
         graph = transform<PrefetchScale>(graph, params, context.get());
 
-        auto findLoop = [&](std::string const& name) {
+        auto findLoop = [&](std::string const& name) -> std::optional<int> {
             auto const rootTag = graph.control.roots().only().value();
             for(auto const loop : filter(graph.control.isElemType<ForLoopOp>(),
                                          graph.control.depthFirstVisit(rootTag)))
@@ -89,10 +89,11 @@ namespace PrefetchScaleTest
                     return loop;
             }
             FAIL("Loop '" + name + "' not found");
-            return -1;
+            return std::nullopt;
         };
 
-        int kLoopTag = findLoop(KLOOP);
+        auto kLoopTag = findLoop(KLOOP);
+        REQUIRE(kLoopTag.has_value());
 
         SECTION("Exchange nodes are placed inside the K loop body")
         {
@@ -102,24 +103,17 @@ namespace PrefetchScaleTest
             int exchangesOutsideK = 0;
             int totalExchanges    = 0;
 
-            std::optional<int> kLoopTailTag;
-            for(auto const loop :
-                filter(graph.control.isElemType<ForLoopOp>(),
-                       graph.control.depthFirstVisit(graph.control.roots().only().value())))
-            {
-                auto forloop = graph.control.get<ForLoopOp>(loop).value();
-                if(forloop.loopName == KLOOPTAIL)
-                    kLoopTailTag = loop;
-            }
+            std::optional<int> kLoopTailTag = findLoop(KLOOPTAIL);
 
             for(auto exchangeTag : graph.control.getNodes().filter(isExchange))
             {
                 totalExchanges++;
-                auto stack       = controlStack(exchangeTag, graph);
-                bool insideKLoop = std::find(stack.begin(), stack.end(), kLoopTag) != stack.end();
+                auto stack = controlStack(exchangeTag, graph);
+                bool insideKLoop
+                    = std::find(stack.begin(), stack.end(), kLoopTag.value()) != stack.end();
                 bool insideKLoopTail
-                    = kLoopTailTag
-                      && std::find(stack.begin(), stack.end(), *kLoopTailTag) != stack.end();
+                    = kLoopTailTag.has_value()
+                      && std::find(stack.begin(), stack.end(), kLoopTailTag.value()) != stack.end();
                 if(insideKLoop && !insideKLoopTail)
                     exchangesInKLoop++;
                 else

--- a/shared/rocroller/test/catch/PrefetchScaleTest.cpp
+++ b/shared/rocroller/test/catch/PrefetchScaleTest.cpp
@@ -1,0 +1,151 @@
+// Copyright Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
+#include <rocRoller/CommandSolution.hpp>
+#include <rocRoller/KernelGraph/Transforms/All.hpp>
+#include <rocRoller/KernelGraph/Utils.hpp>
+#include <rocRoller/KernelOptions.hpp>
+
+#include "TestContext.hpp"
+#include "common/CommonGraphs.hpp"
+#include "common/Utilities.hpp"
+
+namespace PrefetchScaleTest
+{
+    TEST_CASE("PrefetchScale exchange placement", "[kernel-graph][graph-transforms]")
+    {
+        using namespace rocRoller;
+        using namespace rocRoller::KernelGraph;
+        using namespace rocRoller::KernelGraph::ControlGraph;
+        using namespace rocRoller::KernelGraph::CoordinateGraph;
+        using namespace rocRoller::Operations;
+
+        auto context
+            = TestContext::ForTarget(GPUArchitectureTarget{GPUArchitectureGFX::GFX950});
+        auto example = rocRollerTest::Graphs::GEMM(DataType::FP4, DataType::FP4, DataType::Half);
+
+        example.setTileSize(128, 128, 256);
+        example.setMFMA(16, 16, 128, 1);
+        example.setUseLDS(true, true, false);
+        example.setScaling(
+            ScaleMode::Separate, ScaleMode::Separate, DataType::E8M0, DataType::E8M0, 32);
+        example.setScaleLoadPaths(SolutionParams::LoadPath::BufferToVGPR,
+                                  SolutionParams::LoadPath::BufferToVGPR);
+        example.setPrefetch(true, 4, 1, true);
+        example.setSwizzle(32, 32, 8, 8, true);
+        example.setTranspose("T", "N");
+        example.setStreamK(StreamKMode::Standard);
+
+        auto command = example.getCommand();
+        auto graph   = example.getKernelGraph();
+        auto params  = example.getCommandParameters();
+
+        graph = transform<UpdateParameters>(graph, params);
+        graph = transform<IdentifyParallelDimensions>(graph);
+        graph = transform<OrderMemory>(graph, true);
+        graph = transform<AddLDS>(graph, params, context.get());
+        graph = transform<LowerLinear>(graph, context.get());
+        graph = transform<LowerTile>(graph, params, context.get());
+        graph = transform<LowerTensorContraction>(graph, params, context.get());
+        graph = transform<Simplify>(graph);
+        graph = transform<ConstantPropagation>(graph);
+        graph = transform<FuseExpressions>(graph);
+
+        // AddStreamK has pre-loop of K loop inside of
+        // another ForLoop which cause the bug.
+        {
+            auto numWGsArg = findArgumentByName(command, NUMWGS);
+            REQUIRE(numWGsArg != nullptr);
+            graph = transform<AddStreamK>(
+                graph,
+                context.get(),
+                params,
+                XLOOP,
+                KLOOP,
+                std::make_shared<Expression::Expression>(numWGsArg));
+        }
+
+        graph = transform<ConnectWorkgroups>(graph, context.get());
+        graph = transform<WorkgroupRemapXCC>(graph, context.get(), params->workgroupRemapXCC);
+        graph = transform<UnrollLoops>(graph, params, context.get());
+        graph = transform<FuseLoops>(graph);
+        graph = transform<RemoveDuplicates>(graph);
+        graph = transform<OrderEpilogueBlocks>(graph);
+        graph = transform<Simplify>(graph);
+        graph = transform<CleanLoops>(graph);
+
+        graph = transform<SwizzleScale>(graph, params, context.get());
+        graph = transform<AddPrefetch>(graph, params, context.get());
+        graph = transform<PrefetchScale>(graph, params, context.get());
+
+        auto findLoop = [&](std::string const& name) {
+            auto const rootTag = graph.control.roots().only().value();
+            for(auto const loop :
+                filter(graph.control.isElemType<ForLoopOp>(),
+                       graph.control.depthFirstVisit(rootTag)))
+            {
+                auto forloop = graph.control.get<ForLoopOp>(loop).value();
+                if(forloop.loopName == name)
+                    return loop;
+            }
+            FAIL("Loop '" + name + "' not found");
+            return -1;
+        };
+
+        int kLoopTag = findLoop(KLOOP);
+
+        SECTION("Exchange nodes are placed inside the K loop body")
+        {
+            auto isExchange = graph.control.isElemType<Exchange>();
+
+            int exchangesInKLoop  = 0;
+            int exchangesOutsideK = 0;
+            int totalExchanges    = 0;
+
+            std::optional<int> kLoopTailTag;
+            for(auto const loop :
+                filter(graph.control.isElemType<ForLoopOp>(),
+                       graph.control.depthFirstVisit(
+                           graph.control.roots().only().value())))
+            {
+                auto forloop = graph.control.get<ForLoopOp>(loop).value();
+                if(forloop.loopName == KLOOPTAIL)
+                    kLoopTailTag = loop;
+            }
+
+            for(auto exchangeTag : graph.control.getNodes().filter(isExchange))
+            {
+                totalExchanges++;
+                auto stack = controlStack(exchangeTag, graph);
+                bool insideKLoop
+                    = std::find(stack.begin(), stack.end(), kLoopTag) != stack.end();
+                bool insideKLoopTail
+                    = kLoopTailTag
+                      && std::find(stack.begin(), stack.end(), *kLoopTailTag)
+                             != stack.end();
+                if(insideKLoop && !insideKLoopTail)
+                    exchangesInKLoop++;
+                else
+                    exchangesOutsideK++;
+            }
+
+            INFO("totalExchanges=" << totalExchanges
+                 << " inKLoopBody=" << exchangesInKLoop
+                 << " outsideKBody=" << exchangesOutsideK);
+            REQUIRE(totalExchanges > 0);
+
+            // With prefetchScale and StreamK, the K loop body must contain
+            // Exchange nodes for subiters. A prior bug in
+            // DeterminePrefetchPositions caused it to place all
+            // exchanges in the pre-loop instead of the K loop body.
+            CHECK(exchangesInKLoop > 0);
+
+            // The K loop body should have more exchanges than outside
+            // (pre-loop + tail), because it processes all subiters each iteration.
+            CHECK(exchangesInKLoop >= exchangesOutsideK);
+        }
+    }
+}

--- a/shared/rocroller/test/catch/PrefetchScaleTest.cpp
+++ b/shared/rocroller/test/catch/PrefetchScaleTest.cpp
@@ -23,8 +23,7 @@ namespace PrefetchScaleTest
         using namespace rocRoller::KernelGraph::CoordinateGraph;
         using namespace rocRoller::Operations;
 
-        auto context
-            = TestContext::ForTarget(GPUArchitectureTarget{GPUArchitectureGFX::GFX950});
+        auto context = TestContext::ForTarget(GPUArchitectureTarget{GPUArchitectureGFX::GFX950});
         auto example = rocRollerTest::Graphs::GEMM(DataType::FP4, DataType::FP4, DataType::Half);
 
         example.setTileSize(128, 128, 256);
@@ -59,13 +58,12 @@ namespace PrefetchScaleTest
         {
             auto numWGsArg = findArgumentByName(command, NUMWGS);
             REQUIRE(numWGsArg != nullptr);
-            graph = transform<AddStreamK>(
-                graph,
-                context.get(),
-                params,
-                XLOOP,
-                KLOOP,
-                std::make_shared<Expression::Expression>(numWGsArg));
+            graph = transform<AddStreamK>(graph,
+                                          context.get(),
+                                          params,
+                                          XLOOP,
+                                          KLOOP,
+                                          std::make_shared<Expression::Expression>(numWGsArg));
         }
 
         graph = transform<ConnectWorkgroups>(graph, context.get());
@@ -83,9 +81,8 @@ namespace PrefetchScaleTest
 
         auto findLoop = [&](std::string const& name) {
             auto const rootTag = graph.control.roots().only().value();
-            for(auto const loop :
-                filter(graph.control.isElemType<ForLoopOp>(),
-                       graph.control.depthFirstVisit(rootTag)))
+            for(auto const loop : filter(graph.control.isElemType<ForLoopOp>(),
+                                         graph.control.depthFirstVisit(rootTag)))
             {
                 auto forloop = graph.control.get<ForLoopOp>(loop).value();
                 if(forloop.loopName == name)
@@ -108,8 +105,7 @@ namespace PrefetchScaleTest
             std::optional<int> kLoopTailTag;
             for(auto const loop :
                 filter(graph.control.isElemType<ForLoopOp>(),
-                       graph.control.depthFirstVisit(
-                           graph.control.roots().only().value())))
+                       graph.control.depthFirstVisit(graph.control.roots().only().value())))
             {
                 auto forloop = graph.control.get<ForLoopOp>(loop).value();
                 if(forloop.loopName == KLOOPTAIL)
@@ -119,22 +115,19 @@ namespace PrefetchScaleTest
             for(auto exchangeTag : graph.control.getNodes().filter(isExchange))
             {
                 totalExchanges++;
-                auto stack = controlStack(exchangeTag, graph);
-                bool insideKLoop
-                    = std::find(stack.begin(), stack.end(), kLoopTag) != stack.end();
+                auto stack       = controlStack(exchangeTag, graph);
+                bool insideKLoop = std::find(stack.begin(), stack.end(), kLoopTag) != stack.end();
                 bool insideKLoopTail
                     = kLoopTailTag
-                      && std::find(stack.begin(), stack.end(), *kLoopTailTag)
-                             != stack.end();
+                      && std::find(stack.begin(), stack.end(), *kLoopTailTag) != stack.end();
                 if(insideKLoop && !insideKLoopTail)
                     exchangesInKLoop++;
                 else
                     exchangesOutsideK++;
             }
 
-            INFO("totalExchanges=" << totalExchanges
-                 << " inKLoopBody=" << exchangesInKLoop
-                 << " outsideKBody=" << exchangesOutsideK);
+            INFO("totalExchanges=" << totalExchanges << " inKLoopBody=" << exchangesInKLoop
+                                   << " outsideKBody=" << exchangesOutsideK);
             REQUIRE(totalExchanges > 0);
 
             // With prefetchScale and StreamK, the K loop body must contain


### PR DESCRIPTION
## Motivation

Depends on #4637.

DeterminePrefetchPositions used `findContainingOperation<ForLoopOp>` to detect the transition from pre-loop to K loop. With StreamK, the pre-loop is contained by another ForLoop s, so pre-loop loads were misidentified as being inside the K loop. This caused exchangePosition to reference pre-loop nodes for all subiters, placing 16 Exchange nodes in the pre-loop and only 4 (duplicates for subiter 0) in the K loop body. The imbalance triggered WaitcntObserver errors at loop boundaries because prefetch loads were drained too early.

## Technical Details

Ensure that DeterminePrefetchPositions only consider loads strictly inside the K loop and not in any other parent loop.

## Test Plan & Result

Add PrefetchScaleTest to verify Exchange node placement with StreamK+ prefetchScale + swizzleScale on gfx950.
Also adds the full `fp4_kernels_wgm_streamk` test suite, as some tests would fail before the fix in this PR.

All other existing tests should pass.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
