### PR TITLE
[hipDNN] Forward attention kernel workspace size

### DIFF
--- a/dnn-providers/sdpa-kernel-provider/src/SdpaKernelPlan.cpp
+++ b/dnn-providers/sdpa-kernel-provider/src/SdpaKernelPlan.cpp
@@ -7,10 +7,14 @@
 namespace sdpa_kernel_provider
 {
 
+SdpaKernelPlan::SdpaKernelPlan(size_t workspaceSize)
+    : _workspaceSize(workspaceSize)
+{
+}
+
 size_t SdpaKernelPlan::getWorkspaceSize(const SdpaKernelHandle& /*handle*/) const
 {
-    HIPDNN_PLUGIN_LOG_ERROR("SdpaKernelPlan::getWorkspaceSize not implemented");
-    return 0;
+    return _workspaceSize;
 }
 
 void SdpaKernelPlan::execute(const SdpaKernelHandle& /*handle*/,

--- a/dnn-providers/sdpa-kernel-provider/src/SdpaKernelPlan.cpp
+++ b/dnn-providers/sdpa-kernel-provider/src/SdpaKernelPlan.cpp
@@ -7,14 +7,14 @@
 namespace sdpa_kernel_provider
 {
 
-SdpaKernelPlan::SdpaKernelPlan(size_t workspaceSize)
-    : _workspaceSize(workspaceSize)
+SdpaKernelPlan::SdpaKernelPlan()
 {
 }
 
 size_t SdpaKernelPlan::getWorkspaceSize(const SdpaKernelHandle& /*handle*/) const
 {
-    return _workspaceSize;
+    // Forward-only kernel requires no workspace (uses 64KB LDS internally)
+    return 0;
 }
 
 void SdpaKernelPlan::execute(const SdpaKernelHandle& /*handle*/,

--- a/dnn-providers/sdpa-kernel-provider/src/SdpaKernelPlan.hpp
+++ b/dnn-providers/sdpa-kernel-provider/src/SdpaKernelPlan.hpp
@@ -19,10 +19,8 @@ class SdpaKernelPlan : public hipdnn_plugin_sdk::IPlan<SdpaKernelHandle>
 public:
     /**
      * @brief Construct a plan with kernel module and precomputed metadata.
-     *
-     * @param workspaceSize Precomputed LSE buffer size in bytes
      */
-    explicit SdpaKernelPlan(size_t workspaceSize);
+    SdpaKernelPlan();
 
     ~SdpaKernelPlan() override = default;
 
@@ -34,7 +32,6 @@ public:
                  void* workspace = nullptr) const override;
 
 private:
-    size_t _workspaceSize;  ///< LSE buffer size: B * H_q * S_q * sizeof(float)
 };
 
 }

--- a/dnn-providers/sdpa-kernel-provider/src/SdpaKernelPlan.hpp
+++ b/dnn-providers/sdpa-kernel-provider/src/SdpaKernelPlan.hpp
@@ -16,12 +16,25 @@ namespace sdpa_kernel_provider
 */
 class SdpaKernelPlan : public hipdnn_plugin_sdk::IPlan<SdpaKernelHandle>
 {
+public:
+    /**
+     * @brief Construct a plan with kernel module and precomputed metadata.
+     *
+     * @param workspaceSize Precomputed LSE buffer size in bytes
+     */
+    explicit SdpaKernelPlan(size_t workspaceSize);
+
+    ~SdpaKernelPlan() override = default;
+
     size_t getWorkspaceSize(const SdpaKernelHandle& handle) const override;
 
     void execute(const SdpaKernelHandle& handle,
                  const hipdnnPluginDeviceBuffer_t* deviceBuffers,
                  uint32_t numDeviceBuffers,
                  void* workspace = nullptr) const override;
+
+private:
+    size_t _workspaceSize;  ///< LSE buffer size: B * H_q * S_q * sizeof(float)
 };
 
 }

--- a/dnn-providers/sdpa-kernel-provider/src/SdpaKernelPlanBuilder.cpp
+++ b/dnn-providers/sdpa-kernel-provider/src/SdpaKernelPlanBuilder.cpp
@@ -32,22 +32,13 @@ size_t SdpaKernelPlanBuilder::getMaxWorkspaceSize(
     const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
     const SdpaKernelSettings& /* executionSettings */) const
 {
-    // Get SDPA attributes from the first (and only) node
+    // Get SDPA attributes to check for optional LSE output
     auto& sdpaNode = opGraph.getNodeWrapper(0);
     auto& sdpaAttrs = sdpaNode.attributesAs<hipdnn_data_sdk::data_objects::SdpaAttributes>();
-
-    // Get Q tensor to extract batch, head, sequence dimensions
-    auto& tensorMap = opGraph.getTensorMap();
-    const hipdnn_data_sdk::data_objects::TensorAttributes* qTensor = tensorMap.at(sdpaAttrs.q_tensor_uid());
-    auto* qDims = qTensor->dims();
-
-    // Q tensor layout: [B, H_q, S_q, D]
-    // Workspace = LSE buffer: [B, H_q, S_q] in float32
-    size_t B   = static_cast<size_t>(qDims->Get(0));  // batch
-    size_t H_q = static_cast<size_t>(qDims->Get(1));  // num heads
-    size_t S_q = static_cast<size_t>(qDims->Get(2));  // sequence length
-
-    return B * H_q * S_q * sizeof(float);
+    
+    // Forward-only kernel uses 64KB LDS internally, no external workspace needed
+    // LSE (when present) is an optional output tensor, not workspace
+    return 0;
 }
 
 void SdpaKernelPlanBuilder::initializeExecutionSettings(
@@ -60,16 +51,13 @@ void SdpaKernelPlanBuilder::initializeExecutionSettings(
 }
 
 void SdpaKernelPlanBuilder::buildPlan(
-    const SdpaKernelHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const SdpaKernelHandle& /* handle */,
+    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& /* opGraph */,
     const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& /* engineConfig */,
     SdpaKernelContext& executionContext) const
 {
-    // Compute workspace size
-    size_t workspaceSize = getMaxWorkspaceSize(handle, opGraph, SdpaKernelSettings());
-
-    // Create plan with precomputed workspace
-    executionContext.setPlan(std::make_unique<SdpaKernelPlan>(workspaceSize));
+    // Create plan (no workspace needed for forward-only POC)
+    executionContext.setPlan(std::make_unique<SdpaKernelPlan>());
 }
 
 std::vector<hipdnn_data_sdk::data_objects::KnobT> SdpaKernelPlanBuilder::getCustomKnobs(

--- a/dnn-providers/sdpa-kernel-provider/src/SdpaKernelPlanBuilder.cpp
+++ b/dnn-providers/sdpa-kernel-provider/src/SdpaKernelPlanBuilder.cpp
@@ -29,11 +29,25 @@ bool SdpaKernelPlanBuilder::isApplicable(
 
 size_t SdpaKernelPlanBuilder::getMaxWorkspaceSize(
     const SdpaKernelHandle& /* handle */,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& /* opGraph */,
+    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
     const SdpaKernelSettings& /* executionSettings */) const
 {
-    HIPDNN_PLUGIN_LOG_ERROR("SdpaKernelPlanBuilder::getMaxWorkspaceSize not implemented");
-    return 0;
+    // Get SDPA attributes from the first (and only) node
+    auto& sdpaNode = opGraph.getNodeWrapper(0);
+    auto& sdpaAttrs = sdpaNode.attributesAs<hipdnn_data_sdk::data_objects::SdpaAttributes>();
+
+    // Get Q tensor to extract batch, head, sequence dimensions
+    auto& tensorMap = opGraph.getTensorMap();
+    const hipdnn_data_sdk::data_objects::TensorAttributes* qTensor = tensorMap.at(sdpaAttrs.q_tensor_uid());
+    auto* qDims = qTensor->dims();
+
+    // Q tensor layout: [B, H_q, S_q, D]
+    // Workspace = LSE buffer: [B, H_q, S_q] in float32
+    size_t B   = static_cast<size_t>(qDims->Get(0));  // batch
+    size_t H_q = static_cast<size_t>(qDims->Get(1));  // num heads
+    size_t S_q = static_cast<size_t>(qDims->Get(2));  // sequence length
+
+    return B * H_q * S_q * sizeof(float);
 }
 
 void SdpaKernelPlanBuilder::initializeExecutionSettings(
@@ -46,13 +60,16 @@ void SdpaKernelPlanBuilder::initializeExecutionSettings(
 }
 
 void SdpaKernelPlanBuilder::buildPlan(
-    const SdpaKernelHandle& /* handle */,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& /* opGraph */,
+    const SdpaKernelHandle& handle,
+    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
     const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& /* engineConfig */,
     SdpaKernelContext& executionContext) const
 {
-    HIPDNN_PLUGIN_LOG_ERROR("SdpaKernelPlanBuilder::buildPlan not fully implemented");
-    executionContext.setPlan(std::make_unique<SdpaKernelPlan>());
+    // Compute workspace size
+    size_t workspaceSize = getMaxWorkspaceSize(handle, opGraph, SdpaKernelSettings());
+
+    // Create plan with precomputed workspace
+    executionContext.setPlan(std::make_unique<SdpaKernelPlan>(workspaceSize));
 }
 
 std::vector<hipdnn_data_sdk::data_objects::KnobT> SdpaKernelPlanBuilder::getCustomKnobs(

--- a/dnn-providers/sdpa-kernel-provider/src/tests/TestSdpaKernelPlanBuilder.cpp
+++ b/dnn-providers/sdpa-kernel-provider/src/tests/TestSdpaKernelPlanBuilder.cpp
@@ -44,7 +44,7 @@ TEST_F(TestSdpaKernelPlanBuilder, IsApplicableReturnsTrueForSdpaGraph)
 
 TEST_F(TestSdpaKernelPlanBuilder, GetMaxWorkspaceSizeCalculatesCorrectly)
 {
-    // Create an SDPA graph with known dimensions
+    // Create an SDPA graph with known dimensions (withStats = false by default)
     auto builder = hipdnn_test_sdk::utilities::createValidSdpaFpropGraph();
 
     hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graphWrapper(builder.GetBufferPointer(),
@@ -54,11 +54,10 @@ TEST_F(TestSdpaKernelPlanBuilder, GetMaxWorkspaceSizeCalculatesCorrectly)
     SdpaKernelSettings settings;
     size_t workspaceSize = _planBuilder.getMaxWorkspaceSize(_handle, graphWrapper, settings);
 
-    // Workspace = LSE buffer: [B, H_q, S_q] in float32
-    // The test graph has standard dimensions, verify workspace is non-zero and reasonable
-    // For typical SDPA graphs: B=1, H_q=8, S_q=128 → workspace = 1*8*128*4 = 4096 bytes
-    EXPECT_GT(workspaceSize, 0u);
-    EXPECT_TRUE(workspaceSize % 4 == 0);  // Should be multiple of sizeof(float)
+    // Forward-only kernel uses LDS internally, no external workspace needed
+    // LSE (when present) is an optional output tensor (stats_tensor_uid), not workspace
+    // The default test graph has withStats = false, so workspace should be 0
+    EXPECT_EQ(workspaceSize, 0u);
 }
 
 } // namespace

--- a/dnn-providers/sdpa-kernel-provider/src/tests/TestSdpaKernelPlanBuilder.cpp
+++ b/dnn-providers/sdpa-kernel-provider/src/tests/TestSdpaKernelPlanBuilder.cpp
@@ -42,5 +42,24 @@ TEST_F(TestSdpaKernelPlanBuilder, IsApplicableReturnsTrueForSdpaGraph)
     EXPECT_TRUE(_planBuilder.isApplicable(_handle, graphWrapper));
 }
 
+TEST_F(TestSdpaKernelPlanBuilder, GetMaxWorkspaceSizeCalculatesCorrectly)
+{
+    // Create an SDPA graph with known dimensions
+    auto builder = hipdnn_test_sdk::utilities::createValidSdpaFpropGraph();
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graphWrapper(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
+
+    // Get the workspace size from the plan builder
+    SdpaKernelSettings settings;
+    size_t workspaceSize = _planBuilder.getMaxWorkspaceSize(_handle, graphWrapper, settings);
+
+    // Workspace = LSE buffer: [B, H_q, S_q] in float32
+    // The test graph has standard dimensions, verify workspace is non-zero and reasonable
+    // For typical SDPA graphs: B=1, H_q=8, S_q=128 → workspace = 1*8*128*4 = 4096 bytes
+    EXPECT_GT(workspaceSize, 0u);
+    EXPECT_TRUE(workspaceSize % 4 == 0);  // Should be multiple of sizeof(float)
+}
+
 } // namespace
 } // namespace sdpa_kernel_provider


### PR DESCRIPTION
## Motivation

Add workspace size calculation for SDPA forward-only inference kernel. The LSE (log-sum-exp) buffer is an optional output tensor (stats_tensor_uid), not workspace. Forward-only kernel uses 64KB LDS internally and requires no external workspace allocation.

This aligns with `createValidSdpaFpropGraph` params for POC.

## Technical Details

Implemented workspace calculation and storage for the SDPA kernel plan:

1. **SdpaKernelPlanBuilder::getMaxWorkspaceSize()** - Returns 0 instead of calculating `B × H_q × S_q × sizeof(float)`
2. **SdpaKernelPlan** - updated getWorkspaceSize() to return 0 directly.

3. **SdpaKernelPlan::getWorkspaceSize()** - Simplified to create plan without workspace calculation, removing unnecessary parameter passing.

5. **Test Coverage** - GetMaxWorkspaceSizeCalculatesCorrectly unit test to verify workspace = 0 for forward-only inference with withStats = false (default test graph configuration).

## Test Plan


## Test Result


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
