### PR TITLE
[hip-kernel-provider] Implement forward layernorm

### DIFF
--- a/dnn-providers/hip-kernel-provider/kernels/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/kernels/CMakeLists.txt
@@ -83,6 +83,7 @@ set(KERNEL_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/batchnorm/StaticUnroll.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/rmsnorm/RMSNormFwd.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/hip/vector_add.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/layernorm/LayernormFwd.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/types/FloatTypes.h
     ${CMAKE_CURRENT_SOURCE_DIR}/types/VectorTypes.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/types/Bfloat16Dev.hpp

--- a/dnn-providers/hip-kernel-provider/kernels/layernorm/LayernormFwd.cpp
+++ b/dnn-providers/hip-kernel-provider/kernels/layernorm/LayernormFwd.cpp
@@ -1,0 +1,87 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include "FloatTypes.h"
+
+extern "C" __global__ void LayernormFwd(const FLOAT* __restrict__ x,
+                                        FLOAT* __restrict__ y,
+                                        const FLOAT* __restrict__ weight,
+                                        const FLOAT* __restrict__ bias,
+                                        FLOAT* __restrict__ mean,
+                                        FLOAT* __restrict__ rstd,
+                                        const float eps)
+{
+    const unsigned int gid = blockIdx.x;
+    const unsigned int lid = threadIdx.x;
+    const unsigned int o = gid / STRIDE;
+    const unsigned int s = gid % STRIDE;
+
+    FLOAT_ACCUM pmean = CVT_FP32_2ACCUM(0.0f);
+    FLOAT_ACCUM pm2 = CVT_FP32_2ACCUM(0.0f);
+    unsigned int pcount = 0;
+    __shared__ FLOAT_ACCUM ltmp1[LOCAL_SIZE];
+    __shared__ FLOAT_ACCUM ltmp2[LOCAL_SIZE];
+    __shared__ unsigned int ltmp3[LOCAL_SIZE];
+
+    for(unsigned int i = lid; i < INNER_SIZE; i += LOCAL_SIZE)
+    {
+        size_t x_idx = o * INNER_SIZE * STRIDE + i * STRIDE + s;
+
+        FLOAT_ACCUM px = CVT_FLOAT2ACCUM(x[x_idx]);
+        ++pcount;
+        FLOAT_ACCUM delta = px - pmean;
+        pmean += delta / static_cast<FLOAT_ACCUM>(pcount);
+        FLOAT_ACCUM delta2 = px - pmean;
+        pm2 += delta * delta2;
+    }
+
+    ltmp1[lid] = pmean;
+    ltmp2[lid] = pm2;
+    ltmp3[lid] = pcount;
+    __syncthreads();
+    for(unsigned int i = LOCAL_SIZE >> 1; i > 0; i >>= 1)
+    {
+        if(lid < i)
+        {
+            FLOAT_ACCUM leftmean = ltmp1[lid];
+            FLOAT_ACCUM rightmean = ltmp1[lid + i];
+            unsigned int leftcount = ltmp3[lid];
+            unsigned int rightcount = ltmp3[lid + i];
+            unsigned int count = leftcount + rightcount;
+            FLOAT_ACCUM delta = rightmean - leftmean;
+            ltmp1[lid] = count > 0 ? (leftcount * leftmean + rightcount * rightmean) / count
+                                   : CVT_FP32_2ACCUM(0.0f);
+            ltmp2[lid] += ltmp2[lid + i]
+                          + (count > 0 ? delta * delta * leftcount * rightcount / count
+                                       : CVT_FP32_2ACCUM(0.0f));
+            ltmp3[lid] = count;
+        }
+        __syncthreads();
+    }
+    pmean = ltmp1[0];
+    FLOAT_ACCUM pvar = ltmp2[0] / ltmp3[0];
+    FLOAT_ACCUM prstd = rsqrt(pvar + CVT_FP32_2ACCUM(eps));
+
+    if(lid == 0)
+    {
+        if(mean)
+        {
+            mean[gid] = CVT_ACCUM2FLOAT(pmean);
+        }
+        if(rstd)
+        {
+            rstd[gid] = CVT_ACCUM2FLOAT(prstd);
+        }
+    }
+
+    for(unsigned int i = lid; i < INNER_SIZE; i += LOCAL_SIZE)
+    {
+        size_t idx = o * INNER_SIZE * STRIDE + i * STRIDE + s;
+
+        FLOAT_ACCUM pweight = weight ? CVT_FLOAT2ACCUM(weight[i]) : CVT_FP32_2ACCUM(1.0f);
+        FLOAT_ACCUM pbias = bias ? CVT_FLOAT2ACCUM(bias[i]) : CVT_FP32_2ACCUM(0.0f);
+
+        FLOAT_ACCUM val = (CVT_FLOAT2ACCUM(x[idx]) - pmean) * prstd * pweight + pbias;
+        y[idx] = CVT_ACCUM2FLOAT(val);
+    }
+}

--- a/dnn-providers/hip-kernel-provider/src/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/src/CMakeLists.txt
@@ -12,11 +12,11 @@ add_library(
     hip/HipKernel.cpp
     hip/HipProgram.cpp
     ${KERNEL_GENERATED_SOURCES}
-    engines/plans/BatchnormPlanBuilder.cpp
-    engines/plans/BatchnormFwdInferencePlan.cpp
-    engines/plans/BatchnormFwdInferenceWithVariancePlan.cpp
-    engines/plans/BatchnormFwdTrainingPlan.cpp
-    engines/plans/BatchnormApplicabilityChecks.cpp
+    engines/plans/batchnorm/BatchnormPlanBuilder.cpp
+    engines/plans/batchnorm/BatchnormFwdInferencePlan.cpp
+    engines/plans/batchnorm/BatchnormFwdInferenceWithVariancePlan.cpp
+    engines/plans/batchnorm/BatchnormFwdTrainingPlan.cpp
+    engines/plans/batchnorm/BatchnormApplicabilityChecks.cpp
     engines/plans/RMSnorm/RMSnormPlanBuilder.cpp
     engines/plans/RMSnorm/RMSnormFwdPlan.cpp
     engines/plans/RMSnorm/RMSnormApplicabilityChecks.cpp

--- a/dnn-providers/hip-kernel-provider/src/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/src/CMakeLists.txt
@@ -20,6 +20,10 @@ add_library(
     engines/plans/RMSnorm/RMSnormPlanBuilder.cpp
     engines/plans/RMSnorm/RMSnormFwdPlan.cpp
     engines/plans/RMSnorm/RMSnormApplicabilityChecks.cpp
+    engines/plans/layernorm/LayernormApplicabilityChecks.cpp
+    engines/plans/layernorm/LayernormFwdPlan.cpp
+    engines/plans/layernorm/LayernormPlanBuilder.cpp
+    engines/plans/layernorm/LayernormUtilities.cpp
 )
 if(ENABLE_ASM_SDPA_ENGINE)
     add_subdirectory(engines/asm_sdpa_engine)

--- a/dnn-providers/hip-kernel-provider/src/HipKernelContainer.cpp
+++ b/dnn-providers/hip-kernel-provider/src/HipKernelContainer.cpp
@@ -6,6 +6,7 @@
 #include "engines/HipKernelEngine.hpp"
 #include "engines/plans/RMSnorm/RMSnormPlanBuilder.hpp"
 #include "engines/plans/batchnorm/BatchnormPlanBuilder.hpp"
+#include "engines/plans/layernorm/LayernormPlanBuilder.hpp"
 #include "hip/HipKernelCompiler.hpp"
 
 #ifdef HIPDNN_ENGINE_ASM_SDPA
@@ -35,6 +36,8 @@ const std::vector<HipKernelContainer::EngineDefinition>& HipKernelContainer::get
              engine->addPlanBuilder(std::make_unique<batchnorm::BatchnormPlanBuilder>(
                  kernelCompiler, devicePropertyProvider));
              engine->addPlanBuilder(std::make_unique<rmsnorm::RMSnormPlanBuilder>(
+                 kernelCompiler, devicePropertyProvider));
+             engine->addPlanBuilder(std::make_unique<layernorm::LayernormPlanBuilder>(
                  kernelCompiler, devicePropertyProvider));
              return engine;
          }},

--- a/dnn-providers/hip-kernel-provider/src/HipKernelContainer.cpp
+++ b/dnn-providers/hip-kernel-provider/src/HipKernelContainer.cpp
@@ -4,8 +4,8 @@
 #include "HipKernelContainer.hpp"
 #include "CurrentDevicePropertyProvider.hpp"
 #include "engines/HipKernelEngine.hpp"
-#include "engines/plans/BatchnormPlanBuilder.hpp"
 #include "engines/plans/RMSnorm/RMSnormPlanBuilder.hpp"
+#include "engines/plans/batchnorm/BatchnormPlanBuilder.hpp"
 #include "hip/HipKernelCompiler.hpp"
 
 #ifdef HIPDNN_ENGINE_ASM_SDPA
@@ -32,8 +32,8 @@ const std::vector<HipKernelContainer::EngineDefinition>& HipKernelContainer::get
              -> std::unique_ptr<
                  hipdnn_plugin_sdk::IEngine<HipKernelHandle, HipKernelSettings, HipKernelContext>> {
              auto engine = std::make_unique<HipKernelEngine>(HIP_KERNEL_ENGINE_ID);
-             engine->addPlanBuilder(
-                 std::make_unique<BatchnormPlanBuilder>(kernelCompiler, devicePropertyProvider));
+             engine->addPlanBuilder(std::make_unique<batchnorm::BatchnormPlanBuilder>(
+                 kernelCompiler, devicePropertyProvider));
              engine->addPlanBuilder(std::make_unique<rmsnorm::RMSnormPlanBuilder>(
                  kernelCompiler, devicePropertyProvider));
              return engine;

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormApplicabilityChecks.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormApplicabilityChecks.cpp
@@ -11,7 +11,7 @@
 #include "BatchnormApplicabilityChecks.hpp"
 #include "HipKernelUtils.hpp"
 
-namespace hip_kernel_provider
+namespace hip_kernel_provider::batchnorm
 {
 
 // --- Type Configuration Helpers ---
@@ -597,4 +597,4 @@ void checkBatchnormFwdTrainingTensorConfigSupported(
         ioTensorIds, affineTensorIds, statTensorIds, {}, tensorMap, true);
 }
 
-} // namespace hip_kernel_provider
+} // namespace hip_kernel_provider::batchnorm

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormApplicabilityChecks.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormApplicabilityChecks.cpp
@@ -16,7 +16,7 @@ namespace hip_kernel_provider::batchnorm
 
 // --- Type Configuration Helpers ---
 
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType> bn_type_configs::getAllowedIoTypes()
+std::unordered_set<hipdnn_data_sdk::data_objects::DataType> type_configs::getAllowedIoTypes()
 {
     std::unordered_set<hipdnn_data_sdk::data_objects::DataType> types;
     for(const auto& config : VALID)
@@ -26,7 +26,7 @@ std::unordered_set<hipdnn_data_sdk::data_objects::DataType> bn_type_configs::get
     return types;
 }
 
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType> bn_type_configs::getAllowedAffineTypes()
+std::unordered_set<hipdnn_data_sdk::data_objects::DataType> type_configs::getAllowedAffineTypes()
 {
     std::unordered_set<hipdnn_data_sdk::data_objects::DataType> types;
     for(const auto& config : VALID)
@@ -36,7 +36,7 @@ std::unordered_set<hipdnn_data_sdk::data_objects::DataType> bn_type_configs::get
     return types;
 }
 
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType> bn_type_configs::getAllowedStatTypes()
+std::unordered_set<hipdnn_data_sdk::data_objects::DataType> type_configs::getAllowedStatTypes()
 {
     std::unordered_set<hipdnn_data_sdk::data_objects::DataType> types;
     for(const auto& config : VALID)
@@ -47,7 +47,7 @@ std::unordered_set<hipdnn_data_sdk::data_objects::DataType> bn_type_configs::get
 }
 
 std::unordered_set<hipdnn_data_sdk::data_objects::DataType>
-    bn_type_configs::getAllowedIntermediateTypes()
+    type_configs::getAllowedIntermediateTypes()
 {
     std::unordered_set<hipdnn_data_sdk::data_objects::DataType> types;
     for(const auto& config : VALID)
@@ -332,12 +332,12 @@ void checkTensorDataTypesSupported(
     validators::validateConsistentDataTypes(
         ioTensorIds,
         tensorMap,
-        bn_type_configs::getAllowedIoTypes(),
+        type_configs::getAllowedIoTypes(),
         "Batchnorm implementation supports only FLOAT, HALF, and BFLOAT16 data types for x, y, "
         "dy, and dx tensors.",
         "All IO tensors for batchnorm must have the same data type.");
 
-    const auto allowedAffineTypes = bn_type_configs::getAllowedAffineTypes();
+    const auto allowedAffineTypes = type_configs::getAllowedAffineTypes();
     if(allowedAffineTypes.size() == 1)
     {
         validators::validateFixedDataType(affineTensorIds,
@@ -356,7 +356,7 @@ void checkTensorDataTypesSupported(
             "All affine tensors for batchnorm must have the same data type.");
     }
 
-    const auto allowedStatTypes = bn_type_configs::getAllowedStatTypes();
+    const auto allowedStatTypes = type_configs::getAllowedStatTypes();
     if(allowedStatTypes.size() == 1)
     {
         validators::validateFixedDataType(statTensorIds,
@@ -375,7 +375,7 @@ void checkTensorDataTypesSupported(
             "All stat tensors for batchnorm must have the same data type.");
     }
 
-    const auto allowedIntermediateTypes = bn_type_configs::getAllowedIntermediateTypes();
+    const auto allowedIntermediateTypes = type_configs::getAllowedIntermediateTypes();
     if(allowedIntermediateTypes.size() == 1)
     {
         validators::validateFixedDataType(

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormApplicabilityChecks.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormApplicabilityChecks.hpp
@@ -14,7 +14,7 @@
 #include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
 #include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
 
-namespace hip_kernel_provider
+namespace hip_kernel_provider::batchnorm
 {
 
 // --- Tensor Descriptor Value Object ---
@@ -166,4 +166,4 @@ std::unordered_set<hipdnn_data_sdk::data_objects::DataType> getAllowedIntermedia
 
 } // namespace bn_type_configs
 
-} // namespace hip_kernel_provider
+} // namespace hip_kernel_provider::batchnorm

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormCommon.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormCommon.hpp
@@ -50,8 +50,9 @@ inline void getLocalConfigNHWC(size_t c,
     unsigned int maxLocalsize = 1024 / vectorsize;
 
     // default local config in case the while loop is not entered
-    xlocalsize = std::min(size_t{1} << static_cast<size_t>(std::ceil(std::log2(c / vectorsize))),
-                          static_cast<size_t>(xlocalsizeLimit));
+    xlocalsize = std::min(
+        size_t{1} << static_cast<size_t>(std::ceil(std::log2(std::max(c / vectorsize, size_t{1})))),
+        static_cast<size_t>(xlocalsizeLimit));
     ylocalsize = maxLocalsize / xlocalsize;
 
     size_t nworkgroups = 0;
@@ -61,9 +62,9 @@ inline void getLocalConfigNHWC(size_t c,
     {
         // xlocalsize must be power of 2 as reductions in the kernels rely on it, here c is rounded
         // up to next power of 2.
-        xlocalsize
-            = std::min(size_t{1} << static_cast<size_t>(std::ceil(std::log2(c / vectorsize))),
-                       static_cast<size_t>(xlocalsizeLimit));
+        xlocalsize = std::min(size_t{1} << static_cast<size_t>(
+                                  std::ceil(std::log2(std::max(c / vectorsize, size_t{1})))),
+                              static_cast<size_t>(xlocalsizeLimit));
         ylocalsize = maxLocalsize / xlocalsize;
         nworkgroups = ((c / vectorsize + xlocalsize - 1) / xlocalsize)
                       * ((h * w + ylocalsize - 1) / ylocalsize);

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormFwdInferencePlan.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormFwdInferencePlan.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier:  MIT
 
 #include "BatchnormFwdInferencePlan.hpp"
-#include "PlanUtils.hpp"
+#include "engines/plans/PlanUtils.hpp"
 
 #include "hip/IKernelCompiler.hpp"
 
@@ -11,7 +11,7 @@
 #include <hipdnn_data_sdk/utilities/PlatformUtils.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 
-namespace hip_kernel_provider
+namespace hip_kernel_provider::batchnorm
 {
 
 BatchnormFwdInferenceParams::BatchnormFwdInferenceParams(
@@ -162,7 +162,7 @@ void BatchnormFwdInferencePlan::compile(const IKernelCompiler& kernelCompiler,
     bool isLayoutNhwc = hip_kernel_utils::isChannelLastLayout(_inferenceParams.x());
 
     // Calculate vector size based on layout
-    auto vectorsize = batchnorm::computeVectorSize(isLayoutNhwc, c, inCstride);
+    auto vectorsize = computeVectorSize(isLayoutNhwc, c, inCstride);
 
     // Calculate block and grid dimensions
     size_t xlocalsize = 0;
@@ -347,4 +347,4 @@ void BatchnormFwdInferencePlan::execute(const HipKernelHandle& handle,
     }
 }
 
-}
+} // namespace hip_kernel_provider::batchnorm

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormFwdInferencePlan.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormFwdInferencePlan.hpp
@@ -19,6 +19,9 @@ namespace hip_kernel_provider
 
 class IKernelCompiler;
 
+namespace batchnorm
+{
+
 class BatchnormFwdInferenceParams
 {
 public:
@@ -97,4 +100,6 @@ private:
     unsigned int _batchStride = 0;
 };
 
-}
+} // namespace batchnorm
+
+} // namespace hip_kernel_provider

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormFwdInferenceWithVariancePlan.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormFwdInferenceWithVariancePlan.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier:  MIT
 
 #include "BatchnormFwdInferenceWithVariancePlan.hpp"
-#include "PlanUtils.hpp"
+#include "engines/plans/PlanUtils.hpp"
 
 #include "hip/IKernelCompiler.hpp"
 
@@ -12,7 +12,7 @@
 #include <hipdnn_data_sdk/utilities/PlatformUtils.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 
-namespace hip_kernel_provider
+namespace hip_kernel_provider::batchnorm
 {
 
 BatchnormFwdInferenceWithVarianceParams::BatchnormFwdInferenceWithVarianceParams(
@@ -184,7 +184,7 @@ void BatchnormFwdInferenceWithVariancePlan::compile(const IKernelCompiler& kerne
     bool isLayoutNHWC = hip_kernel_utils::isChannelLastLayout(_inferenceParams.x());
 
     // Calculate vector size based on layout
-    auto vectorsize = batchnorm::computeVectorSize(isLayoutNHWC, c, inCstride);
+    auto vectorsize = computeVectorSize(isLayoutNHWC, c, inCstride);
 
     // Calculate block and grid dimensions
     size_t xlocalsize = 0;
@@ -374,4 +374,5 @@ void BatchnormFwdInferenceWithVariancePlan::execute(const HipKernelHandle& handl
                                 activationBeta);
     }
 }
-}
+
+} // namespace hip_kernel_provider::batchnorm

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormFwdInferenceWithVariancePlan.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormFwdInferenceWithVariancePlan.hpp
@@ -19,6 +19,9 @@ namespace hip_kernel_provider
 
 class IKernelCompiler;
 
+namespace batchnorm
+{
+
 class BatchnormFwdInferenceWithVarianceParams
 {
 public:
@@ -107,4 +110,6 @@ private:
     unsigned int _batchStride = 0;
 };
 
-}
+} // namespace batchnorm
+
+} // namespace hip_kernel_provider

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormFwdTrainingPlan.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormFwdTrainingPlan.cpp
@@ -13,7 +13,7 @@
 #include <hipdnn_data_sdk/utilities/PlatformUtils.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 
-namespace hip_kernel_provider
+namespace hip_kernel_provider::batchnorm
 {
 
 BatchnormFwdTrainingParams::BatchnormFwdTrainingParams(
@@ -658,4 +658,5 @@ void BatchnormFwdTrainingPlan::execute(const HipKernelHandle& handle,
                                     activationBeta);
     }
 }
-}
+
+} // namespace hip_kernel_provider::batchnorm

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormFwdTrainingPlan.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormFwdTrainingPlan.hpp
@@ -18,6 +18,9 @@ namespace hip_kernel_provider
 
 class IKernelCompiler;
 
+namespace batchnorm
+{
+
 class BatchnormFwdTrainingParams
 {
 public:
@@ -101,4 +104,6 @@ private:
     float _invInNhw;
 };
 
-}
+} // namespace batchnorm
+
+} // namespace hip_kernel_provider

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormPlanBuilder.cpp
@@ -3,15 +3,14 @@
 
 #include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
 #include <hipdnn_plugin_sdk/PluginLogging.hpp>
-#include <string>
 
 #include "BatchnormPlanBuilder.hpp"
-#include "engines/plans/BatchnormApplicabilityChecks.hpp"
-#include "engines/plans/BatchnormFwdInferencePlan.hpp"
-#include "engines/plans/BatchnormFwdInferenceWithVariancePlan.hpp"
-#include "engines/plans/BatchnormFwdTrainingPlan.hpp"
+#include "engines/plans/batchnorm/BatchnormApplicabilityChecks.hpp"
+#include "engines/plans/batchnorm/BatchnormFwdInferencePlan.hpp"
+#include "engines/plans/batchnorm/BatchnormFwdInferenceWithVariancePlan.hpp"
+#include "engines/plans/batchnorm/BatchnormFwdTrainingPlan.hpp"
 
-namespace hip_kernel_provider
+namespace hip_kernel_provider::batchnorm
 {
 
 namespace
@@ -507,4 +506,4 @@ std::vector<hipdnn_data_sdk::data_objects::KnobT> BatchnormPlanBuilder::getCusto
     return {};
 }
 
-} // namespace hip_kernel_provider
+} // namespace hip_kernel_provider::batchnorm

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormPlanBuilder.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormPlanBuilder.hpp
@@ -12,7 +12,7 @@
 #include "hip/IKernelCompiler.hpp"
 #include "hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp"
 
-namespace hip_kernel_provider
+namespace hip_kernel_provider::batchnorm
 {
 
 class BatchnormPlanBuilder
@@ -54,4 +54,4 @@ private:
     const IDevicePropertyProvider& _devicePropertyProvider;
 };
 
-}
+} // namespace hip_kernel_provider::batchnorm

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormApplicabilityChecks.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormApplicabilityChecks.cpp
@@ -138,7 +138,7 @@ void validateSupportedLayout(const std::vector<int64_t>& strideOrder, size_t num
         {
             throw hipdnn_plugin_sdk::HipdnnPluginException(
                 HIPDNN_PLUGIN_STATUS_BAD_PARAM,
-                "Layernorm implementatino only supports NCHW and NHWC layouts for 4D tensors.");
+                "Layernorm implementation only supports NCHW and NHWC layouts for 4D tensors.");
         }
     }
     else if(numDims == 5)
@@ -150,7 +150,7 @@ void validateSupportedLayout(const std::vector<int64_t>& strideOrder, size_t num
         {
             throw hipdnn_plugin_sdk::HipdnnPluginException(
                 HIPDNN_PLUGIN_STATUS_BAD_PARAM,
-                "Layernorm implementatino only supports NCDHW and NDHWC layouts for 5D tensors.");
+                "Layernorm implementation only supports NCDHW and NDHWC layouts for 5D tensors.");
         }
     }
 }

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormApplicabilityChecks.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormApplicabilityChecks.cpp
@@ -1,0 +1,565 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include "engines/plans/layernorm/LayernormUtilities.hpp"
+#include "hipdnn_data_sdk/data_objects/data_types_generated.h"
+#include "hipdnn_data_sdk/data_objects/tensor_attributes_generated.h"
+#include "hipdnn_plugin_sdk/PluginApiDataTypes.h"
+#include "hipdnn_plugin_sdk/PluginException.hpp"
+#include <cstdint>
+#include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "HipKernelUtils.hpp"
+#include "LayernormApplicabilityChecks.hpp"
+
+namespace hip_kernel_provider::layernorm
+{
+
+// --- Type Configuration Helpers ---
+
+std::unordered_set<hipdnn_data_sdk::data_objects::DataType> type_configs::getAllowedIoTypes()
+{
+    std::unordered_set<hipdnn_data_sdk::data_objects::DataType> types;
+    for(const auto& config : VALID)
+    {
+        types.insert(config.io);
+    }
+    return types;
+}
+
+std::unordered_set<hipdnn_data_sdk::data_objects::DataType> type_configs::getAllowedAffineTypes()
+{
+    std::unordered_set<hipdnn_data_sdk::data_objects::DataType> types;
+    for(const auto& config : VALID)
+    {
+        types.insert(config.affine);
+    }
+    return types;
+}
+
+std::unordered_set<hipdnn_data_sdk::data_objects::DataType> type_configs::getAllowedStatTypes()
+{
+    std::unordered_set<hipdnn_data_sdk::data_objects::DataType> types;
+    for(const auto& config : VALID)
+    {
+        types.insert(config.stat);
+    }
+    return types;
+}
+
+std::unordered_set<hipdnn_data_sdk::data_objects::DataType> type_configs::getAllowedEpsilonTypes()
+{
+    std::unordered_set<hipdnn_data_sdk::data_objects::DataType> types;
+    for(const auto& config : VALID)
+    {
+        types.insert(config.epsilon);
+    }
+    return types;
+}
+
+// --- Tensor Descriptor Implementation ---
+
+LayernormTensorDescriptor::LayernormTensorDescriptor(
+    const hipdnn_data_sdk::data_objects::TensorAttributes* attr)
+    : dims(attr->dims()->begin(), attr->dims()->end())
+    , strides(attr->strides()->begin(), attr->strides()->end())
+    , strideOrder(hipdnn_data_sdk::utilities::extractStrideOrder(strides))
+{
+}
+
+bool LayernormTensorDescriptor::isPacked() const
+{
+    return hipdnn_data_sdk::utilities::isTensorPacked(dims, strides);
+}
+
+// --- Validation Utilities ---
+
+namespace validators
+{
+
+void validateDimensionCount(size_t numDims)
+{
+    constexpr size_t MIN_SUPPORTED_DIMS = 4;
+    constexpr size_t MAX_SUPPORTED_DIMS = 5;
+
+    if(numDims < MIN_SUPPORTED_DIMS || numDims > MAX_SUPPORTED_DIMS)
+    {
+        throw hipdnn_plugin_sdk::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+            "Layernorm implementation supports only 4D or 5D tensors.");
+    }
+}
+
+void validateConsistentDimensions(const std::vector<LayernormTensorDescriptor>& tensors)
+{
+    if(tensors.empty())
+    {
+        return;
+    }
+
+    const size_t expectedDims = tensors[0].numDims();
+    validateDimensionCount(expectedDims);
+
+    for(size_t i = 1; i < tensors.size(); ++i)
+    {
+        if(tensors[i].numDims() != expectedDims)
+        {
+            throw hipdnn_plugin_sdk::HipdnnPluginException(
+                HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                "All tensors for layernorm must have the same number of dimensions.");
+        }
+    }
+}
+
+void validatePackedTensors(const std::vector<LayernormTensorDescriptor>& tensors)
+{
+    for(const auto& tensor : tensors)
+    {
+        if(!tensor.isPacked())
+        {
+            throw hipdnn_plugin_sdk::HipdnnPluginException(
+                HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                "Layernorm implementation only supports all packed tensors.");
+        }
+    }
+}
+
+void validateSupportedLayout(const std::vector<int64_t>& strideOrder, size_t numDims)
+{
+    if(numDims == 4)
+    {
+        const auto layoutNCHW = hipdnn_data_sdk::utilities::TensorLayout::NCHW;
+        const auto layoutNHWC = hipdnn_data_sdk::utilities::TensorLayout::NHWC;
+
+        if(strideOrder != layoutNCHW.strideOrder && strideOrder != layoutNHWC.strideOrder)
+        {
+            throw hipdnn_plugin_sdk::HipdnnPluginException(
+                HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                "Layernorm implementatino only supports NCHW and NHWC layouts for 4D tensors.");
+        }
+    }
+    else if(numDims == 5)
+    {
+        const auto layoutNCDHW = hipdnn_data_sdk::utilities::TensorLayout::NCDHW;
+        const auto layoutNDHWC = hipdnn_data_sdk::utilities::TensorLayout::NDHWC;
+
+        if(strideOrder != layoutNCDHW.strideOrder && strideOrder != layoutNDHWC.strideOrder)
+        {
+            throw hipdnn_plugin_sdk::HipdnnPluginException(
+                HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                "Layernorm implementatino only supports NCDHW and NDHWC layouts for 5D tensors.");
+        }
+    }
+}
+
+void validateConsistentLayouts(const std::vector<LayernormTensorDescriptor>& tensors)
+{
+    if(tensors.empty())
+    {
+        return;
+    }
+
+    // Use first tensor with meaningful layout as reference
+    int64_t referenceIndex = -1;
+    for(size_t i = 0; i < tensors.size(); ++i)
+    {
+        if(hipdnn_data_sdk::utilities::isLayoutAgnostic(tensors[i].dims))
+        {
+            continue;
+        }
+
+        if(referenceIndex == -1)
+        {
+            referenceIndex = static_cast<int64_t>(i);
+            validateSupportedLayout(tensors[static_cast<size_t>(referenceIndex)].strideOrder,
+                                    tensors[static_cast<size_t>(referenceIndex)].numDims());
+        }
+        else
+        {
+            if(tensors[i].strideOrder != tensors[static_cast<size_t>(referenceIndex)].strideOrder)
+            {
+                throw hipdnn_plugin_sdk::HipdnnPluginException(
+                    HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                    "All tensors for layernorm must have the same layout.");
+            }
+        }
+    }
+}
+
+void validateDataTypeIsSupported(
+    hipdnn_data_sdk::data_objects::DataType dataType,
+    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
+    const std::string& errorMessage)
+{
+    if(allowedTypes.count(dataType) > 0)
+    {
+        return;
+    }
+    throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM, errorMessage);
+}
+
+void validateConsistentDataTypes(
+    const std::vector<int64_t>& tensorIds,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap,
+    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
+    const std::string& typeErrorMessage,
+    const std::string& consistencyErrorMessage)
+{
+    if(tensorIds.empty())
+    {
+        return;
+    }
+
+    const auto& firstTensor = hip_kernel_utils::findTensorAttributes(tensorMap, tensorIds[0]);
+    const auto referenceType = firstTensor.data_type();
+
+    validateDataTypeIsSupported(referenceType, allowedTypes, typeErrorMessage);
+
+    for(size_t i = 1; i < tensorIds.size(); ++i)
+    {
+        const auto& tensor = hip_kernel_utils::findTensorAttributes(tensorMap, tensorIds[i]);
+        if(tensor.data_type() != referenceType)
+        {
+            throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                                                           consistencyErrorMessage);
+        }
+    }
+}
+
+void validateConsistentDataTypes(
+    const std::vector<std::optional<int64_t>>& tensorIds,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap,
+    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
+    const std::string& typeErrorMessage,
+    const std::string& consistencyErrorMessage)
+{
+    std::vector<int64_t> actualTensorIds;
+    for(auto i : tensorIds)
+    {
+        if(i.has_value())
+        {
+            actualTensorIds.emplace_back(i.value());
+        }
+    }
+
+    validateConsistentDataTypes(
+        actualTensorIds, tensorMap, allowedTypes, typeErrorMessage, consistencyErrorMessage);
+}
+
+void validateFixedDataType(
+    const std::vector<int64_t>& tensorIds,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap,
+    hipdnn_data_sdk::data_objects::DataType expectedType,
+    const std::string& errorMessage)
+{
+    for(const auto tensorId : tensorIds)
+    {
+        const auto& tensor = hip_kernel_utils::findTensorAttributes(tensorMap, tensorId);
+        if(tensor.data_type() != expectedType)
+        {
+            throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                                                           errorMessage);
+        }
+    }
+}
+
+void validateConsistentShapes(
+    const std::vector<int64_t>& tensorIds,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap,
+    const std::vector<int64_t>& referenceShape,
+    const std::string& errorMessage)
+{
+    for(const auto tensorId : tensorIds)
+    {
+        const auto& tensorAttr = hip_kernel_utils::findTensorAttributes(tensorMap, tensorId);
+        const std::vector<int64_t> dims(tensorAttr.dims()->begin(), tensorAttr.dims()->end());
+        if(dims != referenceShape)
+        {
+            throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                                                           errorMessage);
+        }
+    }
+}
+
+void validateConsistentShapes(
+    const std::vector<std::optional<int64_t>>& tensorIds,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap,
+    const std::vector<int64_t>& referenceShape,
+    const std::string& errorMessage)
+{
+    std::vector<int64_t> actualTensorIds;
+    for(auto i : tensorIds)
+    {
+        if(i.has_value())
+        {
+            actualTensorIds.emplace_back(i.value());
+        }
+    }
+
+    validateConsistentShapes(actualTensorIds, tensorMap, referenceShape, errorMessage);
+}
+
+void validateNormalizedDim(
+    const std::vector<int64_t>& ioTensorIds,
+    const std::vector<int64_t>& affineTensorIds,
+    const std::vector<std::optional<int64_t>>& statTensorIds,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+{
+    if(ioTensorIds.empty())
+    {
+        throw hipdnn_plugin_sdk::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+            "Normalized dimension detection for layernorm requires IO tensors.");
+    }
+
+    if(affineTensorIds.empty() && statTensorIds.empty())
+    {
+        throw hipdnn_plugin_sdk::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+            "Normalized dimension detection for layernorm requires at least one affine tensor or "
+            "one stat tensor.");
+    }
+
+    const auto& ioAttr = hip_kernel_utils::findTensorAttributes(tensorMap, ioTensorIds[0]);
+    const std::vector<int64_t> ioDims(ioAttr.dims()->begin(), ioAttr.dims()->end());
+
+    size_t affineNormalizedDimMin
+        = getMinNormalizedDimFromAffine(ioTensorIds[0], affineTensorIds[0], tensorMap);
+    size_t affineNormalizedDimMax
+        = getMaxNormalizedDimFromAffine(ioTensorIds[0], affineTensorIds[0], tensorMap);
+
+    size_t statNormalizedDimMin = 0;
+    size_t statNormalizedDimMax = ioDims.size();
+    for(auto statTensorId : statTensorIds)
+    {
+        if(statTensorId.has_value())
+        {
+            statNormalizedDimMin
+                = getMinNormalizedDimFromStat(ioTensorIds[0], statTensorId.value(), tensorMap);
+            statNormalizedDimMax
+                = getMaxNormalizedDimFromStat(ioTensorIds[0], statTensorId.value(), tensorMap);
+            break;
+        }
+    }
+
+    if(std::max(affineNormalizedDimMin, statNormalizedDimMin)
+       > std::min(affineNormalizedDimMax, statNormalizedDimMax))
+    {
+        throw hipdnn_plugin_sdk::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+            "Affine tensors and stat tensors produce conflicting normalized dimensions for "
+            "layernorm.");
+    }
+}
+
+} // namespace validators
+
+// --- Component Validators
+
+void checkTensorLayoutsAndDimsSupported(
+    const std::vector<int64_t>& tensorIds,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+{
+    std::vector<LayernormTensorDescriptor> tensors;
+    tensors.reserve(tensorIds.size());
+
+    for(const auto& id : tensorIds)
+    {
+        auto attr = tensorMap.at(id);
+        if(attr->value_type() == hipdnn_data_sdk::data_objects::TensorValue::NONE)
+        {
+            tensors.emplace_back(attr);
+        }
+    }
+
+    validators::validateConsistentDimensions(tensors);
+    validators::validatePackedTensors(tensors);
+    validators::validateConsistentLayouts(tensors);
+}
+
+void checkTensorLayoutsAndDimsSupported(
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+{
+    // Skip tensors with embedded scalar values (epsilon, momentum) - they don't have layouts or dimensions to validate
+    std::vector<int64_t> tensorIds;
+    tensorIds.reserve(tensorMap.size());
+    for(const auto& [id, attr] : tensorMap)
+    {
+        if(attr->value_type() != hipdnn_data_sdk::data_objects::TensorValue::NONE)
+        {
+            continue;
+        }
+        tensorIds.emplace_back(id);
+    }
+
+    checkTensorLayoutsAndDimsSupported(tensorIds, tensorMap);
+}
+
+void checkTensorDataTypesSupported(
+    const std::vector<int64_t>& ioTensorIds,
+    const std::vector<int64_t>& affineTensorIds,
+    const std::vector<std::optional<int64_t>>& statTensorIds,
+    const std::vector<int64_t>& epsilonTensorIds,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+{
+    const auto allowedIoTypes = type_configs::getAllowedIoTypes();
+    validators::validateConsistentDataTypes(
+        ioTensorIds,
+        tensorMap,
+        allowedIoTypes,
+        "Layernorm implementation supports only FLOAT, HALF and BFLOAT16 data types for x and y "
+        "tensors.",
+        "All IO tensors for layernorm must have the same data type.");
+
+    const auto allowedAffineTypes = type_configs::getAllowedAffineTypes();
+    validators::validateConsistentDataTypes(
+        affineTensorIds,
+        tensorMap,
+        allowedAffineTypes,
+        "Layernorm implementation supports only FLOAT, HALF and BFLOAT16 data types for scale and "
+        "bias tensors.",
+        "All affine tensors for layernorm must have the same data type.");
+
+    const auto allowedStatTypes = type_configs::getAllowedStatTypes();
+    validators::validateConsistentDataTypes(
+        statTensorIds,
+        tensorMap,
+        allowedStatTypes,
+        "Layernorm implementation supports only FLOAT, HALF and BFLOAT16 data types for mean and "
+        "inverse variance tensors.",
+        "All stat tensors for layernorm must have the same data type.");
+
+    std::vector<int64_t> allTensorIds;
+    allTensorIds.insert(allTensorIds.end(), ioTensorIds.begin(), ioTensorIds.end());
+    allTensorIds.insert(allTensorIds.end(), affineTensorIds.begin(), affineTensorIds.end());
+    for(auto tensorId : statTensorIds)
+    {
+        if(tensorId.has_value())
+        {
+            allTensorIds.emplace_back(tensorId.value());
+        }
+    }
+    std::unordered_set<hipdnn_data_sdk::data_objects::DataType> allAllowedTypes;
+    allAllowedTypes.insert(allowedIoTypes.begin(), allowedIoTypes.end());
+    allAllowedTypes.insert(allowedAffineTypes.begin(), allowedAffineTypes.end());
+    allAllowedTypes.insert(allowedStatTypes.begin(), allowedStatTypes.end());
+    validators::validateConsistentDataTypes(
+        allTensorIds,
+        tensorMap,
+        allAllowedTypes,
+        "Layernorm implementation only supports FLOAT, HALF and BFLOAT16 data types.",
+        "All IO, affine and stat tensors for layernorm must have the same data type.");
+
+    const auto allowedEpsilonTypes = type_configs::getAllowedEpsilonTypes();
+    if(allowedEpsilonTypes.size() == 1)
+    {
+        validators::validateFixedDataType(
+            epsilonTensorIds,
+            tensorMap,
+            *allowedEpsilonTypes.begin(),
+            "Layernorm implementation supports only FLOAT data type for epsilon tensors.");
+    }
+    else
+    {
+        validators::validateConsistentDataTypes(
+            epsilonTensorIds,
+            tensorMap,
+            allowedEpsilonTypes,
+            "Layernorm epsilon tensors use unsupported data type.",
+            "All epsilon tensors for layernorm must have the same data type.");
+    }
+}
+
+void checkTensorShapesSupported(
+    const std::vector<int64_t>& ioTensorIds,
+    const std::vector<int64_t>& affineTensorIds,
+    const std::vector<std::optional<int64_t>>& statTensorIds,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+{
+    if(ioTensorIds.empty())
+    {
+        throw hipdnn_plugin_sdk::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_INTERNAL_ERROR,
+            "At least one IO tensor must be provided for layernorm.");
+    }
+
+    const auto& ioTensorAttr = hip_kernel_utils::findTensorAttributes(tensorMap, ioTensorIds[0]);
+    const std::vector<int64_t> ioDims(ioTensorAttr.dims()->begin(), ioTensorAttr.dims()->end());
+
+    validators::validateConsistentShapes(
+        ioTensorIds, tensorMap, ioDims, "All IO tensors for layernorm must have the same shape.");
+
+    const auto& affineTensorAttr
+        = hip_kernel_utils::findTensorAttributes(tensorMap, affineTensorIds[0]);
+    const std::vector<int64_t> affineDims(affineTensorAttr.dims()->begin(),
+                                          affineTensorAttr.dims()->end());
+    validators::validateConsistentShapes(
+        affineTensorIds,
+        tensorMap,
+        affineDims,
+        "All affine tensors for layernorm must have the same shape.");
+
+    if(!statTensorIds.empty())
+    {
+        for(const auto& statTensorId : statTensorIds)
+        {
+            if(statTensorId.has_value())
+            {
+                const auto& statTensorAttr
+                    = hip_kernel_utils::findTensorAttributes(tensorMap, statTensorId.value());
+                const std::vector<int64_t> statDims(statTensorAttr.dims()->begin(),
+                                                    statTensorAttr.dims()->end());
+                validators::validateConsistentShapes(
+                    statTensorIds,
+                    tensorMap,
+                    statDims,
+                    "All stat tensors for layernorm must have the same shape.");
+                break;
+            }
+        }
+    }
+}
+
+// --- High-level Configuration Validators ---
+
+void checkLayernormTensorConfigSupported(
+    const hipdnn_data_sdk::data_objects::LayernormAttributes& lnAttr,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+{
+    std::vector<int64_t> ioTensorIds = {lnAttr.x_tensor_uid(), lnAttr.y_tensor_uid()};
+    std::vector<int64_t> affineTensorIds = {lnAttr.scale_tensor_uid(), lnAttr.bias_tensor_uid()};
+    std::vector<std::optional<int64_t>> statTensorIds
+        = {lnAttr.mean_tensor_uid(), lnAttr.inv_variance_tensor_uid()};
+    std::vector<int64_t> epsilonTensorIds = {lnAttr.epsilon_tensor_uid()};
+    std::vector<int64_t> ioAndStatTensorIds
+        = std::vector<int64_t>(ioTensorIds.begin(), ioTensorIds.end());
+    for(auto statTensorId : statTensorIds)
+    {
+        if(statTensorId.has_value())
+        {
+            ioAndStatTensorIds.emplace_back(statTensorId.value());
+        }
+    }
+
+    checkTensorLayoutsAndDimsSupported(ioAndStatTensorIds, tensorMap);
+    checkTensorDataTypesSupported(
+        ioTensorIds, affineTensorIds, statTensorIds, epsilonTensorIds, tensorMap);
+    validators::validateNormalizedDim(ioTensorIds, affineTensorIds, statTensorIds, tensorMap);
+    checkTensorShapesSupported(ioTensorIds, affineTensorIds, statTensorIds, tensorMap);
+}
+
+} // namespace hip_kernel_provider::layernorm

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormApplicabilityChecks.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormApplicabilityChecks.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <array>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormApplicabilityChecks.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormApplicabilityChecks.hpp
@@ -8,24 +8,22 @@
 #include <unordered_set>
 #include <vector>
 
-#include <hipdnn_data_sdk/data_objects/batchnorm_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/batchnorm_inference_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/batchnorm_inference_attributes_variance_ext_generated.h>
+#include <hipdnn_data_sdk/data_objects/layernorm_attributes_generated.h>
 #include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
 #include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
 
-namespace hip_kernel_provider::batchnorm
+namespace hip_kernel_provider::layernorm
 {
 
 // --- Tensor Descriptor Value Object ---
 
-struct BatchnormTensorDescriptor
+struct LayernormTensorDescriptor
 {
     std::vector<int64_t> dims;
     std::vector<int64_t> strides;
     std::vector<int64_t> strideOrder;
 
-    explicit BatchnormTensorDescriptor(const hipdnn_data_sdk::data_objects::TensorAttributes* attr);
+    explicit LayernormTensorDescriptor(const hipdnn_data_sdk::data_objects::TensorAttributes* attr);
 
     size_t numDims() const
     {
@@ -38,15 +36,16 @@ struct BatchnormTensorDescriptor
 
 namespace validators
 {
+
 void validateDimensionCount(size_t numDims);
 
-void validateConsistentDimensions(const std::vector<BatchnormTensorDescriptor>& tensors);
+void validateConsistentDimensions(const std::vector<LayernormTensorDescriptor>& tensors);
 
-void validatePackedTensors(const std::vector<BatchnormTensorDescriptor>& tensors);
+void validatePackedTensors(const std::vector<LayernormTensorDescriptor>& tensors);
 
 void validateSupportedLayout(const std::vector<int64_t>& strideOrder, size_t numDims);
 
-void validateConsistentLayouts(const std::vector<BatchnormTensorDescriptor>& tensors);
+void validateConsistentLayouts(const std::vector<LayernormTensorDescriptor>& tensors);
 
 void validateDataTypeIsSupported(
     hipdnn_data_sdk::data_objects::DataType dataType,
@@ -55,6 +54,14 @@ void validateDataTypeIsSupported(
 
 void validateConsistentDataTypes(
     const std::vector<int64_t>& tensorIds,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap,
+    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
+    const std::string& typeErrorMessage,
+    const std::string& consistencyErrorMessage);
+
+void validateConsistentDataTypes(
+    const std::vector<std::optional<int64_t>>& tensorIds,
     const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
@@ -75,11 +82,28 @@ void validateConsistentShapes(
     const std::vector<int64_t>& referenceShape,
     const std::string& errorMessage);
 
-void validateSpatialDimensions(const std::vector<int64_t>& ioDims);
+void validateConsistentShapes(
+    const std::vector<std::optional<int64_t>>& tensorIds,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap,
+    const std::vector<int64_t>& referenceShape,
+    const std::string& errorMessage);
+
+void validateNormalizedDim(
+    const std::vector<int64_t>& ioTensorIds,
+    const std::vector<int64_t>& affineTensorIds,
+    const std::vector<std::optional<int64_t>>& statTensorIds,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap);
 
 } // namespace validators
 
 // --- Component Validators ---
+
+void checkTensorLayoutsAndDimsSupported(
+    const std::vector<int64_t>& tensorIds,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap);
 
 void checkTensorLayoutsAndDimsSupported(
     const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
@@ -88,82 +112,53 @@ void checkTensorLayoutsAndDimsSupported(
 void checkTensorDataTypesSupported(
     const std::vector<int64_t>& ioTensorIds,
     const std::vector<int64_t>& affineTensorIds,
-    const std::vector<int64_t>& statTensorIds,
-    const std::vector<int64_t>& intermediateTensorIds,
+    const std::vector<std::optional<int64_t>>& statTensorIds,
+    const std::vector<int64_t>& epsilonTensorIds,
     const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
 void checkTensorShapesSupported(
     const std::vector<int64_t>& ioTensorIds,
     const std::vector<int64_t>& affineTensorIds,
-    const std::vector<int64_t>& statTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap,
-    bool isTraining);
-
-// --- High-Level Configuration Validators ---
-
-void checkBatchnormInferenceTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
+    const std::vector<std::optional<int64_t>>& statTensorIds,
     const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
-void checkBatchnormInferenceVarianceExtTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
+// --- High-level Configuration Validators ---
+
+void checkLayernormTensorConfigSupported(
+    const hipdnn_data_sdk::data_objects::LayernormAttributes& lnAttr,
     const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
-void checkBatchnormInferenceActivationTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap);
+// Layernorm Type Configuration ---
 
-void checkBatchnormInferenceVarianceExtActivationTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap);
-
-void checkBatchnormFwdActivationModeSupported(
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& activAttr);
-
-void checkBatchnormBwdActivationModeSupported(
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& activAttr);
-
-void checkBatchnormFwdTrainingTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormAttributes& bnAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap);
-
-// --- Batchnorm Type Configuration ---
-
-// hip-kernel-provider batchnorm requirements (based on underlying kernel constraints):
-// - IO tensors: same type (FLOAT, HALF, or BFLOAT16)
-// - Affine/Stat/Intermediate tensors: FLOAT only
+// hip-kernel-provider layernorm requirements (based on underlying kernel constraints):
+// - IO/Affine/Stat tensors: same type (FLOAT, HALF or BFLOAT16)
+// - Epsilon tensors: FLOAT only
 struct TensorTypes
 {
     hipdnn_data_sdk::data_objects::DataType io;
     hipdnn_data_sdk::data_objects::DataType affine;
     hipdnn_data_sdk::data_objects::DataType stat;
-    hipdnn_data_sdk::data_objects::DataType intermediate;
+    hipdnn_data_sdk::data_objects::DataType epsilon;
 };
 
 namespace type_configs
 {
 using DT = hipdnn_data_sdk::data_objects::DataType;
 
-inline constexpr TensorTypes ALL_FLOAT = {DT::FLOAT, DT::FLOAT, DT::FLOAT, DT::FLOAT};
-inline constexpr TensorTypes HALF_IO = {DT::HALF, DT::FLOAT, DT::FLOAT, DT::FLOAT};
-inline constexpr TensorTypes BFLOAT16_IO = {DT::BFLOAT16, DT::FLOAT, DT::FLOAT, DT::FLOAT};
+inline constexpr TensorTypes FLOAT = {DT::FLOAT, DT::FLOAT, DT::FLOAT, DT::FLOAT};
+inline constexpr TensorTypes HALF = {DT::HALF, DT::HALF, DT::HALF, DT::FLOAT};
+inline constexpr TensorTypes BFLOAT16 = {DT::BFLOAT16, DT::BFLOAT16, DT::BFLOAT16, DT::FLOAT};
 
-inline constexpr std::array<TensorTypes, 3> VALID = {ALL_FLOAT, HALF_IO, BFLOAT16_IO};
+inline constexpr std::array<TensorTypes, 3> VALID = {FLOAT, HALF, BFLOAT16};
 
 std::unordered_set<hipdnn_data_sdk::data_objects::DataType> getAllowedIoTypes();
 std::unordered_set<hipdnn_data_sdk::data_objects::DataType> getAllowedAffineTypes();
 std::unordered_set<hipdnn_data_sdk::data_objects::DataType> getAllowedStatTypes();
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType> getAllowedIntermediateTypes();
+std::unordered_set<hipdnn_data_sdk::data_objects::DataType> getAllowedEpsilonTypes();
 
 } // namespace type_configs
 
-} // namespace hip_kernel_provider::batchnorm
+} // namespace hip_kernel_provider::layernorm

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormFwdPlan.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormFwdPlan.cpp
@@ -1,0 +1,212 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include "LayernormFwdPlan.hpp"
+
+#include "HipKernelUtils.hpp"
+#include "engines/plans/layernorm/LayernormUtilities.hpp"
+#include "hip/IKernelCompiler.hpp"
+
+#include <hipdnn_data_sdk/logging/Logger.hpp>
+#include <hipdnn_data_sdk/utilities/Constants.hpp>
+#include <hipdnn_data_sdk/utilities/FlatbufferUtils.hpp>
+#include <hipdnn_data_sdk/utilities/PlatformUtils.hpp>
+#include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_plugin_sdk/PluginException.hpp>
+
+namespace hip_kernel_provider::layernorm
+{
+
+LayernormFwdParams::LayernormFwdParams(
+    const hipdnn_data_sdk::data_objects::LayernormAttributes& attributes,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+    : _x(tensorMap.at(attributes.x_tensor_uid()))
+    , _y(tensorMap.at(attributes.y_tensor_uid()))
+    , _scale(tensorMap.at(attributes.scale_tensor_uid()))
+    , _bias(tensorMap.at(attributes.bias_tensor_uid()))
+    , _mean(attributes.mean_tensor_uid().has_value()
+                ? tensorMap.at(attributes.mean_tensor_uid().value())
+                : nullptr)
+    , _invVariance(attributes.inv_variance_tensor_uid().has_value()
+                       ? tensorMap.at(attributes.inv_variance_tensor_uid().value())
+                       : nullptr)
+    , _epsilon((tensorMap.at(attributes.epsilon_tensor_uid())))
+{
+}
+
+const hipdnn_data_sdk::data_objects::TensorAttributes* LayernormFwdParams::x() const
+{
+    return _x;
+}
+
+const hipdnn_data_sdk::data_objects::TensorAttributes* LayernormFwdParams::y() const
+{
+    return _y;
+}
+
+const hipdnn_data_sdk::data_objects::TensorAttributes* LayernormFwdParams::scale() const
+{
+    return _scale;
+}
+
+const hipdnn_data_sdk::data_objects::TensorAttributes* LayernormFwdParams::bias() const
+{
+    return _bias;
+}
+
+const hipdnn_data_sdk::data_objects::TensorAttributes* LayernormFwdParams::mean() const
+{
+    return _mean;
+}
+
+const hipdnn_data_sdk::data_objects::TensorAttributes* LayernormFwdParams::invVariance() const
+{
+    return _invVariance;
+}
+
+const hipdnn_data_sdk::data_objects::TensorAttributes* LayernormFwdParams::epsilon() const
+{
+    return _epsilon;
+}
+
+LayernormFwdPlan::LayernormFwdPlan(LayernormFwdParams&& params)
+    : _params(std::move(params))
+{
+}
+
+size_t LayernormFwdPlan::getWorkspaceSize([[maybe_unused]] const HipKernelHandle& handle) const
+{
+    // No workspace needed for layernorm
+    return 0;
+}
+
+void LayernormFwdPlan::compile(const IKernelCompiler& kernelCompiler,
+                               const hipDeviceProp_t& deviceProperties)
+{
+    // Determine data type configuration
+    auto xDataType = _params.x()->data_type();
+
+    // Extract dimensions from x tensor
+    const auto* xDims = _params.x()->dims();
+    const auto* xStrides = _params.x()->strides();
+    const auto strideOrder = hipdnn_data_sdk::utilities::extractStrideOrder(
+        std::vector<int64_t>(xStrides->begin(), xStrides->end()));
+
+    size_t normalizedDim
+        = layernorm::guessNormalizedDim(_params.x(), _params.scale(), _params.mean());
+    long outerSize = 1;
+    long innerSize = 1;
+    long stride = 1;
+    const auto layoutNHWC = hipdnn_data_sdk::utilities::TensorLayout::NHWC;
+    const auto layoutNDHWC = hipdnn_data_sdk::utilities::TensorLayout::NDHWC;
+
+    if(normalizedDim > 1
+       && (strideOrder == layoutNHWC.strideOrder || strideOrder == layoutNDHWC.strideOrder))
+    {
+        stride = xDims->Get(1);
+    }
+
+    for(unsigned int i = 0; i < xDims->size(); ++i)
+    {
+        if(i < normalizedDim)
+        {
+            if(stride == 1 || i != 1) // Don't add C to outerSize if there is a stride
+            {
+                outerSize *= xDims->Get(i);
+            }
+        }
+        else
+        {
+            innerSize *= xDims->Get(i);
+        }
+    }
+
+    long xlocalsize = 1024;
+    long xgridsize = outerSize * stride;
+    long ylocalsize = 1;
+    long ygridsize = 1;
+    long zlocalsize = 1;
+    long zgridsize = 1;
+
+    // Prepare compilation options
+    std::vector<std::string> options;
+    auto rocmPath
+        = hipdnn_data_sdk::utilities::trim(hipdnn_data_sdk::utilities::getEnv("ROCM_PATH"));
+    if(!rocmPath.empty())
+    {
+        auto rocmIncludeArg = "-I" + rocmPath + "/include";
+        options.emplace_back(rocmIncludeArg);
+        HIPDNN_PLUGIN_LOG_INFO(
+            "LayernormFwdPlan: HIPRTC compile ROCm include path: " << rocmIncludeArg);
+    }
+    options.emplace_back(
+        std::string("-DHIP_PLUGIN_USE_FP32=")
+        + (xDataType == hipdnn_data_sdk::data_objects::DataType::FLOAT ? "1" : "0"));
+    options.emplace_back(
+        std::string("-DHIP_PLUGIN_USE_FP16=")
+        + (xDataType == hipdnn_data_sdk::data_objects::DataType::HALF ? "1" : "0"));
+    options.emplace_back(
+        std::string("-DHIP_PLUGIN_USE_BFP16=")
+        + (xDataType == hipdnn_data_sdk::data_objects::DataType::BFLOAT16 ? "1" : "0"));
+    options.emplace_back(std::string("-DOUTER_SIZE=") + std::to_string(outerSize));
+    options.emplace_back(std::string("-DINNER_SIZE=") + std::to_string(innerSize));
+    options.emplace_back(std::string("-DSTRIDE=") + std::to_string(stride));
+    options.emplace_back(std::string("-DLOCAL_SIZE=") + std::to_string(xlocalsize));
+    options.emplace_back(std::string("--offload-arch=") + deviceProperties.gcnArchName);
+
+    // Compile kernel and configure launch dimensions
+    _compiledProgram = kernelCompiler.compile("LayernormFwd.cpp", options);
+    _runnableKernel = _compiledProgram->getKernel("LayernormFwd");
+
+    _runnableKernel->setBlockSize(static_cast<unsigned int>(xlocalsize),
+                                  static_cast<unsigned int>(ylocalsize),
+                                  static_cast<unsigned int>(zlocalsize));
+    _runnableKernel->setGridSize(static_cast<unsigned int>(xgridsize),
+                                 static_cast<unsigned int>(ygridsize),
+                                 static_cast<unsigned int>(zgridsize));
+}
+
+void LayernormFwdPlan::execute(const HipKernelHandle& handle,
+                               const hipdnnPluginDeviceBuffer_t* deviceBuffers,
+                               uint32_t numDeviceBuffers,
+                               [[maybe_unused]] void* workspace) const
+{
+    if(!_runnableKernel)
+    {
+        throw hipdnn_plugin_sdk::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_BAD_PARAM, "LayernormFwdPlan::execute() called before compile()");
+    }
+
+    // Get device buffer pointers
+    auto xBuffer
+        = hip_kernel_utils::findDeviceBuffer(_params.x()->uid(), deviceBuffers, numDeviceBuffers);
+    auto yBuffer
+        = hip_kernel_utils::findDeviceBuffer(_params.y()->uid(), deviceBuffers, numDeviceBuffers);
+    auto scaleBuffer = hip_kernel_utils::findDeviceBuffer(
+        _params.scale()->uid(), deviceBuffers, numDeviceBuffers);
+    auto biasBuffer = hip_kernel_utils::findDeviceBuffer(
+        _params.bias()->uid(), deviceBuffers, numDeviceBuffers);
+    auto meanBuffer = hip_kernel_utils::findDeviceBuffer(
+        _params.mean()->uid(), deviceBuffers, numDeviceBuffers);
+    auto invVarianceBuffer = hip_kernel_utils::findDeviceBuffer(
+        _params.invVariance()->uid(), deviceBuffers, numDeviceBuffers);
+
+    hipdnn_data_sdk::data_objects::TensorAttributesT epsilonTensor;
+    _params.epsilon()->UnPackTo(&epsilonTensor);
+    double epsilon
+        = hipdnn_data_sdk::utilities::extractDoubleFromTensorValue(epsilonTensor, "Epsilon");
+
+    // Launch kernel
+    _runnableKernel->launch(handle.getStream(),
+                            xBuffer.ptr,
+                            yBuffer.ptr,
+                            scaleBuffer.ptr,
+                            biasBuffer.ptr,
+                            meanBuffer.ptr,
+                            invVarianceBuffer.ptr,
+                            static_cast<float>(epsilon));
+}
+
+} // namespace hip_kernel_provider::layernorm

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormFwdPlan.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormFwdPlan.cpp
@@ -13,6 +13,7 @@
 #include <hipdnn_data_sdk/utilities/PlatformUtils.hpp>
 #include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 
 namespace hip_kernel_provider::layernorm
@@ -188,10 +189,15 @@ void LayernormFwdPlan::execute(const HipKernelHandle& handle,
         _params.scale()->uid(), deviceBuffers, numDeviceBuffers);
     auto biasBuffer = hip_kernel_utils::findDeviceBuffer(
         _params.bias()->uid(), deviceBuffers, numDeviceBuffers);
-    auto meanBuffer = hip_kernel_utils::findDeviceBuffer(
-        _params.mean()->uid(), deviceBuffers, numDeviceBuffers);
-    auto invVarianceBuffer = hip_kernel_utils::findDeviceBuffer(
-        _params.invVariance()->uid(), deviceBuffers, numDeviceBuffers);
+    auto meanBuffer = _params.mean() != nullptr
+                          ? hip_kernel_utils::findDeviceBuffer(
+                                _params.mean()->uid(), deviceBuffers, numDeviceBuffers)
+                          : hipdnnPluginDeviceBuffer_t{-1, nullptr};
+    auto invVarianceBuffer = _params.invVariance() != nullptr
+                                 ? hip_kernel_utils::findDeviceBuffer(_params.invVariance()->uid(),
+                                                                      deviceBuffers,
+                                                                      numDeviceBuffers)
+                                 : hipdnnPluginDeviceBuffer_t{-1, nullptr};
 
     hipdnn_data_sdk::data_objects::TensorAttributesT epsilonTensor;
     _params.epsilon()->UnPackTo(&epsilonTensor);

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormFwdPlan.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormFwdPlan.hpp
@@ -1,0 +1,86 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
+
+#include <hipdnn_plugin_sdk/interfaces/IPlan.hpp>
+
+#include "HipKernelHandle.hpp"
+#include "hip/ICompiledProgram.hpp"
+#include "hip/IRunnableKernel.hpp"
+
+#include <memory>
+
+namespace hip_kernel_provider
+{
+
+class IKernelCompiler;
+
+namespace layernorm
+{
+
+class LayernormFwdParams
+{
+public:
+    LayernormFwdParams(
+        const hipdnn_data_sdk::data_objects::LayernormAttributes& attributes,
+        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+            tensorMap);
+
+    LayernormFwdParams(const LayernormFwdParams&) = delete;
+    LayernormFwdParams& operator=(const LayernormFwdParams&) = delete;
+
+    LayernormFwdParams(LayernormFwdParams&&) = default;
+    LayernormFwdParams& operator=(LayernormFwdParams&&) = default;
+
+    const hipdnn_data_sdk::data_objects::TensorAttributes* x() const;
+    const hipdnn_data_sdk::data_objects::TensorAttributes* y() const;
+    const hipdnn_data_sdk::data_objects::TensorAttributes* scale() const;
+    const hipdnn_data_sdk::data_objects::TensorAttributes* bias() const;
+    const hipdnn_data_sdk::data_objects::TensorAttributes* mean() const;
+    const hipdnn_data_sdk::data_objects::TensorAttributes* invVariance() const;
+    const hipdnn_data_sdk::data_objects::TensorAttributes* epsilon() const;
+
+private:
+    const hipdnn_data_sdk::data_objects::TensorAttributes* _x;
+    const hipdnn_data_sdk::data_objects::TensorAttributes* _y;
+    const hipdnn_data_sdk::data_objects::TensorAttributes* _scale;
+    const hipdnn_data_sdk::data_objects::TensorAttributes* _bias;
+    const hipdnn_data_sdk::data_objects::TensorAttributes* _mean;
+    const hipdnn_data_sdk::data_objects::TensorAttributes* _invVariance;
+    const hipdnn_data_sdk::data_objects::TensorAttributes* _epsilon;
+};
+
+class LayernormFwdPlan : public hipdnn_plugin_sdk::IPlan<HipKernelHandle>
+{
+public:
+    explicit LayernormFwdPlan(LayernormFwdParams&& params);
+
+    LayernormFwdPlan(const LayernormFwdPlan&) = delete;
+    LayernormFwdPlan& operator=(const LayernormFwdPlan&) = delete;
+
+    LayernormFwdPlan(LayernormFwdPlan&&) = default;
+    LayernormFwdPlan& operator=(LayernormFwdPlan&&) = default;
+
+    void compile(const IKernelCompiler& kernelCompiler, const hipDeviceProp_t& deviceProperties);
+
+    size_t getWorkspaceSize(const HipKernelHandle& handle) const override;
+
+    void execute(const HipKernelHandle& handle,
+                 const hipdnnPluginDeviceBuffer_t* deviceBuffers,
+                 uint32_t numDeviceBuffers,
+                 void* workspace = nullptr) const override;
+
+private:
+    LayernormFwdParams _params;
+
+    // Populated by compile()
+    std::unique_ptr<ICompiledProgram> _compiledProgram;
+    std::unique_ptr<IRunnableKernel> _runnableKernel;
+};
+
+} // namespace layernorm
+
+} // namespace hip_kernel_provider

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormPlanBuilder.cpp
@@ -1,6 +1,7 @@
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier:  MIT
 
+#include <cstdio>
 #include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 #include <hipdnn_plugin_sdk/PluginLogging.hpp>

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormPlanBuilder.cpp
@@ -1,0 +1,148 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+#include <hipdnn_plugin_sdk/PluginException.hpp>
+#include <hipdnn_plugin_sdk/PluginLogging.hpp>
+#include <string>
+
+#include "IDevicePropertyProvider.hpp"
+#include "LayernormPlanBuilder.hpp"
+#include "engines/plans/layernorm/LayernormApplicabilityChecks.hpp"
+#include "engines/plans/layernorm/LayernormFwdPlan.hpp"
+#include "hip/IKernelCompiler.hpp"
+
+namespace hip_kernel_provider::layernorm
+{
+
+LayernormPlanBuilder::LayernormPlanBuilder(const IKernelCompiler& kernelCompiler,
+                                           const IDevicePropertyProvider& devicePropertyProvider)
+    : _kernelCompiler(kernelCompiler)
+    , _devicePropertyProvider(devicePropertyProvider)
+{
+}
+
+bool LayernormPlanBuilder::isApplicable(
+    [[maybe_unused]] const HipKernelHandle& handle,
+    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+{
+    auto anyNodeIsNotF32Compute = [&]() {
+        return !std::all_of(
+            opGraph.nodeWrappers().begin(), opGraph.nodeWrappers().end(), [](const auto& node) {
+                return node->computeDataType() == hipdnn_data_sdk::data_objects::DataType::FLOAT;
+            });
+    };
+
+    switch(opGraph.nodeCount())
+    {
+    case 1:
+    {
+        if(anyNodeIsNotF32Compute())
+        {
+            HIPDNN_PLUGIN_LOG_ERROR(
+                "Layernorm plan builder only supports nodes with an fp32 compute_data_type");
+            return false;
+        }
+
+        if(!opGraph.hasOnlySupportedAttributes(
+               std::set<hipdnn_data_sdk::data_objects::NodeAttributes>{
+                   hipdnn_data_sdk::data_objects::NodeAttributes::LayernormAttributes}))
+        {
+            HIPDNN_PLUGIN_LOG_INFO("Layernorm plan builder is not applicable for this graph");
+            return false;
+        }
+
+        const auto& node = opGraph.getNode(0);
+
+        try
+        {
+            switch(node.attributes_type())
+            {
+            case hipdnn_data_sdk::data_objects::NodeAttributes::LayernormAttributes:
+                checkLayernormTensorConfigSupported(*node.attributes_as_LayernormAttributes(),
+                                                    opGraph.getTensorMap());
+                break;
+            default:
+                throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_INTERNAL_ERROR,
+                                                               "Unexpected node attribute type");
+            }
+        }
+        catch(const std::exception& e)
+        {
+            HIPDNN_PLUGIN_LOG_INFO(e.what());
+            return false;
+        }
+
+        return true;
+    }
+    default:
+    {
+        HIPDNN_PLUGIN_LOG_INFO(
+            "Layernorm plan builder is only applicable to 1 node graphs. Graph has "
+            << opGraph.nodeCount() << " nodes");
+        return false;
+    }
+    }
+}
+
+size_t LayernormPlanBuilder::getMaxWorkspaceSize(
+    [[maybe_unused]] const HipKernelHandle& handle,
+    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+    [[maybe_unused]] const HipKernelSettings& executionSettings) const
+{
+    // Layernorm plan builder does not require workspace size
+    return 0;
+}
+
+namespace
+{
+
+void buildPlanFwd([[maybe_unused]] const HipKernelHandle& handle,
+                  const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                  const hipdnn_data_sdk::flatbuffer_utilities::INodeWrapper& nodeWrapper,
+                  const IKernelCompiler& kernelCompiler,
+                  const IDevicePropertyProvider& devicePropertyProvider,
+                  HipKernelContext& executionContext)
+{
+    const auto& attr
+        = nodeWrapper.attributesAs<hipdnn_data_sdk::data_objects::LayernormAttributes>();
+
+    LayernormFwdParams params(attr, opGraph.getTensorMap());
+    auto plan = std::make_unique<LayernormFwdPlan>(std::move(params));
+    plan->compile(kernelCompiler, devicePropertyProvider.getDeviceProperties());
+
+    executionContext.setPlan(std::move(plan));
+}
+
+} // namespace
+
+void LayernormPlanBuilder::initializeExecutionSettings(
+    [[maybe_unused]] const HipKernelHandle& handle,
+    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+    [[maybe_unused]] HipKernelSettings& executionSettings) const
+{
+}
+
+void LayernormPlanBuilder::buildPlan(
+    const HipKernelHandle& handle,
+    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+    HipKernelContext& executionContext) const
+{
+    const auto& nodeWrapper = opGraph.getNodeWrapper(0);
+    const auto nodeName = nodeWrapper.name();
+
+    HIPDNN_PLUGIN_LOG_INFO("Building layernorm fwd plan for node: " << nodeName);
+    buildPlanFwd(
+        handle, opGraph, nodeWrapper, _kernelCompiler, _devicePropertyProvider, executionContext);
+}
+
+std::vector<hipdnn_data_sdk::data_objects::KnobT> LayernormPlanBuilder::getCustomKnobs(
+    [[maybe_unused]] const HipKernelHandle& handle,
+    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+{
+    return {};
+}
+
+} // namespace hip_kernel_provider::layernorm

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormPlanBuilder.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormPlanBuilder.hpp
@@ -1,0 +1,57 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <hipdnn_plugin_sdk/interfaces/IPlanBuilder.hpp>
+
+#include "HipKernelContext.hpp"
+#include "HipKernelHandle.hpp"
+#include "HipKernelSettings.hpp"
+#include "IDevicePropertyProvider.hpp"
+#include "hip/IKernelCompiler.hpp"
+#include "hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp"
+
+namespace hip_kernel_provider::layernorm
+{
+
+class LayernormPlanBuilder
+    : public hipdnn_plugin_sdk::IPlanBuilder<HipKernelHandle, HipKernelSettings, HipKernelContext>
+{
+public:
+    LayernormPlanBuilder(const IKernelCompiler& kernelCompiler,
+                         const IDevicePropertyProvider& devicePropertyProvider);
+    ~LayernormPlanBuilder() override = default;
+
+    // Disallow copy and assignment
+    LayernormPlanBuilder(const LayernormPlanBuilder&) = delete;
+    LayernormPlanBuilder& operator=(const LayernormPlanBuilder&) = delete;
+
+    bool isApplicable(const HipKernelHandle& handle,
+                      const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+
+    size_t getMaxWorkspaceSize(const HipKernelHandle& handle,
+                               const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                               const HipKernelSettings& executionSettings) const override;
+
+    void initializeExecutionSettings(
+        const HipKernelHandle& handle,
+        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+        const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+        HipKernelSettings& executionSettings) const override;
+
+    void buildPlan(const HipKernelHandle& handle,
+                   const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                   const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+                   HipKernelContext& executionContext) const override;
+
+    std::vector<hipdnn_data_sdk::data_objects::KnobT>
+        getCustomKnobs(const HipKernelHandle& handle,
+                       const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+
+private:
+    const IKernelCompiler& _kernelCompiler;
+    const IDevicePropertyProvider& _devicePropertyProvider;
+};
+
+} // namespace hip_kernel_provider::layernorm

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormUtilities.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormUtilities.cpp
@@ -53,13 +53,13 @@ size_t
     const std::vector<int64_t> affineDims(affineAttr->dims()->begin(), affineAttr->dims()->end());
 
     auto affineNormalizedDimMax = affineDims.size();
-    for(auto i = affineDims.size() - 1; i >= 0; --i)
+    for(auto i = static_cast<int>(affineDims.size()) - 1; i >= 0; --i)
     {
-        if(affineDims[i] > 1 && ioDims[i] > 1)
+        if(affineDims[static_cast<size_t>(i)] > 1 && ioDims[static_cast<size_t>(i)] > 1)
         {
-            affineNormalizedDimMax = i;
+            affineNormalizedDimMax = static_cast<size_t>(i);
         }
-        else if(affineDims[i] == 1 && ioDims[i] > 1)
+        else if(affineDims[static_cast<size_t>(i)] == 1 && ioDims[static_cast<size_t>(i)] > 1)
         {
             break;
         }
@@ -130,13 +130,13 @@ size_t getMaxNormalizedDimFromStat(const hipdnn_data_sdk::data_objects::TensorAt
     const std::vector<int64_t> statDims(statAttr->dims()->begin(), statAttr->dims()->end());
 
     auto statNormalizedDimMax = statDims.size();
-    for(size_t i = statDims.size() - 1; i >= 0; --i)
+    for(auto i = static_cast<int>(statDims.size()) - 1; i >= 0; --i)
     {
-        if(statDims[i] == 1 && ioDims[i] > 1)
+        if(statDims[static_cast<size_t>(i)] == 1 && ioDims[static_cast<size_t>(i)] > 1)
         {
-            statNormalizedDimMax = i;
+            statNormalizedDimMax = static_cast<size_t>(i);
         }
-        else if(statDims[i] > 1)
+        else if(statDims[static_cast<size_t>(i)] > 1)
         {
             break;
         }
@@ -189,11 +189,11 @@ size_t guessNormalizedDim(
     const std::optional<const hipdnn_data_sdk::data_objects::TensorAttributes*> affineAttr
         = affineTensorId.has_value() ? std::optional(&hip_kernel_utils::findTensorAttributes(
                                            tensorMap, affineTensorId.value()))
-                                     : nullptr;
+                                     : std::nullopt;
     const std::optional<const hipdnn_data_sdk::data_objects::TensorAttributes*> statAttr
         = statTensorId.has_value() ? std::optional(&hip_kernel_utils::findTensorAttributes(
                                          tensorMap, statTensorId.value()))
-                                   : nullptr;
+                                   : std::nullopt;
 
     return guessNormalizedDim(ioAttr, affineAttr, statAttr);
 }

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormUtilities.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormUtilities.cpp
@@ -1,0 +1,201 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include "LayernormUtilities.hpp"
+
+#include <cstdint>
+
+#include "HipKernelUtils.hpp"
+
+namespace hip_kernel_provider::layernorm
+{
+
+size_t
+    getMinNormalizedDimFromAffine(const hipdnn_data_sdk::data_objects::TensorAttributes* ioAttr,
+                                  const hipdnn_data_sdk::data_objects::TensorAttributes* affineAttr)
+{
+    const std::vector<int64_t> ioDims(ioAttr->dims()->begin(), ioAttr->dims()->end());
+    const std::vector<int64_t> affineDims(affineAttr->dims()->begin(), affineAttr->dims()->end());
+
+    size_t affineNormalizedDimMin = 0;
+    for(size_t i = 0; i < affineDims.size(); ++i)
+    {
+        if(affineDims[i] == 1 && ioDims[i] > 1)
+        {
+            affineNormalizedDimMin = i + 1;
+        }
+        else if(affineDims[i] > 1)
+        {
+            break;
+        }
+    }
+
+    return affineNormalizedDimMin;
+}
+
+size_t getMinNormalizedDimFromAffine(
+    const int64_t ioTensorId,
+    const int64_t affineTensorId,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+{
+    const auto* ioAttr = &hip_kernel_utils::findTensorAttributes(tensorMap, ioTensorId);
+    const auto* affineAttr = &hip_kernel_utils::findTensorAttributes(tensorMap, affineTensorId);
+
+    return getMinNormalizedDimFromAffine(ioAttr, affineAttr);
+}
+
+size_t
+    getMaxNormalizedDimFromAffine(const hipdnn_data_sdk::data_objects::TensorAttributes* ioAttr,
+                                  const hipdnn_data_sdk::data_objects::TensorAttributes* affineAttr)
+{
+    const std::vector<int64_t> ioDims(ioAttr->dims()->begin(), ioAttr->dims()->end());
+    const std::vector<int64_t> affineDims(affineAttr->dims()->begin(), affineAttr->dims()->end());
+
+    auto affineNormalizedDimMax = affineDims.size();
+    for(auto i = affineDims.size() - 1; i >= 0; --i)
+    {
+        if(affineDims[i] > 1 && ioDims[i] > 1)
+        {
+            affineNormalizedDimMax = i;
+        }
+        else if(affineDims[i] == 1 && ioDims[i] > 1)
+        {
+            break;
+        }
+    }
+
+    return affineNormalizedDimMax;
+}
+
+size_t getMaxNormalizedDimFromAffine(
+    const int64_t ioTensorId,
+    const int64_t affineTensorId,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+{
+    const auto* ioAttr = &hip_kernel_utils::findTensorAttributes(tensorMap, ioTensorId);
+    const auto* affineAttr = &hip_kernel_utils::findTensorAttributes(tensorMap, affineTensorId);
+
+    return getMaxNormalizedDimFromAffine(ioAttr, affineAttr);
+}
+
+size_t getMinNormalizedDimFromStat(const hipdnn_data_sdk::data_objects::TensorAttributes* ioAttr,
+                                   const hipdnn_data_sdk::data_objects::TensorAttributes* statAttr)
+{
+    if(ioAttr == nullptr || statAttr == nullptr)
+    {
+        return 0;
+    }
+
+    const std::vector<int64_t> ioDims(ioAttr->dims()->begin(), ioAttr->dims()->end());
+    const std::vector<int64_t> statDims(statAttr->dims()->begin(), statAttr->dims()->end());
+
+    size_t statNormalizedDimMin = 0;
+    for(size_t i = 0; i < statDims.size(); ++i)
+    {
+        if(statDims[i] > 1 && ioDims[i] > 1)
+        {
+            statNormalizedDimMin = i + 1;
+        }
+        else if(statDims[i] == 1 && ioDims[i] > 1)
+        {
+            break;
+        }
+    }
+
+    return statNormalizedDimMin;
+}
+
+size_t getMinNormalizedDimFromStat(
+    const int64_t ioTensorId,
+    const int64_t statTensorId,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+{
+    const auto* ioAttr = &hip_kernel_utils::findTensorAttributes(tensorMap, ioTensorId);
+    const auto* statAttr = &hip_kernel_utils::findTensorAttributes(tensorMap, statTensorId);
+
+    return getMinNormalizedDimFromStat(ioAttr, statAttr);
+}
+
+size_t getMaxNormalizedDimFromStat(const hipdnn_data_sdk::data_objects::TensorAttributes* ioAttr,
+                                   const hipdnn_data_sdk::data_objects::TensorAttributes* statAttr)
+{
+    const std::vector<int64_t> ioDims(ioAttr->dims()->begin(), ioAttr->dims()->end());
+    if(statAttr == nullptr)
+    {
+        return ioDims.size();
+    }
+    const std::vector<int64_t> statDims(statAttr->dims()->begin(), statAttr->dims()->end());
+
+    auto statNormalizedDimMax = statDims.size();
+    for(size_t i = statDims.size() - 1; i >= 0; --i)
+    {
+        if(statDims[i] == 1 && ioDims[i] > 1)
+        {
+            statNormalizedDimMax = i;
+        }
+        else if(statDims[i] > 1)
+        {
+            break;
+        }
+    }
+
+    return statNormalizedDimMax;
+}
+
+size_t getMaxNormalizedDimFromStat(
+    const int64_t ioTensorId,
+    const int64_t statTensorId,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+{
+    const auto* ioAttr = &hip_kernel_utils::findTensorAttributes(tensorMap, ioTensorId);
+    const auto* statAttr = &hip_kernel_utils::findTensorAttributes(tensorMap, statTensorId);
+
+    return getMaxNormalizedDimFromStat(ioAttr, statAttr);
+}
+
+size_t guessNormalizedDim(
+    const hipdnn_data_sdk::data_objects::TensorAttributes* ioAttr,
+    const std::optional<const hipdnn_data_sdk::data_objects::TensorAttributes*> affineAttr,
+    const std::optional<const hipdnn_data_sdk::data_objects::TensorAttributes*> statAttr)
+{
+    size_t affineNormalizedDimMin
+        = affineAttr.has_value() ? getMinNormalizedDimFromAffine(ioAttr, affineAttr.value()) : 0;
+    size_t statNormalizedDimMin
+        = statAttr.has_value() ? getMinNormalizedDimFromStat(ioAttr, statAttr.value()) : 0;
+
+    size_t affineNormalizedDimMax
+        = affineAttr.has_value() ? getMaxNormalizedDimFromAffine(ioAttr, affineAttr.value()) : 0;
+    size_t statNormalizedDimMax
+        = statAttr.has_value() ? getMaxNormalizedDimFromStat(ioAttr, statAttr.value()) : 0;
+
+    size_t normalizedDimMin = std::max(affineNormalizedDimMin, statNormalizedDimMin);
+    size_t normalizedDimMax = std::min(affineNormalizedDimMax, statNormalizedDimMax);
+
+    return normalizedDimMin > 0 ? normalizedDimMin : normalizedDimMax;
+}
+
+size_t guessNormalizedDim(
+    const int64_t ioTensorId,
+    const std::optional<int64_t> affineTensorId,
+    const std::optional<int64_t> statTensorId,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+{
+    const auto* ioAttr = &hip_kernel_utils::findTensorAttributes(tensorMap, ioTensorId);
+    const std::optional<const hipdnn_data_sdk::data_objects::TensorAttributes*> affineAttr
+        = affineTensorId.has_value() ? std::optional(&hip_kernel_utils::findTensorAttributes(
+                                           tensorMap, affineTensorId.value()))
+                                     : nullptr;
+    const std::optional<const hipdnn_data_sdk::data_objects::TensorAttributes*> statAttr
+        = statTensorId.has_value() ? std::optional(&hip_kernel_utils::findTensorAttributes(
+                                         tensorMap, statTensorId.value()))
+                                   : nullptr;
+
+    return guessNormalizedDim(ioAttr, affineAttr, statAttr);
+}
+
+} // namespace hip_kernel_provider::layernorm

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormUtilities.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormUtilities.hpp
@@ -1,0 +1,64 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <cstdint>
+#include <unordered_map>
+
+#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
+
+namespace hip_kernel_provider::layernorm
+{
+
+size_t getMinNormalizedDimFromAffine(
+    const hipdnn_data_sdk::data_objects::TensorAttributes* ioAttr,
+    const hipdnn_data_sdk::data_objects::TensorAttributes* affineAttr);
+
+size_t getMinNormalizedDimFromAffine(
+    int64_t ioTensorId,
+    int64_t affineTensorId,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap);
+
+size_t getMaxNormalizedDimFromAffine(
+    const hipdnn_data_sdk::data_objects::TensorAttributes* ioAttr,
+    const hipdnn_data_sdk::data_objects::TensorAttributes* affineAttr);
+
+size_t getMaxNormalizedDimFromAffine(
+    int64_t ioTensorId,
+    int64_t affineTensorId,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap);
+
+size_t getMinNormalizedDimFromStat(const hipdnn_data_sdk::data_objects::TensorAttributes* ioAttr,
+                                   const hipdnn_data_sdk::data_objects::TensorAttributes* statAttr);
+
+size_t getMinNormalizedDimFromStat(
+    int64_t ioTensorId,
+    int64_t statTensorId,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap);
+
+size_t getMaxNormalizedDimFromStat(const hipdnn_data_sdk::data_objects::TensorAttributes* ioAttr,
+                                   const hipdnn_data_sdk::data_objects::TensorAttributes* statAttr);
+
+size_t getMaxNormalizedDimFromStat(
+    int64_t ioTensorId,
+    int64_t statTensorId,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap);
+
+size_t guessNormalizedDim(
+    const hipdnn_data_sdk::data_objects::TensorAttributes* ioAttr,
+    std::optional<const hipdnn_data_sdk::data_objects::TensorAttributes*> affineAttr,
+    std::optional<const hipdnn_data_sdk::data_objects::TensorAttributes*> statAttr);
+
+size_t guessNormalizedDim(
+    int64_t ioTensorId,
+    std::optional<int64_t> affineTensorId,
+    std::optional<int64_t> statTensorId,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap);
+
+} // namespace hip_kernel_provider::layernorm

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormUtilities.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormUtilities.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <unordered_map>
 
 #include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>

--- a/dnn-providers/hip-kernel-provider/src/integration_tests/Batchnorm/BatchnormCommon.hpp
+++ b/dnn-providers/hip-kernel-provider/src/integration_tests/Batchnorm/BatchnormCommon.hpp
@@ -10,7 +10,7 @@
 #include <hipdnn_data_sdk/utilities/StringUtil.hpp>
 #include <hipdnn_test_sdk/utilities/Seeds.hpp>
 
-namespace hip_kernel_provider::test_bn_common
+namespace hip_kernel_provider::batchnorm::test::common
 {
 
 struct BatchnormTestCase
@@ -117,4 +117,4 @@ inline std::vector<BatchnormTestCase> getBnFwdTrainingFull3dTestCases()
     };
 }
 
-} // namespace hip_kernel_provider::test_bn_common
+} // namespace hip_kernel_provider::batchnorm::test::common

--- a/dnn-providers/hip-kernel-provider/src/integration_tests/Batchnorm/IntegrationGpuBatchnormForwardInference.cpp
+++ b/dnn-providers/hip-kernel-provider/src/integration_tests/Batchnorm/IntegrationGpuBatchnormForwardInference.cpp
@@ -14,9 +14,13 @@
 using namespace hipdnn_frontend;
 using namespace hipdnn_frontend::graph;
 using namespace hipdnn_data_sdk::utilities;
-using namespace hipdnn_test_sdk::utilities;
+using namespace hipdnn_test_sdk::utilities::batchnorm;
 using namespace hip_kernel_provider::test_utilities;
-using namespace hip_kernel_provider::test_bn_common;
+
+namespace hip_kernel_provider::batchnorm::test
+{
+
+using namespace common;
 
 namespace
 {
@@ -118,7 +122,7 @@ using IntegrationGpuBatchnormForwardInferenceNdhwcFp16 = BatchnormForwardInferen
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceNchwFp32, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<float>(), TensorLayout::NCHW);
+    runGraphTest(getToleranceInference<float>(), TensorLayout::NCHW);
 }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
@@ -135,7 +139,7 @@ INSTANTIATE_TEST_SUITE_P(Full,
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceNchwBfp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<bfloat16>(), TensorLayout::NCHW);
+    runGraphTest(getToleranceInference<bfloat16>(), TensorLayout::NCHW);
 }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
@@ -152,7 +156,7 @@ INSTANTIATE_TEST_SUITE_P(Full,
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceNchwFp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<half>(), TensorLayout::NCHW);
+    runGraphTest(getToleranceInference<half>(), TensorLayout::NCHW);
 }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
@@ -169,7 +173,7 @@ INSTANTIATE_TEST_SUITE_P(Full,
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceNhwcFp32, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<float>(), TensorLayout::NHWC);
+    runGraphTest(getToleranceInference<float>(), TensorLayout::NHWC);
 }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
@@ -186,7 +190,7 @@ INSTANTIATE_TEST_SUITE_P(Full,
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceNhwcBfp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<bfloat16>(), TensorLayout::NHWC);
+    runGraphTest(getToleranceInference<bfloat16>(), TensorLayout::NHWC);
 }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
@@ -203,7 +207,7 @@ INSTANTIATE_TEST_SUITE_P(Full,
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceNhwcFp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<half>(), TensorLayout::NHWC);
+    runGraphTest(getToleranceInference<half>(), TensorLayout::NHWC);
 }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
@@ -220,7 +224,7 @@ INSTANTIATE_TEST_SUITE_P(Full,
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceNcdhwFp32, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<float>(), TensorLayout::NCDHW);
+    runGraphTest(getToleranceInference<float>(), TensorLayout::NCDHW);
 }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
@@ -233,7 +237,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceNcdhwBfp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<bfloat16>(), TensorLayout::NCDHW);
+    runGraphTest(getToleranceInference<bfloat16>(), TensorLayout::NCDHW);
 }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
@@ -246,7 +250,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceNcdhwFp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<half>(), TensorLayout::NCDHW);
+    runGraphTest(getToleranceInference<half>(), TensorLayout::NCDHW);
 }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
@@ -259,7 +263,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceNdhwcFp32, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<float>(), TensorLayout::NDHWC);
+    runGraphTest(getToleranceInference<float>(), TensorLayout::NDHWC);
 }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
@@ -272,7 +276,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceNdhwcBfp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<bfloat16>(), TensorLayout::NDHWC);
+    runGraphTest(getToleranceInference<bfloat16>(), TensorLayout::NDHWC);
 }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
@@ -285,9 +289,10 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceNdhwcFp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<half>(), TensorLayout::NDHWC);
+    runGraphTest(getToleranceInference<half>(), TensorLayout::NDHWC);
 }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
                          IntegrationGpuBatchnormForwardInferenceNdhwcFp16,
                          testing::ValuesIn(getBnFwdInference3dTestCases()));
+} // namespace hip_kernel_provider::batchnorm::test

--- a/dnn-providers/hip-kernel-provider/src/integration_tests/Batchnorm/IntegrationGpuBatchnormForwardInferenceAndActivation.cpp
+++ b/dnn-providers/hip-kernel-provider/src/integration_tests/Batchnorm/IntegrationGpuBatchnormForwardInferenceAndActivation.cpp
@@ -15,9 +15,13 @@
 using namespace hipdnn_frontend;
 using namespace hipdnn_frontend::graph;
 using namespace hipdnn_data_sdk::utilities;
-using namespace hipdnn_test_sdk::utilities;
+using namespace hipdnn_test_sdk::utilities::batchnorm;
 using namespace hip_kernel_provider::test_utilities;
-using namespace hip_kernel_provider::test_bn_common;
+
+namespace hip_kernel_provider::batchnorm::test
+{
+
+using namespace common;
 
 namespace
 {
@@ -195,7 +199,7 @@ using IntegrationGpuBatchnormForwardInferenceAndActivationNdhwcFp16
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceAndActivationNchwFp32, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<float>(), TensorLayout::NCHW);
+    runGraphTest(getToleranceInference<float>(), TensorLayout::NCHW);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -216,7 +220,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceAndActivationNchwBfp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<bfloat16>(), TensorLayout::NCHW);
+    runGraphTest(getToleranceInference<bfloat16>(), TensorLayout::NCHW);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -237,7 +241,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceAndActivationNchwFp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<half>(), TensorLayout::NCHW);
+    runGraphTest(getToleranceInference<half>(), TensorLayout::NCHW);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -258,7 +262,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceAndActivationNhwcFp32, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<float>(), TensorLayout::NHWC);
+    runGraphTest(getToleranceInference<float>(), TensorLayout::NHWC);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -279,7 +283,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceAndActivationNhwcBfp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<bfloat16>(), TensorLayout::NHWC);
+    runGraphTest(getToleranceInference<bfloat16>(), TensorLayout::NHWC);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -300,7 +304,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceAndActivationNhwcFp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<half>(), TensorLayout::NHWC);
+    runGraphTest(getToleranceInference<half>(), TensorLayout::NHWC);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -321,7 +325,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceAndActivationNcdhwFp32, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<float>(), TensorLayout::NCDHW);
+    runGraphTest(getToleranceInference<float>(), TensorLayout::NCDHW);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -336,7 +340,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceAndActivationNcdhwBfp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<bfloat16>(), TensorLayout::NCDHW);
+    runGraphTest(getToleranceInference<bfloat16>(), TensorLayout::NCDHW);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -351,7 +355,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceAndActivationNcdhwFp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<half>(), TensorLayout::NCDHW);
+    runGraphTest(getToleranceInference<half>(), TensorLayout::NCDHW);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -366,7 +370,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceAndActivationNdhwcFp32, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<float>(), TensorLayout::NDHWC);
+    runGraphTest(getToleranceInference<float>(), TensorLayout::NDHWC);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -381,7 +385,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceAndActivationNdhwcBfp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<bfloat16>(), TensorLayout::NDHWC);
+    runGraphTest(getToleranceInference<bfloat16>(), TensorLayout::NDHWC);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -396,7 +400,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceAndActivationNdhwcFp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<half>(), TensorLayout::NDHWC);
+    runGraphTest(getToleranceInference<half>(), TensorLayout::NDHWC);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -404,3 +408,5 @@ INSTANTIATE_TEST_SUITE_P(
     IntegrationGpuBatchnormForwardInferenceAndActivationNdhwcFp16,
     testing::Combine(testing::ValuesIn(getBnFwdInference3dTestCases()),
                      testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));
+
+} // namespace hip_kernel_provider::batchnorm::test

--- a/dnn-providers/hip-kernel-provider/src/integration_tests/Batchnorm/IntegrationGpuBatchnormForwardInferenceWithVariance.cpp
+++ b/dnn-providers/hip-kernel-provider/src/integration_tests/Batchnorm/IntegrationGpuBatchnormForwardInferenceWithVariance.cpp
@@ -14,9 +14,13 @@
 using namespace hipdnn_frontend;
 using namespace hipdnn_frontend::graph;
 using namespace hipdnn_data_sdk::utilities;
-using namespace hipdnn_test_sdk::utilities;
+using namespace hipdnn_test_sdk::utilities::batchnorm;
 using namespace hip_kernel_provider::test_utilities;
-using namespace hip_kernel_provider::test_bn_common;
+
+namespace hip_kernel_provider::batchnorm::test
+{
+
+using namespace common;
 
 namespace
 {
@@ -27,7 +31,7 @@ class BatchnormForwardInferenceWithVariance
 {
 protected:
     void initializeBundle(const hipdnn_frontend::graph::Graph& /*graph*/,
-                          GraphTensorBundle& bundle,
+                          hipdnn_test_sdk::utilities::GraphTensorBundle& bundle,
                           unsigned int seed) override
     {
         bundle.sentinelFillOutputTensors();
@@ -159,7 +163,7 @@ using IntegrationGpuBatchnormForwardInferenceWithVarianceNdhwcFp16
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceNchwFp32, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInferenceWithVariance<float>(), TensorLayout::NCHW);
+    runGraphTest(getToleranceInferenceWithVariance<float>(), TensorLayout::NCHW);
 }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
@@ -176,7 +180,7 @@ INSTANTIATE_TEST_SUITE_P(Full,
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceNchwBfp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInferenceWithVariance<bfloat16>(), TensorLayout::NCHW);
+    runGraphTest(getToleranceInferenceWithVariance<bfloat16>(), TensorLayout::NCHW);
 }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
@@ -193,7 +197,7 @@ INSTANTIATE_TEST_SUITE_P(Full,
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceNchwFp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInferenceWithVariance<half>(), TensorLayout::NCHW);
+    runGraphTest(getToleranceInferenceWithVariance<half>(), TensorLayout::NCHW);
 }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
@@ -210,7 +214,7 @@ INSTANTIATE_TEST_SUITE_P(Full,
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceNhwcFp32, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInferenceWithVariance<float>(), TensorLayout::NHWC);
+    runGraphTest(getToleranceInferenceWithVariance<float>(), TensorLayout::NHWC);
 }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
@@ -227,7 +231,7 @@ INSTANTIATE_TEST_SUITE_P(Full,
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceNhwcBfp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInferenceWithVariance<bfloat16>(), TensorLayout::NHWC);
+    runGraphTest(getToleranceInferenceWithVariance<bfloat16>(), TensorLayout::NHWC);
 }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
@@ -244,7 +248,7 @@ INSTANTIATE_TEST_SUITE_P(Full,
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceNhwcFp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInferenceWithVariance<half>(), TensorLayout::NHWC);
+    runGraphTest(getToleranceInferenceWithVariance<half>(), TensorLayout::NHWC);
 }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
@@ -261,7 +265,7 @@ INSTANTIATE_TEST_SUITE_P(Full,
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceNcdhwFp32, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInferenceWithVariance<float>(), TensorLayout::NCDHW);
+    runGraphTest(getToleranceInferenceWithVariance<float>(), TensorLayout::NCDHW);
 }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
@@ -274,7 +278,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceNcdhwBfp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInferenceWithVariance<bfloat16>(), TensorLayout::NCDHW);
+    runGraphTest(getToleranceInferenceWithVariance<bfloat16>(), TensorLayout::NCDHW);
 }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
@@ -287,7 +291,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceNcdhwFp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInferenceWithVariance<half>(), TensorLayout::NCDHW);
+    runGraphTest(getToleranceInferenceWithVariance<half>(), TensorLayout::NCDHW);
 }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
@@ -300,7 +304,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceNdhwcFp32, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInferenceWithVariance<float>(), TensorLayout::NDHWC);
+    runGraphTest(getToleranceInferenceWithVariance<float>(), TensorLayout::NDHWC);
 }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
@@ -313,7 +317,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceNdhwcBfp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInferenceWithVariance<bfloat16>(), TensorLayout::NDHWC);
+    runGraphTest(getToleranceInferenceWithVariance<bfloat16>(), TensorLayout::NDHWC);
 }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
@@ -326,9 +330,11 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceNdhwcFp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInferenceWithVariance<half>(), TensorLayout::NDHWC);
+    runGraphTest(getToleranceInferenceWithVariance<half>(), TensorLayout::NDHWC);
 }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
                          IntegrationGpuBatchnormForwardInferenceWithVarianceNdhwcFp16,
                          testing::ValuesIn(getBnFwdInference3dTestCases()));
+
+} // namespace hip_kernel_provider::batchnorm::test

--- a/dnn-providers/hip-kernel-provider/src/integration_tests/Batchnorm/IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivation.cpp
+++ b/dnn-providers/hip-kernel-provider/src/integration_tests/Batchnorm/IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivation.cpp
@@ -15,9 +15,13 @@
 using namespace hipdnn_frontend;
 using namespace hipdnn_frontend::graph;
 using namespace hipdnn_data_sdk::utilities;
-using namespace hipdnn_test_sdk::utilities;
+using namespace hipdnn_test_sdk::utilities::batchnorm;
 using namespace hip_kernel_provider::test_utilities;
-using namespace hip_kernel_provider::test_bn_common;
+
+namespace hip_kernel_provider::batchnorm::test
+{
+
+using namespace common;
 
 namespace
 {
@@ -28,7 +32,7 @@ class BatchnormForwardInferenceWithVarianceAndActivation
 {
 protected:
     void initializeBundle(const hipdnn_frontend::graph::Graph& /*graph*/,
-                          GraphTensorBundle& bundle,
+                          hipdnn_test_sdk::utilities::GraphTensorBundle& bundle,
                           unsigned int seed) override
     {
         bundle.sentinelFillOutputTensors();
@@ -226,7 +230,7 @@ using IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNdhwcFp16
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNchwFp32, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInferenceWithVariance<float>(), TensorLayout::NCHW);
+    runGraphTest(getToleranceInferenceWithVariance<float>(), TensorLayout::NCHW);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -247,7 +251,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNchwBfp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInferenceWithVariance<bfloat16>(), TensorLayout::NCHW);
+    runGraphTest(getToleranceInferenceWithVariance<bfloat16>(), TensorLayout::NCHW);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -268,7 +272,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNchwFp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInferenceWithVariance<half>(), TensorLayout::NCHW);
+    runGraphTest(getToleranceInferenceWithVariance<half>(), TensorLayout::NCHW);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -289,7 +293,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNhwcFp32, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInferenceWithVariance<float>(), TensorLayout::NHWC);
+    runGraphTest(getToleranceInferenceWithVariance<float>(), TensorLayout::NHWC);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -310,7 +314,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNhwcBfp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInferenceWithVariance<bfloat16>(), TensorLayout::NHWC);
+    runGraphTest(getToleranceInferenceWithVariance<bfloat16>(), TensorLayout::NHWC);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -331,7 +335,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNhwcFp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInferenceWithVariance<half>(), TensorLayout::NHWC);
+    runGraphTest(getToleranceInferenceWithVariance<half>(), TensorLayout::NHWC);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -352,7 +356,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNcdhwFp32, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInferenceWithVariance<float>(), TensorLayout::NCDHW);
+    runGraphTest(getToleranceInferenceWithVariance<float>(), TensorLayout::NCDHW);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -367,7 +371,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNcdhwBfp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInferenceWithVariance<bfloat16>(), TensorLayout::NCDHW);
+    runGraphTest(getToleranceInferenceWithVariance<bfloat16>(), TensorLayout::NCDHW);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -382,7 +386,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNcdhwFp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInferenceWithVariance<half>(), TensorLayout::NCDHW);
+    runGraphTest(getToleranceInferenceWithVariance<half>(), TensorLayout::NCDHW);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -397,7 +401,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNdhwcFp32, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInferenceWithVariance<float>(), TensorLayout::NDHWC);
+    runGraphTest(getToleranceInferenceWithVariance<float>(), TensorLayout::NDHWC);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -412,7 +416,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNdhwcBfp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInferenceWithVariance<bfloat16>(), TensorLayout::NDHWC);
+    runGraphTest(getToleranceInferenceWithVariance<bfloat16>(), TensorLayout::NDHWC);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -427,7 +431,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNdhwcFp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInferenceWithVariance<half>(), TensorLayout::NDHWC);
+    runGraphTest(getToleranceInferenceWithVariance<half>(), TensorLayout::NDHWC);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -435,3 +439,5 @@ INSTANTIATE_TEST_SUITE_P(
     IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNdhwcFp16,
     testing::Combine(testing::ValuesIn(getBnFwdInference3dTestCases()),
                      testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));
+
+} // hip_kernel_provider::batchnorm::test

--- a/dnn-providers/hip-kernel-provider/src/integration_tests/Batchnorm/IntegrationGpuBatchnormForwardTraining.cpp
+++ b/dnn-providers/hip-kernel-provider/src/integration_tests/Batchnorm/IntegrationGpuBatchnormForwardTraining.cpp
@@ -16,7 +16,7 @@ using namespace hipdnn_frontend::graph;
 using namespace hipdnn_data_sdk::utilities;
 using namespace hipdnn_test_sdk::utilities;
 using namespace hip_kernel_provider::test_utilities;
-using namespace hip_kernel_provider::test_bn_common;
+using namespace hip_kernel_provider::batchnorm::test::common;
 
 namespace
 {

--- a/dnn-providers/hip-kernel-provider/src/integration_tests/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/src/integration_tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(
     Batchnorm/IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivation.cpp
     Batchnorm/IntegrationGpuBatchnormForwardTraining.cpp
     RMSnorm/IntegrationGpuRMSnormForward.cpp
+    Layernorm/IntegrationGpuLayernormForward.cpp
 )
 
 target_compile_options(hip_kernel_provider_integration_tests PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})

--- a/dnn-providers/hip-kernel-provider/src/integration_tests/Layernorm/IntegrationGpuLayernormForward.cpp
+++ b/dnn-providers/hip-kernel-provider/src/integration_tests/Layernorm/IntegrationGpuLayernormForward.cpp
@@ -1,0 +1,240 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <hip/hip_runtime.h>
+#include <hipdnn_data_sdk/utilities/PlatformUtils.hpp>
+#include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
+#include <hipdnn_test_sdk/utilities/TestTolerances.hpp>
+#include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
+
+#include "../IntegrationGraphVerificationHarness.hpp"
+#include "LayernormCommon.hpp"
+#include "hipdnn_data_sdk/utilities/Tensor.hpp"
+#include "hipdnn_frontend/Types.hpp"
+#include "hipdnn_frontend/attributes/LayernormAttributes.hpp"
+#include "hipdnn_frontend/attributes/TensorAttributes.hpp"
+
+using namespace hipdnn_frontend;
+using namespace hipdnn_data_sdk::utilities;
+using namespace hipdnn_test_sdk::utilities::layernorm;
+using namespace hip_kernel_provider::test_utilities;
+
+namespace hip_kernel_provider::layernorm::test
+{
+
+using namespace common;
+
+namespace
+{
+
+template <typename IoType>
+class LayernormForward : public IntegrationGraphVerificationHarness<IoType, LayernormTestCase>
+{
+protected:
+    void runGraphTest(float tolerance, const TensorLayout& layout = TensorLayout::NCHW)
+    {
+        const LayernormTestCase& testCase = this->GetParam();
+
+        std::vector<int64_t> affineDims(testCase.dims.size(), 1);
+        for(size_t i = testCase.normalizedDim; i < testCase.dims.size(); ++i)
+        {
+            affineDims[i] = testCase.dims[i];
+        }
+
+        graph::Graph graphObj;
+
+        graphObj.set_name("LayernormFwdTest");
+
+        auto dataType = getDataTypeEnumFromType<IoType>();
+        graphObj.set_intermediate_data_type(DataType::FLOAT)
+            .set_compute_data_type(DataType::FLOAT)
+            .set_io_data_type(dataType);
+
+        auto ioStrides = generateStrides(testCase.dims, layout.strideOrder);
+        auto affineStrides = generateStrides(affineDims, layout.strideOrder);
+
+        auto xAttr = graph::makeTensorAttributes("X", testCase.dims, ioStrides);
+        auto xTensorAttr = std::make_shared<graph::TensorAttributes>(std::move(xAttr));
+
+        auto scaleAttr = graph::makeTensorAttributes("scale", affineDims, affineStrides);
+        auto scaleTensorAttr = std::make_shared<graph::TensorAttributes>(std::move(scaleAttr));
+
+        auto biasAttr = graph::makeTensorAttributes("bias", affineDims, affineStrides);
+        auto biasTensorAttr = std::make_shared<graph::TensorAttributes>(std::move(biasAttr));
+
+        auto epsilonAttr = graph::makeTensorAttributes("epsilon", 1e-5f);
+        auto epsilonTensorAttr = std::make_shared<graph::TensorAttributes>(std::move(epsilonAttr));
+
+        graph::LayernormAttributes lnAttrs;
+        lnAttrs.set_epsilon(std::move(epsilonTensorAttr));
+        lnAttrs.set_forward_phase(NormFwdPhase::TRAINING);
+
+        auto results = graphObj.layernorm(xTensorAttr, scaleTensorAttr, biasTensorAttr, lnAttrs);
+        const auto& yTensorAttr = results[0];
+        const auto& meanTensorAttr = results[1];
+        const auto& invVarianceTensorAttr = results[2];
+
+        yTensorAttr->set_output(true);
+        meanTensorAttr->set_output(true);
+        invVarianceTensorAttr->set_output(true);
+
+        this->registerValidator(yTensorAttr, tolerance);
+        this->registerValidator(meanTensorAttr, tolerance);
+        this->registerValidator(invVarianceTensorAttr, tolerance);
+
+        this->verifyGraph(graphObj, testCase.seed);
+    }
+};
+
+using IntegrationGpuLayernormForwardNchwFp32 = LayernormForward<float>;
+using IntegrationGpuLayernormForwardNchwFp16 = LayernormForward<half>;
+using IntegrationGpuLayernormForwardNchwBfp16 = LayernormForward<bfloat16>;
+
+using IntegrationGpuLayernormForwardNhwcFp32 = LayernormForward<float>;
+using IntegrationGpuLayernormForwardNhwcFp16 = LayernormForward<half>;
+using IntegrationGpuLayernormForwardNhwcBfp16 = LayernormForward<bfloat16>;
+
+using IntegrationGpuLayernormForwardNcdhwFp32 = LayernormForward<float>;
+using IntegrationGpuLayernormForwardNcdhwFp16 = LayernormForward<half>;
+using IntegrationGpuLayernormForwardNcdhwBfp16 = LayernormForward<bfloat16>;
+
+using IntegrationGpuLayernormForwardNdhwcFp32 = LayernormForward<float>;
+using IntegrationGpuLayernormForwardNdhwcFp16 = LayernormForward<half>;
+using IntegrationGpuLayernormForwardNdhwcBfp16 = LayernormForward<bfloat16>;
+
+} // namespace
+
+TEST_P(IntegrationGpuLayernormForwardNchwFp32, Correctness)
+{
+    runGraphTest(getTolerance<float>(), TensorLayout::NCHW);
+}
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         IntegrationGpuLayernormForwardNchwFp32,
+                         testing::ValuesIn(getLayernormFwd4DSmokeTestCases()));
+INSTANTIATE_TEST_SUITE_P(Full,
+                         IntegrationGpuLayernormForwardNchwFp32,
+                         testing::ValuesIn(getLayernormFwd4DFullTestCases()));
+
+TEST_P(IntegrationGpuLayernormForwardNchwFp16, Correctness)
+{
+    runGraphTest(getTolerance<half>(), TensorLayout::NCHW);
+}
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         IntegrationGpuLayernormForwardNchwFp16,
+                         testing::ValuesIn(getLayernormFwd4DSmokeTestCases()));
+INSTANTIATE_TEST_SUITE_P(Full,
+                         IntegrationGpuLayernormForwardNchwFp16,
+                         testing::ValuesIn(getLayernormFwd4DFullTestCases()));
+
+TEST_P(IntegrationGpuLayernormForwardNchwBfp16, Correctness)
+{
+    runGraphTest(getTolerance<bfloat16>(), TensorLayout::NCHW);
+}
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         IntegrationGpuLayernormForwardNchwBfp16,
+                         testing::ValuesIn(getLayernormFwd4DSmokeTestCases()));
+INSTANTIATE_TEST_SUITE_P(Full,
+                         IntegrationGpuLayernormForwardNchwBfp16,
+                         testing::ValuesIn(getLayernormFwd4DFullTestCases()));
+
+TEST_P(IntegrationGpuLayernormForwardNhwcFp32, Correctness)
+{
+    runGraphTest(getTolerance<float>(), TensorLayout::NHWC);
+}
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         IntegrationGpuLayernormForwardNhwcFp32,
+                         testing::ValuesIn(getLayernormFwd4DSmokeTestCases()));
+INSTANTIATE_TEST_SUITE_P(Full,
+                         IntegrationGpuLayernormForwardNhwcFp32,
+                         testing::ValuesIn(getLayernormFwd4DFullTestCases()));
+
+TEST_P(IntegrationGpuLayernormForwardNhwcFp16, Correctness)
+{
+    runGraphTest(getTolerance<half>(), TensorLayout::NHWC);
+}
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         IntegrationGpuLayernormForwardNhwcFp16,
+                         testing::ValuesIn(getLayernormFwd4DSmokeTestCases()));
+INSTANTIATE_TEST_SUITE_P(Full,
+                         IntegrationGpuLayernormForwardNhwcFp16,
+                         testing::ValuesIn(getLayernormFwd4DFullTestCases()));
+
+TEST_P(IntegrationGpuLayernormForwardNhwcBfp16, Correctness)
+{
+    runGraphTest(getTolerance<bfloat16>(), TensorLayout::NHWC);
+}
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         IntegrationGpuLayernormForwardNhwcBfp16,
+                         testing::ValuesIn(getLayernormFwd4DSmokeTestCases()));
+INSTANTIATE_TEST_SUITE_P(Full,
+                         IntegrationGpuLayernormForwardNhwcBfp16,
+                         testing::ValuesIn(getLayernormFwd4DFullTestCases()));
+
+TEST_P(IntegrationGpuLayernormForwardNcdhwFp32, Correctness)
+{
+    runGraphTest(getTolerance<float>(), TensorLayout::NCDHW);
+}
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         IntegrationGpuLayernormForwardNcdhwFp32,
+                         testing::ValuesIn(getLayernormFwd5DSmokeTestCases()));
+INSTANTIATE_TEST_SUITE_P(Full,
+                         IntegrationGpuLayernormForwardNcdhwFp32,
+                         testing::ValuesIn(getLayernormFwd5DFullTestCases()));
+
+TEST_P(IntegrationGpuLayernormForwardNcdhwFp16, Correctness)
+{
+    runGraphTest(getTolerance<half>(), TensorLayout::NCDHW);
+}
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         IntegrationGpuLayernormForwardNcdhwFp16,
+                         testing::ValuesIn(getLayernormFwd5DSmokeTestCases()));
+INSTANTIATE_TEST_SUITE_P(Full,
+                         IntegrationGpuLayernormForwardNcdhwFp16,
+                         testing::ValuesIn(getLayernormFwd5DFullTestCases()));
+
+TEST_P(IntegrationGpuLayernormForwardNcdhwBfp16, Correctness)
+{
+    runGraphTest(getTolerance<bfloat16>(), TensorLayout::NCDHW);
+}
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         IntegrationGpuLayernormForwardNcdhwBfp16,
+                         testing::ValuesIn(getLayernormFwd5DSmokeTestCases()));
+INSTANTIATE_TEST_SUITE_P(Full,
+                         IntegrationGpuLayernormForwardNcdhwBfp16,
+                         testing::ValuesIn(getLayernormFwd5DFullTestCases()));
+
+TEST_P(IntegrationGpuLayernormForwardNdhwcFp32, Correctness)
+{
+    runGraphTest(getTolerance<float>(), TensorLayout::NDHWC);
+}
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         IntegrationGpuLayernormForwardNdhwcFp32,
+                         testing::ValuesIn(getLayernormFwd5DSmokeTestCases()));
+INSTANTIATE_TEST_SUITE_P(Full,
+                         IntegrationGpuLayernormForwardNdhwcFp32,
+                         testing::ValuesIn(getLayernormFwd5DFullTestCases()));
+
+TEST_P(IntegrationGpuLayernormForwardNdhwcFp16, Correctness)
+{
+    runGraphTest(getTolerance<half>(), TensorLayout::NDHWC);
+}
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         IntegrationGpuLayernormForwardNdhwcFp16,
+                         testing::ValuesIn(getLayernormFwd5DSmokeTestCases()));
+INSTANTIATE_TEST_SUITE_P(Full,
+                         IntegrationGpuLayernormForwardNdhwcFp16,
+                         testing::ValuesIn(getLayernormFwd5DFullTestCases()));
+
+TEST_P(IntegrationGpuLayernormForwardNdhwcBfp16, Correctness)
+{
+    runGraphTest(getTolerance<bfloat16>(), TensorLayout::NDHWC);
+}
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         IntegrationGpuLayernormForwardNdhwcBfp16,
+                         testing::ValuesIn(getLayernormFwd5DSmokeTestCases()));
+INSTANTIATE_TEST_SUITE_P(Full,
+                         IntegrationGpuLayernormForwardNdhwcBfp16,
+                         testing::ValuesIn(getLayernormFwd5DFullTestCases()));
+
+} // namespace hip_kernel_provider::layernorm::test

--- a/dnn-providers/hip-kernel-provider/src/integration_tests/Layernorm/IntegrationGpuLayernormForward.cpp
+++ b/dnn-providers/hip-kernel-provider/src/integration_tests/Layernorm/IntegrationGpuLayernormForward.cpp
@@ -68,20 +68,34 @@ protected:
 
         graph::LayernormAttributes lnAttrs;
         lnAttrs.set_epsilon(std::move(epsilonTensorAttr));
-        lnAttrs.set_forward_phase(NormFwdPhase::TRAINING);
+        lnAttrs.set_forward_phase(testCase.weightBias ? NormFwdPhase::TRAINING
+                                                      : NormFwdPhase::INFERENCE);
 
         auto results = graphObj.layernorm(xTensorAttr, scaleTensorAttr, biasTensorAttr, lnAttrs);
         const auto& yTensorAttr = results[0];
         const auto& meanTensorAttr = results[1];
         const auto& invVarianceTensorAttr = results[2];
 
+        if(!testCase.weightBias)
+        {
+            EXPECT_EQ(meanTensorAttr, nullptr) << "Mean tensor should be null for inference";
+            EXPECT_EQ(invVarianceTensorAttr, nullptr)
+                << "Inverse variance tensor should be null for inference";
+        }
+
         yTensorAttr->set_output(true);
-        meanTensorAttr->set_output(true);
-        invVarianceTensorAttr->set_output(true);
+        if(testCase.weightBias)
+        {
+            meanTensorAttr->set_output(true);
+            invVarianceTensorAttr->set_output(true);
+        }
 
         this->registerValidator(yTensorAttr, tolerance);
-        this->registerValidator(meanTensorAttr, tolerance);
-        this->registerValidator(invVarianceTensorAttr, tolerance);
+        if(testCase.weightBias)
+        {
+            this->registerValidator(meanTensorAttr, tolerance);
+            this->registerValidator(invVarianceTensorAttr, tolerance);
+        }
 
         this->verifyGraph(graphObj, testCase.seed);
     }

--- a/dnn-providers/hip-kernel-provider/src/integration_tests/Layernorm/LayernormCommon.hpp
+++ b/dnn-providers/hip-kernel-provider/src/integration_tests/Layernorm/LayernormCommon.hpp
@@ -1,0 +1,178 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <cstdint>
+#include <ostream>
+#include <vector>
+
+#include <hipdnn_data_sdk/utilities/StringUtil.hpp>
+#include <hipdnn_test_sdk/utilities/Seeds.hpp>
+
+namespace hip_kernel_provider::layernorm::test::common
+{
+
+using namespace hipdnn_data_sdk::utilities;
+
+namespace
+{
+
+} // namespace
+
+struct LayernormTestCase
+{
+    std::vector<int64_t> dims;
+    size_t normalizedDim;
+    bool weightBias;
+    unsigned int seed;
+
+    LayernormTestCase(std::vector<int64_t>&& dimsLocal,
+                      size_t normalizedDimLocal,
+                      bool weightBiasLocal,
+                      unsigned int seedLocal)
+        : dims(std::move(dimsLocal))
+        , normalizedDim(normalizedDimLocal)
+        , weightBias(weightBiasLocal)
+        , seed(seedLocal)
+    {
+        if(dims.size() != 4 && dims.size() != 5)
+        {
+            throw std::invalid_argument(
+                "Dimensions must be either 4D (NCHW, NHWC) or 5D (NCDHW, NDHWC)");
+        }
+    }
+
+    friend std::ostream& operator<<(std::ostream& ss, const LayernormTestCase& testCase)
+    {
+        ss << "(dims:";
+        vecToStream(ss, testCase.dims);
+        ss << " normalizedDim:" << testCase.normalizedDim;
+        ss << " seed:" << testCase.seed;
+        ss << ")";
+
+        return ss;
+    }
+};
+
+inline std::vector<LayernormTestCase> getLayernormFwd4DSmokeTestCases()
+{
+    unsigned int seed = hipdnn_test_sdk::utilities::getGlobalTestSeed();
+
+    // clang-format off
+    return {
+        {{2, 2, 3, 2}, 3, false, seed}, // Minimal test cases
+        {{2, 2, 3, 2}, 2, false, seed},
+        {{2, 2, 3, 2}, 1, false, seed},
+        {{2, 2, 3, 2}, 3, true, seed},
+        {{2, 2, 3, 2}, 2, true, seed},
+        {{2, 2, 3, 2}, 1, true, seed},
+        {{2, 5, 2, 2}, 1, true, seed}, // Edge case: larger C with normalized dim 1
+    };
+    // clang-format on
+};
+
+inline std::vector<LayernormTestCase> getLayernormFwd5DSmokeTestCases()
+{
+    unsigned int seed = hipdnn_test_sdk::utilities::getGlobalTestSeed();
+
+    // clang-format off
+    return {
+        {{2, 2, 3, 2, 2}, 4, false, seed}, // Minimal test cases
+        {{2, 2, 3, 2, 2}, 3, false, seed},
+        {{2, 2, 3, 2, 2}, 2, false, seed},
+        {{2, 2, 3, 2, 2}, 1, false, seed},
+        {{2, 2, 3, 2, 2}, 4, true, seed},
+        {{2, 2, 3, 2, 2}, 3, true, seed},
+        {{2, 2, 3, 2, 2}, 2, true, seed},
+        {{2, 2, 3, 2, 2}, 1, true, seed},
+        {{2, 5, 2, 2, 2}, 1, true, seed}, // Edge case: larger C with normalized dim 1
+    };
+    // clang-format on
+};
+
+inline std::vector<LayernormTestCase> getLayernormFwd4DFullTestCases()
+{
+    unsigned int seed = hipdnn_test_sdk::utilities::getGlobalTestSeed();
+
+    // Imported from MIOpen
+    // clang-format off
+    return {
+        {{32, 4, 4, 256}, 1, false, seed},
+        {{64, 4, 4, 256}, 1, false, seed},
+        {{32, 4, 4, 256}, 1, true, seed},
+        {{64, 4, 4, 256}, 1, true, seed}
+    };
+    // clang-format on
+}
+
+inline std::vector<LayernormTestCase> getLayernormFwd5DFullTestCases()
+{
+    unsigned int seed = hipdnn_test_sdk::utilities::getGlobalTestSeed();
+
+    // Imported from MIOpen
+    // clang-format off
+    return {
+        {{32, 1, 32, 32, 32}, 4, false, seed}, // 32x32x32 based on VoxNet arch
+        {{32, 1, 14, 14, 14}, 4, false, seed},
+        {{32, 32, 14, 14, 14}, 4, false, seed},
+        {{32, 32, 12, 12, 12}, 4, false, seed},
+        {{32, 32, 6, 6, 6}, 4, false, seed},
+        {{256, 1, 32, 32, 32}, 4, false, seed}, // 32x32x32 based on VoxNet arch
+        {{256, 32, 14, 14, 14}, 4, false, seed},
+        {{256, 32, 12, 12, 12}, 4, false, seed},
+        {{256, 32, 6, 6, 6}, 4, false, seed},
+        {{512, 1, 32, 32, 32}, 4, false, seed}, // 32x32x32 based on VoxNet arch
+        {{512, 32, 14, 14, 14}, 4, false, seed},
+        {{512, 32, 12, 12, 12}, 4, false, seed},
+        {{512, 32, 6, 6, 6}, 4, false, seed},
+        {{32, 2, 32, 57, 125}, 4, false, seed}, // Hand-gesture recognition CVPR 2015 paper High Res Net Path
+        {{32, 32, 14, 25, 59}, 4, false, seed},
+        {{32, 32, 6, 10, 27}, 4, false, seed},
+        {{32, 32, 4, 6, 11}, 4, false, seed},
+        {{32, 32, 2, 2, 3}, 4, false, seed},
+        {{32, 32, 32, 28, 62}, 4, false, seed}, // Hand-gesture recognition CVPR 2015 paper Low Res Net Path
+        {{32, 32, 14, 12, 29}, 4, false, seed},
+        {{32, 32, 6, 4, 12}, 4, false, seed},
+        {{32, 32, 4, 2, 2}, 4, false, seed},
+        {{16, 32, 6, 50, 50}, 4, false, seed}, // Multi-view 3D convnet
+        {{1, 3, 8, 240, 320}, 4, false, seed}, // 3D convet on video
+        {{1, 3, 16, 240, 320}, 4, false, seed}, // 3D convet on video
+        {{1, 3, 8, 128, 171}, 4, false, seed}, // 3D convet on video
+        {{1, 3, 16, 128, 171}, 4, false, seed}, // 3D convet on video
+        {{1, 3, 8, 112, 112}, 4, false, seed}, // 3D convet on video
+        {{1, 3, 16, 112, 112}, 4, false, seed}, // 3D convet on video
+        {{32, 1, 32, 32, 32}, 4, true, seed}, // 32x32x32 based on VoxNet arch
+        {{32, 1, 14, 14, 14}, 4, true, seed},
+        {{32, 32, 14, 14, 14}, 4, true, seed},
+        {{32, 32, 12, 12, 12}, 4, true, seed},
+        {{32, 32, 6, 6, 6}, 4, true, seed},
+        {{256, 1, 32, 32, 32}, 4, true, seed}, // 32x32x32 based on VoxNet arch
+        {{256, 32, 14, 14, 14}, 4, true, seed},
+        {{256, 32, 12, 12, 12}, 4, true, seed},
+        {{256, 32, 6, 6, 6}, 4, true, seed},
+        {{512, 1, 32, 32, 32}, 4, true, seed}, // 32x32x32 based on VoxNet arch
+        {{512, 32, 14, 14, 14}, 4, true, seed},
+        {{512, 32, 12, 12, 12}, 4, true, seed},
+        {{512, 32, 6, 6, 6}, 4, true, seed},
+        {{32, 2, 32, 57, 125}, 4, true, seed}, // Hand-gesture recognition CVPR 2015 paper High Res Net Path
+        {{32, 32, 14, 25, 59}, 4, true, seed},
+        {{32, 32, 6, 10, 27}, 4, true, seed},
+        {{32, 32, 4, 6, 11}, 4, true, seed},
+        {{32, 32, 2, 2, 3}, 4, true, seed},
+        {{32, 32, 32, 28, 62}, 4, true, seed}, // Hand-gesture recognition CVPR 2015 paper Low Res Net Path
+        {{32, 32, 14, 12, 29}, 4, true, seed},
+        {{32, 32, 6, 4, 12}, 4, true, seed},
+        {{32, 32, 4, 2, 2}, 4, true, seed},
+        {{16, 32, 6, 50, 50}, 4, true, seed}, // Multi-view 3D convnet
+        {{1, 3, 8, 240, 320}, 4, true, seed}, // 3D convet on video
+        {{1, 3, 16, 240, 320}, 4, true, seed}, // 3D convet on video
+        {{1, 3, 8, 128, 171}, 4, true, seed}, // 3D convet on video
+        {{1, 3, 16, 128, 171}, 4, true, seed}, // 3D convet on video
+        {{1, 3, 8, 112, 112}, 4, true, seed}, // 3D convet on video
+        {{1, 3, 16, 112, 112}, 4, true, seed} // 3D convet on video
+    };
+    // clang-format on
+}
+
+} // namespace hip_kernel_provider::layernorm::test::common

--- a/dnn-providers/hip-kernel-provider/src/integration_tests/Layernorm/LayernormCommon.hpp
+++ b/dnn-providers/hip-kernel-provider/src/integration_tests/Layernorm/LayernormCommon.hpp
@@ -88,13 +88,13 @@ inline std::vector<LayernormTestCase> getLayernormFwd4DFullTestCases()
 {
     unsigned int seed = hipdnn_test_sdk::utilities::getGlobalTestSeed();
 
-    // Imported from MIOpen
+    // Imported from MIOpen, most commented out due to excessive testing time
     // clang-format off
     return {
         {{32, 4, 4, 256}, 1, false, seed},
-        {{64, 4, 4, 256}, 1, false, seed},
+        // {{64, 4, 4, 256}, 1, false, seed},
         {{32, 4, 4, 256}, 1, true, seed},
-        {{64, 4, 4, 256}, 1, true, seed}
+        // {{64, 4, 4, 256}, 1, true, seed}
     };
     // clang-format on
 }
@@ -103,67 +103,67 @@ inline std::vector<LayernormTestCase> getLayernormFwd5DFullTestCases()
 {
     unsigned int seed = hipdnn_test_sdk::utilities::getGlobalTestSeed();
 
-    // Imported from MIOpen
+    // Imported from MIOpen, most commented out due to excessive testing time
     // clang-format off
     return {
         {{32, 1, 32, 32, 32}, 4, false, seed}, // 32x32x32 based on VoxNet arch
-        {{32, 1, 14, 14, 14}, 4, false, seed},
-        {{32, 32, 14, 14, 14}, 4, false, seed},
-        {{32, 32, 12, 12, 12}, 4, false, seed},
-        {{32, 32, 6, 6, 6}, 4, false, seed},
-        {{256, 1, 32, 32, 32}, 4, false, seed}, // 32x32x32 based on VoxNet arch
-        {{256, 32, 14, 14, 14}, 4, false, seed},
-        {{256, 32, 12, 12, 12}, 4, false, seed},
-        {{256, 32, 6, 6, 6}, 4, false, seed},
-        {{512, 1, 32, 32, 32}, 4, false, seed}, // 32x32x32 based on VoxNet arch
-        {{512, 32, 14, 14, 14}, 4, false, seed},
-        {{512, 32, 12, 12, 12}, 4, false, seed},
-        {{512, 32, 6, 6, 6}, 4, false, seed},
-        {{32, 2, 32, 57, 125}, 4, false, seed}, // Hand-gesture recognition CVPR 2015 paper High Res Net Path
+        // {{32, 1, 14, 14, 14}, 4, false, seed},
+        // {{32, 32, 14, 14, 14}, 4, false, seed},
+        // {{32, 32, 12, 12, 12}, 4, false, seed},
+        // {{32, 32, 6, 6, 6}, 4, false, seed},
+        // {{256, 1, 32, 32, 32}, 4, false, seed}, // 32x32x32 based on VoxNet arch
+        // {{256, 32, 14, 14, 14}, 4, false, seed},
+        // {{256, 32, 12, 12, 12}, 4, false, seed},
+        // {{256, 32, 6, 6, 6}, 4, false, seed},
+        // {{512, 1, 32, 32, 32}, 4, false, seed}, // 32x32x32 based on VoxNet arch
+        // {{512, 32, 14, 14, 14}, 4, false, seed},
+        // {{512, 32, 12, 12, 12}, 4, false, seed},
+        // {{512, 32, 6, 6, 6}, 4, false, seed},
+        // {{32, 2, 32, 57, 125}, 4, false, seed}, // Hand-gesture recognition CVPR 2015 paper High Res Net Path
         {{32, 32, 14, 25, 59}, 4, false, seed},
-        {{32, 32, 6, 10, 27}, 4, false, seed},
-        {{32, 32, 4, 6, 11}, 4, false, seed},
-        {{32, 32, 2, 2, 3}, 4, false, seed},
-        {{32, 32, 32, 28, 62}, 4, false, seed}, // Hand-gesture recognition CVPR 2015 paper Low Res Net Path
-        {{32, 32, 14, 12, 29}, 4, false, seed},
-        {{32, 32, 6, 4, 12}, 4, false, seed},
-        {{32, 32, 4, 2, 2}, 4, false, seed},
-        {{16, 32, 6, 50, 50}, 4, false, seed}, // Multi-view 3D convnet
-        {{1, 3, 8, 240, 320}, 4, false, seed}, // 3D convet on video
-        {{1, 3, 16, 240, 320}, 4, false, seed}, // 3D convet on video
-        {{1, 3, 8, 128, 171}, 4, false, seed}, // 3D convet on video
-        {{1, 3, 16, 128, 171}, 4, false, seed}, // 3D convet on video
-        {{1, 3, 8, 112, 112}, 4, false, seed}, // 3D convet on video
-        {{1, 3, 16, 112, 112}, 4, false, seed}, // 3D convet on video
+        // {{32, 32, 6, 10, 27}, 4, false, seed},
+        // {{32, 32, 4, 6, 11}, 4, false, seed},
+        // {{32, 32, 2, 2, 3}, 4, false, seed},
+        // {{32, 32, 32, 28, 62}, 4, false, seed}, // Hand-gesture recognition CVPR 2015 paper Low Res Net Path
+        // {{32, 32, 14, 12, 29}, 4, false, seed},
+        // {{32, 32, 6, 4, 12}, 4, false, seed},
+        // {{32, 32, 4, 2, 2}, 4, false, seed},
+        // {{16, 32, 6, 50, 50}, 4, false, seed}, // Multi-view 3D convnet
+        // {{1, 3, 8, 240, 320}, 4, false, seed}, // 3D convet on video
+        // {{1, 3, 16, 240, 320}, 4, false, seed}, // 3D convet on video
+        // {{1, 3, 8, 128, 171}, 4, false, seed}, // 3D convet on video
+        // {{1, 3, 16, 128, 171}, 4, false, seed}, // 3D convet on video
+        // {{1, 3, 8, 112, 112}, 4, false, seed}, // 3D convet on video
+        // {{1, 3, 16, 112, 112}, 4, false, seed}, // 3D convet on video
         {{32, 1, 32, 32, 32}, 4, true, seed}, // 32x32x32 based on VoxNet arch
-        {{32, 1, 14, 14, 14}, 4, true, seed},
-        {{32, 32, 14, 14, 14}, 4, true, seed},
-        {{32, 32, 12, 12, 12}, 4, true, seed},
-        {{32, 32, 6, 6, 6}, 4, true, seed},
-        {{256, 1, 32, 32, 32}, 4, true, seed}, // 32x32x32 based on VoxNet arch
-        {{256, 32, 14, 14, 14}, 4, true, seed},
-        {{256, 32, 12, 12, 12}, 4, true, seed},
-        {{256, 32, 6, 6, 6}, 4, true, seed},
-        {{512, 1, 32, 32, 32}, 4, true, seed}, // 32x32x32 based on VoxNet arch
-        {{512, 32, 14, 14, 14}, 4, true, seed},
-        {{512, 32, 12, 12, 12}, 4, true, seed},
-        {{512, 32, 6, 6, 6}, 4, true, seed},
-        {{32, 2, 32, 57, 125}, 4, true, seed}, // Hand-gesture recognition CVPR 2015 paper High Res Net Path
+        // {{32, 1, 14, 14, 14}, 4, true, seed},
+        // {{32, 32, 14, 14, 14}, 4, true, seed},
+        // {{32, 32, 12, 12, 12}, 4, true, seed},
+        // {{32, 32, 6, 6, 6}, 4, true, seed},
+        // {{256, 1, 32, 32, 32}, 4, true, seed}, // 32x32x32 based on VoxNet arch
+        // {{256, 32, 14, 14, 14}, 4, true, seed},
+        // {{256, 32, 12, 12, 12}, 4, true, seed},
+        // {{256, 32, 6, 6, 6}, 4, true, seed},
+        // {{512, 1, 32, 32, 32}, 4, true, seed}, // 32x32x32 based on VoxNet arch
+        // {{512, 32, 14, 14, 14}, 4, true, seed},
+        // {{512, 32, 12, 12, 12}, 4, true, seed},
+        // {{512, 32, 6, 6, 6}, 4, true, seed},
+        // {{32, 2, 32, 57, 125}, 4, true, seed}, // Hand-gesture recognition CVPR 2015 paper High Res Net Path
         {{32, 32, 14, 25, 59}, 4, true, seed},
-        {{32, 32, 6, 10, 27}, 4, true, seed},
-        {{32, 32, 4, 6, 11}, 4, true, seed},
-        {{32, 32, 2, 2, 3}, 4, true, seed},
-        {{32, 32, 32, 28, 62}, 4, true, seed}, // Hand-gesture recognition CVPR 2015 paper Low Res Net Path
-        {{32, 32, 14, 12, 29}, 4, true, seed},
-        {{32, 32, 6, 4, 12}, 4, true, seed},
-        {{32, 32, 4, 2, 2}, 4, true, seed},
-        {{16, 32, 6, 50, 50}, 4, true, seed}, // Multi-view 3D convnet
-        {{1, 3, 8, 240, 320}, 4, true, seed}, // 3D convet on video
-        {{1, 3, 16, 240, 320}, 4, true, seed}, // 3D convet on video
-        {{1, 3, 8, 128, 171}, 4, true, seed}, // 3D convet on video
-        {{1, 3, 16, 128, 171}, 4, true, seed}, // 3D convet on video
-        {{1, 3, 8, 112, 112}, 4, true, seed}, // 3D convet on video
-        {{1, 3, 16, 112, 112}, 4, true, seed} // 3D convet on video
+        // {{32, 32, 6, 10, 27}, 4, true, seed},
+        // {{32, 32, 4, 6, 11}, 4, true, seed},
+        // {{32, 32, 2, 2, 3}, 4, true, seed},
+        // {{32, 32, 32, 28, 62}, 4, true, seed}, // Hand-gesture recognition CVPR 2015 paper Low Res Net Path
+        // {{32, 32, 14, 12, 29}, 4, true, seed},
+        // {{32, 32, 6, 4, 12}, 4, true, seed},
+        // {{32, 32, 4, 2, 2}, 4, true, seed},
+        // {{16, 32, 6, 50, 50}, 4, true, seed}, // Multi-view 3D convnet
+        // {{1, 3, 8, 240, 320}, 4, true, seed}, // 3D convet on video
+        // {{1, 3, 16, 240, 320}, 4, true, seed}, // 3D convet on video
+        // {{1, 3, 8, 128, 171}, 4, true, seed}, // 3D convet on video
+        // {{1, 3, 16, 128, 171}, 4, true, seed}, // 3D convet on video
+        // {{1, 3, 8, 112, 112}, 4, true, seed}, // 3D convet on video
+        // {{1, 3, 16, 112, 112}, 4, true, seed} // 3D convet on video
     };
     // clang-format on
 }

--- a/dnn-providers/hip-kernel-provider/src/integration_tests/Layernorm/LayernormCommon.hpp
+++ b/dnn-providers/hip-kernel-provider/src/integration_tests/Layernorm/LayernormCommon.hpp
@@ -13,13 +13,6 @@
 namespace hip_kernel_provider::layernorm::test::common
 {
 
-using namespace hipdnn_data_sdk::utilities;
-
-namespace
-{
-
-} // namespace
-
 struct LayernormTestCase
 {
     std::vector<int64_t> dims;
@@ -46,7 +39,7 @@ struct LayernormTestCase
     friend std::ostream& operator<<(std::ostream& ss, const LayernormTestCase& testCase)
     {
         ss << "(dims:";
-        vecToStream(ss, testCase.dims);
+        hipdnn_data_sdk::utilities::vecToStream(ss, testCase.dims);
         ss << " normalizedDim:" << testCase.normalizedDim;
         ss << " seed:" << testCase.seed;
         ss << ")";

--- a/dnn-providers/hip-kernel-provider/src/tests/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/src/tests/CMakeLists.txt
@@ -22,6 +22,8 @@ add_executable(
     engines/plans/Batchnorm/TestBatchnormFwdInferenceWithVariancePlan.cpp
     engines/plans/Batchnorm/TestBatchnormFwdTrainingPlan.cpp
     engines/plans/Batchnorm/TestBatchnormCommon.cpp
+    engines/plans/Layernorm/TestLayernormPlanBuilder.cpp
+    engines/plans/Layernorm/TestLayernormFwdPlan.cpp
     engines/plans/TestPlanUtils.cpp
     engines/plans/RMSnorm/TestRMSnormPlanBuilder.cpp
     engines/plans/RMSnorm/TestRMSnormFwdPlan.cpp

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Batchnorm/TestBatchnormCommon.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Batchnorm/TestBatchnormCommon.cpp
@@ -5,7 +5,7 @@
 #include <cstdio>
 #include <gtest/gtest.h>
 
-#include "engines/plans/BatchnormCommon.hpp"
+#include "engines/plans/batchnorm/BatchnormCommon.hpp"
 
 using namespace hip_kernel_provider::batchnorm;
 

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Batchnorm/TestBatchnormFwdInferencePlan.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Batchnorm/TestBatchnormFwdInferencePlan.cpp
@@ -4,7 +4,7 @@
 #include <cstdio>
 #include <gtest/gtest.h>
 
-#include "engines/plans/BatchnormFwdInferencePlan.hpp"
+#include "engines/plans/batchnorm/BatchnormFwdInferencePlan.hpp"
 #include "mocks/MockCompiledProgram.hpp"
 #include "mocks/MockKernelCompiler.hpp"
 #include "mocks/MockRunnableKernel.hpp"
@@ -14,7 +14,8 @@
 #include <hipdnn_plugin_sdk/interfaces/IPlan.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 
-using namespace hip_kernel_provider;
+namespace hip_kernel_provider::batchnorm::test
+{
 
 // ============================================================================
 // BatchnormFwdInferenceParams - construction from valid graph data
@@ -455,3 +456,5 @@ TEST(TestBatchnormFwdInferencePlan, CompileWithUnsupportedDimensionThrows)
 
     EXPECT_THROW(plan.compile(mockCompiler, deviceProps), hipdnn_plugin_sdk::HipdnnPluginException);
 }
+
+} // namespace hip_kernel_provider::batchnorm::test

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Batchnorm/TestBatchnormFwdInferenceWithVariancePlan.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Batchnorm/TestBatchnormFwdInferenceWithVariancePlan.cpp
@@ -4,7 +4,7 @@
 #include <cstdio>
 #include <gtest/gtest.h>
 
-#include "engines/plans/BatchnormFwdInferenceWithVariancePlan.hpp"
+#include "engines/plans/batchnorm/BatchnormFwdInferenceWithVariancePlan.hpp"
 #include "mocks/MockCompiledProgram.hpp"
 #include "mocks/MockKernelCompiler.hpp"
 #include "mocks/MockRunnableKernel.hpp"
@@ -14,7 +14,8 @@
 #include <hipdnn_plugin_sdk/interfaces/IPlan.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 
-using namespace hip_kernel_provider;
+namespace hip_kernel_provider::batchnorm::test
+{
 
 // ============================================================================
 // BatchnormFwdInferenceWithVarianceParams - construction from valid graph data
@@ -461,3 +462,5 @@ TEST(TestBatchnormFwdInferenceWithVariancePlan, CompileWithUnsupportedDimensionT
 
     EXPECT_THROW(plan.compile(mockCompiler, deviceProps), hipdnn_plugin_sdk::HipdnnPluginException);
 }
+
+} // namespace hip_kernel_provider::batchnorm::test

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Batchnorm/TestBatchnormFwdTrainingPlan.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Batchnorm/TestBatchnormFwdTrainingPlan.cpp
@@ -4,7 +4,7 @@
 #include <cstdio>
 #include <gtest/gtest.h>
 
-#include "engines/plans/BatchnormFwdTrainingPlan.hpp"
+#include "engines/plans/batchnorm/BatchnormFwdTrainingPlan.hpp"
 #include "mocks/MockCompiledProgram.hpp"
 #include "mocks/MockKernelCompiler.hpp"
 #include "mocks/MockRunnableKernel.hpp"
@@ -15,6 +15,7 @@
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 
 using namespace hip_kernel_provider;
+using namespace hip_kernel_provider::batchnorm;
 
 // ============================================================================
 // BatchnormFwdTrainingParams - construction from valid graph data

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Batchnorm/TestBatchnormPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Batchnorm/TestBatchnormPlanBuilder.cpp
@@ -6,7 +6,7 @@
 
 #include "HipKernelContext.hpp"
 #include "HipKernelHandle.hpp"
-#include "engines/plans/BatchnormPlanBuilder.hpp"
+#include "engines/plans/batchnorm/BatchnormPlanBuilder.hpp"
 #include "mocks/MockCompiledProgram.hpp"
 #include "mocks/MockDevicePropertyProvider.hpp"
 #include "mocks/MockKernelCompiler.hpp"
@@ -18,8 +18,10 @@
 #include <hipdnn_test_sdk/utilities/MockGraph.hpp>
 #include <hipdnn_test_sdk/utilities/MockNode.hpp>
 
-using namespace hip_kernel_provider;
 using hipdnn_test_sdk::utilities::MockEngineConfig;
+
+namespace hip_kernel_provider::batchnorm::test
+{
 
 class TestBatchnormPlanBuilder : public ::testing::Test
 {
@@ -165,3 +167,5 @@ TEST_F(TestBatchnormPlanBuilder, GetCustomKnobsReturnsEmptyForFwdTrainingGraph)
     auto knobs = _planBuilder.getCustomKnobs(_dummyHandle, graph);
     EXPECT_TRUE(knobs.empty());
 }
+
+} // namespace hip_kernel_provider::batchnorm::test

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Layernorm/TestLayernormFwdPlan.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Layernorm/TestLayernormFwdPlan.cpp
@@ -1,0 +1,25 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include "engines/plans/layernorm/LayernormFwdPlan.hpp"
+#include <gtest/gtest.h>
+#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
+
+using namespace hip_kernel_provider::layernorm;
+
+TEST(TestLayernormFwdParams, InitializesAllTensorsFromValidGraph)
+{
+    // Create a valid layernorm graph
+    auto builder = hipdnn_test_sdk::utilities::createValidLayernormFpropGraph();
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    // Get the layernorm node and attributes
+    const auto& node = graph.getNode(0);
+    auto* attrs = node.attributes_as_LayernormAttributes();
+    ASSERT_NE(attrs, nullptr);
+
+    // Expect that params construction doesn't throw
+    EXPECT_NO_THROW(LayernormFwdParams(*attrs, graph.getTensorMap()));
+}

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Layernorm/TestLayernormPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Layernorm/TestLayernormPlanBuilder.cpp
@@ -1,6 +1,7 @@
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier:  MIT
 
+#include <cstdio>
 #include <gtest/gtest.h>
 #include <hipdnn_frontend/Types.hpp>
 

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Layernorm/TestLayernormPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Layernorm/TestLayernormPlanBuilder.cpp
@@ -1,0 +1,136 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <gtest/gtest.h>
+#include <hipdnn_frontend/Types.hpp>
+
+#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_plugin_sdk/EnginePluginApi.h>
+#include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
+#include <hipdnn_test_sdk/utilities/MockEngineConfig.hpp>
+#include <hipdnn_test_sdk/utilities/MockGraph.hpp>
+#include <hipdnn_test_sdk/utilities/MockNode.hpp>
+
+#include "HipKernelContext.hpp"
+#include "HipKernelHandle.hpp"
+#include "HipKernelSettings.hpp"
+#include "engines/plans/layernorm/LayernormPlanBuilder.hpp"
+#include "mocks/MockCompiledProgram.hpp"
+#include "mocks/MockDevicePropertyProvider.hpp"
+#include "mocks/MockKernelCompiler.hpp"
+#include "mocks/MockRunnableKernel.hpp"
+
+using namespace hipdnn_test_sdk::utilities;
+using namespace hipdnn_data_sdk::flatbuffer_utilities;
+
+namespace hip_kernel_provider::layernorm::test
+{
+
+class TestLayernormPlanBuilder : public ::testing::Test
+{
+protected:
+    MockKernelCompiler _mockKernelCompiler;
+    MockDevicePropertyProvider _mockDevicePropertyProvider;
+    LayernormPlanBuilder _planBuilder{_mockKernelCompiler, _mockDevicePropertyProvider};
+    HipKernelHandle _dummyHandle;
+    MockEngineConfig _mockEngineConfig;
+
+    void setupMockCompileChain()
+    {
+        hipDeviceProp_t deviceProps = {};
+        deviceProps.multiProcessorCount = 60;
+        deviceProps.warpSize = 64;
+        std::snprintf(deviceProps.gcnArchName, sizeof(deviceProps.gcnArchName), "%s", "gfx942");
+
+        EXPECT_CALL(_mockDevicePropertyProvider, getDeviceProperties())
+            .WillOnce(::testing::Return(deviceProps));
+
+        auto mockKernel = std::make_unique<MockRunnableKernel>();
+        EXPECT_CALL(*mockKernel, setBlockSize(::testing::_, ::testing::_, ::testing::_)).Times(1);
+        EXPECT_CALL(*mockKernel, setGridSize(::testing::_, ::testing::_, ::testing::_)).Times(1);
+
+        auto mockProgram = std::make_unique<MockCompiledProgram>();
+        EXPECT_CALL(*mockProgram, getKernel(::testing::_))
+            .WillOnce(::testing::Return(::testing::ByMove(std::move(mockKernel))));
+
+        EXPECT_CALL(_mockKernelCompiler, compile(::testing::_, ::testing::_))
+            .WillOnce(::testing::Return(::testing::ByMove(std::move(mockProgram))));
+    }
+};
+
+// ============================================================================
+// isApplicable - valid graphs
+// ============================================================================
+
+TEST_F(TestLayernormPlanBuilder, IsApplicableReturnsTrueForValidInferenceGraph)
+{
+    auto builder = hipdnn_test_sdk::utilities::createValidLayernormFpropGraph();
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    EXPECT_TRUE(_planBuilder.isApplicable(_dummyHandle, graph));
+}
+
+// ============================================================================
+// isApplicable - invalid graphs
+// ============================================================================
+
+TEST_F(TestLayernormPlanBuilder, IsApplicableReturnsFalseForTwoNodeGraph)
+{
+    MockGraph mockGraph;
+    EXPECT_CALL(mockGraph, nodeCount()).WillRepeatedly(::testing::Return(2));
+    // nodeWrappers is only used in an all_of check which will pass when it's empty
+    std::vector<std::unique_ptr<INodeWrapper>> nodeWrappers;
+    EXPECT_CALL(mockGraph, nodeWrappers()).WillRepeatedly(::testing::ReturnRef(nodeWrappers));
+
+    bool applicable = _planBuilder.isApplicable(_dummyHandle, mockGraph);
+
+    EXPECT_FALSE(applicable);
+}
+
+// ============================================================================
+// buildPlan - valid graphs
+// ============================================================================
+
+TEST_F(TestLayernormPlanBuilder, BuildPlanSetsPlanForSingleNode)
+{
+    setupMockCompileChain();
+
+    auto builder = hipdnn_test_sdk::utilities::createValidLayernormFpropGraph();
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+    HipKernelContext ctx;
+
+    EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx));
+    EXPECT_TRUE(ctx.hasValidPlan());
+}
+
+// ============================================================================
+// getMaxWorkspaceSize
+// ============================================================================
+
+TEST_F(TestLayernormPlanBuilder, GetMaxWorkspaceSizeReturnsZero)
+{
+    auto builder = hipdnn_test_sdk::utilities::createValidLayernormFpropGraph();
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+    HipKernelSettings settings;
+
+    EXPECT_EQ(_planBuilder.getMaxWorkspaceSize(_dummyHandle, graph, settings), 0u);
+}
+
+// ============================================================================
+// getCustomKnobs
+// ============================================================================
+
+TEST_F(TestLayernormPlanBuilder, GetCustomKnobsReturnsEmpty)
+{
+    auto builder = hipdnn_test_sdk::utilities::createValidLayernormFpropGraph();
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    auto knobs = _planBuilder.getCustomKnobs(_dummyHandle, graph);
+    EXPECT_TRUE(knobs.empty());
+}
+
+} // namespace hip_kernel_provider::layernorm::test

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/LayernormFpropSignatureKey.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/LayernormFpropSignatureKey.hpp
@@ -64,7 +64,7 @@ struct LayernormFpropSignatureKey
         auto scaleTensorAttr = tensorMap.at(nodeAttributes->scale_tensor_uid());
         scaleBiasDataType = scaleTensorAttr->data_type();
 
-        // Mean/inv_variance type: use mean if present, otherwise default to compute type
+        // Mean/inv_variance type: use mean if present, otherwise default to IO type (x type)
         if(nodeAttributes->mean_tensor_uid().has_value())
         {
             auto meanTensorAttr = tensorMap.at(nodeAttributes->mean_tensor_uid().value());
@@ -72,7 +72,7 @@ struct LayernormFpropSignatureKey
         }
         else
         {
-            meanInvVarianceDataType = computeDataType;
+            meanInvVarianceDataType = xDataType;
         }
     }
 


### PR DESCRIPTION
## Motivation

This PR implements forward layernorm to be used via the HipDNN frontend API and can be tested against the HipDNN layernorm CPU reference implementation.

I've also moved some bits of batchnorm into their own namespace to prevent naming conflicts between batchnorm and layernorm (and future algorithms). I'm open to feedback about my choices of organisation and naming.

## Technical Details

- Add a forward layernorm implementation.
- Add tests for forward layernorm.
- Reorganise some batchnorm parts into a `hip_kernel_provider::batchnorm` namespace.

## Test Plan

Build with `ninja` and run `ninja check`.

## Test Result

All tests pass.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
