### PR TITLE
[hipDNN] Rename executables: to start with "hipdnn_"; make frontend paths system include paths.

### DIFF
--- a/projects/hipdnn/CMakeLists.txt
+++ b/projects/hipdnn/CMakeLists.txt
@@ -277,7 +277,7 @@ if(HIPDNN_ENABLE_COVERAGE)
         -object
         ./${CMAKE_INSTALL_BINDIR}/hipdnn_frontend_tests
         -object
-        ./${CMAKE_INSTALL_BINDIR}/public_hipdnn_backend_tests
+        ./${CMAKE_INSTALL_BINDIR}/hipdnn_public_backend_tests
         -object
         ./${CMAKE_INSTALL_BINDIR}/hipdnn_data_sdk_tests
         -object

--- a/projects/hipdnn/CMakePresets.json
+++ b/projects/hipdnn/CMakePresets.json
@@ -149,7 +149,7 @@
       "inherits": ["base-test"],
       "filter": {
         "include": {
-          "name": "public_hipdnn_backend_tests|public_hipdnn_frontend_tests|miopen_plugin_integration_test"
+          "name": "hipdnn_public_backend_tests|hipdnn_public_frontend_tests|miopen_plugin_integration_test"
         }
       }
     },
@@ -160,7 +160,7 @@
       "inherits": ["base-test"],
       "filter": {
         "include": {
-          "name": "public_hipdnn_backend_tests|public_hipdnn_frontend_tests|miopen_plugin_integration_test"
+          "name": "hipdnn_public_backend_tests|hipdnn_public_frontend_tests|miopen_plugin_integration_test"
         }
       }
     }

--- a/projects/hipdnn/docs/ai-rules.md
+++ b/projects/hipdnn/docs/ai-rules.md
@@ -43,8 +43,8 @@ ninja doxygen      # Generate Doxygen docs (output: build/docs/html/)
 | `hipdnn_data_sdk_tests` | Data SDK unit tests | Flatbuffer objects, utilities |
 | `hipdnn_plugin_sdk_tests` | Plugin SDK unit tests | Plugin interface utilities |
 | `hipdnn_test_sdk_tests` | Test SDK unit tests | Test utility functions |
-| `public_hipdnn_backend_tests` | Backend API tests | Public C API black-box tests |
-| `public_hipdnn_frontend_tests` | Frontend integration tests | E2E frontend tests |
+| `hipdnn_public_backend_tests` | Backend API tests | Public C API black-box tests |
+| `hipdnn_public_frontend_tests` | Frontend integration tests | E2E frontend tests |
 | `miopen_plugin_tests` | MIOpen plugin unit tests | Plugin-specific tests |
 | `miopen_plugin_integration_tests` | MIOpen integration tests | GPU-required E2E tests |
 

--- a/projects/hipdnn/docs/testing/TestPlan.md
+++ b/projects/hipdnn/docs/testing/TestPlan.md
@@ -129,8 +129,8 @@ Test project /workspace/therock-build/bin/hipdnn
   Test #3: hipdnn_frontend_tests
   Test #4: hipdnn_test_sdk_tests
   Test #5: hipdnn_plugin_sdk_tests
-  Test #6: public_hipdnn_backend_tests
-  Test #7: public_hipdnn_frontend_tests
+  Test #6: hipdnn_public_backend_tests
+  Test #7: hipdnn_public_frontend_tests
 
 Total Tests: 7
 ```
@@ -145,16 +145,16 @@ Internal ctest changing into directory: /workspace/therock-build/bin/hipdnn
 Test project /workspace/therock-build/bin/hipdnn
     Start 1: hipdnn_data_sdk_tests
     Start 2: hipdnn_backend_tests
-    Start 6: public_hipdnn_backend_tests
-    Start 7: public_hipdnn_frontend_tests
+    Start 6: hipdnn_public_backend_tests
+    Start 7: hipdnn_public_frontend_tests
     Start 3: hipdnn_frontend_tests
     Start 4: hipdnn_test_sdk_tests
     Start 5: hipdnn_plugin_sdk_tests
 1/7 Test #4: hipdnn_test_sdk_tests ............   Passed    0.02 sec
 2/7 Test #5: hipdnn_plugin_sdk_tests ..........   Passed    0.02 sec
 3/7 Test #3: hipdnn_frontend_tests ............   Passed    0.02 sec
-4/7 Test #7: public_hipdnn_frontend_tests .....   Passed    0.27 sec
-5/7 Test #6: public_hipdnn_backend_tests ......   Passed    0.84 sec
+4/7 Test #7: hipdnn_public_frontend_tests .....   Passed    0.27 sec
+5/7 Test #6: hipdnn_public_backend_tests ......   Passed    0.84 sec
 6/7 Test #2: hipdnn_backend_tests .............   Passed    1.33 sec
 7/7 Test #1: hipdnn_data_sdk_tests ............   Passed    2.64 sec
 

--- a/projects/hipdnn/frontend/CMakeLists.txt
+++ b/projects/hipdnn/frontend/CMakeLists.txt
@@ -31,6 +31,12 @@ target_include_directories(
                               $<INSTALL_INTERFACE:${HIP_DNN_FRONTEND_INSTALL_INCLUDE_DIR}>
 )
 
+# Export installed hipdnn_frontend include paths as system include paths.
+set_target_properties(hipdnn_frontend PROPERTIES
+    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
+        "$<INSTALL_INTERFACE:${HIP_DNN_FRONTEND_INSTALL_INCLUDE_DIR}>"
+)
+
 target_compile_definitions(
     hipdnn_frontend INTERFACE
     $<$<BOOL:${HIPDNN_FRONTEND_SKIP_JSON_LIB}>:HIPDNN_FRONTEND_SKIP_JSON_LIB>

--- a/projects/hipdnn/samples/CMakeLists.txt
+++ b/projects/hipdnn/samples/CMakeLists.txt
@@ -41,25 +41,25 @@ function(add_hipdnn_sample NAME SOURCE)
     target_compile_options(${NAME} PRIVATE ${HIPDNN_SAMPLE_NO_RTTI_OPTIONS})
 endfunction()
 
-add_hipdnn_sample(bn_inference batchnorm/BnInference.cpp)
-add_hipdnn_sample(bn_inference_with_variance batchnorm/BnInferenceWithVariance.cpp)
-add_hipdnn_sample(bn_training batchnorm/BnTraining.cpp)
-add_hipdnn_sample(fused_bn_training_activ batchnorm/FusedBnTrainingActiv.cpp)
-add_hipdnn_sample(bn_backward batchnorm/BnBackward.cpp)
-add_hipdnn_sample(fused_bn_inference_activ batchnorm/FusedBnInferenceActiv.cpp)
-add_hipdnn_sample(fused_bn_inference_variance_activ batchnorm/FusedBnInferenceVarianceActiv.cpp)
-add_hipdnn_sample(fused_bn_inference_drelu_bn_backward batchnorm/FusedBnInfDReluBnBwd.cpp)
+add_hipdnn_sample(hipdnn_sample_bn_inference batchnorm/BnInference.cpp)
+add_hipdnn_sample(hipdnn_sample_bn_inference_with_variance batchnorm/BnInferenceWithVariance.cpp)
+add_hipdnn_sample(hipdnn_sample_bn_training batchnorm/BnTraining.cpp)
+add_hipdnn_sample(hipdnn_sample_fused_bn_training_activ batchnorm/FusedBnTrainingActiv.cpp)
+add_hipdnn_sample(hipdnn_sample_bn_backward batchnorm/BnBackward.cpp)
+add_hipdnn_sample(hipdnn_sample_fused_bn_inference_activ batchnorm/FusedBnInferenceActiv.cpp)
+add_hipdnn_sample(hipdnn_sample_fused_bn_inference_variance_activ batchnorm/FusedBnInferenceVarianceActiv.cpp)
+add_hipdnn_sample(hipdnn_sample_fused_bn_inference_drelu_bn_backward batchnorm/FusedBnInfDReluBnBwd.cpp)
 
-add_hipdnn_sample(conv_dgrad convolution/ConvDgrad.cpp)
-add_hipdnn_sample(conv_fprop convolution/ConvFprop.cpp)
-add_hipdnn_sample(fused_conv_fprop_activ convolution/FusedConvFpropActiv.cpp)
-add_hipdnn_sample(fused_conv_fprop_bias_activ convolution/FusedConvFpropBiasActiv.cpp)
-add_hipdnn_sample(conv_wgrad convolution/ConvWgrad.cpp)
-add_hipdnn_sample(conv_fprop_deterministic convolution/ConvFpropDeterministic.cpp)
+add_hipdnn_sample(hipdnn_sample_conv_dgrad convolution/ConvDgrad.cpp)
+add_hipdnn_sample(hipdnn_sample_conv_fprop convolution/ConvFprop.cpp)
+add_hipdnn_sample(hipdnn_sample_fused_conv_fprop_activ convolution/FusedConvFpropActiv.cpp)
+add_hipdnn_sample(hipdnn_sample_fused_conv_fprop_bias_activ convolution/FusedConvFpropBiasActiv.cpp)
+add_hipdnn_sample(hipdnn_sample_conv_wgrad convolution/ConvWgrad.cpp)
+add_hipdnn_sample(hipdnn_sample_conv_fprop_deterministic convolution/ConvFpropDeterministic.cpp)
 
-add_hipdnn_sample(serialization_roundtrip serialization/SerializationRoundTrip.cpp)
+add_hipdnn_sample(hipdnn_sample_serialization_roundtrip serialization/SerializationRoundTrip.cpp)
 
-add_hipdnn_sample(knobs_usage knobs/KnobsUsage.cpp)
+add_hipdnn_sample(hipdnn_sample_knobs_usage knobs/KnobsUsage.cpp)
 
 # Enable testing and add sample tests
 enable_testing()
@@ -90,33 +90,33 @@ function(add_hipdnn_sample_test TARGET_NAME)
 endfunction()
 
 # Register convolution samples as tests
-add_hipdnn_sample_test(conv_fprop)
-add_hipdnn_sample_test(conv_dgrad)
-add_hipdnn_sample_test(conv_wgrad)
+add_hipdnn_sample_test(hipdnn_sample_conv_fprop)
+add_hipdnn_sample_test(hipdnn_sample_conv_dgrad)
+add_hipdnn_sample_test(hipdnn_sample_conv_wgrad)
 
 if(NOT WIN32)
     # Some fused conv samples are not supported on windows due to lack of CK support
-    add_hipdnn_sample_test(fused_conv_fprop_activ)
-    add_hipdnn_sample_test(fused_conv_fprop_bias_activ)
-    add_hipdnn_sample_test(conv_fprop_deterministic)
+    add_hipdnn_sample_test(hipdnn_sample_fused_conv_fprop_activ)
+    add_hipdnn_sample_test(hipdnn_sample_fused_conv_fprop_bias_activ)
+    add_hipdnn_sample_test(hipdnn_sample_conv_fprop_deterministic)
 endif()
 
 # Register batchnorm samples as tests
-add_hipdnn_sample_test(bn_inference)
-add_hipdnn_sample_test(bn_inference_with_variance)
-add_hipdnn_sample_test(bn_training)
-add_hipdnn_sample_test(fused_bn_training_activ)
-add_hipdnn_sample_test(bn_backward)
-add_hipdnn_sample_test(fused_bn_inference_activ)
-add_hipdnn_sample_test(fused_bn_inference_drelu_bn_backward)
-add_hipdnn_sample_test(fused_bn_inference_variance_activ)
+add_hipdnn_sample_test(hipdnn_sample_bn_inference)
+add_hipdnn_sample_test(hipdnn_sample_bn_inference_with_variance)
+add_hipdnn_sample_test(hipdnn_sample_bn_training)
+add_hipdnn_sample_test(hipdnn_sample_fused_bn_training_activ)
+add_hipdnn_sample_test(hipdnn_sample_bn_backward)
+add_hipdnn_sample_test(hipdnn_sample_fused_bn_inference_activ)
+add_hipdnn_sample_test(hipdnn_sample_fused_bn_inference_drelu_bn_backward)
+add_hipdnn_sample_test(hipdnn_sample_fused_bn_inference_variance_activ)
 
 # Register serialization samples as tests
-add_hipdnn_sample_test(serialization_roundtrip)
+add_hipdnn_sample_test(hipdnn_sample_serialization_roundtrip)
 
 # Register knobs sample
 # Note: knobs_usage is informational/educational, not validation
-install(TARGETS knobs_usage RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(TARGETS hipdnn_sample_knobs_usage RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install the generated CTestTestfile.cmake to HIPDNN_SAMPLES_CTEST_FILE_INSTALL_PATH
 install(FILES "${INSTALLED_CTEST_FILE}" DESTINATION ${HIPDNN_SAMPLES_CTEST_FILE_INSTALL_PATH}

--- a/projects/hipdnn/tests/backend/CMakeLists.txt
+++ b/projects/hipdnn/tests/backend/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(Threads REQUIRED)
 
 # Main integration test executable WITH HipErrorHandler
 add_executable(
-    public_hipdnn_backend_tests
+    hipdnn_public_backend_tests
     main.cpp
     IntegrationBackendDescriptor.cpp
     IntegrationBackendExecuteApi.cpp
@@ -29,9 +29,9 @@ add_executable(
     TestUtil.cpp
 )
 
-target_compile_options(public_hipdnn_backend_tests PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
+target_compile_options(hipdnn_public_backend_tests PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
 target_link_libraries(
-    public_hipdnn_backend_tests
+    hipdnn_public_backend_tests
     PRIVATE
         GTest::gtest
         GTest::gtest_main
@@ -43,12 +43,12 @@ target_link_libraries(
 )
 
 # Enable spdlog support (tests include backend internal headers that use spdlog/fmt)
-hipdnn_enable_spdlog(public_hipdnn_backend_tests)
+hipdnn_enable_spdlog(hipdnn_public_backend_tests)
 
-target_include_directories(public_hipdnn_backend_tests PRIVATE ${HIPDNN_TEST_INCLUDE_DIRS})
+target_include_directories(hipdnn_public_backend_tests PRIVATE ${HIPDNN_TEST_INCLUDE_DIRS})
 
 target_compile_definitions(
-    public_hipdnn_backend_tests
+    hipdnn_public_backend_tests
     PRIVATE TEST_GOOD_PLUGIN_NAME="${TEST_GOOD_PLUGIN_NAME}"
             TEST_EXECUTE_FAILS_PLUGIN_NAME="${TEST_EXECUTE_FAILS_PLUGIN_NAME}"
             TEST_NO_APPLICABLE_ENGINES_A_PLUGIN_NAME="${TEST_NO_APPLICABLE_ENGINES_A_PLUGIN_NAME}"
@@ -64,7 +64,7 @@ target_compile_definitions(
 
 # Ensure test plugins are built before tests
 add_dependencies(
-    public_hipdnn_backend_tests
+    hipdnn_public_backend_tests
     test_good_plugin
     test_execute_fails_plugin
     test_no_applicable_engines_a_plugin
@@ -77,5 +77,5 @@ add_dependencies(
     test_knob_constraint_validation_plugin
 )
 
-clang_tidy_check(public_hipdnn_backend_tests)
-add_integration_test_target(public_hipdnn_backend_tests ${CMAKE_CURRENT_BINARY_DIR})
+clang_tidy_check(hipdnn_public_backend_tests)
+add_integration_test_target(hipdnn_public_backend_tests ${CMAKE_CURRENT_BINARY_DIR})

--- a/projects/hipdnn/tests/frontend/CMakeLists.txt
+++ b/projects/hipdnn/tests/frontend/CMakeLists.txt
@@ -6,7 +6,7 @@ find_package(hip REQUIRED)
 find_package(Threads REQUIRED)
 
 add_executable(
-    public_hipdnn_frontend_tests
+    hipdnn_public_frontend_tests
     main.cpp
     IntegrationBatchnormBackwardDescriptorLowering.cpp
     IntegrationBatchnormDescriptorLowering.cpp
@@ -39,9 +39,9 @@ add_executable(
     IntegrationSdpaFpropDescriptorLowering.cpp
 )
 
-target_compile_options(public_hipdnn_frontend_tests PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
+target_compile_options(hipdnn_public_frontend_tests PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
 target_link_libraries(
-    public_hipdnn_frontend_tests
+    hipdnn_public_frontend_tests
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -50,10 +50,10 @@ target_link_libraries(
     hip::host
 )
 
-target_include_directories(public_hipdnn_frontend_tests PRIVATE ${HIPDNN_TEST_INCLUDE_DIRS})
+target_include_directories(hipdnn_public_frontend_tests PRIVATE ${HIPDNN_TEST_INCLUDE_DIRS})
 
 target_compile_definitions(
-    public_hipdnn_frontend_tests
+    hipdnn_public_frontend_tests
     PRIVATE TEST_GOOD_PLUGIN_NAME="${TEST_GOOD_PLUGIN_NAME}"
             TEST_EXECUTE_FAILS_PLUGIN_NAME="${TEST_EXECUTE_FAILS_PLUGIN_NAME}"
             TEST_NO_APPLICABLE_ENGINES_A_PLUGIN_NAME="${TEST_NO_APPLICABLE_ENGINES_A_PLUGIN_NAME}"
@@ -69,7 +69,7 @@ target_compile_definitions(
 
 # Ensure test plugins are built before tests
 add_dependencies(
-    public_hipdnn_frontend_tests
+    hipdnn_public_frontend_tests
     test_good_plugin
     test_good_default_plugin
     test_execute_fails_plugin
@@ -82,5 +82,5 @@ add_dependencies(
     test_knob_constraint_validation_plugin
 )
 
-clang_tidy_check(public_hipdnn_frontend_tests)
-add_integration_test_target(public_hipdnn_frontend_tests ${CMAKE_CURRENT_BINARY_DIR})
+clang_tidy_check(hipdnn_public_frontend_tests)
+add_integration_test_target(hipdnn_public_frontend_tests ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
## Motivation

The hipDNN executables in the ROCm bin folder were not easily identifiable. This PR ensures that all executables are prefixed with "hipdnn". This also reduces the chance that these hipdnn executables will collide with other executables in the user's system path.

The hipdnn_frontend paths were being exported as user include paths. If the user application enabled a different version of clang-tidy than the hipdnn_headers were compliant with, then the headers would trigger tidy errors in the user application. Updated the exported hipdnn_frontend package to export the frontend include paths as system paths so that clang-tidy will not scan them.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
