### PR TITLE
Enabling multi stream support in hipblaslt test

### DIFF
--- a/projects/hipblaslt/clients/common/include/d_vector.hpp
+++ b/projects/hipblaslt/clients/common/include/d_vector.hpp
@@ -226,16 +226,19 @@ class memory_pool
 public:
     static M Get(size_t m_bytes, bool use_HMM = false)
     {
+        std::lock_guard<std::mutex> lock(Instance().m_mutex);
         return Instance().get(m_bytes, use_HMM);
     }
 
     static void Restore(M& dm)
     {
+        std::lock_guard<std::mutex> lock(Instance().m_mutex);
         Instance().restore(dm);
     }
 
 private:
     std::vector<M> m_pool, m_pool_managed;
+    std::mutex m_mutex;
 
     static memory_pool& Instance()
     {

--- a/projects/hipblaslt/clients/common/include/hipBuffer.hpp
+++ b/projects/hipblaslt/clients/common/include/hipBuffer.hpp
@@ -155,42 +155,22 @@ inline hipError_t synchronize(HipDeviceBuffer&    dBuf,
 {
     hipError_t hip_err;
 
-    if(stream != nullptr)
+    // Perform async copy for all blocks
+    for(size_t i_block = 0; i_block < block_count; i_block++)
     {
-        // Use stream-aware async copy for multi-threaded contexts
-        for(size_t i_block = 0; i_block < block_count; i_block++)
-        {
-            hip_err = hipMemcpyAsync(dBuf.as<char>() + i_block * dBuf.getNumBytes() / block_count,
-                                     hBuf.as<char>(),
-                                     dBuf.getNumBytes() / block_count,
-                                     dBuf.use_HMM ? hipMemcpyHostToHost : hipMemcpyHostToDevice,
-                                     stream);
+        hip_err = hipMemcpyAsync(dBuf.as<char>() + i_block * dBuf.getNumBytes() / block_count,
+                                 hBuf.as<char>(),
+                                 dBuf.getNumBytes() / block_count,
+                                 dBuf.use_HMM ? hipMemcpyHostToHost : hipMemcpyHostToDevice,
+                                 stream);
 
-            if(hip_err != hipSuccess)
-            {
-                return hip_err;
-            }
-        }
-        // Synchronize the stream to ensure copy is complete
-        return hipStreamSynchronize(stream);
-    }
-    else
-    {
-        // Original synchronous path
-        for(size_t i_block = 0; i_block < block_count; i_block++)
+        if(hip_err != hipSuccess)
         {
-            hip_err = hipMemcpy(dBuf.as<char>() + i_block * dBuf.getNumBytes() / block_count,
-                                hBuf.as<char>(),
-                                dBuf.getNumBytes() / block_count,
-                                dBuf.use_HMM ? hipMemcpyHostToHost : hipMemcpyHostToDevice);
-
-            if(hip_err != hipSuccess)
-            {
-                return hip_err;
-            }
+            return hip_err;
         }
-        return hip_err;
     }
+
+    return hipStreamSynchronize(stream);
 }
 
 inline hipError_t broadcast(HipDeviceBuffer& dBuf, std::size_t repeats)
@@ -225,58 +205,33 @@ inline hipError_t synchronize(HipHostBuffer&         hBuf,
         hipblaslt_cerr << "invalid values of lda in synchronize()" << std::endl;
     hipError_t hip_err;
 
-    if(stream != nullptr)
+    // Synchronize to ensure prior work is complete
+    hip_err = stream != nullptr ? hipStreamSynchronize(stream) : hipDeviceSynchronize();
+    if(hip_err != hipSuccess)
+        return hip_err;
+
+    if(!needSwizzle)
     {
-        // Use stream-aware async copy for multi-threaded contexts
-        // First synchronize stream to ensure prior work is complete
-        if(hipSuccess != (hip_err = hipStreamSynchronize(stream)))
+        hip_err = hipMemcpyAsync(
+            hBuf.as<char>(), dBuf.as<char>(), hBuf.getNumBytes(), hipMemcpyDeviceToHost, stream);
+        if(hip_err != hipSuccess)
             return hip_err;
-
-        if(!needSwizzle)
-        {
-            hip_err = hipMemcpyAsync(
-                hBuf.as<char>(), dBuf.as<char>(), hBuf.getNumBytes(), hipMemcpyDeviceToHost, stream);
-            if(hip_err != hipSuccess)
-                return hip_err;
-            return hipStreamSynchronize(stream);
-        }
-
-        for(size_t j = 0; j < batch * col; j++)
-        {
-            hip_err = hipMemcpyAsync(hBuf.as<char>() + (j * lda * elementSize),
-                                     dBuf.as<char>() + (j * row * elementSize),
-                                     row * elementSize,
-                                     hipMemcpyDeviceToHost,
-                                     stream);
-
-            if(hip_err != hipSuccess)
-                return hip_err;
-        }
-        return hipStreamSynchronize(stream);
+        return stream != nullptr ? hipStreamSynchronize(stream) : hipDeviceSynchronize();
     }
-    else
+
+    for(size_t j = 0; j < batch * col; j++)
     {
-        // Original synchronous path
-        if(hipSuccess != (hip_err = hipDeviceSynchronize()))
+        hip_err = hipMemcpyAsync(hBuf.as<char>() + (j * lda * elementSize),
+                                 dBuf.as<char>() + (j * row * elementSize),
+                                 row * elementSize,
+                                 hipMemcpyDeviceToHost,
+                                 stream);
+
+        if(hip_err != hipSuccess)
             return hip_err;
-
-        if(!needSwizzle)
-            return hipMemcpy(
-                hBuf.as<char>(), dBuf.as<char>(), hBuf.getNumBytes(), hipMemcpyDeviceToHost);
-
-        for(size_t j = 0; j < batch * col; j++)
-        {
-            hip_err = hipMemcpy(hBuf.as<char>() + (j * lda * elementSize),
-                                dBuf.as<char>() + (j * row * elementSize),
-                                row * elementSize,
-                                hipMemcpyDeviceToHost);
-
-            if(hip_err != hipSuccess)
-                return hip_err;
-        }
-
-        return hipSuccess;
     }
+
+    return hipStreamSynchronize(stream);
 }
 
 template <typename T1>

--- a/projects/hipblaslt/clients/common/include/hipBuffer.hpp
+++ b/projects/hipblaslt/clients/common/include/hipBuffer.hpp
@@ -148,23 +148,49 @@ private:
     h_memory buffer;
 };
 
-inline hipError_t
-    synchronize(HipDeviceBuffer& dBuf, const HipHostBuffer& hBuf, std::size_t block_count = 1)
+inline hipError_t synchronize(HipDeviceBuffer&    dBuf,
+                              const HipHostBuffer& hBuf,
+                              std::size_t          block_count = 1,
+                              hipStream_t          stream      = nullptr)
 {
     hipError_t hip_err;
-    for(size_t i_block = 0; i_block < block_count; i_block++)
-    {
-        hip_err = hipMemcpy(dBuf.as<char>() + i_block * dBuf.getNumBytes() / block_count,
-                            hBuf.as<char>(),
-                            dBuf.getNumBytes() / block_count,
-                            dBuf.use_HMM ? hipMemcpyHostToHost : hipMemcpyHostToDevice);
 
-        if(hip_err != hipSuccess)
+    if(stream != nullptr)
+    {
+        // Use stream-aware async copy for multi-threaded contexts
+        for(size_t i_block = 0; i_block < block_count; i_block++)
         {
-            return hip_err;
+            hip_err = hipMemcpyAsync(dBuf.as<char>() + i_block * dBuf.getNumBytes() / block_count,
+                                     hBuf.as<char>(),
+                                     dBuf.getNumBytes() / block_count,
+                                     dBuf.use_HMM ? hipMemcpyHostToHost : hipMemcpyHostToDevice,
+                                     stream);
+
+            if(hip_err != hipSuccess)
+            {
+                return hip_err;
+            }
         }
+        // Synchronize the stream to ensure copy is complete
+        return hipStreamSynchronize(stream);
     }
-    return hip_err;
+    else
+    {
+        // Original synchronous path
+        for(size_t i_block = 0; i_block < block_count; i_block++)
+        {
+            hip_err = hipMemcpy(dBuf.as<char>() + i_block * dBuf.getNumBytes() / block_count,
+                                hBuf.as<char>(),
+                                dBuf.getNumBytes() / block_count,
+                                dBuf.use_HMM ? hipMemcpyHostToHost : hipMemcpyHostToDevice);
+
+            if(hip_err != hipSuccess)
+            {
+                return hip_err;
+            }
+        }
+        return hip_err;
+    }
 }
 
 inline hipError_t broadcast(HipDeviceBuffer& dBuf, std::size_t repeats)
@@ -192,30 +218,65 @@ inline hipError_t synchronize(HipHostBuffer&         hBuf,
                               size_t                 col         = 0,
                               size_t                 lda         = 0,
                               size_t                 elementSize = 1,
-                              bool                   needSwizzle = false)
+                              bool                   needSwizzle = false,
+                              hipStream_t            stream      = nullptr)
 {
     if(row > lda)
         hipblaslt_cerr << "invalid values of lda in synchronize()" << std::endl;
     hipError_t hip_err;
-    if(hipSuccess != (hip_err = hipDeviceSynchronize()))
-        return hip_err;
 
-    if(!needSwizzle)
-        return hipMemcpy(
-            hBuf.as<char>(), dBuf.as<char>(), hBuf.getNumBytes(), hipMemcpyDeviceToHost);
-
-    for(size_t j = 0; j < batch * col; j++)
+    if(stream != nullptr)
     {
-        hip_err = hipMemcpy(hBuf.as<char>() + (j * lda * elementSize),
-                            dBuf.as<char>() + (j * row * elementSize),
-                            row * elementSize,
-                            hipMemcpyDeviceToHost);
-
-        if(hip_err != hipSuccess)
+        // Use stream-aware async copy for multi-threaded contexts
+        // First synchronize stream to ensure prior work is complete
+        if(hipSuccess != (hip_err = hipStreamSynchronize(stream)))
             return hip_err;
-    }
 
-    return hipSuccess;
+        if(!needSwizzle)
+        {
+            hip_err = hipMemcpyAsync(
+                hBuf.as<char>(), dBuf.as<char>(), hBuf.getNumBytes(), hipMemcpyDeviceToHost, stream);
+            if(hip_err != hipSuccess)
+                return hip_err;
+            return hipStreamSynchronize(stream);
+        }
+
+        for(size_t j = 0; j < batch * col; j++)
+        {
+            hip_err = hipMemcpyAsync(hBuf.as<char>() + (j * lda * elementSize),
+                                     dBuf.as<char>() + (j * row * elementSize),
+                                     row * elementSize,
+                                     hipMemcpyDeviceToHost,
+                                     stream);
+
+            if(hip_err != hipSuccess)
+                return hip_err;
+        }
+        return hipStreamSynchronize(stream);
+    }
+    else
+    {
+        // Original synchronous path
+        if(hipSuccess != (hip_err = hipDeviceSynchronize()))
+            return hip_err;
+
+        if(!needSwizzle)
+            return hipMemcpy(
+                hBuf.as<char>(), dBuf.as<char>(), hBuf.getNumBytes(), hipMemcpyDeviceToHost);
+
+        for(size_t j = 0; j < batch * col; j++)
+        {
+            hip_err = hipMemcpy(hBuf.as<char>() + (j * lda * elementSize),
+                                dBuf.as<char>() + (j * row * elementSize),
+                                row * elementSize,
+                                hipMemcpyDeviceToHost);
+
+            if(hip_err != hipSuccess)
+                return hip_err;
+        }
+
+        return hipSuccess;
+    }
 }
 
 template <typename T1>

--- a/projects/hipblaslt/clients/common/include/hipBuffer.hpp
+++ b/projects/hipblaslt/clients/common/include/hipBuffer.hpp
@@ -206,7 +206,7 @@ inline hipError_t synchronize(HipHostBuffer&         hBuf,
     hipError_t hip_err;
 
     // Synchronize to ensure prior work is complete
-    hip_err = stream != nullptr ? hipStreamSynchronize(stream) : hipDeviceSynchronize();
+    hip_err = hipStreamSynchronize(stream);
     if(hip_err != hipSuccess)
         return hip_err;
 
@@ -216,7 +216,7 @@ inline hipError_t synchronize(HipHostBuffer&         hBuf,
             hBuf.as<char>(), dBuf.as<char>(), hBuf.getNumBytes(), hipMemcpyDeviceToHost, stream);
         if(hip_err != hipSuccess)
             return hip_err;
-        return stream != nullptr ? hipStreamSynchronize(stream) : hipDeviceSynchronize();
+        return hipStreamSynchronize(stream);
     }
 
     for(size_t j = 0; j < batch * col; j++)

--- a/projects/hipblaslt/clients/common/include/testing_matmul.hpp
+++ b/projects/hipblaslt/clients/common/include/testing_matmul.hpp
@@ -833,7 +833,7 @@ void copy_gemm_to_host(hipStream_t                   stream,
     CHECK_HIP_ERROR(hipStreamSynchronize(stream));
     for(int gemmIdx = 0; gemmIdx < gemm_count; gemmIdx++)
     {
-        CHECK_HIP_ERROR(synchronize(hDst[gemmIdx], dSrc[gemmIdx]));
+        CHECK_HIP_ERROR(synchronize(hDst[gemmIdx], dSrc[gemmIdx], 0, 0, 0, 0, 1, false, stream));
     }
 }
 
@@ -876,16 +876,16 @@ void check(hipStream_t                   stream,
     {
         if(!arg.gradient && arg.use_e)
         {
-            CHECK_HIP_ERROR(synchronize(hE[gemmIdx], dE[gemmIdx]));
+            CHECK_HIP_ERROR(synchronize(hE[gemmIdx], dE[gemmIdx], 0, 0, 0, 0, 1, false, stream));
         }
 
         if(arg.amaxD)
         {
-            CHECK_HIP_ERROR(synchronize(hAmaxD[gemmIdx], dAmaxD[gemmIdx]));
+            CHECK_HIP_ERROR(synchronize(hAmaxD[gemmIdx], dAmaxD[gemmIdx], 0, 0, 0, 0, 1, false, stream));
         }
         if(arg.gradient && arg.bias_vector)
         {
-            CHECK_HIP_ERROR(synchronize(hBias[gemmIdx], dBias[gemmIdx]));
+            CHECK_HIP_ERROR(synchronize(hBias[gemmIdx], dBias[gemmIdx], 0, 0, 0, 0, 1, false, stream));
         }
         if(arg.unit_check)
         {
@@ -2040,7 +2040,8 @@ void testing_matmul_with_bias(const Arguments& arg,
                                         A_col[i],
                                         lda[i],
                                         realDataTypeSize(TiA),
-                                        do_swizzle_a));
+                                        do_swizzle_a,
+                                        stream));
             CHECK_HIP_ERROR(synchronize(hB[i],
                                         dB[i],
                                         num_batches[i],
@@ -2048,8 +2049,9 @@ void testing_matmul_with_bias(const Arguments& arg,
                                         B_col[i],
                                         ldb[i],
                                         realDataTypeSize(TiB),
-                                        do_swizzle_b));
-            CHECK_HIP_ERROR(synchronize(hC[i], dC[i]));
+                                        do_swizzle_b,
+                                        stream));
+            CHECK_HIP_ERROR(synchronize(hC[i], dC[i], 0, 0, 0, 0, 1, false, stream));
 
             if(arg.dump_matrix)
             {


### PR DESCRIPTION
## Motivation
https://amd-hub.atlassian.net/browse/AIHPBLAS-1431

## Technical Details

We were seeing `hipErrorInvalidValue` during synchronization. This was happening because 

1> `hipDeviceSynchronize()` synchronized ALL streams on the entire device, not just the current stream.

**Impact**:
- Thread 1 calling `hipDeviceSynchronize()` blocked Threads 2 and 3
- Race conditions when multiple threads accessed GPU simultaneously
- Invalid memory states during concurrent operations

2> Synchronous `hipMemcpy()` prevented proper stream isolation.

**Impact**:
- Memory copies blocked entire device instead of operating on specific streams
- Prevented true concurrent execution across threads

3> Singleton `memory_pool` class had NO mutex protection.

**Impact**:
- Multiple threads concurrently modified shared `std::vector<M> m_pool`
- Race conditions in `std::lower_bound()`, `erase()`, and `insert()`
- Corrupted pool state leading to assertion failures in `resize()`

### Implementation Strategy
- Add optional `stream` parameter to synchronization functions (default: `nullptr`)
- Use `hipStreamSynchronize(stream)` instead of `hipDeviceSynchronize()` when stream provided
- Use `hipMemcpyAsync()` for stream-aware memory copies
- Protect memory pool with `std::mutex`

https://github.com/ROCm/rocm-libraries/commit/57d7c076c2698b371be02eb76fe55dee11207ac0

## Test Plan
Ttried all multi-stream test
Tried all test present in hipblaslt-test

## Test Result

```
[ RUN      ] _/matmul_test.matmul/nightly_matmul_multithread_stream_f64_rf64_rf64_rf64_rf64_r_TT_128_128_64_1_128_128_1_128_128_1_t2
[       OK ] _/matmul_test.matmul/nightly_matmul_multithread_stream_f64_rf64_rf64_rf64_rf64_r_TT_128_128_64_1_128_128_1_128_128_1_t2 (55 ms)
[----------] 384 tests from _/matmul_test (32078 ms total)

[----------] Global test environment tear-down
[==========] 384 tests from 1 test suite ran. (32089 ms total)
[  PASSED  ] 384 tests.
hipBLASLt version: 100202
hipBLASLt git version: 57d7c076c2
```
Also tried complete list of test and it's working fine

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
