### PR TITLE
[rocprim] Fixed the toc install titles

### DIFF
--- a/projects/rocprim/docs/index.rst
+++ b/projects/rocprim/docs/index.rst
@@ -19,8 +19,8 @@ The rocPRIM project is located in https://github.com/ROCm/rocm-libraries/tree/de
 
     * :doc:`rocPRIM prerequisites <install/rocPRIM-prerequisites>`
     * :doc:`rocPRIM installation overview <install/rocPRIM-install-overview>`
-    * :doc:`Install rocPRIM on Linux <install/rocPRIM-build-install-linux>`
-    * :doc:`Install rocPRIM on Windows <install/rocPRIM-build-install-windows>`
+    * :doc:`Installing rocPRIM on Linux <install/rocPRIM-build-install-linux>`
+    * :doc:`Installing rocPRIM on Windows <install/rocPRIM-build-install-windows>`
   
   .. grid-item-card:: Conceptual
 

--- a/projects/rocprim/docs/sphinx/_toc.yml.in
+++ b/projects/rocprim/docs/sphinx/_toc.yml.in
@@ -12,7 +12,7 @@ subtrees:
   - file: install/rocPRIM-build-install-linux.rst
     title: Installing on Linux
   - file: install/rocPRIM-build-install-windows.rst
-    title: Building and installing from source
+    title: Installing on Windows
 
 - caption: Conceptual
   entries:


### PR DESCRIPTION
## Motivation

The titles of the install topics in the TOC were wrong; fixed it.