### PR TITLE
[hipDNN] Clear output map in get_knob_lookup_for_engine

### DIFF
--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Graph.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Graph.hpp
@@ -934,6 +934,8 @@ public:
     Error get_knob_lookup_for_engine(int64_t engineId,
                                      std::unordered_map<KnobType_t, Knob>& knobs) const
     {
+        knobs.clear();
+
         std::vector<Knob> knobVector;
         HIPDNN_CHECK_ERROR(get_knobs_for_engine(engineId, knobVector));
 

--- a/projects/hipdnn/frontend/tests/TestGraph.cpp
+++ b/projects/hipdnn/frontend/tests/TestGraph.cpp
@@ -5916,6 +5916,97 @@ TEST_F(TestGraph, GetKnobLookupForEngineReturnsEmptyMapWhenNoKnobs)
     EXPECT_TRUE(knobLookup.empty());
 }
 
+TEST_F(TestGraph, GetKnobLookupForEngineClearsPreExistingEntries)
+{
+    ::testing::FLAGS_gmock_verbose = "error";
+    Graph graph;
+    createBasicBatchnormGraph(graph);
+
+    // Mock build_operation_graph
+    auto graphDesc = reinterpret_cast<hipdnnBackendDescriptor_t>(0x1234);
+    EXPECT_CALL(*_mockBackend, backendCreateAndDeserializeGraphExt(_, _, _))
+        .WillOnce([&graphDesc](hipdnnBackendDescriptor_t* descriptor, const uint8_t*, size_t) {
+            *descriptor = graphDesc;
+            return HIPDNN_STATUS_SUCCESS;
+        });
+    EXPECT_CALL(
+        *_mockBackend,
+        backendSetAttribute(graphDesc, HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, _))
+        .WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+    EXPECT_CALL(*_mockBackend, backendFinalize(graphDesc)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+
+    auto buildResult = graph.build_operation_graph(_handle);
+    EXPECT_TRUE(buildResult.is_good());
+
+    // Mock engine descriptor creation
+    auto engineDesc = reinterpret_cast<hipdnnBackendDescriptor_t>(0x5678);
+    EXPECT_CALL(*_mockBackend, backendCreateDescriptor(HIPDNN_BACKEND_ENGINE_DESCRIPTOR, _))
+        .WillOnce(
+            [&engineDesc](hipdnnBackendDescriptorType_t, hipdnnBackendDescriptor_t* descriptor) {
+                *descriptor = engineDesc;
+                return HIPDNN_STATUS_SUCCESS;
+            });
+
+    EXPECT_CALL(
+        *_mockBackend,
+        backendSetAttribute(
+            engineDesc, HIPDNN_ATTR_ENGINE_OPERATION_GRAPH, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, _))
+        .WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+
+    EXPECT_CALL(
+        *_mockBackend,
+        backendSetAttribute(engineDesc, HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, _))
+        .WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+
+    EXPECT_CALL(*_mockBackend, backendFinalize(engineDesc)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+
+    // Mock getting knob count - return 0
+    EXPECT_CALL(*_mockBackend,
+                backendGetAttribute(engineDesc,
+                                    HIPDNN_ATTR_KNOB_INFO_SERIALIZED_VALUE_EXT,
+                                    HIPDNN_TYPE_FLATBUFFER_DATA_STRUCT_EXT,
+                                    0,
+                                    _,
+                                    nullptr))
+        .WillOnce([](hipdnnBackendDescriptor_t,
+                     hipdnnBackendAttributeName_t,
+                     hipdnnBackendAttributeType_t,
+                     int64_t,
+                     int64_t* elementCount,
+                     void*) {
+            *elementCount = 0;
+            return HIPDNN_STATUS_SUCCESS;
+        });
+
+    // Pre-populate the map with a stale entry via the factory
+    flatbuffers::FlatBufferBuilder staleBuilder;
+    auto staleOffset = hipdnn_data_sdk::data_objects::CreateKnobDirect(
+        staleBuilder,
+        "stale_knob",
+        "Should be cleared",
+        hipdnn_data_sdk::data_objects::KnobValue::IntValue,
+        hipdnn_data_sdk::data_objects::CreateIntValue(staleBuilder, int64_t{0}).Union(),
+        hipdnn_data_sdk::data_objects::KnobConstraint::NONE,
+        0,
+        false);
+    staleBuilder.Finish(staleOffset);
+    auto staleBuffer = staleBuilder.Release();
+
+    const hipdnnBackendFlatbufferData_t staleFbData{staleBuffer.data(), staleBuffer.size()};
+    auto [staleErr, staleKnob] = Knob::tryFromFlatbuffer(staleFbData);
+    ASSERT_EQ(staleErr.code, ErrorCode::OK);
+
+    std::unordered_map<KnobType_t, Knob> knobLookup;
+    knobLookup.emplace(staleKnob.knobId(), std::move(staleKnob));
+
+    ASSERT_EQ(knobLookup.size(), 1u);
+
+    auto result = graph.get_knob_lookup_for_engine(42, knobLookup);
+
+    EXPECT_TRUE(result.is_good()) << result.get_message();
+    EXPECT_TRUE(knobLookup.empty()) << "Stale entries should be cleared";
+}
+
 TEST_F(TestGraph, SetPreferredEngineIdByName)
 {
     Graph graph;


### PR DESCRIPTION
 ## Motivation 

`get_knob_lookup_for_engine` uses `try_emplace` to populate the output map, which means pre-existing entries from a previous call would silently persist. This matches the convention already used by `get_knobs_for_engine` (the underlying vector-based API), which calls `clear()` before populating.

## Test plan

  - New test: pre-populate map with stale knob, call function, verify map only contains engine's knobs
  - Existing knob lookup tests pass
  - Full frontend test suite passes