### PR TITLE
[CK_TILE] Add kpack example 06: FMHA BWD OGradDotO

### DIFF
--- a/projects/composablekernel/experimental/kpack/examples/06_rocm_ck_fmha_bwd/CMakeLists.txt
+++ b/projects/composablekernel/experimental/kpack/examples/06_rocm_ck_fmha_bwd/CMakeLists.txt
@@ -1,0 +1,90 @@
+# Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+# Build for the rocm_ck kpack FMHA BWD OGradDotO example.
+# Compiles multiple dtype x hdim x mode x padding variants per architecture,
+# packs into a .kpack archive, and builds the host-side loader.
+#
+# Usage:
+#   cmake -B build -S . -G Ninja \
+#       -DCMAKE_HIP_COMPILER=/opt/rocm/llvm/bin/clang++ \
+#       -DCMAKE_PREFIX_PATH=/opt/rocm \
+#       -DGPU_TARGETS="gfx90a;gfx942"
+#   ninja -C build
+
+cmake_minimum_required(VERSION 3.21)
+project(kpack_rocm_ck_fmha_bwd LANGUAGES CXX)
+
+enable_language(HIP)
+find_package(hip REQUIRED)
+
+set(GPU_TARGETS "gfx90a;gfx942;gfx950" CACHE STRING "GPU architectures to compile .hsaco for")
+set(KPACK_ROCM_PATH "/opt/rocm" CACHE PATH "ROCm installation path (for --rocm-path)")
+
+# CK Tile headers — four levels up from this example directory
+set(CK_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../../include")
+get_filename_component(CK_INCLUDE_DIR "${CK_INCLUDE_DIR}" ABSOLUTE)
+
+# Pull in the vendored kpack runtime library and shared rocm_ck headers
+add_subdirectory(../../rocm_kpack rocm_kpack_build)
+add_subdirectory(../../include rocm_ck_build)
+
+# --- Kernel variants ---
+set(KERNEL_VARIANTS
+    fmha_bwd_ograd_dot_o_fp16_d128_batch
+    fmha_bwd_ograd_dot_o_bf16_d128_batch
+    fmha_bwd_ograd_dot_o_fp16_d64_batch
+    fmha_bwd_ograd_dot_o_fp16_d128_group
+    fmha_bwd_ograd_dot_o_fp16_d128_batch_npad
+)
+
+# --- Compile each variant x architecture into .hsaco code objects ---
+# Uses --cuda-device-only to produce raw code objects without host stubs.
+# -std=c++20 is required for struct NTTPs and consteval.
+set(HSACO_FILES "")
+foreach(variant IN LISTS KERNEL_VARIANTS)
+    foreach(arch IN LISTS GPU_TARGETS)
+        set(hsaco_output "${CMAKE_BINARY_DIR}/${variant}_${arch}.hsaco")
+        add_custom_command(
+            OUTPUT ${hsaco_output}
+            COMMAND ${CMAKE_HIP_COMPILER}
+                    --offload-arch=${arch}
+                    --cuda-device-only
+                    -x hip
+                    -std=c++20
+                    -O3
+                    --rocm-path=${KPACK_ROCM_PATH}
+                    -I${CK_INCLUDE_DIR}
+                    -I${CMAKE_CURRENT_SOURCE_DIR}
+                    -I${CMAKE_CURRENT_SOURCE_DIR}/../../include
+                    -o ${hsaco_output}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/${variant}.hip
+            DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${variant}.hip
+                    ${CMAKE_CURRENT_SOURCE_DIR}/rocm_fmha_bwd_dev.hpp
+                    ${CMAKE_CURRENT_SOURCE_DIR}/rocm_fmha_bwd_api.hpp
+                    ${CMAKE_CURRENT_SOURCE_DIR}/../../include/rocm_ck/datatype_utils.hpp
+            COMMENT "Compiling ${variant}.hip -> ${arch}.hsaco"
+        )
+        list(APPEND HSACO_FILES ${hsaco_output})
+    endforeach()
+endforeach()
+
+# --- Pack .hsaco files into a kpack archive ---
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/kernels.kpack
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/pack.py ${CMAKE_BINARY_DIR}
+    DEPENDS ${HSACO_FILES} ${CMAKE_CURRENT_SOURCE_DIR}/pack.py
+    COMMENT "Creating kernels.kpack archive"
+)
+add_custom_target(kpack_archive ALL DEPENDS ${CMAKE_BINARY_DIR}/kernels.kpack)
+
+# --- Build the host-side loader executable ---
+# Links against hip::host (host-only HIP runtime) and rocm_kpack (archive reader).
+# Device code is loaded at runtime via hipModuleLoadData, not compiled into this binary.
+add_executable(kpack_rocm_ck_fmha_bwd main.cpp)
+target_compile_features(kpack_rocm_ck_fmha_bwd PRIVATE cxx_std_20)
+target_include_directories(kpack_rocm_ck_fmha_bwd PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(kpack_rocm_ck_fmha_bwd PRIVATE rocm_ck rocm_kpack hip::host)
+add_dependencies(kpack_rocm_ck_fmha_bwd kpack_archive)

--- a/projects/composablekernel/experimental/kpack/examples/06_rocm_ck_fmha_bwd/INSIGHTS.md
+++ b/projects/composablekernel/experimental/kpack/examples/06_rocm_ck_fmha_bwd/INSIGHTS.md
@@ -1,0 +1,75 @@
+# INSIGHTS.md — FMHA BWD OGradDotO kpack Example
+
+Design decisions and lessons learned from mapping the CK Tile FMHA backward
+OGradDotO kernel to the kpack pattern.
+
+## Two Args Structs Instead of a Union
+
+The batch and group modes have different extension fields:
+- **Batch**: 3 x `index_t` (batch_stride_do, batch_stride_o, batch_stride_d) = 12 bytes
+- **Group**: 3 x pointer (seqstart_q_ptr, seqlen_q_ptr, cu_seqlen_q_ptr) = 24 bytes
+
+Using a union would require runtime mode discrimination and waste space. Since mode
+is a compile-time constant per variant (baked into the `.hip` file), separate structs
+are cleaner: the host knows which struct to populate from `kernel.mode`, and the
+device code uses the correct Kargs type via `std::conditional_t`.
+
+## ABI Verification via static_assert
+
+The host populates flat C structs (`FmhaBwdOGradDotOBatchArgs` /
+`FmhaBwdOGradDotOGroupArgs`) and passes them by value through
+`hipModuleLaunchKernel`. The device code uses `__builtin_bit_cast` to convert
+to CK Tile's internal Kargs type (which uses C++ inheritance).
+
+This works because:
+1. Both are standard-layout types with the same fields in the same order
+2. CK Tile's Kargs uses simple single inheritance (no vtable, no virtual)
+3. We verify `sizeof(ApiArgs) == sizeof(Kargs)` and
+   `alignof(ApiArgs) == alignof(Kargs)` at compile time in `dev.hpp`
+
+The `api.hpp` file also has self-consistency asserts (`trivially_copyable`,
+`standard_layout`) to catch accidental additions of non-trivial members.
+
+## Group Mode Requires pad_seqlen_q
+
+The CK Tile dispatcher (`fmha_instance_builder.py`) filters out group-mode
+instances where `spad != "t"`. This is because group mode has variable-length
+sequences within a batch, so partial tiles at sequence boundaries are inherent.
+The `make_kernel` consteval validation enforces this same constraint at compile
+time — attempting to create a group-mode variant with `pad_seqlen_q = false`
+produces a clear error message.
+
+## Group Mode Memory Layout
+
+Group mode uses a different memory layout than batch mode:
+- **Batch**: `[batch, nhead, seqlen_q, hdim_v]` with batch strides
+- **Group**: `[total_seq, nhead, hdim_v]` where `total_seq = sum(seqlen_q_i)`
+
+The kernel computes per-batch offsets from `seqstart_q_ptr` (cumulative sequence
+lengths) rather than fixed batch strides. This means the host test must re-layout
+data when testing group-mode variants against a batch-mode CPU reference.
+
+## D Shares LSE Stride Layout
+
+In `fmha_bwd_dot_do_o_create_kargs_and_grids()`, the D output stride arguments
+use `args.nhead_stride_lsed` and `args.batch_stride_lsed` — D shares the
+log-sum-exp (LSE) stride layout since both are 1D per (batch, head, seqlen_q).
+Our API struct names them `nhead_stride_d` / `batch_stride_d` matching the
+CK Tile Kargs field names.
+
+## Naming Convention: BwdOGradDotO
+
+We follow the CK Tile internal naming (`FmhaBwdOGradDotOKernel`,
+`BlockFmhaBwdOGradDotO`, `TileFmhaBwdOGradDotOTraits`) rather than the legacy
+dispatcher naming (`bwd_dot_do_o`). This aligns type names across our API and
+the CK Tile template chain, reducing confusion when tracing the template
+instantiation path.
+
+## Potential Padding Between Common and Group Extension
+
+The common Kargs ends with `nhead_stride_d` (`index_t`, 4 bytes). The group
+extension starts with `seqstart_q_ptr` (pointer, 8-byte aligned). The compiler
+may insert 4 bytes of padding between them. This is handled automatically by
+using the same inheritance structure (CK Tile side) vs flat struct (API side)
+and verifying with `static_assert(sizeof)`. If the sizes don't match, the
+`static_assert` in `dev.hpp` will catch it at compile time.

--- a/projects/composablekernel/experimental/kpack/examples/06_rocm_ck_fmha_bwd/README.md
+++ b/projects/composablekernel/experimental/kpack/examples/06_rocm_ck_fmha_bwd/README.md
@@ -1,0 +1,79 @@
+# Example 06: FMHA BWD OGradDotO via kpack
+
+Demonstrates shipping the CK Tile FMHA backward `OGradDotO` kernel family
+(`D = rowSum(dO * O) * p_undrop`) as device-only code objects via kpack archives.
+
+This is the simplest FMHA backward kernel — it computes a per-token scalar from
+the output gradient and output tensors. It validates the kpack pattern for
+multi-parameter CK Tile kernels with both batch and group (variable-length) modes.
+
+## Dependencies
+
+- **ROCm** with HIP support (`/opt/rocm`)
+- **System packages**: `libmsgpack-cxx-dev`, `libzstd-dev`
+- **Python packages**: `msgpack` (`pip install msgpack`)
+
+## Build
+
+```bash
+cmake -B build -S . -G Ninja \
+    -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ \
+    -DCMAKE_PREFIX_PATH=/opt/rocm \
+    -DGPU_TARGETS="gfx942" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+ninja -C build
+```
+
+## Run
+
+```bash
+./build/kpack_rocm_ck_fmha_bwd build/kernels.kpack
+```
+
+## Variant Surface
+
+| Variant | dtype | hdim_v | mode  | pad_s | pad_dv | Notes |
+|---------|-------|--------|-------|-------|--------|-------|
+| `fp16_d128_batch`      | FP16 | 128 | batch | yes | yes | Most common config |
+| `bf16_d128_batch`      | BF16 | 128 | batch | yes | yes | BF16 dtype axis |
+| `fp16_d64_batch`       | FP16 | 64  | batch | yes | yes | Smaller hdim axis |
+| `fp16_d128_group`      | FP16 | 128 | group | yes | yes | Group mode axis |
+| `fp16_d128_batch_npad` | FP16 | 128 | batch | no  | no  | No-padding axis |
+
+## Design
+
+### Signature / Algorithm Split
+
+- **Signature** (`FmhaBwdOGradDotOSignature`): WHAT — dtype, hdim_v, mode
+- **Algorithm** (`FmhaBwdOGradDotOAlgorithm`): HOW — padding flags, occupancy hint, block size
+- **Config** = Signature + Algorithm (user-facing)
+- **Kernel** = validated descriptor (structural type, NTTP-safe)
+
+### CK Tile Template Chain
+
+```
+FmhaBwdOGradDotOKernel<Pipeline>
+  -> BlockFmhaBwdOGradDotO<PipelineProblem>
+    -> BlockFmhaBwdOGradDotOPipelineProblem<OType, dOType, DType, bm0, hdim_v, is_group, Traits>
+      -> TileFmhaBwdOGradDotOTraits<spad, dvpad, block_per_cu>
+```
+
+### Two Args Structs
+
+Batch and group modes use separate flat argument structs
+(`FmhaBwdOGradDotOBatchArgs` / `FmhaBwdOGradDotOGroupArgs`) that match CK Tile's
+internal Kargs layout exactly. ABI is verified by `static_assert` on sizeof/alignof
+in the device header.
+
+## File Structure
+
+```
+rocm_fmha_bwd_api.hpp         — Host+device API (NO CK Tile dependency)
+rocm_fmha_bwd_dev.hpp         — Device-side: config NTTP -> CK Tile template chain
+rocm_fmha_bwd_registry.hpp    — Variant table + findVariant()
+fmha_bwd_ograd_dot_o_*.hip    — Per-variant kernel instantiations (~15 lines each)
+main.cpp                       — Host loader + verification
+CMakeLists.txt                 — Build: compile .hip -> .hsaco, pack, build host exe
+pack.py                        — Pack .hsaco files into kpack archive
+```

--- a/projects/composablekernel/experimental/kpack/examples/06_rocm_ck_fmha_bwd/fmha_bwd_ograd_dot_o_bf16_d128_batch.hip
+++ b/projects/composablekernel/experimental/kpack/examples/06_rocm_ck_fmha_bwd/fmha_bwd_ograd_dot_o_bf16_d128_batch.hip
@@ -1,0 +1,17 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include "rocm_fmha_bwd_dev.hpp"
+
+// BF16, hdim_v=128, batch mode, padded. BF16 dtype axis variant.
+static constexpr auto kernel = rocm_ck::make_kernel(
+    rocm_ck::FmhaBwdOGradDotOConfig{
+        .signature = {.dtype = rocm_ck::DataType::BF16,
+                      .hdim_v = 128, .mode = rocm_ck::FmhaMode::BATCH},
+        .algorithm = {.pad_seqlen_q = true, .pad_hdim_v = true}});
+
+extern "C" __global__ __launch_bounds__(kernel.block_size, kernel.block_per_cu)
+void fmha_bwd_ograd_dot_o_bf16_d128_batch(rocm_ck::FmhaBwdOGradDotOBatchArgs args)
+{
+    rocm_ck::runFmhaBwdOGradDotO<kernel>(args);
+}

--- a/projects/composablekernel/experimental/kpack/examples/06_rocm_ck_fmha_bwd/fmha_bwd_ograd_dot_o_fp16_d128_batch.hip
+++ b/projects/composablekernel/experimental/kpack/examples/06_rocm_ck_fmha_bwd/fmha_bwd_ograd_dot_o_fp16_d128_batch.hip
@@ -1,0 +1,17 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include "rocm_fmha_bwd_dev.hpp"
+
+// FP16, hdim_v=128, batch mode, padded. The most common FMHA BWD config.
+static constexpr auto kernel = rocm_ck::make_kernel(
+    rocm_ck::FmhaBwdOGradDotOConfig{
+        .signature = {.dtype = rocm_ck::DataType::FP16,
+                      .hdim_v = 128, .mode = rocm_ck::FmhaMode::BATCH},
+        .algorithm = {.pad_seqlen_q = true, .pad_hdim_v = true}});
+
+extern "C" __global__ __launch_bounds__(kernel.block_size, kernel.block_per_cu)
+void fmha_bwd_ograd_dot_o_fp16_d128_batch(rocm_ck::FmhaBwdOGradDotOBatchArgs args)
+{
+    rocm_ck::runFmhaBwdOGradDotO<kernel>(args);
+}

--- a/projects/composablekernel/experimental/kpack/examples/06_rocm_ck_fmha_bwd/fmha_bwd_ograd_dot_o_fp16_d128_batch_npad.hip
+++ b/projects/composablekernel/experimental/kpack/examples/06_rocm_ck_fmha_bwd/fmha_bwd_ograd_dot_o_fp16_d128_batch_npad.hip
@@ -1,0 +1,18 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include "rocm_fmha_bwd_dev.hpp"
+
+// FP16, hdim_v=128, batch mode, no padding. No-pad axis variant.
+// Use when seqlen_q is a multiple of block_size and hdim_v matches exactly.
+static constexpr auto kernel = rocm_ck::make_kernel(
+    rocm_ck::FmhaBwdOGradDotOConfig{
+        .signature = {.dtype = rocm_ck::DataType::FP16,
+                      .hdim_v = 128, .mode = rocm_ck::FmhaMode::BATCH},
+        .algorithm = {.pad_seqlen_q = false, .pad_hdim_v = false}});
+
+extern "C" __global__ __launch_bounds__(kernel.block_size, kernel.block_per_cu)
+void fmha_bwd_ograd_dot_o_fp16_d128_batch_npad(rocm_ck::FmhaBwdOGradDotOBatchArgs args)
+{
+    rocm_ck::runFmhaBwdOGradDotO<kernel>(args);
+}

--- a/projects/composablekernel/experimental/kpack/examples/06_rocm_ck_fmha_bwd/fmha_bwd_ograd_dot_o_fp16_d128_group.hip
+++ b/projects/composablekernel/experimental/kpack/examples/06_rocm_ck_fmha_bwd/fmha_bwd_ograd_dot_o_fp16_d128_group.hip
@@ -1,0 +1,18 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include "rocm_fmha_bwd_dev.hpp"
+
+// FP16, hdim_v=128, group mode, padded. Group mode axis variant.
+// Group mode uses FmhaBwdOGradDotOGroupArgs (variable-length sequences).
+static constexpr auto kernel = rocm_ck::make_kernel(
+    rocm_ck::FmhaBwdOGradDotOConfig{
+        .signature = {.dtype = rocm_ck::DataType::FP16,
+                      .hdim_v = 128, .mode = rocm_ck::FmhaMode::GROUP},
+        .algorithm = {.pad_seqlen_q = true, .pad_hdim_v = true}});
+
+extern "C" __global__ __launch_bounds__(kernel.block_size, kernel.block_per_cu)
+void fmha_bwd_ograd_dot_o_fp16_d128_group(rocm_ck::FmhaBwdOGradDotOGroupArgs args)
+{
+    rocm_ck::runFmhaBwdOGradDotO<kernel>(args);
+}

--- a/projects/composablekernel/experimental/kpack/examples/06_rocm_ck_fmha_bwd/fmha_bwd_ograd_dot_o_fp16_d64_batch.hip
+++ b/projects/composablekernel/experimental/kpack/examples/06_rocm_ck_fmha_bwd/fmha_bwd_ograd_dot_o_fp16_d64_batch.hip
@@ -1,0 +1,17 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include "rocm_fmha_bwd_dev.hpp"
+
+// FP16, hdim_v=64, batch mode, padded. Smaller head dimension axis variant.
+static constexpr auto kernel = rocm_ck::make_kernel(
+    rocm_ck::FmhaBwdOGradDotOConfig{
+        .signature = {.dtype = rocm_ck::DataType::FP16,
+                      .hdim_v = 64, .mode = rocm_ck::FmhaMode::BATCH},
+        .algorithm = {.pad_seqlen_q = true, .pad_hdim_v = true}});
+
+extern "C" __global__ __launch_bounds__(kernel.block_size, kernel.block_per_cu)
+void fmha_bwd_ograd_dot_o_fp16_d64_batch(rocm_ck::FmhaBwdOGradDotOBatchArgs args)
+{
+    rocm_ck::runFmhaBwdOGradDotO<kernel>(args);
+}

--- a/projects/composablekernel/experimental/kpack/examples/06_rocm_ck_fmha_bwd/main.cpp
+++ b/projects/composablekernel/experimental/kpack/examples/06_rocm_ck_fmha_bwd/main.cpp
@@ -1,0 +1,573 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+//
+// Host-side loader for the FMHA BWD OGradDotO kpack example. Loads kernel
+// variants from a kpack archive and verifies each one against a CPU reference.
+//
+// Computes: D[b][h][s] = sum_v(dO[b][h][s][v] * O[b][h][s][v]) * p_undrop
+
+#include "rocm_fmha_bwd_registry.hpp"
+
+#include <rocm_ck/datatype_utils.hpp>
+#include <rocm_ck/gpu_arch.hpp>
+#include <rocm_ck/hip_check.hpp>
+
+#include <hip/hip_runtime.h>
+
+#include <rocm_kpack/kpack.h>
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+using rocm_ck::ALL_FMHA_BWD_VARIANTS;
+using rocm_ck::ALL_FMHA_BWD_VARIANTS_COUNT;
+
+// ---------------------------------------------------------------------------
+// CPU reference
+// ---------------------------------------------------------------------------
+
+/// Compute D = rowSum(dO * O) * p_undrop on the host.
+/// Layout: [batch, nhead, seqlen_q, hdim_v] row-major.
+static void cpuOGradDotO(const std::vector<float>& O,
+                         const std::vector<float>& dO,
+                         std::vector<float>& D,
+                         int batch,
+                         int nhead,
+                         int seqlen_q,
+                         int hdim_v,
+                         float p_undrop)
+{
+    for(int b = 0; b < batch; ++b)
+    {
+        for(int h = 0; h < nhead; ++h)
+        {
+            for(int s = 0; s < seqlen_q; ++s)
+            {
+                float acc = 0.0f;
+                for(int v = 0; v < hdim_v; ++v)
+                {
+                    int idx = ((b * nhead + h) * seqlen_q + s) * hdim_v + v;
+                    acc += dO[idx] * O[idx];
+                }
+                int d_idx = (b * nhead + h) * seqlen_q + s;
+                D[d_idx]  = acc * p_undrop;
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Batch-mode variant runner
+// ---------------------------------------------------------------------------
+
+static bool runBatchVariant(const rocm_ck::FmhaBwdVariantDescriptor& variant,
+                            kpack_archive_t archive,
+                            const char* gpu_arch,
+                            const std::vector<float>& host_O,
+                            const std::vector<float>& host_dO,
+                            const std::vector<float>& ref_D,
+                            int batch,
+                            int nhead,
+                            int seqlen_q,
+                            int hdim_v,
+                            float p_undrop)
+{
+    const auto dtype         = variant.kernel.dtype;
+    const int dtype_bytes    = rocm_ck::data_type_bits(dtype) / 8;
+    const size_t total_elems = static_cast<size_t>(batch) * nhead * seqlen_q * hdim_v;
+    const size_t total_d     = static_cast<size_t>(batch) * nhead * seqlen_q;
+    const size_t buf_size    = total_elems * dtype_bytes;
+    const size_t d_size      = total_d * sizeof(float); // D is always float
+
+    // Load kernel code object
+    void* kernel_code_object       = nullptr;
+    size_t kernel_code_object_size = 0;
+    kpack_error_t kerr             = kpack_get_kernel(
+        archive, variant.name, gpu_arch, &kernel_code_object, &kernel_code_object_size);
+    if(kerr != KPACK_SUCCESS)
+    {
+        std::fprintf(stderr, "  %s: no kernel for '%s' (error %d)\n", variant.name, gpu_arch, kerr);
+        return false;
+    }
+
+    hipModule_t module            = nullptr;
+    hipFunction_t kernel_function = nullptr;
+    HIP_CHECK(hipModuleLoadData(&module, kernel_code_object));
+    HIP_CHECK(hipModuleGetFunction(&kernel_function, module, variant.name));
+
+    // Allocate device buffers
+    void* dev_O  = nullptr;
+    void* dev_dO = nullptr;
+    void* dev_D  = nullptr;
+    HIP_CHECK(hipMalloc(&dev_O, buf_size));
+    HIP_CHECK(hipMalloc(&dev_dO, buf_size));
+    HIP_CHECK(hipMalloc(&dev_D, d_size));
+
+    // Convert float to typed and upload
+    std::vector<char> typed_O(buf_size);
+    std::vector<char> typed_dO(buf_size);
+    for(size_t i = 0; i < total_elems; ++i)
+    {
+        rocm_ck::float_to_typed(dtype, host_O[i], typed_O.data() + i * dtype_bytes);
+        rocm_ck::float_to_typed(dtype, host_dO[i], typed_dO.data() + i * dtype_bytes);
+    }
+
+    HIP_CHECK(hipMemcpy(dev_O, typed_O.data(), buf_size, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(dev_dO, typed_dO.data(), buf_size, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemset(dev_D, 0, d_size));
+
+    // Strides (row-major: [batch, nhead, seqlen_q, hdim_v])
+    const rocm_ck::index_t stride_o        = hdim_v;
+    const rocm_ck::index_t stride_do       = hdim_v;
+    const rocm_ck::index_t nhead_stride_o  = seqlen_q * hdim_v;
+    const rocm_ck::index_t nhead_stride_do = seqlen_q * hdim_v;
+    const rocm_ck::index_t nhead_stride_d  = seqlen_q;
+    const rocm_ck::index_t batch_stride_o  = nhead * seqlen_q * hdim_v;
+    const rocm_ck::index_t batch_stride_do = nhead * seqlen_q * hdim_v;
+    const rocm_ck::index_t batch_stride_d  = nhead * seqlen_q;
+
+    rocm_ck::FmhaBwdOGradDotOBatchArgs kernel_args = {
+        .o_ptr  = dev_O,
+        .do_ptr = dev_dO,
+        .d_ptr  = dev_D,
+
+        .p_undrop = p_undrop,
+
+        .seqlen_q = static_cast<rocm_ck::index_t>(seqlen_q),
+        .hdim_v   = static_cast<rocm_ck::index_t>(hdim_v),
+
+        .stride_do = stride_do,
+        .stride_o  = stride_o,
+
+        .nhead_stride_do = nhead_stride_do,
+        .nhead_stride_o  = nhead_stride_o,
+        .nhead_stride_d  = nhead_stride_d,
+
+        .batch_stride_do = batch_stride_do,
+        .batch_stride_o  = batch_stride_o,
+        .batch_stride_d  = batch_stride_d,
+    };
+
+    // Launch
+    dim3 grid      = rocm_ck::grid_size(batch, nhead, seqlen_q, variant.kernel.block_size);
+    int block_size = variant.kernel.block_size;
+
+    std::printf(
+        "  %s: grid=(%u,%u,%u), block=%d\n", variant.name, grid.x, grid.y, grid.z, block_size);
+
+    size_t kernel_args_size = sizeof(kernel_args);
+    void* launch_config[]   = {HIP_LAUNCH_PARAM_BUFFER_POINTER,
+                               &kernel_args,
+                               HIP_LAUNCH_PARAM_BUFFER_SIZE,
+                               &kernel_args_size,
+                               HIP_LAUNCH_PARAM_END};
+
+    HIP_CHECK(hipModuleLaunchKernel(kernel_function,
+                                    grid.x,
+                                    grid.y,
+                                    grid.z,
+                                    block_size,
+                                    1,
+                                    1,
+                                    0,
+                                    nullptr,
+                                    nullptr,
+                                    launch_config));
+    HIP_CHECK(hipDeviceSynchronize());
+
+    // Download and verify D
+    std::vector<float> got_D(total_d);
+    HIP_CHECK(hipMemcpy(got_D.data(), dev_D, d_size, hipMemcpyDeviceToHost));
+
+    const float tol = rocm_ck::tolerance_for(dtype);
+    bool passed     = true;
+    for(size_t i = 0; i < total_d; ++i)
+    {
+        if(std::fabs(got_D[i] - ref_D[i]) > tol)
+        {
+            std::fprintf(stderr,
+                         "  %s: MISMATCH at D[%zu]: got %f, expected %f (diff=%e)\n",
+                         variant.name,
+                         i,
+                         got_D[i],
+                         ref_D[i],
+                         got_D[i] - ref_D[i]);
+            passed = false;
+            break;
+        }
+    }
+
+    std::printf("  %s: %s\n", variant.name, passed ? "PASSED" : "FAILED");
+
+    HIP_CHECK(hipFree(dev_O));
+    HIP_CHECK(hipFree(dev_dO));
+    HIP_CHECK(hipFree(dev_D));
+    HIP_CHECK(hipModuleUnload(module));
+    kpack_free_kernel(kernel_code_object);
+
+    return passed;
+}
+
+// ---------------------------------------------------------------------------
+// Group-mode variant runner
+// ---------------------------------------------------------------------------
+
+static bool runGroupVariant(const rocm_ck::FmhaBwdVariantDescriptor& variant,
+                            kpack_archive_t archive,
+                            const char* gpu_arch,
+                            const std::vector<float>& host_O,
+                            const std::vector<float>& host_dO,
+                            const std::vector<float>& ref_D,
+                            int batch,
+                            int nhead,
+                            int seqlen_q,
+                            int hdim_v,
+                            float p_undrop)
+{
+    const auto dtype         = variant.kernel.dtype;
+    const int dtype_bytes    = rocm_ck::data_type_bits(dtype) / 8;
+    const size_t total_elems = static_cast<size_t>(batch) * nhead * seqlen_q * hdim_v;
+    const size_t total_d     = static_cast<size_t>(batch) * nhead * seqlen_q;
+    const size_t buf_size    = total_elems * dtype_bytes;
+    const size_t d_size      = total_d * sizeof(float);
+
+    // Load kernel
+    void* kernel_code_object       = nullptr;
+    size_t kernel_code_object_size = 0;
+    kpack_error_t kerr             = kpack_get_kernel(
+        archive, variant.name, gpu_arch, &kernel_code_object, &kernel_code_object_size);
+    if(kerr != KPACK_SUCCESS)
+    {
+        std::fprintf(stderr, "  %s: no kernel for '%s' (error %d)\n", variant.name, gpu_arch, kerr);
+        return false;
+    }
+
+    hipModule_t module            = nullptr;
+    hipFunction_t kernel_function = nullptr;
+    HIP_CHECK(hipModuleLoadData(&module, kernel_code_object));
+    HIP_CHECK(hipModuleGetFunction(&kernel_function, module, variant.name));
+
+    // Allocate device buffers
+    void* dev_O  = nullptr;
+    void* dev_dO = nullptr;
+    void* dev_D  = nullptr;
+    HIP_CHECK(hipMalloc(&dev_O, buf_size));
+    HIP_CHECK(hipMalloc(&dev_dO, buf_size));
+    HIP_CHECK(hipMalloc(&dev_D, d_size));
+
+    // Convert and upload
+    std::vector<char> typed_O(buf_size);
+    std::vector<char> typed_dO(buf_size);
+    for(size_t i = 0; i < total_elems; ++i)
+    {
+        rocm_ck::float_to_typed(dtype, host_O[i], typed_O.data() + i * dtype_bytes);
+        rocm_ck::float_to_typed(dtype, host_dO[i], typed_dO.data() + i * dtype_bytes);
+    }
+    HIP_CHECK(hipMemcpy(dev_O, typed_O.data(), buf_size, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(dev_dO, typed_dO.data(), buf_size, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemset(dev_D, 0, d_size));
+
+    // Build seqstart_q: cumulative physical sequence lengths [batch + 1].
+    // For simplicity, all sequences have the same length (seqlen_q).
+    std::vector<int32_t> seqstart_q(batch + 1);
+    for(int b = 0; b <= batch; ++b)
+        seqstart_q[b] = b * seqlen_q;
+
+    int32_t* dev_seqstart_q = nullptr;
+    HIP_CHECK(hipMalloc(&dev_seqstart_q, seqstart_q.size() * sizeof(int32_t)));
+    HIP_CHECK(hipMemcpy(dev_seqstart_q,
+                        seqstart_q.data(),
+                        seqstart_q.size() * sizeof(int32_t),
+                        hipMemcpyHostToDevice));
+
+    // Group mode layout: O/dO as [total_seq, nhead, hdim_v], D as [nhead, total_seq].
+    // Strides: stride = nhead * hdim_v, nhead_stride = hdim_v, nhead_stride_d = total_seq.
+    // Re-layout from batch-mode [batch, nhead, seqlen_q, hdim_v] for the test.
+    const int total_seq = batch * seqlen_q;
+
+    // Re-layout O/dO from [batch, nhead, seqlen_q, hdim_v] to [total_seq, nhead, hdim_v]
+    std::vector<float> group_O(total_elems);
+    std::vector<float> group_dO(total_elems);
+    for(int b = 0; b < batch; ++b)
+    {
+        for(int h = 0; h < nhead; ++h)
+        {
+            for(int s = 0; s < seqlen_q; ++s)
+            {
+                for(int v = 0; v < hdim_v; ++v)
+                {
+                    int src_idx       = ((b * nhead + h) * seqlen_q + s) * hdim_v + v;
+                    int dst_idx       = ((b * seqlen_q + s) * nhead + h) * hdim_v + v;
+                    group_O[dst_idx]  = host_O[src_idx];
+                    group_dO[dst_idx] = host_dO[src_idx];
+                }
+            }
+        }
+    }
+
+    // Re-upload with group layout
+    std::vector<char> typed_group_O(buf_size);
+    std::vector<char> typed_group_dO(buf_size);
+    for(size_t i = 0; i < total_elems; ++i)
+    {
+        rocm_ck::float_to_typed(dtype, group_O[i], typed_group_O.data() + i * dtype_bytes);
+        rocm_ck::float_to_typed(dtype, group_dO[i], typed_group_dO.data() + i * dtype_bytes);
+    }
+    HIP_CHECK(hipMemcpy(dev_O, typed_group_O.data(), buf_size, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(dev_dO, typed_group_dO.data(), buf_size, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemset(dev_D, 0, d_size));
+
+    // Group layout strides
+    const rocm_ck::index_t g_stride_o        = nhead * hdim_v;
+    const rocm_ck::index_t g_stride_do       = nhead * hdim_v;
+    const rocm_ck::index_t g_nhead_stride_o  = hdim_v;
+    const rocm_ck::index_t g_nhead_stride_do = hdim_v;
+    const rocm_ck::index_t g_nhead_stride_d  = total_seq; // D layout: [nhead, total_seq]
+
+    // Re-layout reference D from [batch, nhead, seqlen_q] to [nhead, total_seq]
+    std::vector<float> group_ref_D(total_d);
+    for(int b = 0; b < batch; ++b)
+    {
+        for(int h = 0; h < nhead; ++h)
+        {
+            for(int s = 0; s < seqlen_q; ++s)
+            {
+                int src_idx          = (b * nhead + h) * seqlen_q + s;
+                int dst_idx          = h * total_seq + b * seqlen_q + s;
+                group_ref_D[dst_idx] = ref_D[src_idx];
+            }
+        }
+    }
+
+    rocm_ck::FmhaBwdOGradDotOGroupArgs kernel_args = {
+        .o_ptr  = dev_O,
+        .do_ptr = dev_dO,
+        .d_ptr  = dev_D,
+
+        .p_undrop = p_undrop,
+
+        .seqlen_q = -1, // updated per-batch on device
+        .hdim_v   = static_cast<rocm_ck::index_t>(hdim_v),
+
+        .stride_do = g_stride_do,
+        .stride_o  = g_stride_o,
+
+        .nhead_stride_do = g_nhead_stride_do,
+        .nhead_stride_o  = g_nhead_stride_o,
+        .nhead_stride_d  = g_nhead_stride_d,
+
+        .seqstart_q_ptr  = dev_seqstart_q,
+        .seqlen_q_ptr    = nullptr, // use seqstart_q for physical length
+        .cu_seqlen_q_ptr = nullptr,
+    };
+
+    // For group mode, grid uses max_seqlen_q across all batches
+    dim3 grid    = rocm_ck::grid_size(batch, nhead, seqlen_q, variant.kernel.block_size);
+    int block_sz = variant.kernel.block_size;
+
+    std::printf("  %s: grid=(%u,%u,%u), block=%d (group mode)\n",
+                variant.name,
+                grid.x,
+                grid.y,
+                grid.z,
+                block_sz);
+
+    size_t kernel_args_size = sizeof(kernel_args);
+    void* launch_config[]   = {HIP_LAUNCH_PARAM_BUFFER_POINTER,
+                               &kernel_args,
+                               HIP_LAUNCH_PARAM_BUFFER_SIZE,
+                               &kernel_args_size,
+                               HIP_LAUNCH_PARAM_END};
+
+    HIP_CHECK(hipModuleLaunchKernel(kernel_function,
+                                    grid.x,
+                                    grid.y,
+                                    grid.z,
+                                    block_sz,
+                                    1,
+                                    1,
+                                    0,
+                                    nullptr,
+                                    nullptr,
+                                    launch_config));
+    HIP_CHECK(hipDeviceSynchronize());
+
+    // Download and verify D (in group layout)
+    std::vector<float> got_D(total_d);
+    HIP_CHECK(hipMemcpy(got_D.data(), dev_D, d_size, hipMemcpyDeviceToHost));
+
+    const float tol = rocm_ck::tolerance_for(dtype);
+    bool passed     = true;
+    for(size_t i = 0; i < total_d; ++i)
+    {
+        if(std::fabs(got_D[i] - group_ref_D[i]) > tol)
+        {
+            std::fprintf(stderr,
+                         "  %s: MISMATCH at D[%zu]: got %f, expected %f (diff=%e)\n",
+                         variant.name,
+                         i,
+                         got_D[i],
+                         group_ref_D[i],
+                         got_D[i] - group_ref_D[i]);
+            passed = false;
+            break;
+        }
+    }
+
+    std::printf("  %s: %s\n", variant.name, passed ? "PASSED" : "FAILED");
+
+    HIP_CHECK(hipFree(dev_O));
+    HIP_CHECK(hipFree(dev_dO));
+    HIP_CHECK(hipFree(dev_D));
+    HIP_CHECK(hipFree(dev_seqstart_q));
+    HIP_CHECK(hipModuleUnload(module));
+    kpack_free_kernel(kernel_code_object);
+
+    return passed;
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+int main(int argc, char** argv)
+{
+    if(argc != 2)
+    {
+        std::fprintf(stderr, "Usage: %s <path-to-kernels.kpack>\n", argv[0]);
+        return 1;
+    }
+
+    // --- Open the kpack archive ---
+    kpack_archive_t archive = nullptr;
+    kpack_error_t kerr      = kpack_open(argv[1], &archive);
+    if(kerr != KPACK_SUCCESS)
+    {
+        std::fprintf(stderr, "Failed to open archive '%s' (error %d)\n", argv[1], kerr);
+        return 1;
+    }
+
+    size_t arch_count = 0;
+    kpack_get_architecture_count(archive, &arch_count);
+    std::printf("Opened %s — architectures:", argv[1]);
+    for(size_t i = 0; i < arch_count; ++i)
+    {
+        const char* arch_name = nullptr;
+        kpack_get_architecture(archive, i, &arch_name);
+        std::printf("%s %s", (i > 0 ? "," : ""), arch_name);
+    }
+    std::printf("\n");
+
+    // --- Detect current GPU architecture ---
+    std::string gpu_arch = rocm_ck::get_gpu_arch();
+    if(gpu_arch.empty())
+    {
+        std::fprintf(stderr, "Failed to detect GPU architecture\n");
+        kpack_close(archive);
+        return 1;
+    }
+    std::printf("Detected GPU: %s\n", gpu_arch.c_str());
+
+    // --- Test parameters ---
+    const int BATCH      = 2;
+    const int NHEAD      = 2;
+    const int SEQLEN_Q   = 128;
+    const int HDIM_V     = 128; // default; d64 variant uses 64
+    const float P_UNDROP = 1.0f;
+
+    // --- Test data (small integers exactly representable in fp16/bf16) ---
+    auto make_test_data = [](int batch,
+                             int nhead,
+                             int seqlen_q,
+                             int hdim_v,
+                             std::vector<float>& O,
+                             std::vector<float>& dO) {
+        const int total = batch * nhead * seqlen_q * hdim_v;
+        O.resize(total);
+        dO.resize(total);
+        for(int i = 0; i < total; ++i)
+        {
+            O[i]  = static_cast<float>(i % 16);       // [0..15]
+            dO[i] = static_cast<float>((i * 3) % 16); // [0..15]
+        }
+    };
+
+    // --- Demonstrate findVariant ---
+    std::printf("\nVariant selection:\n");
+    for(auto dt : {rocm_ck::DataType::FP16, rocm_ck::DataType::BF16})
+    {
+        const auto* best = rocm_ck::findVariant(
+            {.signature = {.dtype = dt, .hdim_v = HDIM_V, .mode = rocm_ck::FmhaMode::BATCH},
+             .algorithm = {.pad_seqlen_q = true, .pad_hdim_v = true}});
+        if(best)
+            std::printf("  %s d%d batch -> %s\n", rocm_ck::data_type_name(dt), HDIM_V, best->name);
+    }
+    {
+        const auto* best =
+            rocm_ck::findVariant({.signature = {.dtype  = rocm_ck::DataType::FP16,
+                                                .hdim_v = HDIM_V,
+                                                .mode   = rocm_ck::FmhaMode::BATCH},
+                                  .algorithm = {.pad_seqlen_q = false, .pad_hdim_v = false}});
+        if(best)
+            std::printf("  FP16 d%d batch (no-pad) -> %s\n", HDIM_V, best->name);
+    }
+
+    // --- Run all variants ---
+    std::printf("\nRunning all %d variants:\n", ALL_FMHA_BWD_VARIANTS_COUNT);
+    bool all_passed = true;
+
+    for(const auto& variant : ALL_FMHA_BWD_VARIANTS)
+    {
+        const int cur_hdim = variant.kernel.hdim_v;
+
+        std::vector<float> host_O, host_dO;
+        make_test_data(BATCH, NHEAD, SEQLEN_Q, cur_hdim, host_O, host_dO);
+
+        // CPU reference
+        const int total_d = BATCH * NHEAD * SEQLEN_Q;
+        std::vector<float> ref_D(total_d, 0.0f);
+        cpuOGradDotO(host_O, host_dO, ref_D, BATCH, NHEAD, SEQLEN_Q, cur_hdim, P_UNDROP);
+
+        bool passed;
+        if(variant.kernel.mode == rocm_ck::FmhaMode::GROUP)
+        {
+            passed = runGroupVariant(variant,
+                                     archive,
+                                     gpu_arch.c_str(),
+                                     host_O,
+                                     host_dO,
+                                     ref_D,
+                                     BATCH,
+                                     NHEAD,
+                                     SEQLEN_Q,
+                                     cur_hdim,
+                                     P_UNDROP);
+        }
+        else
+        {
+            passed = runBatchVariant(variant,
+                                     archive,
+                                     gpu_arch.c_str(),
+                                     host_O,
+                                     host_dO,
+                                     ref_D,
+                                     BATCH,
+                                     NHEAD,
+                                     SEQLEN_Q,
+                                     cur_hdim,
+                                     P_UNDROP);
+        }
+
+        if(!passed)
+            all_passed = false;
+    }
+
+    // --- Cleanup ---
+    kpack_close(archive);
+
+    std::printf("\n%s\n", all_passed ? "All variants PASSED" : "Some variants FAILED");
+    return all_passed ? 0 : 1;
+}

--- a/projects/composablekernel/experimental/kpack/examples/06_rocm_ck_fmha_bwd/pack.py
+++ b/projects/composablekernel/experimental/kpack/examples/06_rocm_ck_fmha_bwd/pack.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+# Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
+"""Pack per-architecture .hsaco files for FMHA BWD OGradDotO variants into a kpack archive.
+
+Archive format:
+
+    [0x00]  "KPAK"           4 bytes   Magic
+    [0x04]  version          4 bytes   uint32 LE (currently 1)
+    [0x08]  toc_offset       8 bytes   uint64 LE
+    [0x10]  blob_0           variable  Raw .hsaco bytes
+            blob_1           variable  ...
+    [toc_offset]  TOC        variable  MessagePack table of contents
+"""
+
+import struct
+import sys
+from pathlib import Path
+
+try:
+    import msgpack
+except ImportError:
+    print(
+        "Error: msgpack package required. Install with: pip install msgpack",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+KPACK_MAGIC = b"KPAK"
+KPACK_VERSION = 1
+HEADER_SIZE = 16  # 4 (magic) + 4 (version) + 8 (toc_offset)
+
+# Variant metadata mirrors the constexpr ALL_FMHA_BWD_VARIANTS table in
+# rocm_fmha_bwd_registry.hpp.
+VARIANTS = [
+    {
+        "name": "fmha_bwd_ograd_dot_o_fp16_d128_batch",
+        "dtype": "fp16",
+        "hdim_v": 128,
+        "mode": "batch",
+        "pad_seqlen_q": True,
+        "pad_hdim_v": True,
+        "block_per_cu": 2,
+        "block_size": 64,
+    },
+    {
+        "name": "fmha_bwd_ograd_dot_o_bf16_d128_batch",
+        "dtype": "bf16",
+        "hdim_v": 128,
+        "mode": "batch",
+        "pad_seqlen_q": True,
+        "pad_hdim_v": True,
+        "block_per_cu": 2,
+        "block_size": 64,
+    },
+    {
+        "name": "fmha_bwd_ograd_dot_o_fp16_d64_batch",
+        "dtype": "fp16",
+        "hdim_v": 64,
+        "mode": "batch",
+        "pad_seqlen_q": True,
+        "pad_hdim_v": True,
+        "block_per_cu": 2,
+        "block_size": 64,
+    },
+    {
+        "name": "fmha_bwd_ograd_dot_o_fp16_d128_group",
+        "dtype": "fp16",
+        "hdim_v": 128,
+        "mode": "group",
+        "pad_seqlen_q": True,
+        "pad_hdim_v": True,
+        "block_per_cu": 2,
+        "block_size": 64,
+    },
+    {
+        "name": "fmha_bwd_ograd_dot_o_fp16_d128_batch_npad",
+        "dtype": "fp16",
+        "hdim_v": 128,
+        "mode": "batch",
+        "pad_seqlen_q": False,
+        "pad_hdim_v": False,
+        "block_per_cu": 2,
+        "block_size": 64,
+    },
+]
+ARCHITECTURES = ["gfx90a", "gfx942", "gfx950"]
+
+
+def main() -> None:
+    # Accept an optional build directory argument (used by CMake).
+    # Defaults to ./build relative to this script.
+    build_dir = (
+        Path(sys.argv[1]) if len(sys.argv) > 1 else Path(__file__).parent / "build"
+    )
+    output_path = build_dir / "kernels.kpack"
+
+    # Read .hsaco blobs for each variant x architecture
+    blobs: list[bytes] = []
+    found_arches: set[str] = set()
+    # Map: variant_name -> {arch -> ordinal} for building the TOC
+    variant_map: dict[str, dict[str, int]] = {}
+
+    for variant in VARIANTS:
+        name = variant["name"]
+        variant_entries: dict[str, int] = {}
+        for arch in ARCHITECTURES:
+            hsaco_path = build_dir / f"{name}_{arch}.hsaco"
+            if not hsaco_path.exists():
+                print(f"  Skipping {name}/{arch}: {hsaco_path.name} not found")
+                continue
+            blob = hsaco_path.read_bytes()
+            ordinal = len(blobs)
+            blobs.append(blob)
+            found_arches.add(arch)
+            variant_entries[arch] = ordinal
+            print(f"  Read {hsaco_path.name} ({len(blob)} bytes)")
+
+        if variant_entries:
+            variant_map[name] = variant_entries
+
+    if not blobs:
+        print("Error: no .hsaco files found in build/", file=sys.stderr)
+        sys.exit(1)
+
+    # Stable arch ordering for the TOC
+    sorted_arches = sorted(found_arches)
+
+    # Write the archive
+    with output_path.open("wb") as out:
+        # Header (toc_offset patched after writing blobs)
+        out.write(KPACK_MAGIC)
+        out.write(struct.pack("<I", KPACK_VERSION))
+        out.write(struct.pack("<Q", 0))  # toc_offset placeholder
+
+        # Concatenate blobs, recording offsets
+        blob_infos: list[dict] = []
+        for blob in blobs:
+            offset = out.tell()
+            out.write(blob)
+            blob_infos.append({"offset": offset, "size": len(blob)})
+
+        # Build and write the MessagePack TOC
+        toc_offset = out.tell()
+
+        # Variant metadata: tuning surface parameters for each variant
+        variant_metadata = {}
+        for v in VARIANTS:
+            if v["name"] in variant_map:
+                variant_metadata[v["name"]] = {
+                    "dtype": v["dtype"],
+                    "hdim_v": v["hdim_v"],
+                    "mode": v["mode"],
+                    "pad_seqlen_q": v["pad_seqlen_q"],
+                    "pad_hdim_v": v["pad_hdim_v"],
+                    "block_per_cu": v["block_per_cu"],
+                    "block_size": v["block_size"],
+                }
+
+        toc = {
+            "compression_scheme": "none",
+            "gfx_arches": sorted_arches,
+            "blobs": blob_infos,
+            "variant_metadata": variant_metadata,
+            "toc": {
+                variant_name: {
+                    arch: {
+                        "ordinal": ordinal,
+                        "original_size": len(blobs[ordinal]),
+                        "type": "hsaco",
+                    }
+                    for arch, ordinal in arch_entries.items()
+                }
+                for variant_name, arch_entries in variant_map.items()
+            },
+        }
+        out.write(msgpack.packb(toc, use_bin_type=True))
+
+        # Patch header with actual toc_offset
+        out.seek(8)
+        out.write(struct.pack("<Q", toc_offset))
+
+    total_size = sum(len(b) for b in blobs)
+    print(f"\nCreated {output_path}")
+    print(f"  Architectures: {', '.join(sorted_arches)}")
+    print(f"  Variants: {', '.join(variant_map.keys())}")
+    print(f"  Total kernel data: {total_size} bytes")
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/composablekernel/experimental/kpack/examples/06_rocm_ck_fmha_bwd/rocm_fmha_bwd_api.hpp
+++ b/projects/composablekernel/experimental/kpack/examples/06_rocm_ck_fmha_bwd/rocm_fmha_bwd_api.hpp
@@ -14,6 +14,7 @@
 
 #include <hip/hip_runtime.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <type_traits>
 
@@ -168,6 +169,33 @@ static_assert(std::is_trivially_copyable_v<FmhaBwdOGradDotOBatchArgs>,
               "FmhaBwdOGradDotOBatchArgs must be trivially copyable for kernarg passing");
 static_assert(std::is_standard_layout_v<FmhaBwdOGradDotOBatchArgs>,
               "FmhaBwdOGradDotOBatchArgs must be standard layout");
+static_assert(sizeof(FmhaBwdOGradDotOBatchArgs) == 72, "unexpected FmhaBwdOGradDotOBatchArgs size");
+static_assert(alignof(FmhaBwdOGradDotOBatchArgs) == 8,
+              "unexpected FmhaBwdOGradDotOBatchArgs alignment");
+static_assert(offsetof(FmhaBwdOGradDotOBatchArgs, o_ptr) == 0, "unexpected offset for o_ptr");
+static_assert(offsetof(FmhaBwdOGradDotOBatchArgs, do_ptr) == 8, "unexpected offset for do_ptr");
+static_assert(offsetof(FmhaBwdOGradDotOBatchArgs, d_ptr) == 16, "unexpected offset for d_ptr");
+static_assert(offsetof(FmhaBwdOGradDotOBatchArgs, p_undrop) == 24,
+              "unexpected offset for p_undrop");
+static_assert(offsetof(FmhaBwdOGradDotOBatchArgs, seqlen_q) == 28,
+              "unexpected offset for seqlen_q");
+static_assert(offsetof(FmhaBwdOGradDotOBatchArgs, hdim_v) == 32, "unexpected offset for hdim_v");
+static_assert(offsetof(FmhaBwdOGradDotOBatchArgs, stride_do) == 36,
+              "unexpected offset for stride_do");
+static_assert(offsetof(FmhaBwdOGradDotOBatchArgs, stride_o) == 40,
+              "unexpected offset for stride_o");
+static_assert(offsetof(FmhaBwdOGradDotOBatchArgs, nhead_stride_do) == 44,
+              "unexpected offset for nhead_stride_do");
+static_assert(offsetof(FmhaBwdOGradDotOBatchArgs, nhead_stride_o) == 48,
+              "unexpected offset for nhead_stride_o");
+static_assert(offsetof(FmhaBwdOGradDotOBatchArgs, nhead_stride_d) == 52,
+              "unexpected offset for nhead_stride_d");
+static_assert(offsetof(FmhaBwdOGradDotOBatchArgs, batch_stride_do) == 56,
+              "unexpected offset for batch_stride_do");
+static_assert(offsetof(FmhaBwdOGradDotOBatchArgs, batch_stride_o) == 60,
+              "unexpected offset for batch_stride_o");
+static_assert(offsetof(FmhaBwdOGradDotOBatchArgs, batch_stride_d) == 64,
+              "unexpected offset for batch_stride_d");
 
 /// Group-mode kernel arguments.
 /// Layout matches CK Tile's FmhaBwdOGradDotOGroupModeKargs exactly.
@@ -200,6 +228,33 @@ static_assert(std::is_trivially_copyable_v<FmhaBwdOGradDotOGroupArgs>,
               "FmhaBwdOGradDotOGroupArgs must be trivially copyable for kernarg passing");
 static_assert(std::is_standard_layout_v<FmhaBwdOGradDotOGroupArgs>,
               "FmhaBwdOGradDotOGroupArgs must be standard layout");
+static_assert(sizeof(FmhaBwdOGradDotOGroupArgs) == 80, "unexpected FmhaBwdOGradDotOGroupArgs size");
+static_assert(alignof(FmhaBwdOGradDotOGroupArgs) == 8,
+              "unexpected FmhaBwdOGradDotOGroupArgs alignment");
+static_assert(offsetof(FmhaBwdOGradDotOGroupArgs, o_ptr) == 0, "unexpected offset for o_ptr");
+static_assert(offsetof(FmhaBwdOGradDotOGroupArgs, do_ptr) == 8, "unexpected offset for do_ptr");
+static_assert(offsetof(FmhaBwdOGradDotOGroupArgs, d_ptr) == 16, "unexpected offset for d_ptr");
+static_assert(offsetof(FmhaBwdOGradDotOGroupArgs, p_undrop) == 24,
+              "unexpected offset for p_undrop");
+static_assert(offsetof(FmhaBwdOGradDotOGroupArgs, seqlen_q) == 28,
+              "unexpected offset for seqlen_q");
+static_assert(offsetof(FmhaBwdOGradDotOGroupArgs, hdim_v) == 32, "unexpected offset for hdim_v");
+static_assert(offsetof(FmhaBwdOGradDotOGroupArgs, stride_do) == 36,
+              "unexpected offset for stride_do");
+static_assert(offsetof(FmhaBwdOGradDotOGroupArgs, stride_o) == 40,
+              "unexpected offset for stride_o");
+static_assert(offsetof(FmhaBwdOGradDotOGroupArgs, nhead_stride_do) == 44,
+              "unexpected offset for nhead_stride_do");
+static_assert(offsetof(FmhaBwdOGradDotOGroupArgs, nhead_stride_o) == 48,
+              "unexpected offset for nhead_stride_o");
+static_assert(offsetof(FmhaBwdOGradDotOGroupArgs, nhead_stride_d) == 52,
+              "unexpected offset for nhead_stride_d");
+static_assert(offsetof(FmhaBwdOGradDotOGroupArgs, seqstart_q_ptr) == 56,
+              "unexpected offset for seqstart_q_ptr");
+static_assert(offsetof(FmhaBwdOGradDotOGroupArgs, seqlen_q_ptr) == 64,
+              "unexpected offset for seqlen_q_ptr");
+static_assert(offsetof(FmhaBwdOGradDotOGroupArgs, cu_seqlen_q_ptr) == 72,
+              "unexpected offset for cu_seqlen_q_ptr");
 
 // ---------------------------------------------------------------------------
 // Grid calculation

--- a/projects/composablekernel/experimental/kpack/examples/06_rocm_ck_fmha_bwd/rocm_fmha_bwd_api.hpp
+++ b/projects/composablekernel/experimental/kpack/examples/06_rocm_ck_fmha_bwd/rocm_fmha_bwd_api.hpp
@@ -1,0 +1,217 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+//
+// Shared argument structs and compile-time configuration for the FMHA BWD
+// OGradDotO kernel family.
+//
+// This header has no CK Tile dependency. It is included by both host code
+// (main.cpp) and device code (.hip files) to share the kernel ABI and
+// compile-time-validated configuration. Requires HIP for dim3.
+
+#pragma once
+
+#include <rocm_ck/datatype_utils.hpp>
+
+#include <hip/hip_runtime.h>
+
+#include <cstdint>
+#include <type_traits>
+
+namespace rocm_ck {
+
+/// Fixed-width integer type for kernel index/size arguments.
+/// Matches ck_tile::index_t but avoids pulling in CK Tile headers.
+using index_t = std::int32_t;
+
+/// FMHA attention mode: fixed-length batches vs variable-length groups.
+enum class FmhaMode
+{
+    BATCH,
+    GROUP
+};
+
+// ---------------------------------------------------------------------------
+// Signature / Algorithm / Config / Kernel
+// ---------------------------------------------------------------------------
+
+/// Signature: describes WHAT the kernel computes (data types, dimensions, mode).
+struct FmhaBwdOGradDotOSignature
+{
+    DataType dtype; // fp16 or bf16 (controls O, dO types; D is always float)
+    int hdim_v;     // head dimension: 32, 64, 96, 128, 256
+    FmhaMode mode;  // batch or group
+};
+
+/// Algorithm: describes HOW the kernel executes (padding, occupancy, block size).
+struct FmhaBwdOGradDotOAlgorithm
+{
+    bool pad_seqlen_q;     // kPadSeqLenQ
+    bool pad_hdim_v;       // kPadHeadDimV
+    int block_per_cu = 2;  // occupancy hint (default from TileFmhaBwdOGradDotOTraits)
+    int block_size   = 64; // tile_m0 = kM0 = kBlockSize
+};
+
+/// Config: user-facing Signature + Algorithm pair.
+struct FmhaBwdOGradDotOConfig
+{
+    FmhaBwdOGradDotOSignature signature;
+    FmhaBwdOGradDotOAlgorithm algorithm;
+};
+
+/// Validated kernel descriptor — structural type, safe for use as NTTP.
+/// All optional/default values are resolved; no std::optional.
+struct FmhaBwdOGradDotOKernel
+{
+    DataType dtype;
+    int hdim_v;
+    FmhaMode mode;
+    bool pad_seqlen_q;
+    bool pad_hdim_v;
+    int block_per_cu;
+    int block_size;
+};
+
+/// Validate config and produce a structural kernel descriptor.
+consteval FmhaBwdOGradDotOKernel make_kernel(FmhaBwdOGradDotOConfig cfg)
+{
+    auto sig  = cfg.signature;
+    auto algo = cfg.algorithm;
+
+    if(sig.dtype != DataType::FP16 && sig.dtype != DataType::BF16)
+        throw "FmhaBwdOGradDotO only supports FP16 or BF16 (O/dO types; D is always float)";
+
+    // Valid head dimensions per BWD_DOT_DO_O_HDIMS in dispatcher
+    if(sig.hdim_v != 32 && sig.hdim_v != 64 && sig.hdim_v != 96 && sig.hdim_v != 128 &&
+       sig.hdim_v != 256)
+        throw "hdim_v must be one of {32, 64, 96, 128, 256}";
+
+    // BlockFmhaBwdOGradDotOPipelineProblem requires:
+    //   0 < kBlockSize && kBlockSize % get_warp_size() == 0
+    if(algo.block_size <= 0)
+        throw "block_size must be positive";
+    if(algo.block_size % 64 != 0)
+        throw "block_size must be divisible by warp size (64)";
+
+    if(algo.block_per_cu <= 0)
+        throw "block_per_cu must be positive";
+
+    // Group mode requires seqlen padding (variable-length sequences)
+    if(sig.mode == FmhaMode::GROUP && !algo.pad_seqlen_q)
+        throw "group mode requires pad_seqlen_q=true (variable-length sequences)";
+
+    return {sig.dtype,
+            sig.hdim_v,
+            sig.mode,
+            algo.pad_seqlen_q,
+            algo.pad_hdim_v,
+            algo.block_per_cu,
+            algo.block_size};
+}
+
+// --- make_kernel compile-time tests ---
+// clang-format off
+
+// Valid configs compile:
+static_assert(make_kernel(FmhaBwdOGradDotOConfig{
+    .signature = {.dtype = DataType::FP16, .hdim_v = 128, .mode = FmhaMode::BATCH},
+    .algorithm = {.pad_seqlen_q = true, .pad_hdim_v = true}}).dtype == DataType::FP16);
+static_assert(make_kernel(FmhaBwdOGradDotOConfig{
+    .signature = {.dtype = DataType::BF16, .hdim_v = 64, .mode = FmhaMode::BATCH},
+    .algorithm = {.pad_seqlen_q = true, .pad_hdim_v = true}}).hdim_v == 64);
+static_assert(make_kernel(FmhaBwdOGradDotOConfig{
+    .signature = {.dtype = DataType::FP16, .hdim_v = 128, .mode = FmhaMode::GROUP},
+    .algorithm = {.pad_seqlen_q = true, .pad_hdim_v = true}}).mode == FmhaMode::GROUP);
+static_assert(make_kernel(FmhaBwdOGradDotOConfig{
+    .signature = {.dtype = DataType::FP16, .hdim_v = 128, .mode = FmhaMode::BATCH},
+    .algorithm = {.pad_seqlen_q = false, .pad_hdim_v = false}}).pad_seqlen_q == false);
+
+// Invalid configs (uncommenting produces consteval compile errors):
+// make_kernel({.signature = {.dtype = DataType::FP32, ...}})  — FP32 not supported
+// make_kernel({.signature = {.hdim_v = 100, ...}})            — invalid hdim
+// make_kernel({.signature = {.mode = FmhaMode::GROUP}, .algorithm = {.pad_seqlen_q = false}})
+//   — group mode requires pad_seqlen_q
+
+// clang-format on
+
+// ---------------------------------------------------------------------------
+// Kernel arguments — flat structs matching CK Tile's internal Kargs layout
+// ---------------------------------------------------------------------------
+
+/// Batch-mode kernel arguments.
+/// Layout matches CK Tile's FmhaBwdOGradDotOBatchModeKargs exactly.
+struct FmhaBwdOGradDotOBatchArgs
+{
+    // --- Common (matches FmhaBwdOGradDotOCommonKargs) ---
+    const void* o_ptr;
+    const void* do_ptr;
+    void* d_ptr;
+
+    float p_undrop;
+
+    index_t seqlen_q;
+    index_t hdim_v;
+
+    index_t stride_do;
+    index_t stride_o;
+
+    index_t nhead_stride_do;
+    index_t nhead_stride_o;
+    index_t nhead_stride_d;
+
+    // --- Batch extension ---
+    index_t batch_stride_do;
+    index_t batch_stride_o;
+    index_t batch_stride_d;
+};
+
+static_assert(std::is_trivially_copyable_v<FmhaBwdOGradDotOBatchArgs>,
+              "FmhaBwdOGradDotOBatchArgs must be trivially copyable for kernarg passing");
+static_assert(std::is_standard_layout_v<FmhaBwdOGradDotOBatchArgs>,
+              "FmhaBwdOGradDotOBatchArgs must be standard layout");
+
+/// Group-mode kernel arguments.
+/// Layout matches CK Tile's FmhaBwdOGradDotOGroupModeKargs exactly.
+struct FmhaBwdOGradDotOGroupArgs
+{
+    // --- Common (same fields as batch, seqlen_q = -1 placeholder) ---
+    const void* o_ptr;
+    const void* do_ptr;
+    void* d_ptr;
+
+    float p_undrop;
+
+    index_t seqlen_q; // -1 (updated per-batch on device)
+    index_t hdim_v;
+
+    index_t stride_do;
+    index_t stride_o;
+
+    index_t nhead_stride_do;
+    index_t nhead_stride_o;
+    index_t nhead_stride_d;
+
+    // --- Group extension ---
+    const int32_t* seqstart_q_ptr;
+    const int32_t* seqlen_q_ptr;
+    const int32_t* cu_seqlen_q_ptr;
+};
+
+static_assert(std::is_trivially_copyable_v<FmhaBwdOGradDotOGroupArgs>,
+              "FmhaBwdOGradDotOGroupArgs must be trivially copyable for kernarg passing");
+static_assert(std::is_standard_layout_v<FmhaBwdOGradDotOGroupArgs>,
+              "FmhaBwdOGradDotOGroupArgs must be standard layout");
+
+// ---------------------------------------------------------------------------
+// Grid calculation
+// ---------------------------------------------------------------------------
+
+/// Compute the launch grid for OGradDotO.
+/// Matches FmhaBwdOGradDotOKernel::GridSize(): dim3(ceil(seqlen_q / kM0), nhead, batch).
+constexpr dim3 grid_size(int batch, int nhead, int seqlen_q, int block_size)
+{
+    return dim3(static_cast<unsigned>((seqlen_q + block_size - 1) / block_size),
+                static_cast<unsigned>(nhead),
+                static_cast<unsigned>(batch));
+}
+
+} // namespace rocm_ck

--- a/projects/composablekernel/experimental/kpack/examples/06_rocm_ck_fmha_bwd/rocm_fmha_bwd_dev.hpp
+++ b/projects/composablekernel/experimental/kpack/examples/06_rocm_ck_fmha_bwd/rocm_fmha_bwd_dev.hpp
@@ -1,0 +1,92 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+//
+// Device-side bridge for FMHA BWD OGradDotO. Maps the validated kernel
+// descriptor (FmhaBwdOGradDotOKernel) to the CK Tile template chain.
+//
+// Uses C++20 struct NTTPs: template <FmhaBwdOGradDotOKernel K>.
+
+#pragma once
+
+#include "rocm_fmha_bwd_api.hpp"
+
+#include "ck_tile/core.hpp"
+#include "ck_tile/ops/fmha.hpp"
+
+namespace rocm_ck {
+
+/// Maps a DataType enum value to the corresponding CK Tile numeric type.
+/// Only FP16 and BF16 are needed for FMHA BWD OGradDotO.
+template <DataType>
+struct CkTypeMap;
+
+template <>
+struct CkTypeMap<DataType::FP16>
+{
+    using type = ck_tile::half_t;
+};
+template <>
+struct CkTypeMap<DataType::BF16>
+{
+    using type = ck_tile::bf16_t;
+};
+
+/// Maps a FmhaBwdOGradDotOKernel descriptor to the full CK Tile type chain.
+///
+/// Template chain (matches dispatcher codegen):
+///   FmhaBwdOGradDotOKernel<Pipeline>
+///     -> BlockFmhaBwdOGradDotO<PipelineProblem>
+///       -> BlockFmhaBwdOGradDotOPipelineProblem<OType, dOType, DType,
+///              bm0, hdim_v, is_group, Traits>
+///         -> TileFmhaBwdOGradDotOTraits<spad, dvpad, block_per_cu>
+template <FmhaBwdOGradDotOKernel K>
+struct FmhaBwdOGradDotOTypes
+{
+    using ODataType     = typename CkTypeMap<K.dtype>::type; // half_t or bf16_t
+    using OGradDataType = ODataType;                         // dO always same type as O
+    using DDataType     = float;                             // D is always float
+
+    using Traits =
+        ck_tile::TileFmhaBwdOGradDotOTraits<K.pad_seqlen_q, K.pad_hdim_v, K.block_per_cu>;
+
+    using PipelineProblem =
+        ck_tile::BlockFmhaBwdOGradDotOPipelineProblem<ODataType,
+                                                      OGradDataType,
+                                                      DDataType,
+                                                      K.block_size,
+                                                      K.hdim_v,
+                                                      (K.mode == FmhaMode::GROUP),
+                                                      Traits>;
+
+    using Pipeline = ck_tile::BlockFmhaBwdOGradDotO<PipelineProblem>;
+    using Kernel   = ck_tile::FmhaBwdOGradDotOKernel<Pipeline>;
+    using Kargs    = typename Kernel::Kargs;
+    using ApiArgs  = std::conditional_t<K.mode == FmhaMode::GROUP,
+                                        FmhaBwdOGradDotOGroupArgs,
+                                        FmhaBwdOGradDotOBatchArgs>;
+};
+
+/// Device function that invokes the CK Tile FMHA BWD OGradDotO kernel.
+///
+/// The API args struct (FmhaBwdOGradDotOBatchArgs or FmhaBwdOGradDotOGroupArgs)
+/// has identical memory layout to CK Tile's internal Kargs (verified by
+/// static_assert). We use __builtin_bit_cast to convert safely (no strict
+/// aliasing violation, zero runtime cost).
+///
+/// Call this from an extern "C" __global__ wrapper.
+template <FmhaBwdOGradDotOKernel K>
+__device__ void runFmhaBwdOGradDotO(const typename FmhaBwdOGradDotOTypes<K>::ApiArgs& args)
+{
+    using T = FmhaBwdOGradDotOTypes<K>;
+
+    // ABI safety: verify our flat API args struct matches CK Tile's internal Kargs
+    static_assert(sizeof(typename T::ApiArgs) == sizeof(typename T::Kargs),
+                  "API args size mismatch with CK Tile Kargs");
+    static_assert(alignof(typename T::ApiArgs) == alignof(typename T::Kargs),
+                  "API args alignment mismatch with CK Tile Kargs");
+
+    const auto kargs = __builtin_bit_cast(typename T::Kargs, args);
+    typename T::Kernel{}(kargs);
+}
+
+} // namespace rocm_ck

--- a/projects/composablekernel/experimental/kpack/examples/06_rocm_ck_fmha_bwd/rocm_fmha_bwd_registry.hpp
+++ b/projects/composablekernel/experimental/kpack/examples/06_rocm_ck_fmha_bwd/rocm_fmha_bwd_registry.hpp
@@ -1,0 +1,81 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+//
+// Variant registry for programmatic kernel selection.
+// Host-only header — no CK Tile dependency.
+
+#pragma once
+
+#include "rocm_fmha_bwd_api.hpp"
+
+namespace rocm_ck {
+
+/// Descriptor for a compiled FMHA BWD OGradDotO variant in the kpack archive.
+struct FmhaBwdVariantDescriptor
+{
+    const char* name;
+    FmhaBwdOGradDotOKernel kernel;
+};
+
+/// Complete table of all compiled variants, matching the kpack archive contents.
+/// Each entry corresponds to a .hip file and its make_kernel configuration.
+// clang-format off
+static constexpr FmhaBwdVariantDescriptor ALL_FMHA_BWD_VARIANTS[] = {
+    {"fmha_bwd_ograd_dot_o_fp16_d128_batch", make_kernel(FmhaBwdOGradDotOConfig{
+         .signature = {.dtype = DataType::FP16, .hdim_v = 128, .mode = FmhaMode::BATCH},
+         .algorithm = {.pad_seqlen_q = true, .pad_hdim_v = true}})},
+    {"fmha_bwd_ograd_dot_o_bf16_d128_batch", make_kernel(FmhaBwdOGradDotOConfig{
+         .signature = {.dtype = DataType::BF16, .hdim_v = 128, .mode = FmhaMode::BATCH},
+         .algorithm = {.pad_seqlen_q = true, .pad_hdim_v = true}})},
+    {"fmha_bwd_ograd_dot_o_fp16_d64_batch", make_kernel(FmhaBwdOGradDotOConfig{
+         .signature = {.dtype = DataType::FP16, .hdim_v = 64, .mode = FmhaMode::BATCH},
+         .algorithm = {.pad_seqlen_q = true, .pad_hdim_v = true}})},
+    {"fmha_bwd_ograd_dot_o_fp16_d128_group", make_kernel(FmhaBwdOGradDotOConfig{
+         .signature = {.dtype = DataType::FP16, .hdim_v = 128, .mode = FmhaMode::GROUP},
+         .algorithm = {.pad_seqlen_q = true, .pad_hdim_v = true}})},
+    {"fmha_bwd_ograd_dot_o_fp16_d128_batch_npad", make_kernel(FmhaBwdOGradDotOConfig{
+         .signature = {.dtype = DataType::FP16, .hdim_v = 128, .mode = FmhaMode::BATCH},
+         .algorithm = {.pad_seqlen_q = false, .pad_hdim_v = false}})},
+};
+// clang-format on
+
+static constexpr int ALL_FMHA_BWD_VARIANTS_COUNT =
+    sizeof(ALL_FMHA_BWD_VARIANTS) / sizeof(ALL_FMHA_BWD_VARIANTS[0]);
+
+/// Find the best variant matching the given config.
+///
+/// Matching logic: exact match on signature (dtype + hdim_v + mode). Among
+/// matches, prefer the variant whose padding flags match the algorithm's
+/// pad_seqlen_q/pad_hdim_v. Falls back to padded if no exact match.
+///
+/// Returns nullptr if no variant matches the signature.
+constexpr const FmhaBwdVariantDescriptor* findVariant(FmhaBwdOGradDotOConfig cfg)
+{
+    const auto& sig  = cfg.signature;
+    const auto& algo = cfg.algorithm;
+
+    const FmhaBwdVariantDescriptor* best_nopad  = nullptr;
+    const FmhaBwdVariantDescriptor* best_padded = nullptr;
+
+    for(int i = 0; i < ALL_FMHA_BWD_VARIANTS_COUNT; ++i)
+    {
+        const auto& v = ALL_FMHA_BWD_VARIANTS[i];
+        if(v.kernel.dtype != sig.dtype || v.kernel.hdim_v != sig.hdim_v ||
+           v.kernel.mode != sig.mode)
+            continue;
+
+        if(!v.kernel.pad_seqlen_q && !v.kernel.pad_hdim_v)
+            best_nopad = &ALL_FMHA_BWD_VARIANTS[i];
+        else
+            best_padded = &ALL_FMHA_BWD_VARIANTS[i];
+    }
+
+    // If caller doesn't need padding and a no-pad variant exists, use it
+    if(!algo.pad_seqlen_q && !algo.pad_hdim_v && best_nopad)
+        return best_nopad;
+
+    // Otherwise use padded (works for all alignments)
+    return best_padded ? best_padded : best_nopad;
+}
+
+} // namespace rocm_ck


### PR DESCRIPTION
## Summary

- Add example 06 demonstrating the CK Tile FMHA backward `OGradDotO` kernel family shipped as device-only code objects via kpack archives
- Covers five variant axes: dtype (fp16/bf16), hdim_v (64/128), mode (batch/group), and padding (padded/no-pad)
- Validates the kpack pattern for multi-parameter CK Tile kernels with separate batch and group argument structs verified by `static_assert` against CK Tile's internal Kargs layout
- Add comprehensive `sizeof`/`alignof`/`offsetof` static_asserts pinning the exact memory layout of both args structs (batch: 72 bytes, group: 80 bytes) to catch ABI drift at compile time

## Test plan

- [x] Build example 06 on gfx942 with `cmake + ninja` (16/16 targets, 14.4s)
- [x] Run `pack.py` to generate kpack archives for all variants
- [x] Run `main` to load and execute kernels from kpack archives
- [x] Verify numerical correctness against reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)