### PR TITLE
[hipblaslt] Emit ROCTX markers around GEMM kernel launches

### DIFF
--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -791,7 +791,6 @@ namespace
         if(rocblaslt::Debug::Instance().printLogAsMarker())
         {
             rocblaslt::Debug::Instance().logMarkerStart(s.c_str());
-            rocblaslt::Debug::Instance().logMarkerStop();
         }
         if(rocblaslt::Debug::Instance().benchPrintCommand())
         {
@@ -1138,7 +1137,6 @@ namespace
         if(rocblaslt::Debug::Instance().printLogAsMarker())
         {
             rocblaslt::Debug::Instance().logMarkerStart(s.c_str());
-            rocblaslt::Debug::Instance().logMarkerStop();
         }
         if(rocblaslt::Debug::Instance().benchPrintCommand())
         {
@@ -2734,6 +2732,8 @@ rocblaslt_status runContractionProblem(rocblaslt_handle                   handle
             }
             status = hip2RocStatus(
                 adapter->launchKernels(kernels, prob.stream, nullptr, nullptr, isPreloaded));
+            if(rocblaslt::Debug::Instance().printLogAsMarker())
+                rocblaslt::Debug::Instance().logMarkerStop();
         }
     }
     catch(const std::exception& e)
@@ -3166,6 +3166,8 @@ rocblaslt_status runKernelFromInvocation(rocblaslt_handle       handle,
                                               true);
             }
             status = hip2RocStatus(adapter->launchKernels(data->kernels, stream, start, stop));
+            if(rocblaslt::Debug::Instance().printLogAsMarker())
+                rocblaslt::Debug::Instance().logMarkerStop();
         }
         else if(gemmType == rocblaslt::RocGemmType::ROCBLASLT_GROUPED_GEMM)
         {
@@ -3218,6 +3220,8 @@ rocblaslt_status runKernelFromInvocation(rocblaslt_handle       handle,
             }
 
             status = hip2RocStatus(adapter->launchKernels(data->kernels, stream, start, stop));
+            if(rocblaslt::Debug::Instance().printLogAsMarker())
+                rocblaslt::Debug::Instance().logMarkerStop();
         }
         else
         {
@@ -3399,6 +3403,8 @@ rocblaslt_status runKernelFromNewDeviceUserArguments(rocblaslt_handle       hand
                 }
             }
             status = hip2RocStatus(adapter->launchKernels(data->kernels, stream, nullptr, nullptr));
+            if(rocblaslt::Debug::Instance().printLogAsMarker())
+                rocblaslt::Debug::Instance().logMarkerStop();
         }
         else
         {


### PR DESCRIPTION
## Motivation

`HIPBLASLT_ENABLE_MARKER=2` emits ROCTX markers with detailed GEMM info (shapes, types, solution index). Previously, both `logMarkerStart` and `logMarkerStop` were called back-to-back inside `logBenchFromTensileDataGemm`, *before* the kernel launch. This produced zero-duration markers that were invisible in profiler timelines and disconnected from GPU kernel execution.

## Summary

This PR moves `logMarkerStop()` (roctxRangePop) from inside `logBenchFromTensileDataGemm` to after the actual `adapter->launchKernels()` calls, so the ROCTX marker spans the kernel launch instead of being zero-duration.