### PR TITLE
[hipDNN] Fix flaky IntegrationPluginLoading.PluginWithIncompatibleApiVersion test

### DIFF
--- a/projects/hipdnn/tests/backend/CMakeLists.txt
+++ b/projects/hipdnn/tests/backend/CMakeLists.txt
@@ -75,6 +75,7 @@ add_dependencies(
     test_incomplete_api_plugin
     test_knobs_plugin
     test_knob_constraint_validation_plugin
+    test_incompatible_version_plugin
 )
 
 clang_tidy_check(public_hipdnn_backend_tests)


### PR DESCRIPTION
## Summary

- `test_incompatible_version_plugin` was missing from the `add_dependencies()` list for `public_hipdnn_backend_tests` in `tests/backend/CMakeLists.txt`
- The plugin name was correctly defined as a compile definition, but the `.so` was never declared a build dependency. This meant the plugin likely only existed if you built everything, and `ninja check` wouldn't necessarily build it since it isn't dependent.

## Test plan

- [x] Run `IntegrationPluginLoading.PluginWithIncompatibleApiVersion` with
  `public_hipdnn_backend_tests` and confirm it passes consistently
- [x] Run `ninja check` to confirm no regressions