### PR TITLE
[hipsparselt] Fix numSplitMetadata logic

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
@@ -653,32 +653,7 @@ class LocalReadMFMA(LocalRead):
             useDirect32XEmulation = writer.states.a.useDirect32XEmulationThis if tc == "A" else writer.states.b.useDirect32XEmulationThis
         indexTranpose = lrvwTile > 1 and (not useTransposeCode)
 
-        # Change the logic of numSplitMetadata:
-        # Without Cap: numSplitMetadata = max(ceil((blockWidth * 4) // tP["bpeDS"]) - 1, 0) if tP["isM"] else 0
-        # 2nd formula: numSplitMetadata = max(ceil((blockWidth * 4) // (kernel["MIInputPerThread%s"%tc] * tP["bpeDS"])) - 1, 0) if tP["isM"] else 0
-        # With Cap as below is based on the following consideration:
-        # Compare:
-        # lrvwTile  MIInputPerThread    w/ cap             2nd          w/o cap
-        # Metadata      Metadata     numSplitMetadata     ditto         ditto
-        # --------  ----------------  -------------  --------------  -------------
-        #    1            2                0               0              0
-        #    1            4                0               0              0
-        #    2            2                1               0(X)           1
-        #    2            4                1               0(X)           1
-        #    4            2                3               1(X)           3
-        #    4            4                3               0(X)           3
-        #    8            2                3               3              7(->3, otherwise we need 8 registers for 4 elements which is more than 4 registers we have for metadata)
-        #    8            4                3               1              7(->3, ditto)
-        
         numSplitMetadata = max(ceil((blockWidth * 4) // tP["bpeDS"]) - 1, 0) if tP["isM"] else 0
-        # Cap numSplitMetadata to the number of available PackKForMV sgprs
-        if tP["isM"] and numSplitMetadata > 0:
-            if lrvwTile > 2:
-                numSplitMetadata = min(numSplitMetadata, 3)  # PackKForMV0-MV3
-            elif lrvwTile > 1:
-                numSplitMetadata = min(numSplitMetadata, 1)  # PackKForMV0-MV1
-            else:
-                numSplitMetadata = 0
 
         # caculate SMFMA layout
         blocksPerTGroupSMFMA = 1
@@ -1053,6 +1028,8 @@ class LocalReadMFMA(LocalRead):
                                                     vgprOffset = 0
                                                     for rIdx_ in range(0, numReadsPerUnroll*miInputGroup):
                                                         for elementIdx in range(0, numSplitMetadata+1):
+                                                            if elementIdx >= writer.states.bpr:
+                                                                break
                                                             # since the number of input thread is 4, so will alwasy be D0, D1, D2, D3
                                                             packCodeT.add(VPermB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx+elementIdx)), \
                                                                             src0=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, 1, i+vIdx*numVgpr)), \
@@ -1073,6 +1050,8 @@ class LocalReadMFMA(LocalRead):
                                                     vgprOffset = 0
                                                     for rIdx_ in range(0, numReadsPerUnroll*miInputGroup):
                                                         for elementIdx in range(0, numSplitMetadata+1):
+                                                            if elementIdx >= writer.states.bpr:
+                                                                break
                                                             # since the number of input thread is 2, so will alwasy be D0 and D1
                                                             packCodeT.add(VPermB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx+elementIdx)), \
                                                                                     src0=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, 1, i+vIdx*numVgpr)), \
@@ -1084,6 +1063,8 @@ class LocalReadMFMA(LocalRead):
                                                     vgprIdx_ = vgprIdx+vIdx*(numSplitMetadata+1)
                                                     packCodeT.add(VMovB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx_)), src=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, 0, i+vIdx*numVgpr))))
                                                     for elementIdx in range(1, numSplitMetadata+1):
+                                                        if elementIdx >= writer.states.bpr:
+                                                            break
                                                         packCodeT.add(VMovB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx_ + elementIdx)), src=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, 0, i+vIdx*numVgpr)), \
                                                                             comment="another VGPR storing lshr 8-bit value %d %d" %(vgprIdx, elementIdx)))
                                                         packCodeT.add(VLShiftRightB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx_+elementIdx)), \

--- a/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
@@ -653,10 +653,32 @@ class LocalReadMFMA(LocalRead):
             useDirect32XEmulation = writer.states.a.useDirect32XEmulationThis if tc == "A" else writer.states.b.useDirect32XEmulationThis
         indexTranpose = lrvwTile > 1 and (not useTransposeCode)
 
-        # split Metadata when localread width > mi input
-        #TODO:
-        #numSplitMetadata = max(ceil((blockWidth * 4) // tP["bpeDS"]) - 1, 0) if tP["isM"] else 0
-        numSplitMetadata = max(ceil((blockWidth * 4) // (kernel["MIInputPerThread%s"%tc] * tP["bpeDS"])) - 1, 0) if tP["isM"] else 0
+        # Change the logic of numSplitMetadata:
+        # Without Cap: numSplitMetadata = max(ceil((blockWidth * 4) // tP["bpeDS"]) - 1, 0) if tP["isM"] else 0
+        # 2nd formula: numSplitMetadata = max(ceil((blockWidth * 4) // (kernel["MIInputPerThread%s"%tc] * tP["bpeDS"])) - 1, 0) if tP["isM"] else 0
+        # With Cap as below is based on the following consideration:
+        # Compare:
+        # lrvwTile  MIInputPerThread    w/ cap             2nd          w/o cap
+        # Metadata      Metadata     numSplitMetadata     ditto         ditto
+        # --------  ----------------  -------------  --------------  -------------
+        #    1            2                0               0              0
+        #    1            4                0               0              0
+        #    2            2                1               0(X)           1
+        #    2            4                1               0(X)           1
+        #    4            2                3               1(X)           3
+        #    4            4                3               0(X)           3
+        #    8            2                3               3              7(->3, otherwise we need 8 registers for 4 elements which is more than 4 registers we have for metadata)
+        #    8            4                3               1              7(->3, ditto)
+        
+        numSplitMetadata = max(ceil((blockWidth * 4) // tP["bpeDS"]) - 1, 0) if tP["isM"] else 0
+        # Cap numSplitMetadata to the number of available PackKForMV sgprs
+        if tP["isM"] and numSplitMetadata > 0:
+            if lrvwTile > 2:
+                numSplitMetadata = min(numSplitMetadata, 3)  # PackKForMV0-MV3
+            elif lrvwTile > 1:
+                numSplitMetadata = min(numSplitMetadata, 1)  # PackKForMV0-MV1
+            else:
+                numSplitMetadata = 0
 
         # caculate SMFMA layout
         blocksPerTGroupSMFMA = 1


### PR DESCRIPTION
## Motivation

- hipsparselt-test failed a lots: https://math-ci.amd.com/job/rocm-libraries/job/precheckin/job/hipsparselt/job/PR-5202/26/pipeline-overview/?selected-node=624
- Fix numSplitMetadata logic

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

- Change the numSplitMetadata logic the same as develop branch


<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<img width="1150" height="224" alt="image" src="https://github.com/user-attachments/assets/d3fd68a1-b0d0-422b-a419-183cabb2bf50" />

Note that I only count the common failed test between my local and CI.

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
