### PR TITLE
Fix brief doc comment on hipblasLtMatmul

### DIFF
--- a/projects/hipblaslt/library/include/hipblaslt/hipblaslt.h
+++ b/projects/hipblaslt/library/include/hipblaslt/hipblaslt.h
@@ -837,7 +837,7 @@ hipblasStatus_t
                                     int*                             returnAlgoCount);
 
 /*! \ingroup library_module
- *  \brief Retrieve the possible algorithms.
+ *  \brief Compute a matrix multiplication on the described inputs.
  *
  *  \details
  *  This function computes the matrix multiplication of matrices A and B to


### PR DESCRIPTION
- Fix an apparent copy/paste error for the brief comment on `hipblasLtMatmul`

- `hipblasLtMatmul` has the comment "Retrieve the possible algorithms" which is actually a duplicate comment for `hipblasLtMatmulAlgoGetHeuristic`

- Replace with a brief comment about performing a matrix multiplication.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
