### PR TITLE
[HIPDNN] Remove set_normalized_dim_count from public API

### DIFF
--- a/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/LayernormAttributes.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/LayernormAttributes.hpp
@@ -206,21 +206,6 @@ public:
         return _forwardPhase;
     }
 
-    /// @cond INTERNAL
-    // NOLINTNEXTLINE(readability-identifier-naming)
-    LayernormAttributes& set_normalized_dim_count(int64_t value)
-    {
-        _normalizedDimCount = value;
-        return *this;
-    }
-
-    // NOLINTNEXTLINE(readability-identifier-naming)
-    int64_t get_normalized_dim_count() const
-    {
-        return _normalizedDimCount;
-    }
-    /// @endcond
-
     flatbuffers::Offset<hipdnn_data_sdk::data_objects::LayernormAttributes>
         pack_attributes(flatbuffers::FlatBufferBuilder& builder) const // NOLINT
     {
@@ -253,7 +238,7 @@ public:
         attr.set_bias(tensorMap.at(fb->bias_tensor_uid()));
         attr.set_epsilon(tensorMap.at(fb->epsilon_tensor_uid()));
         attr.set_y(tensorMap.at(fb->y_tensor_uid()));
-        attr.set_normalized_dim_count(fb->normalized_dim_count());
+        attr._normalizedDimCount = fb->normalized_dim_count();
         attr.set_forward_phase(fromSdkType(fb->forward_phase()));
 
         if(fb->mean_tensor_uid().has_value())
@@ -269,6 +254,21 @@ public:
     }
 
 private:
+    friend class LayerNormNode;
+
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    LayernormAttributes& set_normalized_dim_count(int64_t value)
+    {
+        _normalizedDimCount = value;
+        return *this;
+    }
+
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    int64_t get_normalized_dim_count() const
+    {
+        return _normalizedDimCount;
+    }
+
     int64_t _normalizedDimCount = 0;
     NormFwdPhase _forwardPhase = NormFwdPhase::NOT_SET;
 };

--- a/projects/hipdnn/frontend/tests/TestLayerNormNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestLayerNormNode.cpp
@@ -14,6 +14,17 @@ using namespace hipdnn_frontend::graph;
 
 namespace
 {
+// Helper: verify normalized_dim_count via FlatBuffer round-trip (field is private)
+int64_t getPackedNormalizedDimCount(const LayernormAttributes& attrs)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    auto packed = attrs.pack_attributes(builder);
+    builder.Finish(packed);
+    auto fb = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::LayernormAttributes>(
+        builder.GetBufferPointer());
+    return fb->normalized_dim_count();
+}
+
 // Helper: create a tensor with given dims and optional strides
 std::shared_ptr<TensorAttributes> makeTensor(const std::vector<int64_t>& dims,
                                              const std::vector<int64_t>& strides = {})
@@ -419,7 +430,7 @@ TEST(TestLayerNormNode, InferPropertiesSetsNormalizedDimCount)
     auto err = node.infer_properties_node();
     EXPECT_EQ(err.code, error_code_t::OK) << err.err_msg;
 
-    EXPECT_EQ(node.attributes.get_normalized_dim_count(), 3);
+    EXPECT_EQ(getPackedNormalizedDimCount(node.attributes), 3);
 }
 
 TEST(TestLayerNormNode, InferPropertiesSetsAmbiguousNormalizedDimCount)
@@ -439,7 +450,7 @@ TEST(TestLayerNormNode, InferPropertiesSetsAmbiguousNormalizedDimCount)
     auto err = node.infer_properties_node();
     EXPECT_EQ(err.code, error_code_t::OK) << err.err_msg;
 
-    EXPECT_EQ(node.attributes.get_normalized_dim_count(), 2);
+    EXPECT_EQ(getPackedNormalizedDimCount(node.attributes), 2);
 }
 
 TEST(TestLayerNormNode, InferPropertiesSetsNormalizedDimCountWithAlternativeLayoutConvention)
@@ -459,7 +470,7 @@ TEST(TestLayerNormNode, InferPropertiesSetsNormalizedDimCountWithAlternativeLayo
     auto err = node.infer_properties_node();
     EXPECT_EQ(err.code, error_code_t::OK) << err.err_msg;
 
-    EXPECT_EQ(node.attributes.get_normalized_dim_count(), 3);
+    EXPECT_EQ(getPackedNormalizedDimCount(node.attributes), 3);
 }
 
 TEST(TestLayerNormNode, InferPropertiesStatsSkippedInInferenceMode)

--- a/projects/hipdnn/frontend/tests/TestLayernormAttributes.cpp
+++ b/projects/hipdnn/frontend/tests/TestLayernormAttributes.cpp
@@ -16,7 +16,6 @@ TEST(TestLayernormAttributes, DefaultValues)
     EXPECT_EQ(attrs.get_bias(), nullptr);
     EXPECT_EQ(attrs.get_epsilon(), nullptr);
     EXPECT_EQ(attrs.get_y(), nullptr);
-    EXPECT_EQ(attrs.get_normalized_dim_count(), 0);
     EXPECT_EQ(attrs.get_mean(), nullptr);
     EXPECT_EQ(attrs.get_inv_variance(), nullptr);
     EXPECT_EQ(attrs.get_forward_phase(), NormFwdPhase::NOT_SET);
@@ -50,16 +49,6 @@ TEST(TestLayernormAttributes, SetRequiredTensors)
     EXPECT_EQ(attrs.get_y(), y);
     EXPECT_EQ(attrs.get_mean(), nullptr);
     EXPECT_EQ(attrs.get_inv_variance(), nullptr);
-}
-
-TEST(TestLayernormAttributes, SetNormalizedDimCount)
-{
-    LayernormAttributes attrs;
-
-    const int64_t normalizedDimCount = 3;
-    attrs.set_normalized_dim_count(normalizedDimCount);
-
-    EXPECT_EQ(attrs.get_normalized_dim_count(), normalizedDimCount);
 }
 
 TEST(TestLayernormAttributes, SetOptionalMean)
@@ -121,7 +110,6 @@ TEST(TestLayernormAttributes, PackAttributes)
     attrs.set_bias(bias);
     attrs.set_epsilon(epsilon);
     attrs.set_y(y);
-    attrs.set_normalized_dim_count(3);
     attrs.set_mean(mean);
     attrs.set_inv_variance(invVariance);
     attrs.set_forward_phase(NormFwdPhase::TRAINING);
@@ -138,7 +126,7 @@ TEST(TestLayernormAttributes, PackAttributes)
     EXPECT_EQ(fb->bias_tensor_uid(), 3);
     EXPECT_EQ(fb->epsilon_tensor_uid(), 4);
     EXPECT_EQ(fb->y_tensor_uid(), 5);
-    EXPECT_EQ(fb->normalized_dim_count(), 3);
+    EXPECT_EQ(fb->normalized_dim_count(), 0);
     ASSERT_TRUE(fb->mean_tensor_uid().has_value());
     EXPECT_EQ(*fb->mean_tensor_uid(), 6);
     ASSERT_TRUE(fb->inv_variance_tensor_uid().has_value());
@@ -224,7 +212,15 @@ TEST(TestLayernormAttributes, FromFlatBuffer)
     EXPECT_EQ(attrs.get_epsilon()->get_uid(), 40);
     ASSERT_NE(attrs.get_y(), nullptr);
     EXPECT_EQ(attrs.get_y()->get_uid(), 50);
-    EXPECT_EQ(attrs.get_normalized_dim_count(), 3);
+    // Verify normalized_dim_count via FlatBuffer round-trip (private field)
+    {
+        flatbuffers::FlatBufferBuilder rtBuilder;
+        auto rtPacked = attrs.pack_attributes(rtBuilder);
+        rtBuilder.Finish(rtPacked);
+        auto rtFb = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::LayernormAttributes>(
+            rtBuilder.GetBufferPointer());
+        EXPECT_EQ(rtFb->normalized_dim_count(), 3);
+    }
     ASSERT_NE(attrs.get_mean(), nullptr);
     EXPECT_EQ(attrs.get_mean()->get_uid(), 60);
     ASSERT_NE(attrs.get_inv_variance(), nullptr);


### PR DESCRIPTION
## Motivation

`set_normalized_dim_count` is always derivable from scale tensor shape. Exposing it as a user-facing setter adds no valid configuration that can't already be inferred, creates no benefit for plugins (the node resolves it before plugins see it), and introduces an unvalidated field that can only conflict with scale shape, "a field that can only be set wrong."