### PR TITLE
[hipSPARSELt] Enable "--keep-build-tmp" to dump the .s files when building hipSPARSELt via install.sh

### DIFF
--- a/projects/hipsparselt/install.sh
+++ b/projects/hipsparselt/install.sh
@@ -681,6 +681,10 @@ pushd .
     tensile_opt="${tensile_opt} -DHIPSPARSELT_ENABLE_MARKER=OFF"
   fi
 
+  if [[ "${keep_build_tmp}" == true ]]; then
+    tensile_opt="${tensile_opt} -DTENSILELITE_KEEP_BUILD_TMP=ON"
+  fi
+
   echo $cmake_common_options
   cmake_common_options="${cmake_common_options} ${tensile_opt}"
 


### PR DESCRIPTION
## Motivation
Used to dump the .s files.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
