### PR TITLE
[HipDNN]: Fix 11 findings from comprehensive code review of the hipdnn project

### DIFF
--- a/dnn-providers/integration-tests/src/harness/TestConfig.hpp
+++ b/dnn-providers/integration-tests/src/harness/TestConfig.hpp
@@ -5,6 +5,7 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <hipdnn_data_sdk/utilities/EngineNames.hpp>
 #include <map>

--- a/dnn-providers/miopen-provider/CMakeLists.txt
+++ b/dnn-providers/miopen-provider/CMakeLists.txt
@@ -169,6 +169,7 @@ add_library(
 target_include_directories(miopen_plugin_impl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(miopen_plugin_impl PUBLIC MIOpen hipdnn_data_sdk hipdnn_plugin_sdk)
 
+target_compile_definitions(miopen_plugin_impl PUBLIC MIOPEN_BETA_API)
 target_compile_options(miopen_plugin_impl PRIVATE ${MIOPENPROVIDER_WARNING_COMPILE_OPTIONS})
 set_target_properties(miopen_plugin_impl PROPERTIES
     CXX_VISIBILITY_PRESET hidden

--- a/dnn-providers/miopen-provider/HipdnnMiopenHandle.hpp
+++ b/dnn-providers/miopen-provider/HipdnnMiopenHandle.hpp
@@ -32,6 +32,11 @@ class MiopenContainer;
 struct HipdnnMiopenHandle : HipdnnEnginePluginHandle
 {
 public:
+    HipdnnMiopenHandle(const HipdnnMiopenHandle&) = delete;
+    HipdnnMiopenHandle& operator=(const HipdnnMiopenHandle&) = delete;
+    HipdnnMiopenHandle(HipdnnMiopenHandle&&) = delete;
+    HipdnnMiopenHandle& operator=(HipdnnMiopenHandle&&) = delete;
+
     HipdnnMiopenHandle()
     {
         miopenStatus_t status = miopenCreate(&miopenHandle);

--- a/dnn-providers/miopen-provider/MiopenTensor.cpp
+++ b/dnn-providers/miopen-provider/MiopenTensor.cpp
@@ -4,6 +4,7 @@
 #include "MiopenTensor.hpp"
 #include "MiopenUtils.hpp"
 #include <hipdnn_plugin_sdk/PluginException.hpp>
+#include <limits>
 
 namespace miopen_plugin
 {
@@ -19,8 +20,35 @@ MiopenTensor::MiopenTensor(const hipdnn_data_sdk::data_objects::TensorAttributes
     PLUGIN_THROW_IF_NULL(tensor.strides(),
                          HIPDNN_PLUGIN_STATUS_BAD_PARAM,
                          "Tensor strides pointer is null for tensor UID: " + std::to_string(_uid));
-    std::vector<int> dims(tensor.dims()->begin(), tensor.dims()->end());
-    std::vector<int> strides(tensor.strides()->begin(), tensor.strides()->end());
+
+    // Validate dimensions and strides fit in int (MIOpen uses int for these values)
+    std::vector<int> dims;
+    dims.reserve(tensor.dims()->size());
+    for(auto d : *tensor.dims())
+    {
+        if(d > std::numeric_limits<int>::max() || d < std::numeric_limits<int>::min())
+        {
+            throw hipdnn_plugin_sdk::HipdnnPluginException(
+                HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                "Tensor dimension value " + std::to_string(d)
+                    + " exceeds int range for tensor UID: " + std::to_string(_uid));
+        }
+        dims.push_back(static_cast<int>(d));
+    }
+
+    std::vector<int> strides;
+    strides.reserve(tensor.strides()->size());
+    for(auto s : *tensor.strides())
+    {
+        if(s > std::numeric_limits<int>::max() || s < std::numeric_limits<int>::min())
+        {
+            throw hipdnn_plugin_sdk::HipdnnPluginException(
+                HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                "Tensor stride value " + std::to_string(s)
+                    + " exceeds int range for tensor UID: " + std::to_string(_uid));
+        }
+        strides.push_back(static_cast<int>(s));
+    }
     THROW_ON_MIOPEN_FAILURE(
         miopenSetTensorDescriptor(_descriptor,
                                   miopen_utils::tensorDataTypeToMiopenDataType(tensor.data_type()),

--- a/dnn-providers/miopen-provider/MiopenTensor.cpp
+++ b/dnn-providers/miopen-provider/MiopenTensor.cpp
@@ -21,40 +21,49 @@ MiopenTensor::MiopenTensor(const hipdnn_data_sdk::data_objects::TensorAttributes
                          HIPDNN_PLUGIN_STATUS_BAD_PARAM,
                          "Tensor strides pointer is null for tensor UID: " + std::to_string(_uid));
 
-    // Validate dimensions and strides fit in int (MIOpen uses int for these values)
-    std::vector<int> dims;
+    // Validate number of dimensions fits in int (miopenSetTensorDescriptorV2 nbDims parameter is int)
+    if(tensor.dims()->size() > static_cast<size_t>(std::numeric_limits<int>::max()))
+    {
+        throw hipdnn_plugin_sdk::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+            "Number of tensor dimensions (" + std::to_string(tensor.dims()->size())
+                + ") exceeds int range for tensor UID: " + std::to_string(_uid));
+    }
+
+    // Convert int64_t dims/strides to size_t for miopenSetTensorDescriptorV2
+    std::vector<size_t> dims;
     dims.reserve(tensor.dims()->size());
     for(auto d : *tensor.dims())
     {
-        if(d > std::numeric_limits<int>::max() || d < std::numeric_limits<int>::min())
+        if(d < 0)
         {
             throw hipdnn_plugin_sdk::HipdnnPluginException(
                 HIPDNN_PLUGIN_STATUS_BAD_PARAM,
-                "Tensor dimension value " + std::to_string(d)
-                    + " exceeds int range for tensor UID: " + std::to_string(_uid));
+                "Negative tensor dimension value " + std::to_string(d)
+                    + " for tensor UID: " + std::to_string(_uid));
         }
-        dims.push_back(static_cast<int>(d));
+        dims.push_back(static_cast<size_t>(d));
     }
 
-    std::vector<int> strides;
+    std::vector<size_t> strides;
     strides.reserve(tensor.strides()->size());
     for(auto s : *tensor.strides())
     {
-        if(s > std::numeric_limits<int>::max() || s < std::numeric_limits<int>::min())
+        if(s < 0)
         {
             throw hipdnn_plugin_sdk::HipdnnPluginException(
                 HIPDNN_PLUGIN_STATUS_BAD_PARAM,
-                "Tensor stride value " + std::to_string(s)
-                    + " exceeds int range for tensor UID: " + std::to_string(_uid));
+                "Negative tensor stride value " + std::to_string(s)
+                    + " for tensor UID: " + std::to_string(_uid));
         }
-        strides.push_back(static_cast<int>(s));
+        strides.push_back(static_cast<size_t>(s));
     }
-    THROW_ON_MIOPEN_FAILURE(
-        miopenSetTensorDescriptor(_descriptor,
-                                  miopen_utils::tensorDataTypeToMiopenDataType(tensor.data_type()),
-                                  static_cast<int>(dims.size()),
-                                  reinterpret_cast<int*>(dims.data()),
-                                  reinterpret_cast<int*>(strides.data())));
+    THROW_ON_MIOPEN_FAILURE(miopenSetTensorDescriptorV2(
+        _descriptor,
+        miopen_utils::tensorDataTypeToMiopenDataType(tensor.data_type()),
+        static_cast<int>(dims.size()),
+        dims.data(),
+        strides.data()));
 }
 
 MiopenTensor::MiopenTensor(MiopenTensor&& other) noexcept

--- a/projects/hipdnn/backend/src/PlatformUtils.windows.cpp
+++ b/projects/hipdnn/backend/src/PlatformUtils.windows.cpp
@@ -82,9 +82,10 @@ std::string getSystemInfo()
 {
     // Get Windows version using RtlGetVersion (more reliable than deprecated GetVersionEx)
     typedef LONG(WINAPI * RtlGetVersionPtr)(PRTL_OSVERSIONINFOW);
-    RTL_OSVERSIONINFOW versionInfo;
+    RTL_OSVERSIONINFOW versionInfo = {};
     versionInfo.dwOSVersionInfoSize = sizeof(versionInfo);
 
+    bool versionInfoValid = false;
     HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
     if(ntdll != nullptr)
     {
@@ -92,7 +93,7 @@ std::string getSystemInfo()
             = reinterpret_cast<RtlGetVersionPtr>(GetProcAddress(ntdll, "RtlGetVersion"));
         if(rtlGetVersion != nullptr)
         {
-            rtlGetVersion(&versionInfo);
+            versionInfoValid = (rtlGetVersion(&versionInfo) == 0);
         }
     }
 
@@ -124,13 +125,23 @@ std::string getSystemInfo()
         architecture = "Unknown";
     }
 
-    return fmt::format("System Information: {{System Name: Windows, Node Name: {}, Release: {}.{}, "
-                       "Version: {}, Machine: {}}}",
-                       computerName.data(),
-                       versionInfo.dwMajorVersion,
-                       versionInfo.dwMinorVersion,
-                       versionInfo.dwBuildNumber,
-                       architecture);
+    if(versionInfoValid)
+    {
+        return fmt::format(
+            "System Information: {{System Name: Windows, Node Name: {}, Release: {}.{}, "
+            "Version: {}, Machine: {}}}",
+            computerName.data(),
+            versionInfo.dwMajorVersion,
+            versionInfo.dwMinorVersion,
+            versionInfo.dwBuildNumber,
+            architecture);
+    }
+
+    return fmt::format(
+        "System Information: {{System Name: Windows, Node Name: {}, Release: unknown, "
+        "Version: unknown, Machine: {}}}",
+        computerName.data(),
+        architecture);
 }
 
 }

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/EngineNames.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/EngineNames.hpp
@@ -105,20 +105,27 @@ struct EngineRegistrar
 {
     EngineRegistrar(std::string_view name)
     {
-        detail::getMutableEngineNames().insert(name);
         auto id = engineNameToId(name);
-        detail::getMutableEngineIdToNameMap()[id] = name;
 
-        // Check for collisions
-        for(const auto& [existingId, existingName] : getEngineIdToNameMap())
+        // Check for duplicate registration or hash collision BEFORE inserting
+        auto& idToNameMap = detail::getMutableEngineIdToNameMap();
+        auto it = idToNameMap.find(id);
+        if(it != idToNameMap.end())
         {
-            if(existingId == id && existingName != name)
+            if(it->second == name)
             {
-                throw std::runtime_error("Engine name collision detected! '"
-                                         + std::string(existingName) + "' and '" + std::string(name)
-                                         + "' both hash to ID: " + formatEngineIdHex(id));
+                throw std::runtime_error("Duplicate engine registration detected! '"
+                                         + std::string(name) + "' is already registered with ID: "
+                                         + formatEngineIdHex(id));
             }
+
+            throw std::runtime_error("Engine name collision detected! '" + std::string(it->second)
+                                     + "' and '" + std::string(name)
+                                     + "' both hash to ID: " + formatEngineIdHex(id));
         }
+
+        detail::getMutableEngineNames().insert(name);
+        idToNameMap[id] = name;
     }
 };
 

--- a/projects/hipdnn/data_sdk/tests/utilities/TestEngineNames.cpp
+++ b/projects/hipdnn/data_sdk/tests/utilities/TestEngineNames.cpp
@@ -98,7 +98,8 @@ TEST_F(TestEngineNames, RegistrarSucceedsForNewUniqueName)
 
 TEST_F(TestEngineNames, RegistrarThrowsOnDuplicateName)
 {
-    // Registering an already-registered engine name should throw
+    // These names are already in the map from HIPDNN_REGISTER_ENGINE static initialization.
+    // Re-registering should throw to catch accidental duplicate engine definitions.
     const std::string_view miopenName{MIOPEN_ENGINE_NAME};
     const std::string_view fusilliName{FUSILLI_ENGINE_NAME};
     EXPECT_THROW(EngineRegistrar{miopenName}, std::runtime_error);

--- a/projects/hipdnn/data_sdk/tests/utilities/TestEngineNames.cpp
+++ b/projects/hipdnn/data_sdk/tests/utilities/TestEngineNames.cpp
@@ -85,6 +85,42 @@ TEST_F(TestEngineNames, EngineCountMatches)
     }
 }
 
+TEST_F(TestEngineNames, RegistrarSucceedsForNewUniqueName)
+{
+    // Registering a brand-new unique engine name should not throw
+    EXPECT_NO_THROW(EngineRegistrar{"TEST_UNIQUE_ENGINE_FOR_REGISTRAR"});
+
+    // Verify it was registered
+    EXPECT_TRUE(isEngineNameRegistered("TEST_UNIQUE_ENGINE_FOR_REGISTRAR"));
+    auto id = engineNameToId("TEST_UNIQUE_ENGINE_FOR_REGISTRAR");
+    EXPECT_EQ(getEngineNameFromId(id), "TEST_UNIQUE_ENGINE_FOR_REGISTRAR");
+}
+
+TEST_F(TestEngineNames, RegistrarThrowsOnDuplicateName)
+{
+    // Registering an already-registered engine name should throw
+    const std::string_view miopenName{MIOPEN_ENGINE_NAME};
+    const std::string_view fusilliName{FUSILLI_ENGINE_NAME};
+    EXPECT_THROW(EngineRegistrar{miopenName}, std::runtime_error);
+    EXPECT_THROW(EngineRegistrar{fusilliName}, std::runtime_error);
+}
+
+TEST_F(TestEngineNames, RegistrarDetectsCollision)
+{
+    // Simulate a collision by inserting a fake entry into the ID map
+    // with the same ID that "COLLISION_TEST_ENGINE" would generate,
+    // but mapped to a different name
+    auto collisionId = engineNameToId("COLLISION_TEST_ENGINE");
+    detail::getMutableEngineIdToNameMap()[collisionId] = "SOME_OTHER_ENGINE";
+
+    // Now registering "COLLISION_TEST_ENGINE" should throw because the ID
+    // is already taken by "SOME_OTHER_ENGINE"
+    EXPECT_THROW(EngineRegistrar{"COLLISION_TEST_ENGINE"}, std::runtime_error);
+
+    // Clean up: remove the fake entry so other tests aren't affected
+    detail::getMutableEngineIdToNameMap().erase(collisionId);
+}
+
 TEST_F(TestEngineNames, EnsureAllEngineNameToIdsBehaveTheSame)
 {
     {

--- a/projects/hipdnn/docs/Design.md
+++ b/projects/hipdnn/docs/Design.md
@@ -284,4 +284,4 @@ hipdnnEnginePluginExecuteOpGraph(handle, context, workspace, buffers, num_buffer
 See [Plugin Development](./PluginDevelopment.md) for advanced information on developing and using plugins.
 
 ### Reference Implementation: CPU Graph Executor
-The CPU Graph Executor is a reference graph execution implementation build for graph verification and testing. See the [CPU Graph Executor Design Document](./CpuGraphExecutorDesign.md) for more details.
+The CPU Graph Executor is a reference graph execution implementation build for graph verification and testing. See the [CPU Graph Executor Design Document](./rfcs/0001_CpuGraphExecutorDesign.md) for more details.

--- a/projects/hipdnn/docs/OperationSupport-ReferenceImpl.md
+++ b/projects/hipdnn/docs/OperationSupport-ReferenceImpl.md
@@ -86,10 +86,10 @@ The following table lists all operations currently supported in the CPU Referenc
 
 ## Extension Guidelines
 
-For detailed information on adding new operations or datatypes to the CPU Reference Implementation, please refer to the [Extension Guidelines](./CpuGraphExecutorDesign.md#extension-guidelines) section in the CPU Graph Executor Design document.
+For detailed information on adding new operations or datatypes to the CPU Reference Implementation, please refer to the [Extension Guidelines](./rfcs/0001_CpuGraphExecutorDesign.md#extension-guidelines) section in the CPU Graph Executor Design document.
 
 ## Related Documentation
 
 - [hipDNN Operation Support](./OperationSupport.md) - Central hub for hipDNN operation support
-- [CPU Graph Executor Design](./CpuGraphExecutorDesign.md) - Detailed architecture documentation
+- [CPU Graph Executor Design](./rfcs/0001_CpuGraphExecutorDesign.md) - Detailed architecture documentation
 - [Testing Plan](./testing/TestPlan.md) - Testing strategy and procedures

--- a/projects/hipdnn/docs/PluginDevelopment.md
+++ b/projects/hipdnn/docs/PluginDevelopment.md
@@ -97,20 +97,20 @@ hipDNN uses a deterministic hash-based system for managing engine IDs. This syst
 ### Using Engine IDs
 
 ```cpp
-#include <hipdnn_plugin_sdk/EngineNames.hpp>
+#include <hipdnn_data_sdk/utilities/EngineNames.hpp>
 
 // Option 1: Use a registered engine ID
-const int64_t engineId = hipdnn_plugin_sdk::engine_names::MIOPEN_PLUGIN_ID;
+const int64_t engineId = hipdnn_data_sdk::utilities::MIOPEN_ENGINE_ID;
 
 // Option 2: Generate ID from custom name
-const int64_t customEngineId = hipdnn_data_sdk::engineNameToId("MY_CUSTOM_ENGINE");
+const int64_t customEngineId = hipdnn_data_sdk::utilities::engineNameToId("MY_CUSTOM_ENGINE");
 
 // In your engine implementation
 class MyEngine {
     int64_t _id;
 public:
     MyEngine(const char* engineName)
-        : _id(hipdnn_data_sdk::engineNameToId(engineName)) {
+        : _id(hipdnn_data_sdk::utilities::engineNameToId(engineName)) {
         // Engine is now initialized with a unique ID
     }
 };
@@ -139,7 +139,7 @@ To add your engine name to the official registry:
 - **Forward Compatible**: New engines can be used without registry updates
 
 > [!TIP]
-> 💡 The engine ID system ensures globally unique identifiers across all plugins. You can query registered engines using `hipdnn_plugin_sdk::engine_names::getAllEngineNames()` and check for name collisions using the provided test utilities.
+> 💡 The engine ID system ensures globally unique identifiers across all plugins. You can query registered engines using `hipdnn_data_sdk::utilities::getAllEngineNames()` and check for name collisions using the provided test utilities.
 
 
 ## Creating a Kernel Engine Plugin
@@ -163,7 +163,7 @@ Before creating a plugin, ensure you have **built and installed hipDNN**. Plugin
    - **Engine Manager**: Manages available engines and their capabilities
    - **Engine**: Implements graph execution for specific operations (each engine must have a globally unique `int64_t` ID)
    - **Execution Plans**: Define how operations are executed
-   - **Engine Name & ID**: Name your engine and place it in the [EngineNames](../plugin_sdk/include/hipdnn_plugin_sdk/EngineNames.hpp) registry
+   - **Engine Name & ID**: Name your engine and place it in the [EngineNames](../data_sdk/include/hipdnn_data_sdk/utilities/EngineNames.hpp) registry
 
 3. **Build and Deploy Plugin**
    - Configure CMake to build the plugin as a shared library

--- a/projects/hipdnn/docs/testing/TestingStrategy.md
+++ b/projects/hipdnn/docs/testing/TestingStrategy.md
@@ -128,7 +128,7 @@ Integration tests validate end-to-end functionality across components.
   - **Full** - These tests can contain regression shapes, large shapes, or slow shapes
 
 ### Graph Validation
-We use reference implementations via the CPU Graph Executor to validate correctness of graph execution in integration tests. See the [CPU Graph Executor Design Document](./CpuGraphExecutorDesign.md) for more details.
+We use reference implementations via the CPU Graph Executor to validate correctness of graph execution in integration tests. See the [CPU Graph Executor Design Document](../rfcs/0001_CpuGraphExecutorDesign.md) for more details.
 
 ---
 

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Error.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Error.hpp
@@ -50,10 +50,19 @@ enum class ErrorCode
 // NOLINTNEXTLINE(readability-identifier-naming)
 inline std::string to_string(ErrorCode code)
 {
-    static std::vector<std::string> s_errorCodes{
-        "OK", "INVALID_VALUE", "HIPDNN_BACKEND_ERROR", "ATTRIBUTE_NOT_SET"};
-
-    return s_errorCodes[static_cast<size_t>(code)];
+    switch(code)
+    {
+    case ErrorCode::OK:
+        return "OK";
+    case ErrorCode::INVALID_VALUE:
+        return "INVALID_VALUE";
+    case ErrorCode::HIPDNN_BACKEND_ERROR:
+        return "HIPDNN_BACKEND_ERROR";
+    case ErrorCode::ATTRIBUTE_NOT_SET:
+        return "ATTRIBUTE_NOT_SET";
+    default:
+        return "UNKNOWN_ERROR";
+    }
 }
 
 inline std::ostream& operator<<(std::ostream& os, const ErrorCode& error)

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/ConvolutionDgradAttributes.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/ConvolutionDgradAttributes.hpp
@@ -125,10 +125,10 @@ public:
      * @return Reference to this for method chaining
      */
     // NOLINTNEXTLINE(readability-identifier-naming)
-    ConvDgradAttributes& set_padding(std::vector<int64_t> padding)
+    ConvDgradAttributes& set_padding(const std::vector<int64_t>& padding)
     {
         set_pre_padding(padding);
-        set_post_padding(std::move(padding));
+        set_post_padding(padding);
         return *this;
     }
 

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/ConvolutionFpropAttributes.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/ConvolutionFpropAttributes.hpp
@@ -131,10 +131,10 @@ public:
      * @return Reference to this for method chaining
      */
     // NOLINTNEXTLINE(readability-identifier-naming)
-    ConvFpropAttributes& set_padding(std::vector<int64_t> padding)
+    ConvFpropAttributes& set_padding(const std::vector<int64_t>& padding)
     {
         pre_padding = padding;
-        post_padding = std::move(padding);
+        post_padding = padding;
         return *this;
     }
 

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/ConvolutionWgradAttributes.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/ConvolutionWgradAttributes.hpp
@@ -125,10 +125,10 @@ public:
      * @return Reference to this for method chaining
      */
     // NOLINTNEXTLINE(readability-identifier-naming)
-    ConvWgradAttributes& set_padding(std::vector<int64_t> padding)
+    ConvWgradAttributes& set_padding(const std::vector<int64_t>& padding)
     {
         set_pre_padding(padding);
-        set_post_padding(std::move(padding));
+        set_post_padding(padding);
         return *this;
     }
 

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/detail/HipdnnBackendInterface.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/detail/HipdnnBackendInterface.hpp
@@ -65,20 +65,35 @@ public:
         = 0;
 
     // HIPDNN_HIDDEN on accessor functions ensures each shared object has its own backendInstance
-    static inline std::shared_ptr<IHipdnnBackend> backendInstance;
     HIPDNN_HIDDEN static std::shared_ptr<IHipdnnBackend> getInstance()
     {
-        return backendInstance;
+        const std::lock_guard<std::mutex> lock(backendMutex());
+        return backendInstance();
     }
 
     HIPDNN_HIDDEN static void setInstance(std::shared_ptr<IHipdnnBackend> instance)
     {
-        backendInstance = std::move(instance);
+        const std::lock_guard<std::mutex> lock(backendMutex());
+        backendInstance() = std::move(instance);
     }
 
     HIPDNN_HIDDEN static void resetInstance()
     {
-        backendInstance.reset();
+        const std::lock_guard<std::mutex> lock(backendMutex());
+        backendInstance().reset();
+    }
+
+private:
+    HIPDNN_HIDDEN static std::shared_ptr<IHipdnnBackend>& backendInstance()
+    {
+        static std::shared_ptr<IHipdnnBackend> s_instance;
+        return s_instance;
+    }
+
+    HIPDNN_HIDDEN static std::mutex& backendMutex()
+    {
+        static std::mutex s_mtx;
+        return s_mtx;
     }
 };
 

--- a/projects/hipdnn/frontend/tests/TestError.cpp
+++ b/projects/hipdnn/frontend/tests/TestError.cpp
@@ -46,6 +46,24 @@ TEST(TestError, CodeEqualityOperators)
     EXPECT_FALSE(error != hipdnn_frontend::ErrorCode::INVALID_VALUE);
 }
 
+TEST(TestError, ToStringReturnsCorrectStringForAllErrorCodes)
+{
+    EXPECT_EQ(hipdnn_frontend::to_string(hipdnn_frontend::ErrorCode::OK), "OK");
+    EXPECT_EQ(hipdnn_frontend::to_string(hipdnn_frontend::ErrorCode::INVALID_VALUE),
+              "INVALID_VALUE");
+    EXPECT_EQ(hipdnn_frontend::to_string(hipdnn_frontend::ErrorCode::HIPDNN_BACKEND_ERROR),
+              "HIPDNN_BACKEND_ERROR");
+    EXPECT_EQ(hipdnn_frontend::to_string(hipdnn_frontend::ErrorCode::ATTRIBUTE_NOT_SET),
+              "ATTRIBUTE_NOT_SET");
+}
+
+TEST(TestError, ToStringReturnsUnknownForInvalidCode)
+{
+    // Cast an out-of-range value to ErrorCode to verify the default case
+    auto invalidCode = static_cast<hipdnn_frontend::ErrorCode>(999);
+    EXPECT_EQ(hipdnn_frontend::to_string(invalidCode), "UNKNOWN_ERROR");
+}
+
 TEST(TestError, CheckHipdnnErrorMacro)
 {
     auto successFunction

--- a/projects/hipdnn/samples/README.md
+++ b/projects/hipdnn/samples/README.md
@@ -61,6 +61,15 @@ All samples are templated for mixed-precision execution with Fp32, Fp16, and Bfp
 The current samples include:
 
 
+### [**`BnInference`**](./batchnorm/BnInference.cpp)
+
+Executes a single-node batch normalization inference graph on a 4D input tensor using inverse variance.
+
+- It normalizes each dimension of the input tensor `x` of shape `(N, C, H, W)`, using pre-calculated population statistics (mean and inverse variance). The result is then transformed by the learned parameters `scale` and `bias`, each with shape `(1, C, 1, 1)`:
+    ```python
+    y = scale * ((x - mean) * inv_variance) + bias
+    ```
+
 ### [**`BnInferenceWithVariance`**](./batchnorm/BnInferenceWithVariance.cpp)
 
 Executes a single-node batch normalization inference with variance graph on a 4D input tensor.
@@ -285,6 +294,22 @@ Executes the backward pass (filter gradient) of a 2D convolution operation to co
     - `C` = number of input channels per filter
     - `R, S` = filter spatial dimensions (height, width)
 
+### [**`ConvFpropDeterministic`**](./convolution/ConvFpropDeterministic.cpp)
+
+Executes a deterministic forward pass of a 2D convolution operation. This sample specifically targets the deterministic engine variant (`MIOPEN_ENGINE_DETERMINISTIC`), which guarantees bit-reproducible results across runs at a potential performance cost. This is useful for debugging and validation scenarios where exact reproducibility is required.
+
+### [**`FusedConvFpropBiasActiv`**](./convolution/FusedConvFpropBiasActiv.cpp)
+
+Executes a fused convolution forward pass with bias addition and activation function in a single graph.
+
+The fused graph consists of three operations:
+
+1. **Convolution Forward**: Performs standard 2D convolution
+2. **Pointwise Add (Bias)**: Adds a per-channel bias vector to the convolution output
+3. **Activation**: Applies an activation function (clamped ReLU) to the result
+
+This demonstrates a common deep learning pattern where convolution, bias, and activation are fused into a single graph for improved performance.
+
 ### [**`FusedConvFpropActiv`**](./convolution/FusedConvFpropActiv.cpp)
 
 Executes a fused convolution forward pass with activation function in a single graph.
@@ -322,6 +347,10 @@ Output: y (activated convolution result)
 - Reduces memory bandwidth by avoiding intermediate tensor writes/reads
 - Eliminates kernel launch overhead between operations
 - Enables better cache utilization by processing data in a single pass
+
+### [**`SerializationRoundTrip`**](./serialization/SerializationRoundTrip.cpp)
+
+Demonstrates graph serialization and deserialization (round-trip) using hipDNN's FlatBuffer-based serialization format. The sample builds a convolution forward graph, serializes it to a binary format, deserializes it back, and then executes the deserialized graph to verify correctness. This shows how graphs can be saved, transmitted, and restored for deployment or caching scenarios.
 
 ### [**`KnobsUsage`**](./knobs/KnobsUsage.cpp)
 


### PR DESCRIPTION
## Motivation

Addresses critical bugs, safety issues, and documentation errors identified during a full-project code review of hipDNN, MIOpen provider, and integration tests.

## Technical Details

Changes:
- Fix uninitialized versionInfo read in Windows getSystemInfo (H1)
- Fix broken EngineRegistrar collision detection by checking before insert, and reject duplicate name registration (H2)
- Add Rule of Five to HipdnnMiopenHandle to prevent double-free (H4)
- Add int64_t-to-int range validation in MiopenTensor constructor (H5)
- Replace unsafe vector index with switch in to_string(ErrorCode) (H6)
- Fix fragile copy-then-move in set_padding() across 3 conv attrs (H7)
- Add mutex protection to IHipdnnBackend::backendInstance singleton (H8)
- Add missing #include <filesystem> in integration test TestConfig (H10)
- Fix 4 broken links to CpuGraphExecutorDesign.md in 3 docs (H11)
- Fix wrong EngineNames.hpp path and namespace refs in PluginDevelopment.md (H12)
- Document 4 undocumented samples in samples/README.md (H13)
- Add 3 new EngineRegistrar unit tests covering registration, duplicate detection, and hash collision detection

## Test Plan

All tests pass

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
