### PR TITLE
[SDPA][HipDNN] Integration test for SDPA

### DIFF
--- a/dnn-providers/sdpa-kernel-provider/src/integration_tests/CMakeLists.txt
+++ b/dnn-providers/sdpa-kernel-provider/src/integration_tests/CMakeLists.txt
@@ -15,6 +15,7 @@ endif()
 add_executable(
     sdpa_kernel_plugin_integration_tests
     main.cpp
+    IntegrationGpuSdpaForward.cpp
     IntegrationNoEngines.cpp
 )
 

--- a/dnn-providers/sdpa-kernel-provider/src/integration_tests/IntegrationGpuSdpaForward.cpp
+++ b/dnn-providers/sdpa-kernel-provider/src/integration_tests/IntegrationGpuSdpaForward.cpp
@@ -1,0 +1,150 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <filesystem>
+#include <random>
+
+#include <hip/hip_runtime.h>
+#include <hipdnn_data_sdk/types.hpp>
+#include <hipdnn_data_sdk/utilities/PlatformUtils.hpp>
+#include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
+#include <hipdnn_test_sdk/utilities/DynamicTolerances.hpp>
+#include <hipdnn_test_sdk/utilities/TestTolerances.hpp>
+#include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
+
+#include "IntegrationGraphVerificationHarness.hpp"
+
+using namespace hipdnn_frontend;
+using namespace hipdnn_frontend::graph;
+using namespace hipdnn_data_sdk::utilities;
+using namespace hipdnn_test_sdk::utilities;
+using namespace hipdnn_test_sdk::utilities::conv;
+using namespace sdpa_plugin::test_utilities;
+
+namespace
+{
+
+struct SdpaTestCase
+{
+    SdpaTestCase(std::vector<int64_t> qDimsIn,
+                 std::vector<int64_t> kDimsIn,
+                 std::vector<int64_t> vDimsIn,
+                 std::optional<float> attnScaleValueIn = std::nullopt,
+                 std::vector<int64_t> attnMaskDimsIn = {},
+                 bool causalMaskIn = false)
+        : qDims(std::move(qDimsIn))
+        , kDims(std::move(kDimsIn))
+        , vDims(std::move(vDimsIn))
+        , qStrides(generateStrides(qDims))
+        , kStrides(generateStrides(kDims))
+        , vStrides(generateStrides(vDims))
+        , attnScaleValue(attnScaleValueIn)
+        , attnMaskDims(std::move(attnMaskDimsIn))
+        , attnMaskStrides(generateStrides(attnMaskDims))
+        , causalMask(causalMaskIn)
+    {
+    }
+
+    std::vector<int64_t> qDims;
+    std::vector<int64_t> kDims;
+    std::vector<int64_t> vDims;
+    std::vector<int64_t> qStrides;
+    std::vector<int64_t> kStrides;
+    std::vector<int64_t> vStrides;
+
+    std::optional<float> attnScaleValue;
+    std::vector<int64_t> attnMaskDims;
+    std::vector<int64_t> attnMaskStrides;
+    bool causalMask;
+};
+
+std::vector<SdpaTestCase> getSdpaTestCases()
+{
+    return {SdpaTestCase({4, 8, 16, 32}, {4, 8, 16, 32}, {4, 8, 16, 32})};
+}
+
+template <typename DataType>
+class SdpaForward : public IntegrationGraphVerificationHarness<DataType, SdpaTestCase>
+{
+protected:
+    void initializeBundle(const hipdnn_frontend::graph::Graph& /*graph*/,
+                          GraphTensorBundle& bundle,
+                          unsigned int seed) override
+    {
+
+        for(auto& tensorPair : bundle.tensors)
+        {
+            bundle.randomizeTensor(tensorPair.first, _minVal, _maxVal, seed);
+        }
+    }
+
+    void runGraphTest(float tolerance)
+    {
+        SKIP_IF_WINDOWS();
+
+        const SdpaTestCase& testCase = this->GetParam();
+
+        Graph graph;
+        graph.set_io_data_type(hipdnn_frontend::DataType::FLOAT)
+            .set_compute_data_type(hipdnn_frontend::DataType::FLOAT)
+            .set_intermediate_data_type(hipdnn_frontend::DataType::FLOAT);
+
+        auto q = std::make_shared<TensorAttributes>();
+        q->set_dim(testCase.qDims)
+            .set_stride(testCase.qStrides)
+            .set_data_type(getDataTypeEnumFromType<DataType>());
+
+        auto k = std::make_shared<TensorAttributes>();
+        k->set_dim(testCase.kDims)
+            .set_stride(testCase.kStrides)
+            .set_data_type(getDataTypeEnumFromType<DataType>());
+
+        auto v = std::make_shared<TensorAttributes>();
+        v->set_dim(testCase.vDims)
+            .set_stride(testCase.vStrides)
+            .set_data_type(getDataTypeEnumFromType<DataType>());
+
+        SdpaAttributes attributes;
+        attributes.set_name("SdpaNode");
+        if(testCase.attnScaleValue.has_value())
+        {
+            attributes.set_attn_scale_value(testCase.attnScaleValue.value());
+        }
+        if(!testCase.attnMaskDims.empty())
+        {
+            auto attnMask = std::make_shared<TensorAttributes>();
+            attnMask->set_dim(testCase.attnMaskDims)
+                .set_stride(testCase.attnMaskStrides)
+                .set_data_type(getDataTypeEnumFromType<DataType>());
+            attributes.set_attn_mask(attnMask);
+        }
+        attributes.set_causal_mask(testCase.causalMask);
+
+        auto [o, stats] = graph.sdpa(q, k, v, attributes);
+
+        o->set_output(true);
+        o->set_data_type(getDataTypeEnumFromType<DataType>());
+
+        auto validationResult = graph.validate();
+        EXPECT_TRUE(validationResult.is_good()) << validationResult.get_message();
+
+        this->registerValidator(o, tolerance);
+        this->verifyGraph(graph, 0);
+    }
+
+    float _minVal = -1.0;
+    float _maxVal = 1.0;
+};
+
+using IntegrationGpuSdpaFwdBf16 = SdpaForward<bfloat16>;
+
+} // namespace
+
+TEST_P(IntegrationGpuSdpaFwdBf16, Correctness)
+{
+    auto tolerance = 1e-7f;
+
+    runGraphTest(tolerance);
+}
+
+INSTANTIATE_TEST_SUITE_P(Smoke, IntegrationGpuSdpaFwdBf16, testing::ValuesIn(getSdpaTestCases()));

--- a/dnn-providers/sdpa-kernel-provider/src/integration_tests/IntegrationGpuSdpaForward.cpp
+++ b/dnn-providers/sdpa-kernel-provider/src/integration_tests/IntegrationGpuSdpaForward.cpp
@@ -60,7 +60,7 @@ struct SdpaTestCase
 
 std::vector<SdpaTestCase> getSdpaTestCases()
 {
-    return {SdpaTestCase({4, 8, 16, 32}, {4, 8, 16, 32}, {4, 8, 16, 32})};
+    return {SdpaTestCase({4, 8, 256, 128}, {4, 8, 256, 128}, {4, 8, 256, 128})};
 }
 
 template <typename DataType>
@@ -142,7 +142,7 @@ using IntegrationGpuSdpaFwdBf16 = SdpaForward<bfloat16>;
 
 TEST_P(IntegrationGpuSdpaFwdBf16, Correctness)
 {
-    auto tolerance = 1e-7f;
+    auto tolerance = 1e-2f;
 
     runGraphTest(tolerance);
 }

--- a/dnn-providers/sdpa-kernel-provider/src/integration_tests/IntegrationGraphVerificationHarness.hpp
+++ b/dnn-providers/sdpa-kernel-provider/src/integration_tests/IntegrationGraphVerificationHarness.hpp
@@ -1,0 +1,318 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_data_sdk/utilities/Workspace.hpp>
+#include <hipdnn_frontend/Graph.hpp>
+#include <hipdnn_frontend/Utilities.hpp>
+#include <hipdnn_frontend/attributes/TensorAttributes.hpp>
+#include <hipdnn_frontend/knob/Knob.hpp>
+#include <hipdnn_frontend/node/Node.hpp>
+#include <hipdnn_plugin_sdk/PluginLogging.hpp>
+#include <hipdnn_test_sdk/utilities/CpuFpReferenceMiopenRmsValidation.hpp>
+#include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
+#include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
+#include <hipdnn_test_sdk/utilities/VectorLoggingUtils.hpp>
+#include <hipdnn_test_sdk/utilities/cpu_graph_executor/CpuReferenceGraphExecutor.hpp>
+#include <hipdnn_test_sdk/utilities/cpu_graph_executor/GraphTensorBundle.hpp>
+
+#include <functional>
+
+namespace sdpa_plugin::test_utilities
+{
+
+// NOLINTBEGIN (portability-template-virtual-member-function)
+template <typename DataType, typename TestCaseType>
+class IntegrationGraphVerificationHarness : public ::testing::TestWithParam<TestCaseType>
+{
+protected:
+    static constexpr float DEFAULT_MIN = -1.0f;
+    static constexpr float DEFAULT_MAX = 1.0f;
+    static constexpr unsigned int DEFAULT_SMOKE_TEST_SEED = 42;
+
+    void SetUp() override
+    {
+        SKIP_IF_NO_DEVICES();
+
+        // Initialize HIP
+        ASSERT_EQ(hipInit(0), hipSuccess);
+        ASSERT_EQ(hipGetDevice(&_deviceId), hipSuccess);
+
+        // Note: The plugin paths has to be set before we create the hipdnn handle.
+        auto pluginPath = std::filesystem::weakly_canonical(
+            hipdnn_data_sdk::utilities::getCurrentExecutableDirectory() / PLUGIN_PATH);
+        const std::string pluginPathStr = pluginPath.string();
+        const std::array<const char*, 1> paths = {pluginPathStr.c_str()};
+        ASSERT_EQ(hipdnnSetEnginePluginPaths_ext(
+                      paths.size(), paths.data(), HIPDNN_PLUGIN_LOADING_ABSOLUTE),
+                  HIPDNN_STATUS_SUCCESS);
+
+        // Create handle and stream
+        ASSERT_EQ(hipdnnCreate(&_handle), HIPDNN_STATUS_SUCCESS);
+        ASSERT_EQ(hipStreamCreate(&_stream), hipSuccess);
+        ASSERT_EQ(hipdnnSetStream(_handle, _stream), HIPDNN_STATUS_SUCCESS);
+    }
+
+    void TearDown() override
+    {
+        if(_handle != nullptr)
+        {
+            ASSERT_EQ(hipdnnDestroy(_handle), HIPDNN_STATUS_SUCCESS);
+        }
+        if(_stream != nullptr)
+        {
+            ASSERT_EQ(hipStreamDestroy(_stream), hipSuccess);
+        }
+    }
+
+protected:
+    /// Execute graph with knob settings (for smoke tests without CPU validation)
+    void executeGraphWithKnobs(hipdnn_frontend::graph::Graph& graph,
+                               std::vector<hipdnn_frontend::KnobSetting> knobSettings)
+    {
+        hipdnn_test_sdk::utilities::GraphTensorBundle gpuBundle;
+
+        auto result = graph.validate();
+        ASSERT_EQ(result.code, hipdnn_frontend::ErrorCode::OK) << result.err_msg;
+
+        result = graph.build_operation_graph(_handle);
+        ASSERT_EQ(result.code, hipdnn_frontend::ErrorCode::OK) << result.err_msg;
+
+        std::vector<int64_t> rankedEngineIds;
+        result = graph.get_ranked_engine_ids(rankedEngineIds);
+        ASSERT_EQ(result.code, hipdnn_frontend::ErrorCode::OK) << result.err_msg;
+        ASSERT_GT(rankedEngineIds.size(), 0) << "No engines available";
+
+        result = graph.create_execution_plan_ext(rankedEngineIds[0], knobSettings);
+        ASSERT_EQ(result.code, hipdnn_frontend::ErrorCode::OK) << result.err_msg;
+
+        result = graph.build_plans();
+        ASSERT_EQ(result.code, hipdnn_frontend::ErrorCode::OK) << result.err_msg;
+
+        // Generate tensor bundle
+        graph.visit([&](const hipdnn_frontend::graph::INode& node) {
+            for(const auto& tensorAttr : node.getNodeOutputTensorAttributes())
+            {
+                tryAddTensorToBundle(tensorAttr, gpuBundle);
+            }
+            for(const auto& tensorAttr : node.getNodeInputTensorAttributes())
+            {
+                tryAddTensorToBundle(tensorAttr, gpuBundle);
+            }
+        });
+
+        // Initialize with zeros
+        for(auto& tensorPair : gpuBundle.tensors)
+        {
+            gpuBundle.randomizeTensor(tensorPair.first, 0.0f, 0.1f, DEFAULT_SMOKE_TEST_SEED);
+        }
+
+        // Execute
+        int64_t workspaceSize;
+        result = graph.get_workspace_size(workspaceSize);
+        ASSERT_EQ(result.code, hipdnn_frontend::ErrorCode::OK) << result.err_msg;
+        ASSERT_GE(workspaceSize, 0);
+        hipdnn_data_sdk::utilities::Workspace workspace(static_cast<size_t>(workspaceSize));
+
+        auto variantPack = gpuBundle.toDeviceVariantPack();
+        result = graph.execute(_handle, variantPack, workspace.get());
+        ASSERT_EQ(result.code, hipdnn_frontend::ErrorCode::OK) << result.err_msg;
+
+        ASSERT_EQ(hipStreamSynchronize(_stream), hipSuccess);
+    }
+
+    void verifyGraph(hipdnn_frontend::graph::Graph& graph, unsigned int seed)
+    {
+        hipdnn_test_sdk::utilities::GraphTensorBundle gpuBundle, cpuBundle;
+        std::vector<int64_t> outputTensorIds;
+
+        auto result = graph.build(_handle);
+        ASSERT_EQ(result.code, hipdnn_frontend::ErrorCode::OK) << result.err_msg;
+
+        generateBundles(graph, cpuBundle, gpuBundle, outputTensorIds);
+
+        initializeBundle(graph, gpuBundle, seed);
+        initializeBundle(graph, cpuBundle, seed);
+
+        ASSERT_NO_FATAL_FAILURE(executeGpuGraph(_handle, graph, gpuBundle));
+        executeCpuGraph(graph, cpuBundle);
+
+        ASSERT_GE(outputTensorIds.size(), 1)
+            << "At least one output tensor id must be specified for "
+               "validation.";
+
+        HIPDNN_PLUGIN_LOG_INFO("Validating " << outputTensorIds.size() << " output tensors");
+
+        // Lazily register validators after graph execution since tensor Ids and types may be inferred during graph finalization
+        for(const auto& registerValidator : _deferredValidators)
+        {
+            registerValidator();
+        }
+
+        for(const auto& tensorId : outputTensorIds)
+        {
+            auto& cpuTensor = cpuBundle.tensors.at(tensorId);
+            auto& gpuTensor = gpuBundle.tensors.at(tensorId);
+
+            // This tells the tensor that its data has been modified on the device side
+            // All frontend graph knows is a (void*) pointer to device memory, so we need to inform the tensor
+            // that the data there is now valid so that it knows to copy from device to host when requested
+            // by the validation step.
+            gpuTensor->markDeviceModified();
+
+            if(_tensorIdToValidatorMap.find(tensorId) == _tensorIdToValidatorMap.end())
+            {
+                FAIL() << "No validator registered for tensor with id: " << tensorId
+                       << ", name: " << getOutputTensorName(tensorId);
+            }
+
+            bool valid = _tensorIdToValidatorMap.at(tensorId)->allClose(*cpuTensor, *gpuTensor);
+            ASSERT_TRUE(valid) << "Mismatch found in tensor with id: " << tensorId
+                               << ", name: " << _tensorIdToNameMap.at(tensorId);
+        }
+    }
+
+    void registerValidator(const std::shared_ptr<hipdnn_frontend::graph::TensorAttributes> attr,
+                           float tolerance)
+    {
+        registerValidator(attr, tolerance, tolerance);
+    }
+
+    void registerValidator(const std::shared_ptr<hipdnn_frontend::graph::TensorAttributes> attr,
+                           float absoluteTolerance,
+                           float relativeTolerance)
+    {
+        // Since the graph can infer properties + Ids, we defer validator registration until right before validation in verifyGraph
+        _deferredValidators.emplace_back([this, attr, absoluteTolerance, relativeTolerance]() {
+            _tensorIdToValidatorMap.insert(
+                {attr->get_uid(),
+                 hipdnn_test_sdk::utilities::createAllCloseValidator(
+                     toSdkType(attr->get_data_type()), absoluteTolerance, relativeTolerance)});
+            _tensorIdToNameMap.insert({attr->get_uid(), attr->get_name()});
+        });
+    }
+
+    void registerRmsValidator(const std::shared_ptr<hipdnn_frontend::graph::TensorAttributes> attr,
+                              float rmsThreshold)
+    {
+        // Since the graph can infer properties + Ids, we defer validator registration until right before validation in verifyGraph
+        _deferredValidators.emplace_back([this, attr, rmsThreshold]() {
+            _tensorIdToValidatorMap.insert({attr->get_uid(),
+                                            hipdnn_test_sdk::utilities::createRmsValidator(
+                                                toSdkType(attr->get_data_type()), rmsThreshold)});
+            _tensorIdToNameMap.insert({attr->get_uid(), attr->get_name()});
+        });
+    }
+
+    virtual void generateBundles(hipdnn_frontend::graph::Graph& graph,
+                                 hipdnn_test_sdk::utilities::GraphTensorBundle& cpuBundle,
+                                 hipdnn_test_sdk::utilities::GraphTensorBundle& gpuBundle,
+                                 std::vector<int64_t>& outputTensorIds)
+    {
+        graph.visit([&](const hipdnn_frontend::graph::INode& node) {
+            for(const auto& tensorAttr : node.getNodeOutputTensorAttributes())
+            {
+                if(tryAddTensorToBundles(tensorAttr, cpuBundle, gpuBundle))
+                {
+                    outputTensorIds.push_back(tensorAttr->get_uid());
+                }
+            }
+            for(const auto& tensorAttr : node.getNodeInputTensorAttributes())
+            {
+                tryAddTensorToBundles(tensorAttr, cpuBundle, gpuBundle);
+            }
+        });
+    }
+
+    virtual void initializeBundle([[maybe_unused]] const hipdnn_frontend::graph::Graph& graph,
+                                  hipdnn_test_sdk::utilities::GraphTensorBundle& bundle,
+                                  unsigned int seed)
+    {
+        for(auto& tensorPair : bundle.tensors)
+        {
+            bundle.randomizeTensor(tensorPair.first, DEFAULT_MIN, DEFAULT_MAX, seed);
+        }
+    }
+
+private:
+    void executeGpuGraph(hipdnnHandle_t handle,
+                         hipdnn_frontend::graph::Graph& graph,
+                         hipdnn_test_sdk::utilities::GraphTensorBundle& bundle)
+    {
+        int64_t workspaceSize;
+        auto result = graph.get_workspace_size(workspaceSize);
+        ASSERT_EQ(result.code, hipdnn_frontend::ErrorCode::OK) << result.err_msg;
+        ASSERT_GE(workspaceSize, 0) << result.err_msg;
+        hipdnn_data_sdk::utilities::Workspace workspace(static_cast<size_t>(workspaceSize));
+
+        auto variantPack = bundle.toDeviceVariantPack();
+        result = graph.execute(handle, variantPack, workspace.get());
+        ASSERT_EQ(result.code, hipdnn_frontend::ErrorCode::OK) << result.err_msg;
+    }
+
+    void executeCpuGraph(hipdnn_frontend::graph::Graph& graph,
+                         hipdnn_test_sdk::utilities::GraphTensorBundle& bundle)
+    {
+        auto flatbufferGraph = graph.buildFlatbufferOperationGraph();
+
+        hipdnn_test_sdk::utilities::CpuReferenceGraphExecutor().execute(
+            flatbufferGraph.data(), flatbufferGraph.size(), bundle.toHostVariantPack());
+    }
+
+    std::string getOutputTensorName(int64_t tensorId)
+    {
+        return _tensorIdToNameMap.at(tensorId);
+    }
+
+    bool tryAddTensorToBundle(
+        const std::shared_ptr<hipdnn_frontend::graph::TensorAttributes>& tensorAttr,
+        hipdnn_test_sdk::utilities::GraphTensorBundle& bundle)
+    {
+        int64_t tensorId = tensorAttr->get_uid();
+
+        if(tensorAttr->get_is_virtual() || bundle.tensors.find(tensorId) != bundle.tensors.end())
+        {
+            return false;
+        }
+
+        bundle.tensors.insert({tensorId, createTensorFromAttribute(*tensorAttr)});
+        return true;
+    }
+
+    bool tryAddTensorToBundles(
+        const std::shared_ptr<hipdnn_frontend::graph::TensorAttributes>& tensorAttr,
+        hipdnn_test_sdk::utilities::GraphTensorBundle& cpuBundle,
+        hipdnn_test_sdk::utilities::GraphTensorBundle& gpuBundle)
+    {
+        int64_t tensorId = tensorAttr->get_uid();
+
+        if(tensorAttr->get_is_virtual()
+           || cpuBundle.tensors.find(tensorId) != cpuBundle.tensors.end())
+        {
+            return false;
+        }
+
+        cpuBundle.tensors.insert(
+            {tensorId, hipdnn_frontend::graph::createTensorFromAttribute(*tensorAttr)});
+        gpuBundle.tensors.insert(
+            {tensorId, hipdnn_frontend::graph::createTensorFromAttribute(*tensorAttr)});
+        _tensorIdToNameMap.insert({tensorId, tensorAttr->get_name()});
+
+        return true;
+    }
+
+    hipdnnHandle_t _handle = nullptr;
+    hipStream_t _stream = nullptr;
+    int _deviceId = 0;
+    std::unordered_map<int64_t, std::string> _tensorIdToNameMap;
+    std::unordered_map<int64_t, std::unique_ptr<hipdnn_test_sdk::utilities::IReferenceValidation>>
+        _tensorIdToValidatorMap;
+    std::vector<std::function<void()>> _deferredValidators;
+};
+
+// NOLINTEND (portability-template-virtual-member-function)
+
+} // namespace miopen_plugin::test_utilities


### PR DESCRIPTION
## Motivation

Adds an integration test for testing the end to end execution of a sdpa kernel. Currently this test will fail, and success will indicate when the kernel has been successfully integrated

## Technical Details

Notes:
- The tolerance used may be too small, it may have to be increased to consistently mark success
- The setup of the sdpa graph may need to be updated based on the requirements of the kernel
- The IntegrationGraphVerificationHarness is mostly copied from the hip_kernel_provider, with some small changes to remove the deprecated `=` lambda capture