### PR TITLE
hipblaslt/clients: Include and link cblas.

### DIFF
--- a/projects/hipblaslt/CMakeLists.txt
+++ b/projects/hipblaslt/CMakeLists.txt
@@ -148,6 +148,17 @@ if(HIPBLASLT_ENABLE_CLIENT)
 
     # There is an implicit find_package(BLAS) when finding lapack
     find_package(LAPACK REQUIRED)
+
+    # However find_package(BLAS) only adds the fortran libraries
+    # and not the required cblas C library.
+    # For BLAS implementations like OpenBLAS and MKL this is not a problem
+    # but using the netlib implementation will result in linker errors.
+    # CMake also does not offer any functionality to do so, so let's
+    # use PkgConfig on supported platoforms to find the library.
+    find_package(PkgConfig)
+    if(PKG_CONFIG_FOUND)
+        pkg_search_module(CBLAS REQUIRED cblas)
+    endif()
 endif()
 
 if(HIPBLASLT_ENABLE_OPENMP)

--- a/projects/hipblaslt/clients/CMakeLists.txt
+++ b/projects/hipblaslt/clients/CMakeLists.txt
@@ -10,6 +10,7 @@ target_include_directories(hipblaslt-clients-common
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../tensilelite/include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../tensilelite>
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/library/src/amd_detail/include>
+        ${CBLAS_INCLUDE_DIRS}
     PRIVATE
         "${CMAKE_CURRENT_SOURCE_DIR}/../../tensilelite"
 )
@@ -24,6 +25,7 @@ target_link_libraries(hipblaslt-clients-common
         roc::hipblaslt
         OpenMP::OpenMP_CXX
         ${LAPACK_LIBRARIES}
+        ${CBLAS_LIBRARIES}
     PRIVATE
         hip::device
 )


### PR DESCRIPTION
## Motivation

This patch is the result from packaging `hipblaslt-bench` for Arch Linux.

It fixes the clients build with the netlib/LAPACK as well as the OpenBLAS implementations of BLAS.

Enabling clients by setting `HIPBLASLT_ENABLE_CLIENT` results in linking errors due to cblas not being implicitly linked when calling `find_package(LAPACK)` when building with netlib/LAPACK:
```
ld.lld: error: undefined symbol: cblas_sgemm
ld.lld: error: undefined symbol: cblas_dgemm
```
In addition this patch adds the cblas include directories to the `hipblaslt-clients-common` target, which fixes the build with OpenBLAS and other BLAS implementation that put cblas.h into a different path than netlib.

Fixes the following build issue when building with OpenBLAS:
```
clients/common/include/allclose.hpp:30:10: fatal error: 'cblas.h' file not found
   30 | #include "cblas.h"
      |          ^~~~~~~~~
```

## Technical Details

Since CMake only ships internal modules to find the Fortran implementation of BLAS, this patch resolves this by using pkg-config to retrieve and explicitly link the cblas library which exposes the above symbols.

Before the hipblaslt build system was overhauled last August there was indeed a notion of handling cblas, by calling a custom CMake script, which was although not shipped / part of the `cmake` directory:
https://github.com/ROCm/rocm-libraries/commit/6b5f435db745e53f5ef04fa580fd062c8d3cf3e2#diff-7c58aa7da23791a071940227770492f0ba7f8fe20f91fca6ed0e3ccbf9f3019dL90 

## Test Plan

Since this patch only affects a build issue that the CI was not able to find, letting the CI build pass should be enough to ensure it's validity.
This patch should not have any impact on platforms where pkg-config is unavailable or the build already succeeded.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
