### PR TITLE
[hipDNN] Fixing support for C++20 projects consuming frontend

### DIFF
--- a/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/BatchnormAttributes.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/BatchnormAttributes.hpp
@@ -69,6 +69,8 @@ namespace hipdnn_frontend::graph
 class BatchnormAttributes : public Attributes<BatchnormAttributes>
 {
 public:
+    BatchnormAttributes() = default;
+
     enum class InputNames
     {
         X = 0,

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/BatchnormBackwardAttributes.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/BatchnormBackwardAttributes.hpp
@@ -54,6 +54,8 @@ namespace hipdnn_frontend::graph
 class BatchnormBackwardAttributes : public Attributes<BatchnormBackwardAttributes>
 {
 public:
+    BatchnormBackwardAttributes() = default;
+
     enum class InputNames
     {
         DY = 0,

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/BatchnormInferenceAttributes.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/BatchnormInferenceAttributes.hpp
@@ -39,6 +39,8 @@ namespace hipdnn_frontend::graph
 class BatchnormInferenceAttributes : public Attributes<BatchnormInferenceAttributes>
 {
 public:
+    BatchnormInferenceAttributes() = default;
+
     /// Input tensor identifiers
     enum class InputNames
     {

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/BatchnormInferenceAttributesVarianceExt.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/BatchnormInferenceAttributesVarianceExt.hpp
@@ -52,6 +52,8 @@ class BatchnormInferenceAttributesVarianceExt
     : public Attributes<BatchnormInferenceAttributesVarianceExt>
 {
 public:
+    BatchnormInferenceAttributesVarianceExt() = default;
+
     enum class InputNames
     {
         X = 0,

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/BlockScaleDequantizeAttributes.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/BlockScaleDequantizeAttributes.hpp
@@ -57,6 +57,8 @@ namespace hipdnn_frontend::graph
 class BlockScaleDequantizeAttributes : public Attributes<BlockScaleDequantizeAttributes>
 {
 public:
+    BlockScaleDequantizeAttributes() = default;
+
     enum class InputNames
     {
         X = 0,

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/BlockScaleQuantizeAttributes.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/BlockScaleQuantizeAttributes.hpp
@@ -55,6 +55,8 @@ namespace hipdnn_frontend::graph
 class BlockScaleQuantizeAttributes : public Attributes<BlockScaleQuantizeAttributes>
 {
 public:
+    BlockScaleQuantizeAttributes() = default;
+
     enum class InputNames
     {
         X = 0
@@ -162,15 +164,17 @@ public:
     {
         const flatbuffers::Optional<int64_t> fbAxis = axis;
 
+        // NOLINTBEGIN(bugprone-unchecked-optional-access)
+        // Throws if block_size not set; requires prior validation
         return hipdnn_data_sdk::data_objects::CreateBlockScaleQuantizeAttributes(
             builder,
             get_x()->get_uid(),
             get_y()->get_uid(),
             get_scale()->get_uid(),
-            block_size
-                .value(), // NOLINT(bugprone-unchecked-optional-access) Throws if block_size not set; requires prior validation
+            block_size.value(),
             fbAxis,
             transpose);
+        // NOLINTEND(bugprone-unchecked-optional-access)
     }
 
     static BlockScaleQuantizeAttributes fromFlatBuffer(

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/ConvolutionDgradAttributes.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/ConvolutionDgradAttributes.hpp
@@ -41,6 +41,8 @@ namespace hipdnn_frontend::graph
 class ConvDgradAttributes : public Attributes<ConvDgradAttributes>
 {
 public:
+    ConvDgradAttributes() = default;
+
     /// Input tensor identifiers
     enum class InputNames
     {

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/ConvolutionFpropAttributes.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/ConvolutionFpropAttributes.hpp
@@ -48,6 +48,8 @@ namespace hipdnn_frontend::graph
 class ConvFpropAttributes : public Attributes<ConvFpropAttributes>
 {
 public:
+    ConvFpropAttributes() = default;
+
     /// Input tensor identifiers
     enum class InputNames
     {

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/ConvolutionWgradAttributes.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/ConvolutionWgradAttributes.hpp
@@ -41,6 +41,8 @@ namespace hipdnn_frontend::graph
 class ConvWgradAttributes : public Attributes<ConvWgradAttributes>
 {
 public:
+    ConvWgradAttributes() = default;
+
     /// Input tensor identifiers
     enum class InputNames
     {

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/CustomOpAttributes.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/CustomOpAttributes.hpp
@@ -46,6 +46,8 @@ namespace hipdnn_frontend::graph
 class CustomOpAttributes
 {
 public:
+    CustomOpAttributes() = default;
+
     // NOLINTBEGIN(readability-identifier-naming)
     std::string name;
     DataType compute_data_type = DataType::NOT_SET;

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/LayernormAttributes.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/LayernormAttributes.hpp
@@ -56,6 +56,8 @@ namespace hipdnn_frontend::graph
 class LayernormAttributes : public Attributes<LayernormAttributes>
 {
 public:
+    LayernormAttributes() = default;
+
     enum class InputNames
     {
         X = 0,

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/MatmulAttributes.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/MatmulAttributes.hpp
@@ -46,6 +46,8 @@ namespace hipdnn_frontend::graph
 class MatmulAttributes : public Attributes<MatmulAttributes>
 {
 public:
+    MatmulAttributes() = default;
+
     /// Input tensor identifiers
     enum class InputNames
     {

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/PointwiseAttributes.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/PointwiseAttributes.hpp
@@ -58,6 +58,8 @@ namespace hipdnn_frontend::graph
 class PointwiseAttributes : public Attributes<PointwiseAttributes>
 {
 public:
+    PointwiseAttributes() = default;
+
     /// @brief Get the pointwise operation mode
     // NOLINTNEXTLINE(readability-identifier-naming)
     PointwiseMode get_mode() const

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/RMSNormAttributes.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/RMSNormAttributes.hpp
@@ -63,6 +63,8 @@ namespace hipdnn_frontend::graph
 class RMSNormAttributes : public Attributes<RMSNormAttributes>
 {
 public:
+    RMSNormAttributes() = default;
+
     enum class InputNames
     {
         X = 0,

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/SdpaAttributes.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/SdpaAttributes.hpp
@@ -62,6 +62,8 @@ namespace hipdnn_frontend::graph
 class SdpaAttributes : public Attributes<SdpaAttributes>
 {
 public:
+    SdpaAttributes() = default;
+
     // NOLINTBEGIN(readability-identifier-naming)
     enum class InputNames
     {

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/SdpaBackwardAttributes.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/SdpaBackwardAttributes.hpp
@@ -65,6 +65,8 @@ namespace hipdnn_frontend::graph
 class SdpaBackwardAttributes : public Attributes<SdpaBackwardAttributes>
 {
 public:
+    SdpaBackwardAttributes() = default;
+
     // NOLINTBEGIN(readability-identifier-naming)
     enum class InputNames
     {


### PR DESCRIPTION
## Motivation
The project `dnn-providers/integration-tests` is a C++20 project that consumes the hipDNN frontend.  It was noticed when doing a standalone build of the integration tests that a change was made between C++17 and C++20 in regards to how aggregate constructors are propogated.

## Technical Details
- Added a default constructor to the frontend Attribute-derived classes

## Test Plan
- CI passes
- Tested a build of integration-tests by hand to verify the changes

## Test Result
- [x] Hand build of intergration-tests succeeds (with another change that will be in another PR)

## Submission Checklist
- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
