### PR TITLE
[hipblaslt] fixed no-solutions-found for non-standard-cu

### DIFF
--- a/projects/hipblaslt/tensilelite/include/Tensile/ExactLogicLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/ExactLogicLibrary.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,6 +28,7 @@
 
 #include <atomic>
 
+#include <Tensile/AMDGPU.hpp>
 #include <Tensile/ContractionProblemPredicates.hpp>
 #include <Tensile/Debug.hpp>
 #include <Tensile/PredicateDebugger.hpp>
@@ -139,15 +140,24 @@ namespace TensileLite
                              = SolutionLibrarySearchType::DEFAULT) const override
         {
             SolutionSet<MySolution> rv;
-            const bool              debug = Debug::Instance().printPropertyEvaluation();
-            const bool              streamK = Debug::Instance().useExperimentalSelection() == 2;
+            const bool              debug       = Debug::Instance().printPropertyEvaluation();
+            const bool              streamK     = Debug::Instance().useExperimentalSelection() == 2;
             const auto&             excludedLib = Debug::Instance().excludedLibFromGetAll();
+
+            auto amdGPU             = static_cast<AMDGPU const*>(&hardware);
+            bool isStandardCUDevice = amdGPU->isStandardCU();
 
             for(auto const& row : rows)
             {
-                // we want to exclude this lib from getAll
-                if(excludedLib.count(row.first.value->type()))
-                    continue;
+                // we want to exclude this lib from getAll. If the Set is not empty,
+                // it means we want to skip searched GridBased, Prediction.
+                // But if this is a non-standard-CU GPU, we still need to search all for CU-Fallback solutions.
+                // In this case, we don't skip the excludedLib.
+                if(!excludedLib.empty() && isStandardCUDevice)
+                {
+                    if(excludedLib.count(row.first.value->type()))
+                        continue;
+                }
 
                 if(row.first.value->type() == "ExperimentalStreamK" && !streamK)
                     continue;
@@ -166,22 +176,26 @@ namespace TensileLite
                 // except for Equal, we test others only when debug mode.
                 else if(debug)
                 {
-                    if(dynamic_cast<Predicates::Contraction::GridBasedMatching*>(row.first.value.get()))
+                    if(dynamic_cast<Predicates::Contraction::GridBasedMatching*>(
+                           row.first.value.get()))
                     {
                         for(auto& sol : rowSolutions)
                             sol->tag = MySolution::MatchingTag::GridBased;
                     }
-                    else if(dynamic_cast<Predicates::Contraction::RangeMatching*>(row.first.value.get()))
+                    else if(dynamic_cast<Predicates::Contraction::RangeMatching*>(
+                                row.first.value.get()))
                     {
                         for(auto& sol : rowSolutions)
                             sol->tag = MySolution::MatchingTag::Range;
                     }
-                    else if(dynamic_cast<Predicates::Contraction::FreeSizeMatching*>(row.first.value.get()))
+                    else if(dynamic_cast<Predicates::Contraction::FreeSizeMatching*>(
+                                row.first.value.get()))
                     {
                         for(auto& sol : rowSolutions)
                             sol->tag = MySolution::MatchingTag::FreeSize;
                     }
-                    else if(dynamic_cast<Predicates::Contraction::PredictionMatching*>(row.first.value.get()))
+                    else if(dynamic_cast<Predicates::Contraction::PredictionMatching*>(
+                                row.first.value.get()))
                     {
                         for(auto& sol : rowSolutions)
                             sol->tag = MySolution::MatchingTag::Prediction;
@@ -226,7 +240,7 @@ namespace TensileLite
                                                             int numSolutions) const override
         {
             SolutionVector<MySolution> rv, solutions;
-            const bool                 debug = Debug::Instance().printPropertyEvaluation();
+            const bool                 debug   = Debug::Instance().printPropertyEvaluation();
             const bool                 streamK = Debug::Instance().useExperimentalSelection() == 2;
             const bool                 predictionLib = Debug::Instance().usePredictionLibrary();
 
@@ -238,8 +252,9 @@ namespace TensileLite
                 if(row.first.value->type() == "ExperimentalStreamK" && !streamK)
                     continue;
 
-                if(predictionLib && ((row.first.value->type() == "EqualityMatching")
-                                     || (row.first.value->type() == "RangeMatching")))
+                if(predictionLib
+                   && ((row.first.value->type() == "EqualityMatching")
+                       || (row.first.value->type() == "RangeMatching")))
                     continue;
 
                 if(row.first(problem, hardware))
@@ -248,7 +263,8 @@ namespace TensileLite
                         = row.second->findTopSolutions(problem, hardware, numSolutions - rv.size());
 
                     // hipblaslt_ext::matmulIsTuned() -> rocblaslt_matmul_is_tuned() needs this Equal test
-                    if(dynamic_cast<Predicates::Contraction::EqualityMatching*>(row.first.value.get()))
+                    if(dynamic_cast<Predicates::Contraction::EqualityMatching*>(
+                           row.first.value.get()))
                     {
                         for(auto& sol : solutions)
                             sol->tag = MySolution::MatchingTag::Equal;
@@ -256,22 +272,26 @@ namespace TensileLite
                     // except for Equal, we test others only when debug mode.
                     else if(debug)
                     {
-                        if(dynamic_cast<Predicates::Contraction::GridBasedMatching*>(row.first.value.get()))
+                        if(dynamic_cast<Predicates::Contraction::GridBasedMatching*>(
+                               row.first.value.get()))
                         {
                             for(auto& sol : solutions)
                                 sol->tag = MySolution::MatchingTag::GridBased;
                         }
-                        else if(dynamic_cast<Predicates::Contraction::RangeMatching*>(row.first.value.get()))
+                        else if(dynamic_cast<Predicates::Contraction::RangeMatching*>(
+                                    row.first.value.get()))
                         {
                             for(auto& sol : solutions)
                                 sol->tag = MySolution::MatchingTag::Range;
                         }
-                        else if(dynamic_cast<Predicates::Contraction::FreeSizeMatching*>(row.first.value.get()))
+                        else if(dynamic_cast<Predicates::Contraction::FreeSizeMatching*>(
+                                    row.first.value.get()))
                         {
                             for(auto& sol : solutions)
                                 sol->tag = MySolution::MatchingTag::FreeSize;
                         }
-                        else if(dynamic_cast<Predicates::Contraction::PredictionMatching*>(row.first.value.get()))
+                        else if(dynamic_cast<Predicates::Contraction::PredictionMatching*>(
+                                    row.first.value.get()))
                         {
                             for(auto& sol : solutions)
                                 sol->tag = MySolution::MatchingTag::Prediction;
@@ -331,8 +351,8 @@ namespace TensileLite
         template <typename Any>
         bool operator()(Any const& problem, Hardware const& hardware) const
         {
-            bool debug  = Debug::Instance().printDeviceSelection();
-            bool rv = (*value)(hardware);
+            bool debug = Debug::Instance().printDeviceSelection();
+            bool rv    = (*value)(hardware);
 
             if(debug)
             {
@@ -385,8 +405,8 @@ namespace TensileLite
 
         bool operator()(MyProblem const& problem, Hardware const& hardware) const
         {
-            bool debug  = Debug::Instance().printPredicateEvaluation();
-            bool rv = (*value)(problem);
+            bool debug = Debug::Instance().printPredicateEvaluation();
+            bool rv    = (*value)(problem);
 
             if(debug)
             {


### PR DESCRIPTION
## Motivation

Resolved ROCM-1324
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

The root cause is by a new speed-up mechanism "`setExcludedLibFromGetAll()`" when `GetHeuristic()` returns insufficient solutions.

In this case, the search path will call `FindAllSolutions()`. Before this PR, since `GetHeuristic()` already searched GridBased library and Prediction library, therefore, `setExcludedLibFromGetAll("GridBased","Prediction")` can hugely reduce the overhead by avoiding re-searching, and focusing on searching Range, Exact, FreeSizes...etc.

However, the mechanism works well on a standard-CU device; on a non-standardCU device, skipping searching GridBased and Prediction means it also skips searching the CU-Fallback solutions (i.e. StandardCU solutions). This makes `FindAllSolutions()` **skip searching the GridBased and Prediction libraries of CU-Fallback solutions**, causing no solution found.

The fixing is to identify if the current device is a standard-CU device or not. If is not a standard-CU, then we do not apply the new mechanism. (which is doing exact the same searching without the speed-up mechanism.)

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

Running the gtest with 
`./hipblaslt-test --gtest_filter=*matmul_heuristic_all_solutions_real_1byte_fnuz*`
on a 300A, since CI runs gfx942 on a 300X
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Passed.

[----------] 640 tests from _/matmul_test (721026 ms total)
[----------] Global test environment tear-down
[==========] 640 tests from 1 test suite ran. (721211 ms total)
[  PASSED  ] 640 tests.
hipBLASLt version: 100202
hipBLASLt git version: 4b80e14530-dirty
command line: `./hipblaslt-test --gtest_filter=*matmul_heuristic_all_solutions_real_1byte_fnuz* `

Another test:

[----------] Global test environment tear-down
[==========] 5710 tests from 1 test suite ran. (2400012 ms total)
[  PASSED  ] 5710 tests.
hipBLASLt version: 100202
hipBLASLt git version: 4b80e14530-dirty
command line: `./hipblaslt-test --gtest_filter=*nightly*`

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
