### PR TITLE
Adding Instance Id and exposing api to get Pipeline version

### DIFF
--- a/projects/composablekernel/include/ck/tensor_operation/gpu/device/device_base.hpp
+++ b/projects/composablekernel/include/ck/tensor_operation/gpu/device/device_base.hpp
@@ -10,6 +10,7 @@
 #include <optional>
 #include <memory>
 
+#include "ck/utility/scheduler_enum.hpp"
 #include "ck/stream_config.hpp"
 
 #ifdef CK_EXPERIMENTAL_BUILDER
@@ -300,6 +301,7 @@ struct BaseOperator
 #if !defined(__HIPCC_RTC__) || !defined(CK_CODE_GEN_RTC)
     virtual bool IsSupportedArgument(const BaseArgument*) { return false; }
     virtual std::string GetTypeString() const { return ""; }
+    virtual ck::BlockGemmPipelineVersion GetBlkGemmPipelineVersion() const { return ck::BlockGemmPipelineVersion::v1; }
 
 #ifdef CK_EXPERIMENTAL_BUILDER
     // Return a description object for this operator, or nullptr if not supported.

--- a/projects/composablekernel/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_xdl_cshuffle_v3.hpp
+++ b/projects/composablekernel/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_xdl_cshuffle_v3.hpp
@@ -1654,6 +1654,11 @@ struct DeviceGroupedConvBwdWeight_Xdl_CShuffleV3
         return std::make_unique<Invoker>(Invoker{});
     }
 
+    BlockGemmPipelineVersion GetBlkGemmPipelineVersion() const override
+    {
+        return BlkGemmPipelineVer;
+    }
+
     std::string GetTypeString() const override
     {
         auto str = std::stringstream();
@@ -1684,7 +1689,8 @@ struct DeviceGroupedConvBwdWeight_Xdl_CShuffleV3
             << BBlockTransferDstScalarPerVector_K1 << ", "
             << CShuffleMXdlPerWavePerShuffle << ", "
             << CShuffleNXdlPerWavePerShuffle << ", "
-            << CBlockTransferScalarPerVector_NWaveNPerXdl;
+            << CBlockTransferScalarPerVector_NWaveNPerXdl << ", "
+            << "PipelineVer: " << int(BlkGemmPipelineVer);
             if constexpr(NumGroupsToMerge > 1) 
                 str << ", " << NumGroupsToMerge;
             str << ">";

--- a/projects/composablekernel/profiler/include/profiler/profile_grouped_conv_bwd_weight_impl.hpp
+++ b/projects/composablekernel/profiler/include/profiler/profile_grouped_conv_bwd_weight_impl.hpp
@@ -429,7 +429,7 @@ bool profile_grouped_conv_bwd_weight_impl(int do_verification,
 
                 std::cout << "Perf: " << std::setw(10) << avg_time << " ms, " << tflops
                           << " TFlops, " << gb_per_sec << " GB/s, " << op_name << ", SplitK "
-                          << split_k_param_str << std::endl;
+                          << split_k_param_str << " instance#" << (num_kernel - 1) << " " << int(op_ptr->GetBlkGemmPipelineVersion()) << std::endl;
 
                 if(tflops > best_tflops)
                 {


### PR DESCRIPTION
## Motivation

While using ckProfiler, It was hard to find the pipeline version used by Instance. Hence exposing function to get Pipeline Version.

## Test Result

Tested with ckProfiler.