### PR TITLE
[rocblas][hipblaslt] bugfix while querying grouped gemm solutions on hipblaslt

### DIFF
--- a/projects/rocblas/library/src/hipblaslt_host.cpp
+++ b/projects/rocblas/library/src/hipblaslt_host.cpp
@@ -423,7 +423,7 @@ rocblas_status runContractionProblemHipBlasLT(const RocblasContractionProblem<Ti
     bool solution_query = algo == rocblas_gemm_algo_solution_index
                           && prob.flags & rocblas_gemm_flags_check_solution_index;
 
-    if(prob.batch_A == 0)
+    if(prob.strided_batch)
     {
         auto gemm = ConstructHipBlasLTGemm(prob);
 
@@ -565,7 +565,7 @@ rocblas_status getAllSolutionsHipBlasLT(const RocblasContractionProblem<Ti, To, 
             std::vector<hipblasLtMatmulHeuristicResult_t> heuristicResults;
             std::vector<hipblasOperation_t> ops = {HIPBLAS_OP_N, HIPBLAS_OP_T, HIPBLAS_OP_C};
             hipblaslt_ext::GemmType         gemmType
-                = prob.batch_A == 0 ? hipblaslt_ext::GemmType::HIPBLASLT_GEMM
+                = prob.strided_batch ? hipblaslt_ext::GemmType::HIPBLASLT_GEMM
                                     : hipblaslt_ext::GemmType::HIPBLASLT_GROUPED_GEMM;
             for(auto op1 : ops)
             {
@@ -625,7 +625,7 @@ rocblas_status getAllSolutionsHipBlasLT(const RocblasContractionProblem<Ti, To, 
         else if(option == CAN_SOLVE)
         {
             hipblaslt_ext::GemmType gemmType
-                = prob.batch_A == 0 ? hipblaslt_ext::GemmType::HIPBLASLT_GEMM
+                = prob.strided_batch ? hipblaslt_ext::GemmType::HIPBLASLT_GEMM
                                     : hipblaslt_ext::GemmType::HIPBLASLT_GROUPED_GEMM;
             std::vector<hipblasLtMatmulHeuristicResult_t> heuristicResults;
             auto                                          fetch = hipblaslt_ext::getAllAlgos(handle,
@@ -641,7 +641,7 @@ rocblas_status getAllSolutionsHipBlasLT(const RocblasContractionProblem<Ti, To, 
 
             std::shared_ptr<hipblaslt_ext::GemmInstance> gemm;
 
-            if(prob.batch_A == 0)
+            if(prob.strided_batch)
             {
                 gemm = std::make_shared<hipblaslt_ext::GemmInstance>(ConstructHipBlasLTGemm(prob));
             }

--- a/projects/rocblas/library/src/hipblaslt_host.cpp
+++ b/projects/rocblas/library/src/hipblaslt_host.cpp
@@ -566,7 +566,7 @@ rocblas_status getAllSolutionsHipBlasLT(const RocblasContractionProblem<Ti, To, 
             std::vector<hipblasOperation_t> ops = {HIPBLAS_OP_N, HIPBLAS_OP_T, HIPBLAS_OP_C};
             hipblaslt_ext::GemmType         gemmType
                 = prob.strided_batch ? hipblaslt_ext::GemmType::HIPBLASLT_GEMM
-                                    : hipblaslt_ext::GemmType::HIPBLASLT_GROUPED_GEMM;
+                                     : hipblaslt_ext::GemmType::HIPBLASLT_GROUPED_GEMM;
             for(auto op1 : ops)
             {
                 for(auto op2 : ops)
@@ -626,7 +626,7 @@ rocblas_status getAllSolutionsHipBlasLT(const RocblasContractionProblem<Ti, To, 
         {
             hipblaslt_ext::GemmType gemmType
                 = prob.strided_batch ? hipblaslt_ext::GemmType::HIPBLASLT_GEMM
-                                    : hipblaslt_ext::GemmType::HIPBLASLT_GROUPED_GEMM;
+                                     : hipblaslt_ext::GemmType::HIPBLASLT_GROUPED_GEMM;
             std::vector<hipblasLtMatmulHeuristicResult_t> heuristicResults;
             auto                                          fetch = hipblaslt_ext::getAllAlgos(handle,
                                                     gemmType,

--- a/projects/rocblas/library/src/tensile_host.cpp
+++ b/projects/rocblas/library/src/tensile_host.cpp
@@ -1178,7 +1178,7 @@ bool useHipBLASLt(const RocblasContractionProblem<Ti, To, Tc>& prob)
         }
     }
 
-    bool batched = prob.batch_A != nullptr;
+    bool batched = !prob.strided_batch;
     return prob.handle->tryHipBLASLt(batched);
 #else
     return false;


### PR DESCRIPTION
## Motivation

The bug: 

1. In hipblaslt_host.cpp, lines 426, 568, 628, and 644 all use prob.batch_A == 0 to decide between GEMM and GroupedGemm. But when get_solutions is called for a batched GEMM (grouped GEMM), the data pointers are nullptr, making batch_A == 0 true even though it's a batched (grouped GEMM) problem. 
2. And line 1181 in tensile_host.cpp has the same issue in useHipBLASLt().


## Technical Details

The RocblasContractionProblem already has the correct information via the strided_batch field:

strided_batch == false → pointer-to-pointer batched → should use HIPBLASLT_GROUPED_GEMM
strided_batch == true → strided batched or non-batched → should use HIPBLASLT_GEMM

The fix is to replace prob.batch_A == 0 with prob.strided_batch (or !prob.strided_batch for the grouped case) in all these locations. The condition !prob.strided_batch is equivalent to "this is a pointer-to-pointer batched GEMM" regardless of whether data pointers are null.

## Test Plan

./build/clients/staging/rocblas-test --gtest_output=xml --gtest_color=yes --gtest_filter=*_/gemm_batched_ex.blas3_tensile/pre_checkin_gemm_ex_get_solutions_custom_bf16_rbf16_rbf16_rbf16_rf32_r_NT_16_16_1_1_16_16_1_16_16_2*

## Test Result

The above command passed on gfx942 (you need to explicitly set ROCBLAS_USE_HIPBLASLT=1, otherwise tensile kernels of rocblas itself would be used. )
The previous failure was gone on MI350x(gfx950) by skipping the above kernel. 

## Still pending question

Why were there no errors on MI355x ?
https://math-ci.amd.com/blue/organizations/jenkins/rocm-libraries%2Fprecheckin%2Frocblas/detail/develop/392/pipeline 

The reason may be on MI355X, the algo indices that hipBLASLt returns for non-grouped GEMM happen to also be valid for grouped GEMM on that specific hardware. The isAlgoSupported check in hipBlasLTInit passes for both GEMM types on MI355X.