### PR TITLE
Revert "[hipblaslt] Set HasSchedMode from device attribute instead of…

### DIFF
--- a/projects/hipblaslt/tensilelite/rocisa/CMakeLists.txt
+++ b/projects/hipblaslt/tensilelite/rocisa/CMakeLists.txt
@@ -17,8 +17,6 @@ target_include_directories(rocisa-cpp
 )
 
 if(HIPBLASLT_BUNDLE_PYTHON_DEPS)
-    find_package(hip REQUIRED)
-
     include(FetchContent)
     FetchContent_Declare(
       nanobind
@@ -61,7 +59,7 @@ if(HIPBLASLT_BUNDLE_PYTHON_DEPS)
                             ${ROCISAINST_SOURCE}
                             ${ROCISAPASS_SOURCE}
                             ${ROCISAFUNC_SOURCE})
-    target_include_directories(rocisa PRIVATE 
+    target_include_directories(rocisa PRIVATE
         "${CMAKE_CURRENT_SOURCE_DIR}/rocisa/include"
         "${CMAKE_CURRENT_SOURCE_DIR}/../../../../shared/origami/include"
     )

--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/include/hardware_caps.hpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/include/hardware_caps.hpp
@@ -378,7 +378,7 @@ inline std::map<std::string, int>
     return rv;
 }
 
-inline std::map<std::string, int> initArchCaps(const IsaVersion& isaVersion, int deviceId = 0)
+inline std::map<std::string, int> initArchCaps(const IsaVersion& isaVersion)
 {
     std::vector<std::array<int, 3>> b = {{9, 0, 6}, {9, 0, 8}, {9, 0, 10}, {9, 4, 2}};
     std::map<std::string, int>      rv;
@@ -391,13 +391,7 @@ inline std::map<std::string, int> initArchCaps(const IsaVersion& isaVersion, int
     rv["DeviceLDS"]          = deviceLDS;
     rv["CMPXWritesSGPR"]     = checkNotInList(isaVersion[0], {10, 11, 12});
     rv["HasWave32"]          = checkInList(isaVersion[0], {10, 11, 12});
-#if HIP_VERSION >= 70353390
-    rv["HasSchedMode"] = checkInList(isaVersion[0], {12})
-                             ? getDeviceAttribute(hipDeviceAttributeExpertSchedMode, deviceId, 0)
-                             : 0;
-#else
-    rv["HasSchedMode"] = 0;
-#endif
+    rv["HasSchedMode"]       = checkInList(isaVersion[0], {}); //TODO: https://github.com/ROCm/rocm-libraries/issues/3211
     rv["HasAccCD"]           = checkInList(isaVersion, {{9, 0, 10}, {9, 4, 2}, {9, 5, 0}});
     rv["ArchAccUnifiedRegs"] = checkInList(isaVersion, {{9, 0, 10}, {9, 4, 2}, {9, 5, 0}});
     rv["CrosslaneWait"]      = checkInList(isaVersion, {{9, 4, 2}, {9, 5, 0}});

--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/include/helper.hpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/include/helper.hpp
@@ -23,7 +23,6 @@
 #pragma once
 #include <algorithm>
 #include <array>
-#include <hip/hip_runtime.h>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -59,15 +58,4 @@ template <typename T>
 bool checkNotInList(const T& a, const std::vector<T> b)
 {
     return std::find(b.begin(), b.end(), a) == b.end();
-}
-
-// Helper to get device attribute from HIP runtime
-inline int getDeviceAttribute(hipDeviceAttribute_t attr, int deviceId, int defaultValue = 0)
-{
-    int value = defaultValue;
-    if(hipDeviceGetAttribute(&value, attr, deviceId) == hipSuccess)
-    {
-        return value;
-    }
-    return defaultValue;
 }


### PR DESCRIPTION

This reverts commit c5946cf2382a46b280c402f4ff397e382df1516e.

## Motivation

After HIP version bump https://github.com/ROCm/rocm-systems/pull/4010, this change started breaking Windows build.