### PR TITLE
[SDPA][HipDNN]  ASM kernel loading and dispatch

### DIFF
--- a/dnn-providers/sdpa-kernel-provider/src/SdpaKernelPlan.cpp
+++ b/dnn-providers/sdpa-kernel-provider/src/SdpaKernelPlan.cpp
@@ -10,34 +10,34 @@
 namespace sdpa_kernel_provider
 {
 
-SdpaKernelPlan::SdpaKernelPlan(hipModule_t module,
+SdpaKernelPlan::SdpaKernelPlan(hipModule_t kernelModule,
                                hipFunction_t function,
                                int64_t qUid,
                                int64_t kUid,
                                int64_t vUid,
                                int64_t oUid,
-                               size_t batchSize,
-                               size_t numHeadsQ,
-                               size_t numHeadsKv,
-                               size_t seqLenQ,
-                               size_t seqLenKv,
-                               size_t headDimQk,
-                               size_t headDimV,
-                               size_t qStrideSeq,
-                               size_t qStrideRow,
-                               size_t qStrideHead,
-                               size_t qStrideBatch,
-                               size_t kStrideSeq,
-                               size_t kStrideHead,
-                               size_t kStrideBatch,
-                               size_t vStrideSeq,
-                               size_t vStrideHead,
-                               size_t vStrideBatch,
-                               size_t oStrideSeq,
-                               size_t oStrideHead,
-                               size_t oStrideBatch,
+                               unsigned int batchSize,
+                               unsigned int numHeadsQ,
+                               unsigned int numHeadsKv,
+                               unsigned int seqLenQ,
+                               unsigned int seqLenKv,
+                               unsigned int headDimQk,
+                               unsigned int headDimV,
+                               unsigned int qStrideSeq,
+                               unsigned int qStrideRow,
+                               unsigned int qStrideHead,
+                               unsigned int qStrideBatch,
+                               unsigned int kStrideSeq,
+                               unsigned int kStrideHead,
+                               unsigned int kStrideBatch,
+                               unsigned int vStrideSeq,
+                               unsigned int vStrideHead,
+                               unsigned int vStrideBatch,
+                               unsigned int oStrideSeq,
+                               unsigned int oStrideHead,
+                               unsigned int oStrideBatch,
                                float attnScale)
-    : _module(module)
+    : _module(kernelModule)
     , _function(function)
     , _qUid(qUid)
     , _kUid(kUid)
@@ -80,6 +80,92 @@ SdpaKernelPlan::~SdpaKernelPlan()
     }
 }
 
+SdpaKernelPlan::SdpaKernelPlan(SdpaKernelPlan&& other) noexcept
+    : _module(other._module)
+    , _function(other._function)
+    , _qUid(other._qUid)
+    , _kUid(other._kUid)
+    , _vUid(other._vUid)
+    , _oUid(other._oUid)
+    , _batchSize(other._batchSize)
+    , _numHeadsQ(other._numHeadsQ)
+    , _numHeadsKv(other._numHeadsKv)
+    , _seqLenQ(other._seqLenQ)
+    , _seqLenKv(other._seqLenKv)
+    , _headDimQk(other._headDimQk)
+    , _headDimV(other._headDimV)
+    , _qStrideSeq(other._qStrideSeq)
+    , _qStrideRow(other._qStrideRow)
+    , _qStrideHead(other._qStrideHead)
+    , _qStrideBatch(other._qStrideBatch)
+    , _kStrideSeq(other._kStrideSeq)
+    , _kStrideHead(other._kStrideHead)
+    , _kStrideBatch(other._kStrideBatch)
+    , _vStrideSeq(other._vStrideSeq)
+    , _vStrideHead(other._vStrideHead)
+    , _vStrideBatch(other._vStrideBatch)
+    , _oStrideSeq(other._oStrideSeq)
+    , _oStrideHead(other._oStrideHead)
+    , _oStrideBatch(other._oStrideBatch)
+    , _attnScale(other._attnScale)
+{
+    // Transfer ownership - set source to nullptr to prevent double-free
+    other._module = nullptr;
+    other._function = nullptr;
+}
+
+SdpaKernelPlan& SdpaKernelPlan::operator=(SdpaKernelPlan&& other) noexcept
+{
+    if(this != &other)
+    {
+        // Clean up existing resource
+        if(_module != nullptr)
+        {
+            hipError_t err = hipModuleUnload(_module);
+            if(err != hipSuccess)
+            {
+                HIPDNN_PLUGIN_LOG_ERROR(
+                    "Failed to unload kernel module during move assignment, error: "
+                    << hipGetErrorString(err));
+            }
+        }
+
+        // Transfer ownership
+        _module = other._module;
+        _function = other._function;
+        _qUid = other._qUid;
+        _kUid = other._kUid;
+        _vUid = other._vUid;
+        _oUid = other._oUid;
+        _batchSize = other._batchSize;
+        _numHeadsQ = other._numHeadsQ;
+        _numHeadsKv = other._numHeadsKv;
+        _seqLenQ = other._seqLenQ;
+        _seqLenKv = other._seqLenKv;
+        _headDimQk = other._headDimQk;
+        _headDimV = other._headDimV;
+        _qStrideSeq = other._qStrideSeq;
+        _qStrideRow = other._qStrideRow;
+        _qStrideHead = other._qStrideHead;
+        _qStrideBatch = other._qStrideBatch;
+        _kStrideSeq = other._kStrideSeq;
+        _kStrideHead = other._kStrideHead;
+        _kStrideBatch = other._kStrideBatch;
+        _vStrideSeq = other._vStrideSeq;
+        _vStrideHead = other._vStrideHead;
+        _vStrideBatch = other._vStrideBatch;
+        _oStrideSeq = other._oStrideSeq;
+        _oStrideHead = other._oStrideHead;
+        _oStrideBatch = other._oStrideBatch;
+        _attnScale = other._attnScale;
+
+        // Set source to nullptr to prevent double-free
+        other._module = nullptr;
+        other._function = nullptr;
+    }
+    return *this;
+}
+
 size_t SdpaKernelPlan::getWorkspaceSize(const SdpaKernelHandle& /*handle*/) const
 {
     // Forward-only kernel requires no workspace (uses 64KB LDS internally)
@@ -118,40 +204,40 @@ void SdpaKernelPlan::execute(const SdpaKernelHandle& /*handle*/,
     args.scalar = _attnScale;
 
     // Q dimensions and strides (convert to bytes: stride * sizeof(bfloat16))
-    constexpr size_t bf16_size = 2;
-    args.s_seq_len = static_cast<unsigned int>(_seqLenQ);
-    args.s_Seqs = static_cast<unsigned int>(_qStrideSeq * bf16_size);
-    args.s_Ts = static_cast<unsigned int>(_qStrideRow * bf16_size);
-    args.s_Hs = static_cast<unsigned int>(_qStrideHead * bf16_size);
-    args.s_Bs = static_cast<unsigned int>(_qStrideBatch * bf16_size);
+    constexpr unsigned int K_BF16_SIZE = 2;
+    args.s_seq_len = _seqLenQ;
+    args.s_Seqs = _qStrideSeq * K_BF16_SIZE;
+    args.s_Ts = _qStrideRow * K_BF16_SIZE;
+    args.s_Hs = _qStrideHead * K_BF16_SIZE;
+    args.s_Bs = _qStrideBatch * K_BF16_SIZE;
 
     // GQA ratio
-    args.s_gqa = static_cast<unsigned int>(_numHeadsQ / _numHeadsKv);
+    args.s_gqa = _numHeadsQ / _numHeadsKv;
 
     // K strides (in bytes)
-    args.s_k_Seqs = static_cast<unsigned int>(_kStrideSeq * bf16_size);
-    args.s_k_Hs = static_cast<unsigned int>(_kStrideHead * bf16_size);
-    args.s_k_Bs = static_cast<unsigned int>(_kStrideBatch * bf16_size);
+    args.s_k_Seqs = _kStrideSeq * K_BF16_SIZE;
+    args.s_k_Hs = _kStrideHead * K_BF16_SIZE;
+    args.s_k_Bs = _kStrideBatch * K_BF16_SIZE;
 
     // Options
     args.s_opt = 0; // Default: no special options (RTNE rounding)
     args.s_lse = 0; // POC: don't compute LSE
 
     // KV dimensions
-    args.s_kv_seq_len = static_cast<unsigned int>(_seqLenKv);
-    args.s_qk_head_dim = static_cast<unsigned int>(_headDimQk);
-    args.s_v_head_dim = static_cast<unsigned int>(_headDimV);
-    args.s_q_head_num = static_cast<unsigned int>(_numHeadsQ);
+    args.s_kv_seq_len = _seqLenKv;
+    args.s_qk_head_dim = _headDimQk;
+    args.s_v_head_dim = _headDimV;
+    args.s_q_head_num = _numHeadsQ;
 
     // V strides (in bytes)
-    args.s_v_Seqs = static_cast<unsigned int>(_vStrideSeq * bf16_size);
-    args.s_v_Hs = static_cast<unsigned int>(_vStrideHead * bf16_size);
-    args.s_v_Bs = static_cast<unsigned int>(_vStrideBatch * bf16_size);
+    args.s_v_Seqs = _vStrideSeq * K_BF16_SIZE;
+    args.s_v_Hs = _vStrideHead * K_BF16_SIZE;
+    args.s_v_Bs = _vStrideBatch * K_BF16_SIZE;
 
     // O strides (in bytes)
-    args.s_o_Seqs = static_cast<unsigned int>(_oStrideSeq * bf16_size);
-    args.s_o_Hs = static_cast<unsigned int>(_oStrideHead * bf16_size);
-    args.s_o_Bs = static_cast<unsigned int>(_oStrideBatch * bf16_size);
+    args.s_o_Seqs = _oStrideSeq * K_BF16_SIZE;
+    args.s_o_Hs = _oStrideHead * K_BF16_SIZE;
+    args.s_o_Bs = _oStrideBatch * K_BF16_SIZE;
 
     // Variable-length sequence pointers (nullptr for batch mode)
     args.ptr_qseq = nullptr;
@@ -179,19 +265,20 @@ void SdpaKernelPlan::execute(const SdpaKernelHandle& /*handle*/,
 
     // Compute grid dimensions
     // From AITER: gdx = (S_q + ts_qo - 1) / ts_qo, where ts_qo = 256
-    constexpr size_t ts_qo = 256;
-    unsigned int gdx = static_cast<unsigned int>((_seqLenQ + ts_qo - 1) / ts_qo);
-    unsigned int gdy = static_cast<unsigned int>(_numHeadsQ);
-    unsigned int gdz = static_cast<unsigned int>(_batchSize);
+    constexpr unsigned int K_TS_QO = 256;
+    unsigned int gridDimX = (_seqLenQ + K_TS_QO - 1) / K_TS_QO;
+    unsigned int gridDimY = _numHeadsQ;
+    unsigned int gridDimZ = _batchSize;
 
     // Block dimensions (fixed for this kernel)
-    constexpr unsigned int bdx = 512;
-    constexpr unsigned int bdy = 1;
-    constexpr unsigned int bdz = 1;
+    constexpr unsigned int K_BLOCK_DIM_X = 512;
+    constexpr unsigned int K_BLOCK_DIM_Y = 1;
+    constexpr unsigned int K_BLOCK_DIM_Z = 1;
 
     // Launch kernel using HIP_LAUNCH_PARAM mechanism
     // This is required for passing large argument structures(656 bytes) to ASM kernels
     size_t argSize = sizeof(args);
+    // NOLINTNEXTLINE(modernize-avoid-c-arrays) - HIP API requires C-style array
     void* config[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER,
                       &args,
                       HIP_LAUNCH_PARAM_BUFFER_SIZE,
@@ -199,12 +286,12 @@ void SdpaKernelPlan::execute(const SdpaKernelHandle& /*handle*/,
                       HIP_LAUNCH_PARAM_END};
 
     hipError_t err = hipModuleLaunchKernel(_function,
-                                           gdx,
-                                           gdy,
-                                           gdz, // grid dimensions
-                                           bdx,
-                                           bdy,
-                                           bdz, // block dimensions
+                                           gridDimX,
+                                           gridDimY,
+                                           gridDimZ, // grid dimensions
+                                           K_BLOCK_DIM_X,
+                                           K_BLOCK_DIM_Y,
+                                           K_BLOCK_DIM_Z, // block dimensions
                                            0, // shared memory bytes (kernel uses LDS internally)
                                            nullptr, // stream (use default)
                                            nullptr, // kernel arguments (not used with config)
@@ -216,9 +303,9 @@ void SdpaKernelPlan::execute(const SdpaKernelHandle& /*handle*/,
         return;
     }
 
-    HIPDNN_PLUGIN_LOG_INFO("SDPA kernel launched: grid=[" << gdx << "," << gdy << "," << gdz
-                                                          << "] block=[" << bdx << "," << bdy << ","
-                                                          << bdz << "]");
+    HIPDNN_PLUGIN_LOG_INFO("SDPA kernel launched: grid=["
+                           << gridDimX << "," << gridDimY << "," << gridDimZ << "] block=["
+                           << K_BLOCK_DIM_X << "," << K_BLOCK_DIM_Y << "," << K_BLOCK_DIM_Z << "]");
 }
 
 }

--- a/dnn-providers/sdpa-kernel-provider/src/SdpaKernelPlan.cpp
+++ b/dnn-providers/sdpa-kernel-provider/src/SdpaKernelPlan.cpp
@@ -3,24 +3,40 @@
 
 #include "SdpaKernelPlan.hpp"
 #include "asm/AsmSdpaFwdKernelArgs.hpp"
-#include <hipdnn_plugin_sdk/PluginLogging.hpp>
 #include <hip/hip_runtime.h>
+#include <hipdnn_plugin_sdk/PluginLogging.hpp>
 #include <unordered_map>
 
 namespace sdpa_kernel_provider
 {
 
-SdpaKernelPlan::SdpaKernelPlan(
-    hipModule_t module,
-    hipFunction_t function,
-    int64_t qUid, int64_t kUid, int64_t vUid, int64_t oUid,
-    size_t batchSize, size_t numHeadsQ, size_t numHeadsKv,
-    size_t seqLenQ, size_t seqLenKv, size_t headDimQk, size_t headDimV,
-    size_t qStrideSeq, size_t qStrideRow, size_t qStrideHead, size_t qStrideBatch,
-    size_t kStrideSeq, size_t kStrideHead, size_t kStrideBatch,
-    size_t vStrideSeq, size_t vStrideHead, size_t vStrideBatch,
-    size_t oStrideSeq, size_t oStrideHead, size_t oStrideBatch,
-    float attnScale)
+SdpaKernelPlan::SdpaKernelPlan(hipModule_t module,
+                               hipFunction_t function,
+                               int64_t qUid,
+                               int64_t kUid,
+                               int64_t vUid,
+                               int64_t oUid,
+                               size_t batchSize,
+                               size_t numHeadsQ,
+                               size_t numHeadsKv,
+                               size_t seqLenQ,
+                               size_t seqLenKv,
+                               size_t headDimQk,
+                               size_t headDimV,
+                               size_t qStrideSeq,
+                               size_t qStrideRow,
+                               size_t qStrideHead,
+                               size_t qStrideBatch,
+                               size_t kStrideSeq,
+                               size_t kStrideHead,
+                               size_t kStrideBatch,
+                               size_t vStrideSeq,
+                               size_t vStrideHead,
+                               size_t vStrideBatch,
+                               size_t oStrideSeq,
+                               size_t oStrideHead,
+                               size_t oStrideBatch,
+                               float attnScale)
     : _module(module)
     , _function(function)
     , _qUid(qUid)
@@ -58,8 +74,8 @@ SdpaKernelPlan::~SdpaKernelPlan()
         hipError_t err = hipModuleUnload(_module);
         if(err != hipSuccess)
         {
-            HIPDNN_PLUGIN_LOG_ERROR("Failed to unload kernel module, error: "
-                                    << hipGetErrorString(err));
+            HIPDNN_PLUGIN_LOG_ERROR(
+                "Failed to unload kernel module, error: " << hipGetErrorString(err));
         }
     }
 }
@@ -75,20 +91,20 @@ void SdpaKernelPlan::execute(const SdpaKernelHandle& /*handle*/,
                              uint32_t numDeviceBuffers,
                              void* /*workspace*/) const
 {
-    // 1. Build UID→ptr map from device buffers
+    // Build UID→ptr map from device buffers
     std::unordered_map<int64_t, void*> uidToPtrMap;
     for(uint32_t i = 0; i < numDeviceBuffers; ++i)
     {
         uidToPtrMap[deviceBuffers[i].uid] = deviceBuffers[i].ptr;
     }
 
-    // 2. Get tensor pointers
+    // Get tensor pointers
     void* qPtr = uidToPtrMap.at(_qUid);
     void* kPtr = uidToPtrMap.at(_kUid);
     void* vPtr = uidToPtrMap.at(_vUid);
     void* oPtr = uidToPtrMap.at(_oUid);
 
-    // 3. Populate kernel args struct
+    // Populate kernel args struct
     fmha_fwd_v3_args args{};
 
     // Output/input pointers
@@ -96,7 +112,7 @@ void SdpaKernelPlan::execute(const SdpaKernelHandle& /*handle*/,
     args.ptr_q = qPtr;
     args.ptr_k = kPtr;
     args.ptr_v = vPtr;
-    args.ptr_lse = nullptr;  // POC: no LSE output (withStats = false)
+    args.ptr_lse = nullptr; // POC: no LSE output (withStats = false)
 
     // Attention scale
     args.scalar = _attnScale;
@@ -118,8 +134,8 @@ void SdpaKernelPlan::execute(const SdpaKernelHandle& /*handle*/,
     args.s_k_Bs = static_cast<unsigned int>(_kStrideBatch * bf16_size);
 
     // Options
-    args.s_opt = 0;  // Default: no special options (RTNE rounding)
-    args.s_lse = 0;  // POC: don't compute LSE
+    args.s_opt = 0; // Default: no special options (RTNE rounding)
+    args.s_lse = 0; // POC: don't compute LSE
 
     // KV dimensions
     args.s_kv_seq_len = static_cast<unsigned int>(_seqLenKv);
@@ -161,7 +177,7 @@ void SdpaKernelPlan::execute(const SdpaKernelHandle& /*handle*/,
     args.s_descale_v_Bs = 0;
     args.s_descale_v_Hs = 0;
 
-    // 4. Compute grid dimensions
+    // Compute grid dimensions
     // From AITER: gdx = (S_q + ts_qo - 1) / ts_qo, where ts_qo = 256
     constexpr size_t ts_qo = 256;
     unsigned int gdx = static_cast<unsigned int>((_seqLenQ + ts_qo - 1) / ts_qo);
@@ -173,17 +189,26 @@ void SdpaKernelPlan::execute(const SdpaKernelHandle& /*handle*/,
     constexpr unsigned int bdy = 1;
     constexpr unsigned int bdz = 1;
 
-    // 5. Launch kernel
-    void* kernelArgs[] = {&args};
+    // Launch kernel using HIP_LAUNCH_PARAM mechanism
+    // This is required for passing large argument structures(656 bytes) to ASM kernels
+    size_t argSize = sizeof(args);
+    void* config[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER,
+                      &args,
+                      HIP_LAUNCH_PARAM_BUFFER_SIZE,
+                      &argSize,
+                      HIP_LAUNCH_PARAM_END};
 
-    hipError_t err = hipModuleLaunchKernel(
-        _function,
-        gdx, gdy, gdz,  // grid dimensions
-        bdx, bdy, bdz,  // block dimensions
-        0,              // shared memory bytes (kernel uses LDS internally)
-        nullptr,        // stream (use default)
-        kernelArgs,     // kernel arguments
-        nullptr);       // extra options
+    hipError_t err = hipModuleLaunchKernel(_function,
+                                           gdx,
+                                           gdy,
+                                           gdz, // grid dimensions
+                                           bdx,
+                                           bdy,
+                                           bdz, // block dimensions
+                                           0, // shared memory bytes (kernel uses LDS internally)
+                                           nullptr, // stream (use default)
+                                           nullptr, // kernel arguments (not used with config)
+                                           config); // extra options (HIP_LAUNCH_PARAM config)
 
     if(err != hipSuccess)
     {
@@ -192,7 +217,8 @@ void SdpaKernelPlan::execute(const SdpaKernelHandle& /*handle*/,
     }
 
     HIPDNN_PLUGIN_LOG_INFO("SDPA kernel launched: grid=[" << gdx << "," << gdy << "," << gdz
-                           << "] block=[" << bdx << "," << bdy << "," << bdz << "]");
+                                                          << "] block=[" << bdx << "," << bdy << ","
+                                                          << bdz << "]");
 }
 
 }

--- a/dnn-providers/sdpa-kernel-provider/src/SdpaKernelPlan.cpp
+++ b/dnn-providers/sdpa-kernel-provider/src/SdpaKernelPlan.cpp
@@ -2,13 +2,66 @@
 // SPDX-License-Identifier:  MIT
 
 #include "SdpaKernelPlan.hpp"
+#include "asm/AsmSdpaFwdKernelArgs.hpp"
 #include <hipdnn_plugin_sdk/PluginLogging.hpp>
+#include <hip/hip_runtime.h>
+#include <unordered_map>
 
 namespace sdpa_kernel_provider
 {
 
-SdpaKernelPlan::SdpaKernelPlan()
+SdpaKernelPlan::SdpaKernelPlan(
+    hipModule_t module,
+    hipFunction_t function,
+    int64_t qUid, int64_t kUid, int64_t vUid, int64_t oUid,
+    size_t batchSize, size_t numHeadsQ, size_t numHeadsKv,
+    size_t seqLenQ, size_t seqLenKv, size_t headDimQk, size_t headDimV,
+    size_t qStrideSeq, size_t qStrideRow, size_t qStrideHead, size_t qStrideBatch,
+    size_t kStrideSeq, size_t kStrideHead, size_t kStrideBatch,
+    size_t vStrideSeq, size_t vStrideHead, size_t vStrideBatch,
+    size_t oStrideSeq, size_t oStrideHead, size_t oStrideBatch,
+    float attnScale)
+    : _module(module)
+    , _function(function)
+    , _qUid(qUid)
+    , _kUid(kUid)
+    , _vUid(vUid)
+    , _oUid(oUid)
+    , _batchSize(batchSize)
+    , _numHeadsQ(numHeadsQ)
+    , _numHeadsKv(numHeadsKv)
+    , _seqLenQ(seqLenQ)
+    , _seqLenKv(seqLenKv)
+    , _headDimQk(headDimQk)
+    , _headDimV(headDimV)
+    , _qStrideSeq(qStrideSeq)
+    , _qStrideRow(qStrideRow)
+    , _qStrideHead(qStrideHead)
+    , _qStrideBatch(qStrideBatch)
+    , _kStrideSeq(kStrideSeq)
+    , _kStrideHead(kStrideHead)
+    , _kStrideBatch(kStrideBatch)
+    , _vStrideSeq(vStrideSeq)
+    , _vStrideHead(vStrideHead)
+    , _vStrideBatch(vStrideBatch)
+    , _oStrideSeq(oStrideSeq)
+    , _oStrideHead(oStrideHead)
+    , _oStrideBatch(oStrideBatch)
+    , _attnScale(attnScale)
 {
+}
+
+SdpaKernelPlan::~SdpaKernelPlan()
+{
+    if(_module != nullptr)
+    {
+        hipError_t err = hipModuleUnload(_module);
+        if(err != hipSuccess)
+        {
+            HIPDNN_PLUGIN_LOG_ERROR("Failed to unload kernel module, error: "
+                                    << hipGetErrorString(err));
+        }
+    }
 }
 
 size_t SdpaKernelPlan::getWorkspaceSize(const SdpaKernelHandle& /*handle*/) const
@@ -18,11 +71,128 @@ size_t SdpaKernelPlan::getWorkspaceSize(const SdpaKernelHandle& /*handle*/) cons
 }
 
 void SdpaKernelPlan::execute(const SdpaKernelHandle& /*handle*/,
-                             const hipdnnPluginDeviceBuffer_t* /*deviceBuffers*/,
-                             uint32_t /*numDeviceBuffers*/,
+                             const hipdnnPluginDeviceBuffer_t* deviceBuffers,
+                             uint32_t numDeviceBuffers,
                              void* /*workspace*/) const
 {
-    HIPDNN_PLUGIN_LOG_ERROR("SdpaKernelPlan::execute not implemented");
+    // 1. Build UID→ptr map from device buffers
+    std::unordered_map<int64_t, void*> uidToPtrMap;
+    for(uint32_t i = 0; i < numDeviceBuffers; ++i)
+    {
+        uidToPtrMap[deviceBuffers[i].uid] = deviceBuffers[i].ptr;
+    }
+
+    // 2. Get tensor pointers
+    void* qPtr = uidToPtrMap.at(_qUid);
+    void* kPtr = uidToPtrMap.at(_kUid);
+    void* vPtr = uidToPtrMap.at(_vUid);
+    void* oPtr = uidToPtrMap.at(_oUid);
+
+    // 3. Populate kernel args struct
+    fmha_fwd_v3_args args{};
+
+    // Output/input pointers
+    args.ptr_o = oPtr;
+    args.ptr_q = qPtr;
+    args.ptr_k = kPtr;
+    args.ptr_v = vPtr;
+    args.ptr_lse = nullptr;  // POC: no LSE output (withStats = false)
+
+    // Attention scale
+    args.scalar = _attnScale;
+
+    // Q dimensions and strides (convert to bytes: stride * sizeof(bfloat16))
+    constexpr size_t bf16_size = 2;
+    args.s_seq_len = static_cast<unsigned int>(_seqLenQ);
+    args.s_Seqs = static_cast<unsigned int>(_qStrideSeq * bf16_size);
+    args.s_Ts = static_cast<unsigned int>(_qStrideRow * bf16_size);
+    args.s_Hs = static_cast<unsigned int>(_qStrideHead * bf16_size);
+    args.s_Bs = static_cast<unsigned int>(_qStrideBatch * bf16_size);
+
+    // GQA ratio
+    args.s_gqa = static_cast<unsigned int>(_numHeadsQ / _numHeadsKv);
+
+    // K strides (in bytes)
+    args.s_k_Seqs = static_cast<unsigned int>(_kStrideSeq * bf16_size);
+    args.s_k_Hs = static_cast<unsigned int>(_kStrideHead * bf16_size);
+    args.s_k_Bs = static_cast<unsigned int>(_kStrideBatch * bf16_size);
+
+    // Options
+    args.s_opt = 0;  // Default: no special options (RTNE rounding)
+    args.s_lse = 0;  // POC: don't compute LSE
+
+    // KV dimensions
+    args.s_kv_seq_len = static_cast<unsigned int>(_seqLenKv);
+    args.s_qk_head_dim = static_cast<unsigned int>(_headDimQk);
+    args.s_v_head_dim = static_cast<unsigned int>(_headDimV);
+    args.s_q_head_num = static_cast<unsigned int>(_numHeadsQ);
+
+    // V strides (in bytes)
+    args.s_v_Seqs = static_cast<unsigned int>(_vStrideSeq * bf16_size);
+    args.s_v_Hs = static_cast<unsigned int>(_vStrideHead * bf16_size);
+    args.s_v_Bs = static_cast<unsigned int>(_vStrideBatch * bf16_size);
+
+    // O strides (in bytes)
+    args.s_o_Seqs = static_cast<unsigned int>(_oStrideSeq * bf16_size);
+    args.s_o_Hs = static_cast<unsigned int>(_oStrideHead * bf16_size);
+    args.s_o_Bs = static_cast<unsigned int>(_oStrideBatch * bf16_size);
+
+    // Variable-length sequence pointers (nullptr for batch mode)
+    args.ptr_qseq = nullptr;
+    args.ptr_kseq = nullptr;
+
+    // LSE stride (not used since ptr_lse = nullptr)
+    args.s_lse_Hs = 0;
+
+    // Padding pointers (nullptr for batch mode)
+    args.ptr_qseq_padding = nullptr;
+    args.ptr_kseq_padding = nullptr;
+
+    // FP8 descale pointers (nullptr for BF16)
+    args.ptr_q_descale = nullptr;
+    args.ptr_k_descale = nullptr;
+    args.ptr_v_descale = nullptr;
+
+    // FP8 descale strides (unused)
+    args.s_descale_q_Bs = 0;
+    args.s_descale_q_Hs = 0;
+    args.s_descale_k_Bs = 0;
+    args.s_descale_k_Hs = 0;
+    args.s_descale_v_Bs = 0;
+    args.s_descale_v_Hs = 0;
+
+    // 4. Compute grid dimensions
+    // From AITER: gdx = (S_q + ts_qo - 1) / ts_qo, where ts_qo = 256
+    constexpr size_t ts_qo = 256;
+    unsigned int gdx = static_cast<unsigned int>((_seqLenQ + ts_qo - 1) / ts_qo);
+    unsigned int gdy = static_cast<unsigned int>(_numHeadsQ);
+    unsigned int gdz = static_cast<unsigned int>(_batchSize);
+
+    // Block dimensions (fixed for this kernel)
+    constexpr unsigned int bdx = 512;
+    constexpr unsigned int bdy = 1;
+    constexpr unsigned int bdz = 1;
+
+    // 5. Launch kernel
+    void* kernelArgs[] = {&args};
+
+    hipError_t err = hipModuleLaunchKernel(
+        _function,
+        gdx, gdy, gdz,  // grid dimensions
+        bdx, bdy, bdz,  // block dimensions
+        0,              // shared memory bytes (kernel uses LDS internally)
+        nullptr,        // stream (use default)
+        kernelArgs,     // kernel arguments
+        nullptr);       // extra options
+
+    if(err != hipSuccess)
+    {
+        HIPDNN_PLUGIN_LOG_ERROR("Failed to launch kernel, error: " << hipGetErrorString(err));
+        return;
+    }
+
+    HIPDNN_PLUGIN_LOG_INFO("SDPA kernel launched: grid=[" << gdx << "," << gdy << "," << gdz
+                           << "] block=[" << bdx << "," << bdy << "," << bdz << "]");
 }
 
 }

--- a/dnn-providers/sdpa-kernel-provider/src/SdpaKernelPlan.hpp
+++ b/dnn-providers/sdpa-kernel-provider/src/SdpaKernelPlan.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <hipdnn_plugin_sdk/interfaces/IPlan.hpp>
+#include <hip/hip_runtime.h>
 
 #include "SdpaKernelHandle.hpp"
 #include "SdpaKernelSettings.hpp"
@@ -20,9 +21,19 @@ public:
     /**
      * @brief Construct a plan with kernel module and precomputed metadata.
      */
-    SdpaKernelPlan();
+    SdpaKernelPlan(
+        hipModule_t module,
+        hipFunction_t function,
+        int64_t qUid, int64_t kUid, int64_t vUid, int64_t oUid,
+        size_t batchSize, size_t numHeadsQ, size_t numHeadsKv,
+        size_t seqLenQ, size_t seqLenKv, size_t headDimQk, size_t headDimV,
+        size_t qStrideSeq, size_t qStrideRow, size_t qStrideHead, size_t qStrideBatch,
+        size_t kStrideSeq, size_t kStrideHead, size_t kStrideBatch,
+        size_t vStrideSeq, size_t vStrideHead, size_t vStrideBatch,
+        size_t oStrideSeq, size_t oStrideHead, size_t oStrideBatch,
+        float attnScale);
 
-    ~SdpaKernelPlan() override = default;
+    ~SdpaKernelPlan() override;
 
     size_t getWorkspaceSize(const SdpaKernelHandle& handle) const override;
 
@@ -32,6 +43,47 @@ public:
                  void* workspace = nullptr) const override;
 
 private:
+    hipModule_t _module;
+    hipFunction_t _function;
+
+    // Tensor UIDs
+    int64_t _qUid;
+    int64_t _kUid;
+    int64_t _vUid;
+    int64_t _oUid;
+
+    // Tensor dimensions
+    size_t _batchSize;       // B
+    size_t _numHeadsQ;       // H_q
+    size_t _numHeadsKv;      // H_kv
+    size_t _seqLenQ;         // S_q
+    size_t _seqLenKv;        // S_kv
+    size_t _headDimQk;       // D_qk (128 for POC)
+    size_t _headDimV;        // D_v
+
+    // Q tensor strides (in elements)
+    size_t _qStrideSeq;
+    size_t _qStrideRow;
+    size_t _qStrideHead;
+    size_t _qStrideBatch;
+
+    // K tensor strides (in elements)
+    size_t _kStrideSeq;
+    size_t _kStrideHead;
+    size_t _kStrideBatch;
+
+    // V tensor strides (in elements)
+    size_t _vStrideSeq;
+    size_t _vStrideHead;
+    size_t _vStrideBatch;
+
+    // O tensor strides (in elements)
+    size_t _oStrideSeq;
+    size_t _oStrideHead;
+    size_t _oStrideBatch;
+
+    // Attention scale
+    float _attnScale;
 };
 
 }

--- a/dnn-providers/sdpa-kernel-provider/src/SdpaKernelPlan.hpp
+++ b/dnn-providers/sdpa-kernel-provider/src/SdpaKernelPlan.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <hipdnn_plugin_sdk/interfaces/IPlan.hpp>
 #include <hip/hip_runtime.h>
+#include <hipdnn_plugin_sdk/interfaces/IPlan.hpp>
 
 #include "SdpaKernelHandle.hpp"
 #include "SdpaKernelSettings.hpp"
@@ -21,19 +21,43 @@ public:
     /**
      * @brief Construct a plan with kernel module and precomputed metadata.
      */
-    SdpaKernelPlan(
-        hipModule_t module,
-        hipFunction_t function,
-        int64_t qUid, int64_t kUid, int64_t vUid, int64_t oUid,
-        size_t batchSize, size_t numHeadsQ, size_t numHeadsKv,
-        size_t seqLenQ, size_t seqLenKv, size_t headDimQk, size_t headDimV,
-        size_t qStrideSeq, size_t qStrideRow, size_t qStrideHead, size_t qStrideBatch,
-        size_t kStrideSeq, size_t kStrideHead, size_t kStrideBatch,
-        size_t vStrideSeq, size_t vStrideHead, size_t vStrideBatch,
-        size_t oStrideSeq, size_t oStrideHead, size_t oStrideBatch,
-        float attnScale);
+    SdpaKernelPlan(hipModule_t kernelModule,
+                   hipFunction_t function,
+                   int64_t qUid,
+                   int64_t kUid,
+                   int64_t vUid,
+                   int64_t oUid,
+                   unsigned int batchSize,
+                   unsigned int numHeadsQ,
+                   unsigned int numHeadsKv,
+                   unsigned int seqLenQ,
+                   unsigned int seqLenKv,
+                   unsigned int headDimQk,
+                   unsigned int headDimV,
+                   unsigned int qStrideSeq,
+                   unsigned int qStrideRow,
+                   unsigned int qStrideHead,
+                   unsigned int qStrideBatch,
+                   unsigned int kStrideSeq,
+                   unsigned int kStrideHead,
+                   unsigned int kStrideBatch,
+                   unsigned int vStrideSeq,
+                   unsigned int vStrideHead,
+                   unsigned int vStrideBatch,
+                   unsigned int oStrideSeq,
+                   unsigned int oStrideHead,
+                   unsigned int oStrideBatch,
+                   float attnScale);
 
     ~SdpaKernelPlan() override;
+
+    // Delete copy operations (resource ownership)
+    SdpaKernelPlan(const SdpaKernelPlan&) = delete;
+    SdpaKernelPlan& operator=(const SdpaKernelPlan&) = delete;
+
+    // Move operations
+    SdpaKernelPlan(SdpaKernelPlan&& other) noexcept;
+    SdpaKernelPlan& operator=(SdpaKernelPlan&& other) noexcept;
 
     size_t getWorkspaceSize(const SdpaKernelHandle& handle) const override;
 
@@ -53,34 +77,34 @@ private:
     int64_t _oUid;
 
     // Tensor dimensions
-    size_t _batchSize;       // B
-    size_t _numHeadsQ;       // H_q
-    size_t _numHeadsKv;      // H_kv
-    size_t _seqLenQ;         // S_q
-    size_t _seqLenKv;        // S_kv
-    size_t _headDimQk;       // D_qk (128 for POC)
-    size_t _headDimV;        // D_v
+    unsigned int _batchSize; // B
+    unsigned int _numHeadsQ; // H_q
+    unsigned int _numHeadsKv; // H_kv
+    unsigned int _seqLenQ; // S_q
+    unsigned int _seqLenKv; // S_kv
+    unsigned int _headDimQk; // D_qk (128 for POC)
+    unsigned int _headDimV; // D_v
 
     // Q tensor strides (in elements)
-    size_t _qStrideSeq;
-    size_t _qStrideRow;
-    size_t _qStrideHead;
-    size_t _qStrideBatch;
+    unsigned int _qStrideSeq;
+    unsigned int _qStrideRow;
+    unsigned int _qStrideHead;
+    unsigned int _qStrideBatch;
 
     // K tensor strides (in elements)
-    size_t _kStrideSeq;
-    size_t _kStrideHead;
-    size_t _kStrideBatch;
+    unsigned int _kStrideSeq;
+    unsigned int _kStrideHead;
+    unsigned int _kStrideBatch;
 
     // V tensor strides (in elements)
-    size_t _vStrideSeq;
-    size_t _vStrideHead;
-    size_t _vStrideBatch;
+    unsigned int _vStrideSeq;
+    unsigned int _vStrideHead;
+    unsigned int _vStrideBatch;
 
     // O tensor strides (in elements)
-    size_t _oStrideSeq;
-    size_t _oStrideHead;
-    size_t _oStrideBatch;
+    unsigned int _oStrideSeq;
+    unsigned int _oStrideHead;
+    unsigned int _oStrideBatch;
 
     // Attention scale
     float _attnScale;

--- a/dnn-providers/sdpa-kernel-provider/src/SdpaKernelPlanBuilder.cpp
+++ b/dnn-providers/sdpa-kernel-provider/src/SdpaKernelPlanBuilder.cpp
@@ -29,13 +29,9 @@ bool SdpaKernelPlanBuilder::isApplicable(
 
 size_t SdpaKernelPlanBuilder::getMaxWorkspaceSize(
     const SdpaKernelHandle& /* handle */,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& /* opGraph */,
     const SdpaKernelSettings& /* executionSettings */) const
 {
-    // Get SDPA attributes to check for optional LSE output
-    auto& sdpaNode = opGraph.getNodeWrapper(0);
-    auto& sdpaAttrs = sdpaNode.attributesAs<hipdnn_data_sdk::data_objects::SdpaAttributes>();
-    
     // Forward-only kernel uses 64KB LDS internally, no external workspace needed
     // LSE (when present) is an optional output tensor, not workspace
     return 0;

--- a/dnn-providers/sdpa-kernel-provider/src/SdpaKernelPlanBuilder.cpp
+++ b/dnn-providers/sdpa-kernel-provider/src/SdpaKernelPlanBuilder.cpp
@@ -4,9 +4,9 @@
 #include "SdpaKernelPlanBuilder.hpp"
 #include "SdpaKernelPlan.hpp"
 #include "asm/AsmKernelPath.hpp"
-#include <hipdnn_plugin_sdk/PluginLogging.hpp>
-#include <hip/hip_runtime.h>
 #include <cmath>
+#include <hip/hip_runtime.h>
+#include <hipdnn_plugin_sdk/PluginLogging.hpp>
 
 namespace sdpa_kernel_provider
 {
@@ -55,16 +55,16 @@ void SdpaKernelPlanBuilder::buildPlan(
     const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& /* engineConfig */,
     SdpaKernelContext& executionContext) const
 {
-    // 1. Load kernel module
-    std::string coPath = asm_kernels::getAsmKernelPath(
-        "gfx942/fmha_v3_fwd/MI300/fwd_hd128_bf16_rtne.co");
+    // Load kernel module
+    std::string coPath
+        = asm_kernels::getAsmKernelPath("gfx942/fmha_v3_fwd/MI300/fwd_hd128_bf16_rtne.co");
 
     hipModule_t module;
     hipError_t err = hipModuleLoad(&module, coPath.c_str());
     if(err != hipSuccess)
     {
-        HIPDNN_PLUGIN_LOG_ERROR("Failed to load kernel module: " << coPath
-                                << " error: " << hipGetErrorString(err));
+        HIPDNN_PLUGIN_LOG_ERROR(
+            "Failed to load kernel module: " << coPath << " error: " << hipGetErrorString(err));
         return;
     }
 
@@ -72,18 +72,17 @@ void SdpaKernelPlanBuilder::buildPlan(
     err = hipModuleGetFunction(&function, module, "_ZN5aiter24fmha_fwd_hd128_bf16_rtneE");
     if(err != hipSuccess)
     {
-        HIPDNN_PLUGIN_LOG_ERROR("Failed to get kernel function, error: "
-                                << hipGetErrorString(err));
+        HIPDNN_PLUGIN_LOG_ERROR("Failed to get kernel function, error: " << hipGetErrorString(err));
         err = hipModuleUnload(module);
         if(err != hipSuccess)
         {
-            HIPDNN_PLUGIN_LOG_ERROR("Failed to unload kernel module on error, error: "
-                                    << hipGetErrorString(err));
+            HIPDNN_PLUGIN_LOG_ERROR(
+                "Failed to unload kernel module on error, error: " << hipGetErrorString(err));
         }
         return;
     }
 
-    // 2. Extract SDPA attributes and tensor metadata
+    // Extract SDPA attributes and tensor metadata
     auto& sdpaNode = opGraph.getNodeWrapper(0);
     auto& sdpaAttrs = sdpaNode.attributesAs<hipdnn_data_sdk::data_objects::SdpaAttributes>();
     auto& tensorMap = opGraph.getTensorMap();
@@ -121,7 +120,7 @@ void SdpaKernelPlanBuilder::buildPlan(
     size_t qStrideBatch = static_cast<size_t>(qStrides->Get(0));
     size_t qStrideHead = static_cast<size_t>(qStrides->Get(1));
     size_t qStrideSeq = static_cast<size_t>(qStrides->Get(2));
-    size_t qStrideRow = qStrideSeq;  // Same as sequence stride
+    size_t qStrideRow = qStrideSeq; // Same as sequence stride
 
     // Extract strides - K: [B, H_kv, S_kv, D_qk]
     auto* kStrides = kTensor->strides();
@@ -149,17 +148,34 @@ void SdpaKernelPlanBuilder::buildPlan(
         attnScale = scaleValue.value();
     }
 
-    // 3. Create plan with all metadata
-    executionContext.setPlan(std::make_unique<SdpaKernelPlan>(
-        module, function,
-        qUid, kUid, vUid, oUid,
-        batchSize, numHeadsQ, numHeadsKv,
-        seqLenQ, seqLenKv, headDimQk, headDimV,
-        qStrideSeq, qStrideRow, qStrideHead, qStrideBatch,
-        kStrideSeq, kStrideHead, kStrideBatch,
-        vStrideSeq, vStrideHead, vStrideBatch,
-        oStrideSeq, oStrideHead, oStrideBatch,
-        attnScale));
+    // Create plan with all metadata
+    executionContext.setPlan(std::make_unique<SdpaKernelPlan>(module,
+                                                              function,
+                                                              qUid,
+                                                              kUid,
+                                                              vUid,
+                                                              oUid,
+                                                              batchSize,
+                                                              numHeadsQ,
+                                                              numHeadsKv,
+                                                              seqLenQ,
+                                                              seqLenKv,
+                                                              headDimQk,
+                                                              headDimV,
+                                                              qStrideSeq,
+                                                              qStrideRow,
+                                                              qStrideHead,
+                                                              qStrideBatch,
+                                                              kStrideSeq,
+                                                              kStrideHead,
+                                                              kStrideBatch,
+                                                              vStrideSeq,
+                                                              vStrideHead,
+                                                              vStrideBatch,
+                                                              oStrideSeq,
+                                                              oStrideHead,
+                                                              oStrideBatch,
+                                                              attnScale));
 }
 
 std::vector<hipdnn_data_sdk::data_objects::KnobT> SdpaKernelPlanBuilder::getCustomKnobs(

--- a/dnn-providers/sdpa-kernel-provider/src/SdpaKernelPlanBuilder.cpp
+++ b/dnn-providers/sdpa-kernel-provider/src/SdpaKernelPlanBuilder.cpp
@@ -3,7 +3,10 @@
 
 #include "SdpaKernelPlanBuilder.hpp"
 #include "SdpaKernelPlan.hpp"
-#include <iostream>
+#include "asm/AsmKernelPath.hpp"
+#include <hipdnn_plugin_sdk/PluginLogging.hpp>
+#include <hip/hip_runtime.h>
+#include <cmath>
 
 namespace sdpa_kernel_provider
 {
@@ -48,12 +51,115 @@ void SdpaKernelPlanBuilder::initializeExecutionSettings(
 
 void SdpaKernelPlanBuilder::buildPlan(
     const SdpaKernelHandle& /* handle */,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& /* opGraph */,
+    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
     const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& /* engineConfig */,
     SdpaKernelContext& executionContext) const
 {
-    // Create plan (no workspace needed for forward-only POC)
-    executionContext.setPlan(std::make_unique<SdpaKernelPlan>());
+    // 1. Load kernel module
+    std::string coPath = asm_kernels::getAsmKernelPath(
+        "gfx942/fmha_v3_fwd/MI300/fwd_hd128_bf16_rtne.co");
+
+    hipModule_t module;
+    hipError_t err = hipModuleLoad(&module, coPath.c_str());
+    if(err != hipSuccess)
+    {
+        HIPDNN_PLUGIN_LOG_ERROR("Failed to load kernel module: " << coPath
+                                << " error: " << hipGetErrorString(err));
+        return;
+    }
+
+    hipFunction_t function;
+    err = hipModuleGetFunction(&function, module, "_ZN5aiter24fmha_fwd_hd128_bf16_rtneE");
+    if(err != hipSuccess)
+    {
+        HIPDNN_PLUGIN_LOG_ERROR("Failed to get kernel function, error: "
+                                << hipGetErrorString(err));
+        err = hipModuleUnload(module);
+        if(err != hipSuccess)
+        {
+            HIPDNN_PLUGIN_LOG_ERROR("Failed to unload kernel module on error, error: "
+                                    << hipGetErrorString(err));
+        }
+        return;
+    }
+
+    // 2. Extract SDPA attributes and tensor metadata
+    auto& sdpaNode = opGraph.getNodeWrapper(0);
+    auto& sdpaAttrs = sdpaNode.attributesAs<hipdnn_data_sdk::data_objects::SdpaAttributes>();
+    auto& tensorMap = opGraph.getTensorMap();
+
+    // Get tensor UIDs
+    int64_t qUid = sdpaAttrs.q_tensor_uid();
+    int64_t kUid = sdpaAttrs.k_tensor_uid();
+    int64_t vUid = sdpaAttrs.v_tensor_uid();
+    int64_t oUid = sdpaAttrs.o_tensor_uid();
+
+    // Get tensor attributes
+    auto* qTensor = tensorMap.at(qUid);
+    auto* kTensor = tensorMap.at(kUid);
+    auto* vTensor = tensorMap.at(vUid);
+    auto* oTensor = tensorMap.at(oUid);
+
+    // Extract dimensions from Q tensor: [B, H_q, S_q, D_qk]
+    auto* qDims = qTensor->dims();
+    size_t batchSize = static_cast<size_t>(qDims->Get(0));
+    size_t numHeadsQ = static_cast<size_t>(qDims->Get(1));
+    size_t seqLenQ = static_cast<size_t>(qDims->Get(2));
+    size_t headDimQk = static_cast<size_t>(qDims->Get(3));
+
+    // Extract dimensions from K tensor: [B, H_kv, S_kv, D_qk]
+    auto* kDims = kTensor->dims();
+    size_t numHeadsKv = static_cast<size_t>(kDims->Get(1));
+    size_t seqLenKv = static_cast<size_t>(kDims->Get(2));
+
+    // Extract dimensions from V tensor: [B, H_kv, S_kv, D_v]
+    auto* vDims = vTensor->dims();
+    size_t headDimV = static_cast<size_t>(vDims->Get(3));
+
+    // Extract strides (in elements) - Q: [B, H_q, S_q, D_qk]
+    auto* qStrides = qTensor->strides();
+    size_t qStrideBatch = static_cast<size_t>(qStrides->Get(0));
+    size_t qStrideHead = static_cast<size_t>(qStrides->Get(1));
+    size_t qStrideSeq = static_cast<size_t>(qStrides->Get(2));
+    size_t qStrideRow = qStrideSeq;  // Same as sequence stride
+
+    // Extract strides - K: [B, H_kv, S_kv, D_qk]
+    auto* kStrides = kTensor->strides();
+    size_t kStrideBatch = static_cast<size_t>(kStrides->Get(0));
+    size_t kStrideHead = static_cast<size_t>(kStrides->Get(1));
+    size_t kStrideSeq = static_cast<size_t>(kStrides->Get(2));
+
+    // Extract strides - V: [B, H_kv, S_kv, D_v]
+    auto* vStrides = vTensor->strides();
+    size_t vStrideBatch = static_cast<size_t>(vStrides->Get(0));
+    size_t vStrideHead = static_cast<size_t>(vStrides->Get(1));
+    size_t vStrideSeq = static_cast<size_t>(vStrides->Get(2));
+
+    // Extract strides - O: [B, H_q, S_q, D_v]
+    auto* oStrides = oTensor->strides();
+    size_t oStrideBatch = static_cast<size_t>(oStrides->Get(0));
+    size_t oStrideHead = static_cast<size_t>(oStrides->Get(1));
+    size_t oStrideSeq = static_cast<size_t>(oStrides->Get(2));
+
+    // Get attention scale (default: 1/sqrt(D_qk) if not provided)
+    float attnScale = 1.0f / std::sqrt(static_cast<float>(headDimQk));
+    auto scaleValue = sdpaAttrs.attn_scale_value();
+    if(scaleValue.has_value())
+    {
+        attnScale = scaleValue.value();
+    }
+
+    // 3. Create plan with all metadata
+    executionContext.setPlan(std::make_unique<SdpaKernelPlan>(
+        module, function,
+        qUid, kUid, vUid, oUid,
+        batchSize, numHeadsQ, numHeadsKv,
+        seqLenQ, seqLenKv, headDimQk, headDimV,
+        qStrideSeq, qStrideRow, qStrideHead, qStrideBatch,
+        kStrideSeq, kStrideHead, kStrideBatch,
+        vStrideSeq, vStrideHead, vStrideBatch,
+        oStrideSeq, oStrideHead, oStrideBatch,
+        attnScale));
 }
 
 std::vector<hipdnn_data_sdk::data_objects::KnobT> SdpaKernelPlanBuilder::getCustomKnobs(

--- a/dnn-providers/sdpa-kernel-provider/src/SdpaKernelPlanBuilder.cpp
+++ b/dnn-providers/sdpa-kernel-provider/src/SdpaKernelPlanBuilder.cpp
@@ -101,44 +101,44 @@ void SdpaKernelPlanBuilder::buildPlan(
 
     // Extract dimensions from Q tensor: [B, H_q, S_q, D_qk]
     auto* qDims = qTensor->dims();
-    size_t batchSize = static_cast<size_t>(qDims->Get(0));
-    size_t numHeadsQ = static_cast<size_t>(qDims->Get(1));
-    size_t seqLenQ = static_cast<size_t>(qDims->Get(2));
-    size_t headDimQk = static_cast<size_t>(qDims->Get(3));
+    auto batchSize = static_cast<unsigned int>(qDims->Get(0));
+    auto numHeadsQ = static_cast<unsigned int>(qDims->Get(1));
+    auto seqLenQ = static_cast<unsigned int>(qDims->Get(2));
+    auto headDimQk = static_cast<unsigned int>(qDims->Get(3));
 
     // Extract dimensions from K tensor: [B, H_kv, S_kv, D_qk]
     auto* kDims = kTensor->dims();
-    size_t numHeadsKv = static_cast<size_t>(kDims->Get(1));
-    size_t seqLenKv = static_cast<size_t>(kDims->Get(2));
+    auto numHeadsKv = static_cast<unsigned int>(kDims->Get(1));
+    auto seqLenKv = static_cast<unsigned int>(kDims->Get(2));
 
     // Extract dimensions from V tensor: [B, H_kv, S_kv, D_v]
     auto* vDims = vTensor->dims();
-    size_t headDimV = static_cast<size_t>(vDims->Get(3));
+    auto headDimV = static_cast<unsigned int>(vDims->Get(3));
 
     // Extract strides (in elements) - Q: [B, H_q, S_q, D_qk]
     auto* qStrides = qTensor->strides();
-    size_t qStrideBatch = static_cast<size_t>(qStrides->Get(0));
-    size_t qStrideHead = static_cast<size_t>(qStrides->Get(1));
-    size_t qStrideSeq = static_cast<size_t>(qStrides->Get(2));
-    size_t qStrideRow = qStrideSeq; // Same as sequence stride
+    auto qStrideBatch = static_cast<unsigned int>(qStrides->Get(0));
+    auto qStrideHead = static_cast<unsigned int>(qStrides->Get(1));
+    auto qStrideSeq = static_cast<unsigned int>(qStrides->Get(2));
+    auto qStrideRow = qStrideSeq; // Same as sequence stride
 
     // Extract strides - K: [B, H_kv, S_kv, D_qk]
     auto* kStrides = kTensor->strides();
-    size_t kStrideBatch = static_cast<size_t>(kStrides->Get(0));
-    size_t kStrideHead = static_cast<size_t>(kStrides->Get(1));
-    size_t kStrideSeq = static_cast<size_t>(kStrides->Get(2));
+    auto kStrideBatch = static_cast<unsigned int>(kStrides->Get(0));
+    auto kStrideHead = static_cast<unsigned int>(kStrides->Get(1));
+    auto kStrideSeq = static_cast<unsigned int>(kStrides->Get(2));
 
     // Extract strides - V: [B, H_kv, S_kv, D_v]
     auto* vStrides = vTensor->strides();
-    size_t vStrideBatch = static_cast<size_t>(vStrides->Get(0));
-    size_t vStrideHead = static_cast<size_t>(vStrides->Get(1));
-    size_t vStrideSeq = static_cast<size_t>(vStrides->Get(2));
+    auto vStrideBatch = static_cast<unsigned int>(vStrides->Get(0));
+    auto vStrideHead = static_cast<unsigned int>(vStrides->Get(1));
+    auto vStrideSeq = static_cast<unsigned int>(vStrides->Get(2));
 
     // Extract strides - O: [B, H_q, S_q, D_v]
     auto* oStrides = oTensor->strides();
-    size_t oStrideBatch = static_cast<size_t>(oStrides->Get(0));
-    size_t oStrideHead = static_cast<size_t>(oStrides->Get(1));
-    size_t oStrideSeq = static_cast<size_t>(oStrides->Get(2));
+    auto oStrideBatch = static_cast<unsigned int>(oStrides->Get(0));
+    auto oStrideHead = static_cast<unsigned int>(oStrides->Get(1));
+    auto oStrideSeq = static_cast<unsigned int>(oStrides->Get(2));
 
     // Get attention scale (default: 1/sqrt(D_qk) if not provided)
     float attnScale = 1.0f / std::sqrt(static_cast<float>(headDimQk));


### PR DESCRIPTION
## Motivation

Implements ASM kernel loading and dispatch

## Technical Details
**Kernel Execution Implementation**

Implements the complete kernel loading and dispatch pipeline for `fwd_hd128_bf16_rtne.co` ASM kernel:

1. **SdpaKernelPlan** - Kernel execution state (26 member variables):
   - Stores kernel module/function handles
   - Tensor UIDs and metadata (dims, strides)
   - Attention scale
   - `execute()`: Populates `fmha_fwd_v3_args` (656 bytes) and launches via `hipModuleLaunchKernel()`

2. **SdpaKernelPlanBuilder** - Plan creation:
   - `buildPlan()`: Loads kernel via `hipModuleLoad()` and extracts tensor metadata from graph
   - Parses Q/K/V tensor dimensions and strides from SDPA graph node
   - Computes attention scale (default: 1/√D_qk)

3. **Key Implementation Details**:
   - Kernel launch: `HIP_LAUNCH_PARAM` mechanism for large arg structures
   - Grid dimensions: `[ceil(S_q/256), H_q, B]`
   - Block dimensions: `[512, 1, 1]` (fixed for this kernel)
   - Strides: Converted from elements to bytes (stride × 2 for BF16)
   - Module lifecycle: Loaded on plan build, unloaded in destructor

**Modified Files:**
- `src/SdpaKernelPlan.{hpp,cpp}` - Execution implementation
- `src/SdpaKernelPlanBuilder.cpp` - Plan building with graph parsing

## Test Plan

Verified with existing unit test infrastructure and[ integration tests](https://github.com/ROCm/rocm-libraries/pull/5623)

```
ninja install
 ./bin/sdpa_kernel_plugin_integration_tests
[==========] Running 2 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 1 test from IntegrationSdpaKernelNoEngines
[ RUN      ] IntegrationSdpaKernelNoEngines.BatchnormInferenceGraphBuildFails
[       OK ] IntegrationSdpaKernelNoEngines.BatchnormInferenceGraphBuildFails (1476 ms)
[----------] 1 test from IntegrationSdpaKernelNoEngines (1476 ms total)

[----------] 1 test from Smoke/IntegrationGpuSdpaFwdBf16
[ RUN      ] Smoke/IntegrationGpuSdpaFwdBf16.Correctness/0
[       OK ] Smoke/IntegrationGpuSdpaFwdBf16.Correctness/0 (1806 ms)
[----------] 1 test from Smoke/IntegrationGpuSdpaFwdBf16 (1806 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 2 test suites ran. (3283 ms total)
[  PASSED  ] 2 tests.
```
<img width="907" height="760" alt="image" src="https://github.com/user-attachments/assets/0ea7e547-f128-453e-b3b2-28dc335dcacf" />

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
