### PR TITLE
[hipDNN] Fix inv_rms tensor shape from (1,C,1,1) to (N,1,H,W)

### DIFF
--- a/projects/hipdnn/frontend/include/hipdnn_frontend/node/RMSNormNode.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/node/RMSNormNode.hpp
@@ -89,10 +89,11 @@ public:
                             "RMSNormNode forward_phase must be set to TRAINING or INFERENCE");
 
         // Validate inv_rms tensor based on forward_phase
+        // inv_rms has shape [N, 1, H, W] — one value per (batch, spatial) position
         if(attributes.get_forward_phase() == NormFwdPhase::TRAINING)
         {
-            HIPDNN_CHECK_ERROR(detail::validateChannelOnlyShapeIfSet(
-                attributes.get_inv_rms(), channels, "Inverse RMS tensor"));
+            HIPDNN_CHECK_ERROR(detail::validateNormStatsShapeIfSet(
+                attributes.get_inv_rms(), x, "Inverse RMS tensor"));
         }
 
         return {ErrorCode::OK, ""};
@@ -155,7 +156,29 @@ public:
             auto invRms = attributes.get_inv_rms();
             if(invRms)
             {
-                inferCTensor(invRms);
+                // inv_rms shape is [N, 1, H, W] — batch and spatial from input, channel = 1
+                if(invRms->get_dim().empty())
+                {
+                    auto invRmsDims = x->get_dim();
+                    invRmsDims[1] = 1;
+                    invRms->set_dim(invRmsDims);
+                }
+
+                if(invRms->get_stride().empty())
+                {
+                    if(!x->get_stride().empty())
+                    {
+                        auto strideOrder
+                            = hipdnn_data_sdk::utilities::extractStrideOrder(x->get_stride());
+                        invRms->set_stride(hipdnn_data_sdk::utilities::generateStrides(
+                            invRms->get_dim(), strideOrder));
+                    }
+                    else
+                    {
+                        invRms->set_stride(
+                            hipdnn_data_sdk::utilities::generateStrides(invRms->get_dim()));
+                    }
+                }
             }
         }
 

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/node/RMSNormNode.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/node/RMSNormNode.hpp
@@ -89,11 +89,11 @@ public:
                             "RMSNormNode forward_phase must be set to TRAINING or INFERENCE");
 
         // Validate inv_rms tensor based on forward_phase
-        // inv_rms has shape [N, 1, H, W] — one value per (batch, spatial) position
+        // Stats shape is derived from scale: where scale is non-1, stats must be 1
         if(attributes.get_forward_phase() == NormFwdPhase::TRAINING)
         {
             HIPDNN_CHECK_ERROR(detail::validateNormStatsShapeIfSet(
-                attributes.get_inv_rms(), x, "Inverse RMS tensor"));
+                attributes.get_inv_rms(), x, scale, "Inverse RMS tensor"));
         }
 
         return {ErrorCode::OK, ""};
@@ -156,11 +156,32 @@ public:
             auto invRms = attributes.get_inv_rms();
             if(invRms)
             {
-                // inv_rms shape is [N, 1, H, W] — batch and spatial from input, channel = 1
+                // Derive inv_rms dims from input and scale:
+                // Where scale has a non-1 dim, inv_rms gets 1 (normalized dimension collapses).
+                // Where scale has dim 1, inv_rms keeps the input dim.
+                // Fallback (no scale dims): all dims except batch become 1 → [N, 1, 1, 1].
                 if(invRms->get_dim().empty())
                 {
                     auto invRmsDims = x->get_dim();
-                    invRmsDims[1] = 1;
+                    auto scale = attributes.get_scale();
+                    if(scale && !scale->get_dim().empty())
+                    {
+                        const auto& scaleDims = scale->get_dim();
+                        for(size_t i = 0; i < invRmsDims.size(); ++i)
+                        {
+                            if(scaleDims[i] != 1)
+                            {
+                                invRmsDims[i] = 1;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        for(size_t i = 1; i < invRmsDims.size(); ++i)
+                        {
+                            invRmsDims[i] = 1;
+                        }
+                    }
                     invRms->set_dim(invRmsDims);
                 }
 

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/node/detail/Utilities.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/node/detail/Utilities.hpp
@@ -314,11 +314,14 @@ inline Error validateChannelOnlyShapeIfSet(const std::shared_ptr<graph::TensorAt
     return validateChannelOnlyTensorShape(tensor, expectedChannels, fallbackName);
 }
 
-// Validates normalization statistics tensor shape (e.g., inv_rms) matches input batch and spatial
-// dims with channel=1. Expected shape: [N, 1, H, W, ...] where N, H, W come from the input tensor.
+// Validates normalization statistics tensor shape (e.g., inv_rms) against input and scale tensors.
+// Where scale has a non-1 dim (normalized axis), stats must be 1;
+// where scale has dim 1 (non-normalized axis), stats must match input.
+// For typical channel-norm with scale [1,C,1,1], this yields stats shape [N,1,H,W].
 // Only validates if tensor dimensions are already set (same pattern as validateChannelOnlyShapeIfSet)
 inline Error validateNormStatsShapeIfSet(const std::shared_ptr<graph::TensorAttributes>& tensor,
                                          const std::shared_ptr<graph::TensorAttributes>& input,
+                                         const std::shared_ptr<graph::TensorAttributes>& scale,
                                          const std::string& fallbackName = "Tensor")
 {
     if(!areTensorDimensionsSet(tensor))
@@ -331,8 +334,14 @@ inline Error validateNormStatsShapeIfSet(const std::shared_ptr<graph::TensorAttr
         return {ErrorCode::ATTRIBUTE_NOT_SET, "Input tensor is not set"};
     }
 
+    if(!scale || scale->get_dim().empty())
+    {
+        return {ErrorCode::ATTRIBUTE_NOT_SET, "Scale tensor dimensions are not set"};
+    }
+
     const auto& dims = tensor->get_dim();
     const auto& inputDims = input->get_dim();
+    const auto& scaleDims = scale->get_dim();
 
     HIPDNN_RETURN_IF_NE(
         dims.size(),
@@ -341,32 +350,30 @@ inline Error validateNormStatsShapeIfSet(const std::shared_ptr<graph::TensorAttr
         getTensorNameForError(tensor, fallbackName) + " must have the same rank as input, expected "
             + std::to_string(inputDims.size()) + " but got " + std::to_string(dims.size()));
 
-    // Batch dimension must match input
-    HIPDNN_RETURN_IF_NE(dims[0],
-                        inputDims[0],
-                        ErrorCode::INVALID_VALUE,
-                        getTensorNameForError(tensor, fallbackName)
-                            + " batch dimension (index 0) must match input ("
-                            + std::to_string(inputDims[0]) + "), got " + std::to_string(dims[0]));
-
-    // Channel dimension must be 1 (reduced dimension)
-    HIPDNN_RETURN_IF_NE(dims[1],
-                        1,
-                        ErrorCode::INVALID_VALUE,
-                        getTensorNameForError(tensor, fallbackName)
-                            + " channel dimension (index 1) must be 1, got "
-                            + std::to_string(dims[1]));
-
-    // Spatial dimensions must match input
-    for(size_t i = 2; i < dims.size(); ++i)
+    for(size_t i = 0; i < dims.size(); ++i)
     {
-        HIPDNN_RETURN_IF_NE(dims[i],
-                            inputDims[i],
-                            ErrorCode::INVALID_VALUE,
-                            getTensorNameForError(tensor, fallbackName)
-                                + " spatial dimension at index " + std::to_string(i)
-                                + " must match input (" + std::to_string(inputDims[i]) + "), got "
-                                + std::to_string(dims[i]));
+        if(scaleDims[i] != 1)
+        {
+            // Normalized axis: stats dim must be 1
+            HIPDNN_RETURN_IF_NE(dims[i],
+                                1,
+                                ErrorCode::INVALID_VALUE,
+                                getTensorNameForError(tensor, fallbackName) + " dimension at index "
+                                    + std::to_string(i)
+                                    + " must be 1 (normalized axis, scale is non-1), got "
+                                    + std::to_string(dims[i]));
+        }
+        else
+        {
+            // Non-normalized axis: stats dim must match input
+            HIPDNN_RETURN_IF_NE(dims[i],
+                                inputDims[i],
+                                ErrorCode::INVALID_VALUE,
+                                getTensorNameForError(tensor, fallbackName) + " dimension at index "
+                                    + std::to_string(i) + " must match input ("
+                                    + std::to_string(inputDims[i]) + "), got "
+                                    + std::to_string(dims[i]));
+        }
     }
 
     return {ErrorCode::OK, ""};

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/node/detail/Utilities.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/node/detail/Utilities.hpp
@@ -314,6 +314,64 @@ inline Error validateChannelOnlyShapeIfSet(const std::shared_ptr<graph::TensorAt
     return validateChannelOnlyTensorShape(tensor, expectedChannels, fallbackName);
 }
 
+// Validates normalization statistics tensor shape (e.g., inv_rms) matches input batch and spatial
+// dims with channel=1. Expected shape: [N, 1, H, W, ...] where N, H, W come from the input tensor.
+// Only validates if tensor dimensions are already set (same pattern as validateChannelOnlyShapeIfSet)
+inline Error validateNormStatsShapeIfSet(const std::shared_ptr<graph::TensorAttributes>& tensor,
+                                         const std::shared_ptr<graph::TensorAttributes>& input,
+                                         const std::string& fallbackName = "Tensor")
+{
+    if(!areTensorDimensionsSet(tensor))
+    {
+        return {ErrorCode::OK, ""}; // Dimensions not set yet, will be inferred
+    }
+
+    if(!input)
+    {
+        return {ErrorCode::ATTRIBUTE_NOT_SET, "Input tensor is not set"};
+    }
+
+    const auto& dims = tensor->get_dim();
+    const auto& inputDims = input->get_dim();
+
+    HIPDNN_RETURN_IF_NE(
+        dims.size(),
+        inputDims.size(),
+        ErrorCode::INVALID_VALUE,
+        getTensorNameForError(tensor, fallbackName) + " must have the same rank as input, expected "
+            + std::to_string(inputDims.size()) + " but got " + std::to_string(dims.size()));
+
+    // Batch dimension must match input
+    HIPDNN_RETURN_IF_NE(dims[0],
+                        inputDims[0],
+                        ErrorCode::INVALID_VALUE,
+                        getTensorNameForError(tensor, fallbackName)
+                            + " batch dimension (index 0) must match input ("
+                            + std::to_string(inputDims[0]) + "), got " + std::to_string(dims[0]));
+
+    // Channel dimension must be 1 (reduced dimension)
+    HIPDNN_RETURN_IF_NE(dims[1],
+                        1,
+                        ErrorCode::INVALID_VALUE,
+                        getTensorNameForError(tensor, fallbackName)
+                            + " channel dimension (index 1) must be 1, got "
+                            + std::to_string(dims[1]));
+
+    // Spatial dimensions must match input
+    for(size_t i = 2; i < dims.size(); ++i)
+    {
+        HIPDNN_RETURN_IF_NE(dims[i],
+                            inputDims[i],
+                            ErrorCode::INVALID_VALUE,
+                            getTensorNameForError(tensor, fallbackName)
+                                + " spatial dimension at index " + std::to_string(i)
+                                + " must match input (" + std::to_string(inputDims[i]) + "), got "
+                                + std::to_string(dims[i]));
+    }
+
+    return {ErrorCode::OK, ""};
+}
+
 // Validates scalar parameter tensor is properly configured
 // Uses param's name if set, otherwise uses fallbackName for error messages
 // Used for required scalar parameters (e.g., epsilon) that must have dimensions set

--- a/projects/hipdnn/frontend/tests/TestRMSNormNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestRMSNormNode.cpp
@@ -620,6 +620,281 @@ TEST(TestRMSNormNode, PreValidateAcceptsSingleElementSpatialDimensions)
     EXPECT_EQ(error.code, ErrorCode::OK);
 }
 
+// ============================================================================
+// Scale-driven inv_rms Shape Inference Tests
+// ============================================================================
+
+TEST(TestRMSNormNode, InferInvRmsShapeFromScale5D)
+{
+    RMSNormAttributes rmsnormAttributes;
+    rmsnormAttributes.set_x(std::make_shared<TensorAttributes>());
+    rmsnormAttributes.set_y(std::make_shared<TensorAttributes>());
+    rmsnormAttributes.set_scale(std::make_shared<TensorAttributes>());
+    rmsnormAttributes.set_epsilon(std::make_shared<TensorAttributes>());
+    rmsnormAttributes.set_inv_rms(std::make_shared<TensorAttributes>());
+    rmsnormAttributes.set_forward_phase(NormFwdPhase::TRAINING);
+
+    auto inputTensor = rmsnormAttributes.get_x();
+    inputTensor->set_uid(1)
+        .set_data_type(DataType::FLOAT)
+        .set_dim({2, 64, 4, 8, 8})
+        .set_stride({16384, 256, 64, 8, 1});
+
+    rmsnormAttributes.get_y()->set_uid(2);
+
+    auto scaleTensor = rmsnormAttributes.get_scale();
+    scaleTensor->set_dim({1, 64, 1, 1, 1}); // Channel-norm in 5D
+
+    rmsnormAttributes.get_epsilon()->set_dim({1}).set_value(1e-5f);
+
+    auto invRmsTensor = rmsnormAttributes.get_inv_rms();
+    invRmsTensor->set_uid(5);
+
+    const GraphAttributes graphAttributes;
+    RMSNormNode node(std::move(rmsnormAttributes), graphAttributes);
+
+    auto error = node.infer_properties_node();
+    EXPECT_EQ(error.code, ErrorCode::OK);
+
+    // inv_rms: where scale is non-1 (channel), collapse to 1 → [N, 1, D, H, W]
+    EXPECT_EQ(invRmsTensor->get_dim(), (std::vector<int64_t>{2, 1, 4, 8, 8}));
+}
+
+TEST(TestRMSNormNode, InferInvRmsStridesFromInputLayout)
+{
+    RMSNormAttributes rmsnormAttributes;
+    rmsnormAttributes.set_x(std::make_shared<TensorAttributes>());
+    rmsnormAttributes.set_y(std::make_shared<TensorAttributes>());
+    rmsnormAttributes.set_scale(std::make_shared<TensorAttributes>());
+    rmsnormAttributes.set_epsilon(std::make_shared<TensorAttributes>());
+    rmsnormAttributes.set_inv_rms(std::make_shared<TensorAttributes>());
+    rmsnormAttributes.set_forward_phase(NormFwdPhase::TRAINING);
+
+    auto inputTensor = rmsnormAttributes.get_x();
+    inputTensor->set_uid(1)
+        .set_data_type(DataType::FLOAT)
+        .set_dim({2, 64, 8, 8})
+        .set_stride({4096, 64, 8, 1});
+
+    rmsnormAttributes.get_y()->set_uid(2);
+    rmsnormAttributes.get_scale()->set_dim({1, 64, 1, 1});
+    rmsnormAttributes.get_epsilon()->set_dim({1}).set_value(1e-5f);
+
+    auto invRmsTensor = rmsnormAttributes.get_inv_rms();
+    invRmsTensor->set_uid(5);
+
+    const GraphAttributes graphAttributes;
+    RMSNormNode node(std::move(rmsnormAttributes), graphAttributes);
+
+    auto error = node.infer_properties_node();
+    EXPECT_EQ(error.code, ErrorCode::OK);
+
+    EXPECT_EQ(invRmsTensor->get_dim(), (std::vector<int64_t>{2, 1, 8, 8}));
+    EXPECT_FALSE(invRmsTensor->get_stride().empty());
+
+    // Row-major strides for [2, 1, 8, 8]: {64, 64, 8, 1}
+    EXPECT_EQ(invRmsTensor->get_stride(), (std::vector<int64_t>{64, 64, 8, 1}));
+}
+
+TEST(TestRMSNormNode, InferInvRmsPreservesUserSetDims)
+{
+    RMSNormAttributes rmsnormAttributes;
+    rmsnormAttributes.set_x(std::make_shared<TensorAttributes>());
+    rmsnormAttributes.set_y(std::make_shared<TensorAttributes>());
+    rmsnormAttributes.set_scale(std::make_shared<TensorAttributes>());
+    rmsnormAttributes.set_epsilon(std::make_shared<TensorAttributes>());
+    rmsnormAttributes.set_inv_rms(std::make_shared<TensorAttributes>());
+    rmsnormAttributes.set_forward_phase(NormFwdPhase::TRAINING);
+
+    auto inputTensor = rmsnormAttributes.get_x();
+    inputTensor->set_uid(1)
+        .set_data_type(DataType::FLOAT)
+        .set_dim({2, 64, 8, 8})
+        .set_stride({4096, 64, 8, 1});
+
+    rmsnormAttributes.get_y()->set_uid(2);
+    rmsnormAttributes.get_scale()->set_dim({1, 64, 1, 1});
+    rmsnormAttributes.get_epsilon()->set_dim({1}).set_value(1e-5f);
+
+    // User explicitly sets inv_rms dims — inference should not overwrite
+    auto invRmsTensor = rmsnormAttributes.get_inv_rms();
+    invRmsTensor->set_uid(5).set_dim({2, 1, 8, 8}).set_stride({64, 64, 8, 1});
+
+    const GraphAttributes graphAttributes;
+    RMSNormNode node(std::move(rmsnormAttributes), graphAttributes);
+
+    auto error = node.infer_properties_node();
+    EXPECT_EQ(error.code, ErrorCode::OK);
+
+    EXPECT_EQ(invRmsTensor->get_dim(), (std::vector<int64_t>{2, 1, 8, 8}));
+    EXPECT_EQ(invRmsTensor->get_stride(), (std::vector<int64_t>{64, 64, 8, 1}));
+}
+
+// ============================================================================
+// Scale-driven inv_rms Validation Tests
+// ============================================================================
+
+TEST(TestRMSNormNode, PreValidateAcceptsCorrectInvRmsShape)
+{
+    RMSNormAttributes rmsnormAttributes;
+
+    auto xTensor = std::make_shared<TensorAttributes>();
+    xTensor->set_dim({2, 64, 32, 32}).set_stride({65536, 1024, 32, 1});
+    rmsnormAttributes.set_x(xTensor);
+
+    rmsnormAttributes.set_y(std::make_shared<TensorAttributes>());
+
+    auto scaleTensor = std::make_shared<TensorAttributes>();
+    scaleTensor->set_dim({1, 64, 1, 1});
+    rmsnormAttributes.set_scale(scaleTensor);
+
+    // Correct inv_rms shape derived from scale: [N, 1, H, W]
+    auto invRmsTensor = std::make_shared<TensorAttributes>();
+    invRmsTensor->set_dim({2, 1, 32, 32});
+    rmsnormAttributes.set_inv_rms(invRmsTensor);
+
+    auto epsilonTensor = std::make_shared<TensorAttributes>();
+    epsilonTensor->set_dim({1}).set_value(1e-5f);
+    rmsnormAttributes.set_epsilon(epsilonTensor);
+
+    rmsnormAttributes.set_forward_phase(NormFwdPhase::TRAINING);
+
+    const GraphAttributes graphAttributes;
+    const RMSNormNode node(std::move(rmsnormAttributes), graphAttributes);
+
+    auto error = node.pre_validate_node();
+    EXPECT_EQ(error.code, ErrorCode::OK);
+}
+
+TEST(TestRMSNormNode, PreValidateRejectsInvRmsWithChannelOnlyShape)
+{
+    RMSNormAttributes rmsnormAttributes;
+
+    auto xTensor = std::make_shared<TensorAttributes>();
+    xTensor->set_dim({2, 64, 32, 32}).set_stride({65536, 1024, 32, 1});
+    rmsnormAttributes.set_x(xTensor);
+
+    rmsnormAttributes.set_y(std::make_shared<TensorAttributes>());
+
+    auto scaleTensor = std::make_shared<TensorAttributes>();
+    scaleTensor->set_dim({1, 64, 1, 1});
+    rmsnormAttributes.set_scale(scaleTensor);
+
+    // Old incorrect shape [1, C, 1, 1] — should be rejected
+    auto invRmsTensor = std::make_shared<TensorAttributes>();
+    invRmsTensor->set_dim({1, 64, 1, 1});
+    rmsnormAttributes.set_inv_rms(invRmsTensor);
+
+    auto epsilonTensor = std::make_shared<TensorAttributes>();
+    epsilonTensor->set_dim({1}).set_value(1e-5f);
+    rmsnormAttributes.set_epsilon(epsilonTensor);
+
+    rmsnormAttributes.set_forward_phase(NormFwdPhase::TRAINING);
+
+    const GraphAttributes graphAttributes;
+    const RMSNormNode node(std::move(rmsnormAttributes), graphAttributes);
+
+    auto error = node.pre_validate_node();
+    EXPECT_EQ(error.code, ErrorCode::INVALID_VALUE);
+    EXPECT_TRUE(error.get_message().find("Inverse RMS tensor") != std::string::npos);
+}
+
+TEST(TestRMSNormNode, PreValidateRejectsInvRmsWithMismatchedBatchDim)
+{
+    RMSNormAttributes rmsnormAttributes;
+
+    auto xTensor = std::make_shared<TensorAttributes>();
+    xTensor->set_dim({2, 64, 32, 32}).set_stride({65536, 1024, 32, 1});
+    rmsnormAttributes.set_x(xTensor);
+
+    rmsnormAttributes.set_y(std::make_shared<TensorAttributes>());
+
+    auto scaleTensor = std::make_shared<TensorAttributes>();
+    scaleTensor->set_dim({1, 64, 1, 1});
+    rmsnormAttributes.set_scale(scaleTensor);
+
+    // Batch dim mismatch: input has N=2, inv_rms has N=4
+    auto invRmsTensor = std::make_shared<TensorAttributes>();
+    invRmsTensor->set_dim({4, 1, 32, 32});
+    rmsnormAttributes.set_inv_rms(invRmsTensor);
+
+    auto epsilonTensor = std::make_shared<TensorAttributes>();
+    epsilonTensor->set_dim({1}).set_value(1e-5f);
+    rmsnormAttributes.set_epsilon(epsilonTensor);
+
+    rmsnormAttributes.set_forward_phase(NormFwdPhase::TRAINING);
+
+    const GraphAttributes graphAttributes;
+    const RMSNormNode node(std::move(rmsnormAttributes), graphAttributes);
+
+    auto error = node.pre_validate_node();
+    EXPECT_EQ(error.code, ErrorCode::INVALID_VALUE);
+    EXPECT_TRUE(error.get_message().find("Inverse RMS tensor") != std::string::npos);
+}
+
+TEST(TestRMSNormNode, PreValidateRejectsInvRmsWithWrongRank)
+{
+    RMSNormAttributes rmsnormAttributes;
+
+    auto xTensor = std::make_shared<TensorAttributes>();
+    xTensor->set_dim({2, 64, 32, 32}).set_stride({65536, 1024, 32, 1});
+    rmsnormAttributes.set_x(xTensor);
+
+    rmsnormAttributes.set_y(std::make_shared<TensorAttributes>());
+
+    auto scaleTensor = std::make_shared<TensorAttributes>();
+    scaleTensor->set_dim({1, 64, 1, 1});
+    rmsnormAttributes.set_scale(scaleTensor);
+
+    // Wrong rank: 5D instead of 4D
+    auto invRmsTensor = std::make_shared<TensorAttributes>();
+    invRmsTensor->set_dim({2, 1, 32, 32, 1});
+    rmsnormAttributes.set_inv_rms(invRmsTensor);
+
+    auto epsilonTensor = std::make_shared<TensorAttributes>();
+    epsilonTensor->set_dim({1}).set_value(1e-5f);
+    rmsnormAttributes.set_epsilon(epsilonTensor);
+
+    rmsnormAttributes.set_forward_phase(NormFwdPhase::TRAINING);
+
+    const GraphAttributes graphAttributes;
+    const RMSNormNode node(std::move(rmsnormAttributes), graphAttributes);
+
+    auto error = node.pre_validate_node();
+    EXPECT_EQ(error.code, ErrorCode::INVALID_VALUE);
+    EXPECT_TRUE(error.get_message().find("same rank") != std::string::npos);
+}
+
+TEST(TestRMSNormNode, PreValidateSkipsInvRmsValidationWhenDimsNotSet)
+{
+    RMSNormAttributes rmsnormAttributes;
+
+    auto xTensor = std::make_shared<TensorAttributes>();
+    xTensor->set_dim({2, 64, 32, 32}).set_stride({65536, 1024, 32, 1});
+    rmsnormAttributes.set_x(xTensor);
+
+    rmsnormAttributes.set_y(std::make_shared<TensorAttributes>());
+
+    auto scaleTensor = std::make_shared<TensorAttributes>();
+    scaleTensor->set_dim({1, 64, 1, 1});
+    rmsnormAttributes.set_scale(scaleTensor);
+
+    // inv_rms with no dims set — validation should pass (dims will be inferred)
+    rmsnormAttributes.set_inv_rms(std::make_shared<TensorAttributes>());
+
+    auto epsilonTensor = std::make_shared<TensorAttributes>();
+    epsilonTensor->set_dim({1}).set_value(1e-5f);
+    rmsnormAttributes.set_epsilon(epsilonTensor);
+
+    rmsnormAttributes.set_forward_phase(NormFwdPhase::TRAINING);
+
+    const GraphAttributes graphAttributes;
+    const RMSNormNode node(std::move(rmsnormAttributes), graphAttributes);
+
+    auto error = node.pre_validate_node();
+    EXPECT_EQ(error.code, ErrorCode::OK);
+}
+
 TEST(TestRMSNormNode, GetNodeTypeReturnsRmsNorm)
 {
     const GraphAttributes graphAttrs;

--- a/projects/hipdnn/frontend/tests/TestRMSNormNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestRMSNormNode.cpp
@@ -258,8 +258,8 @@ TEST(TestRMSNormNode, InferPropertiesNodeWithInvRms)
     EXPECT_EQ(outputTensor->get_dim(), (std::vector<int64_t>{2, 64, 8, 8}));
     EXPECT_EQ(outputTensor->get_stride(), (std::vector<int64_t>{4096, 64, 8, 1}));
 
-    // inv_rms should get channel-only shape [1, C, 1, 1]
-    EXPECT_EQ(invRmsTensor->get_dim(), (std::vector<int64_t>{1, 64, 1, 1}));
+    // inv_rms should get norm stats shape [N, 1, H, W]
+    EXPECT_EQ(invRmsTensor->get_dim(), (std::vector<int64_t>{2, 1, 8, 8}));
 }
 
 TEST(TestRMSNormNode, InferPropertiesNodeWithBias)

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/constants/RMSNormConstants.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/constants/RMSNormConstants.hpp
@@ -12,7 +12,7 @@ namespace hipdnn_tests::constants
 // Standard 4D RMSNorm constants for testing get/set of valid rmsnorm operations.
 // Represents: X(1,64,32,32) normalized per-channel with Scale(1,64,1,1),
 // Epsilon scalar, optional Bias(1,64,1,1), output Y(1,64,32,32),
-// optional Inv_rms(1,64,1,1).
+// optional Inv_rms(1,1,32,32).
 
 constexpr int64_t K_RMSNORM_TENSOR_X_UID = 40;
 constexpr std::array<int64_t, 4> K_RMSNORM_TENSOR_X_DIMS = {1, 64, 32, 32};
@@ -35,7 +35,7 @@ constexpr std::array<int64_t, 4> K_RMSNORM_TENSOR_BIAS_DIMS = {1, 64, 1, 1};
 constexpr std::array<int64_t, 4> K_RMSNORM_TENSOR_BIAS_STRIDES = {64, 1, 1, 1};
 
 constexpr int64_t K_RMSNORM_TENSOR_INV_RMS_UID = 45;
-constexpr std::array<int64_t, 4> K_RMSNORM_TENSOR_INV_RMS_DIMS = {1, 64, 1, 1};
-constexpr std::array<int64_t, 4> K_RMSNORM_TENSOR_INV_RMS_STRIDES = {64, 1, 1, 1};
+constexpr std::array<int64_t, 4> K_RMSNORM_TENSOR_INV_RMS_DIMS = {1, 1, 32, 32};
+constexpr std::array<int64_t, 4> K_RMSNORM_TENSOR_INV_RMS_STRIDES = {1024, 1024, 32, 1};
 
 } // namespace hipdnn_tests::constants


### PR DESCRIPTION
## Summary

- RMSNorm normalizes over the channel dimension for each (batch, spatial) position, so `inv_rms` has one value per `(N, H, W)` — correct shape is `(N, 1, H, W)`, not `(1, C, 1, 1)`
- The frontend incorrectly treated `inv_rms` like a per-channel parameter (scale/bias), using the same `inferCTensor` helper and `validateChannelOnlyShapeIfSet` validator
- Added `validateNormStatsShapeIfSet()` for proper stats tensor validation and dedicated inference logic in `RMSNormNode`

## Test plan

- [x] `ninja check` (full test suite)