### PR TITLE
[hipDNN] add RMSNorm dynamic tolerance

### DIFF
--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerances.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerances.hpp
@@ -12,3 +12,4 @@
 #include <hipdnn_test_sdk/utilities/DynamicTolerancesConv.hpp>
 #include <hipdnn_test_sdk/utilities/DynamicTolerancesMatmul.hpp>
 #include <hipdnn_test_sdk/utilities/DynamicTolerancesPointwise.hpp>
+#include <hipdnn_test_sdk/utilities/DynamicTolerancesRMSNorm.hpp>

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerancesRMSNorm.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerancesRMSNorm.hpp
@@ -1,0 +1,146 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+
+#include <hipdnn_data_sdk/types.hpp>
+#include <hipdnn_test_sdk/utilities/DynamicTolerancesCommon.hpp>
+
+namespace hipdnn_test_sdk::utilities::rmsnorm
+{
+using hipdnn_data_sdk::types::bfloat16;
+using hipdnn_data_sdk::types::half;
+
+/**
+ * @brief Calculates the expected tolerance for RMSNorm forward operations.
+ *
+ * RMSNorm: y[n,c,h,w] = x[n,c,h,w] / RMS(x) * scale[c] [+ bias[c]]
+ * where RMS is computed across channels for each (batch, spatial) position.
+ *
+ * Error sources:
+ * 1. Sum of squares accumulation: C multiply-adds (dominant)
+ * 2. Nonlinear operations: div, sqrt, reciprocal (O(u) each)
+ * 3. Output multiply by scale and optional bias add
+ *
+ * Uses the shared computeGamma() helper for the accumulation error growth factor,
+ * then propagates that error through the nonlinear chain (div, sqrt, reciprocal).
+ *
+ * @tparam OutputType  Data type of y output tensor
+ * @tparam InputType   Data type of x input tensor
+ * @tparam ComputeType Data type for intermediate computation (default: float)
+ * @param xMin       Minimum value in input tensor x
+ * @param xMax       Maximum value in input tensor x
+ * @param scaleMin   Minimum value in scale tensor
+ * @param scaleMax   Maximum value in scale tensor
+ * @param nChannels  Number of channels C (the reduction dimension)
+ * @param biasMin    Minimum value in bias tensor (0 if no bias)
+ * @param biasMax    Maximum value in bias tensor (0 if no bias)
+ * @return Calculated tolerance value as float
+ *
+ * Known Limitations:
+ * - Black-box: does not use kernel implementation details
+ * - Conservative bound from nonlinear propagation (may overestimate for sparse
+ *   activations where most channels are near zero but max(|x|) is large)
+ * - Assumes RMS ~ max(|x|); sparse-spike workloads get looser tolerances
+ * - NONLINEAR_OPS_UPPER_BOUND=5 models worst-case op count; hardware rsqrt fusion
+ *   or multiply reordering may produce fewer rounding errors in practice
+ * - No backward pass support (only forward)
+ * - No invRms-specific tolerance (training mode)
+ */
+template <typename OutputType, typename InputType, typename ComputeType = float>
+float calculateRMSNormFwdTolerance(double xMin,
+                                   double xMax,
+                                   double scaleMin,
+                                   double scaleMax,
+                                   int64_t nChannels,
+                                   double biasMin = 0.0,
+                                   double biasMax = 0.0)
+{
+    validateComputeType<ComputeType>();
+
+    if(nChannels < 1)
+    {
+        throw std::invalid_argument("nChannels must be at least 1.");
+    }
+
+    // Compute bounds
+    const double maxAbsX = std::max(std::abs(xMin), std::abs(xMax));
+    const double maxAbsScale = std::max(std::abs(scaleMin), std::abs(scaleMax));
+    const double maxAbsBias = std::max(std::abs(biasMin), std::abs(biasMax));
+
+    // Sum of squares accumulation error
+    // S = sum_{c=0}^{C-1} x_c^2 (self-product)
+    auto numberOfAccumulations = static_cast<uint64_t>(nChannels);
+    const double maxProduct = maxAbsX * maxAbsX; // self-product
+    const double sumAbsProductBound = static_cast<double>(numberOfAccumulations) * maxProduct;
+
+    auto epsilon = static_cast<double>(std::numeric_limits<ComputeType>::epsilon());
+
+    // Use shared computeGamma() for the error growth factor
+    const double gamma = computeGamma(numberOfAccumulations, epsilon);
+    validateGamma(gamma);
+
+    double accumulatedTolerance = gamma * sumAbsProductBound;
+
+    // Input casting error (if InputType precision > ComputeType precision).
+    // Unlike conv (which casts two distinct tensors, factor 2), RMSNorm squares a single
+    // tensor, so only one operand is cast per product term -- factor 1.
+    // This error is added to accumulatedTolerance before nonlinear propagation, so it is
+    // propagated through the same div/sqrt/recip chain as the accumulation error.
+    accumulatedTolerance += computeInputCastingError<InputType, ComputeType>(sumAbsProductBound, 1);
+
+    // Propagate accumulation error through the nonlinear chain to get output error.
+    //
+    // Derivation of the accTol / (2 * sumAbsProductBound) term:
+    //   invRms = (S/C + eps)^(-1/2),  so  d(invRms)/dS = -1/(2C) * (S/C+eps)^(-3/2)
+    //   |delta_invRms| = |d(invRms)/dS| * |delta_S| = accTol / (2C * RMS^3)
+    //   |delta_invRms / invRms| = accTol / (2 * S)    [since invRms = 1/RMS, eps << S/C]
+    //                           = accTol / (2 * C * mean(x^2))
+    //   Using the worst-case bound S = sumAbsProductBound = C * maxAbsX^2:
+    //     |delta_invRms / invRms| <= accTol / (2 * C * maxAbsX^2) = gamma / 2
+    //   Absolute output error: y = x * invRms * scale, so
+    //     |delta_y| = |x * invRms * scale| * |delta_invRms / invRms|
+    //   Under the worst-case bound invRms = 1/RMS approx 1/maxAbsX:
+    //     |x * invRms| <= maxAbsX * (1/maxAbsX) = 1
+    //     |delta_y| <= maxAbsScale * accTol / (2 * sumAbsProductBound)
+    //               =  maxAbsScale * gamma / 2
+    //
+    // Additional per-op rounding (div, sqrt, recip, 2 muls) and bias:
+    //   Since |y| <= maxAbsScale (under the same invRms approx 1/maxAbsX assumption):
+    //   |delta_y| += NONLINEAR_OPS_UPPER_BOUND * u * maxAbsScale
+    //             += maxAbsBias * epsilon
+    //
+    // Upper bound on distinct rounding ops: div(S,C) + sqrt + recip + mul(x,invRms) + mul(*,scale).
+    // Hardware may fuse some (e.g. rsqrt), so 5 is a modelling upper bound, not a literal count.
+    constexpr double NONLINEAR_OPS_UPPER_BOUND = 5.0;
+
+    double propagatedTolerance = 0.0;
+
+    // When maxAbsX == 0, all inputs are zero. S = 0, invRms = 1/sqrt(eps),
+    // y = 0*invRms*scale + bias = bias.
+    // Accumulation error is zero, the nonlinear-ops term on the x*invRms*scale chain vanishes,
+    // and maxOutputMagnitude reduces to maxAbsBias, leaving only the bias-related terms.
+    if(maxAbsX > 0.0)
+    {
+        propagatedTolerance = (accumulatedTolerance / (2.0 * sumAbsProductBound)) * maxAbsScale;
+        propagatedTolerance += NONLINEAR_OPS_UPPER_BOUND * epsilon * maxAbsScale;
+    }
+    propagatedTolerance += maxAbsBias * epsilon;
+
+    // Output casting error (if OutputType precision < ComputeType precision).
+    // Output magnitude bound: under invRms approx 1/maxAbsX, |y| <= maxAbsScale + maxAbsBias.
+    // When maxAbsX == 0, the x*invRms*scale term is zero, so |y| <= maxAbsBias.
+    const double maxOutputMagnitude = (maxAbsX > 0.0 ? maxAbsScale : 0.0) + maxAbsBias;
+    propagatedTolerance += computeOutputCastingError<OutputType, ComputeType>(maxOutputMagnitude);
+
+    validateToleranceRange<OutputType>(propagatedTolerance);
+
+    return static_cast<float>(propagatedTolerance);
+}
+
+} // namespace hipdnn_test_sdk::utilities::rmsnorm

--- a/projects/hipdnn/test_sdk/tests/CMakeLists.txt
+++ b/projects/hipdnn/test_sdk/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(
     utilities/TestDynamicTolerancesConv.cpp
     utilities/TestDynamicTolerancesMatmul.cpp
     utilities/TestDynamicTolerancesPointwise.cpp
+    utilities/TestDynamicTolerancesRMSNorm.cpp
     utilities/TestFlatbufferDatatypeMapping.cpp
     utilities/TestFlatbufferTensorAttributesUtils.cpp
     utilities/TestLoadGraphAndTensors.cpp

--- a/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerancesRMSNorm.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerancesRMSNorm.cpp
@@ -1,0 +1,425 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include <cmath>
+#include <gtest/gtest.h>
+#include <hipdnn_data_sdk/types.hpp>
+#include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
+#include <hipdnn_test_sdk/utilities/DynamicTolerancesCommon.hpp>
+#include <hipdnn_test_sdk/utilities/DynamicTolerancesRMSNorm.hpp>
+#include <vector>
+
+using namespace hipdnn_test_sdk::utilities::rmsnorm;
+using hipdnn_data_sdk::types::bfloat16;
+using hipdnn_data_sdk::types::half;
+using hipdnn_test_sdk::utilities::computeGamma;
+
+template <typename Out, typename In, typename Comp>
+struct TypeTriple
+{
+    using OutputType = Out;
+    using InputType = In;
+    using ComputeType = Comp;
+};
+
+// =================================================================================================
+// TestCalculateRMSNormFwdTolerance
+// =================================================================================================
+
+struct RMSNormFwdToleranceTestCase
+{
+    double xMin;
+    double xMax;
+    double scaleMin;
+    double scaleMax;
+    int64_t nChannels;
+    double biasMin;
+    double biasMax;
+    double expectedTolerance;
+    bool expectThrow = false;
+
+    friend std::ostream& operator<<(std::ostream& os, const RMSNormFwdToleranceTestCase& tc)
+    {
+        os << "xMin: " << tc.xMin << ", xMax: " << tc.xMax << ", scaleMin: " << tc.scaleMin
+           << ", scaleMax: " << tc.scaleMax << ", nChannels: " << tc.nChannels
+           << ", biasMin: " << tc.biasMin << ", biasMax: " << tc.biasMax
+           << ", expectedTolerance: " << tc.expectedTolerance
+           << ", expectThrow: " << (tc.expectThrow ? "true" : "false");
+        return os;
+    }
+};
+
+template <typename T>
+std::vector<RMSNormFwdToleranceTestCase> getRMSNormFwdToleranceTestCases();
+
+// RMSNorm tests use computeGamma() from the shared utilities namespace.
+// propTol = (computeGamma(C, u) * C * maxAbsX^2 / (2 * C * maxAbsX^2)) * maxAbsScale
+//         + NONLINEAR_OPS * u * maxAbsScale
+//         + maxAbsBias * u
+//         = (gamma / 2 + 5u) * maxAbsScale + maxAbsBias * u
+
+// Float / Float / Float
+// For FP32 at small C, computeGamma uses linear bound: nU/(1-nU)
+template <>
+std::vector<RMSNormFwdToleranceTestCase>
+    getRMSNormFwdToleranceTestCases<TypeTriple<float, float, float>>()
+{
+    auto u = static_cast<double>(std::numeric_limits<float>::epsilon());
+    auto gamma = [&](int64_t c) { return computeGamma(static_cast<uint64_t>(c), u); };
+    return {// nChannels = 0 => throws
+            {-1.0, 1.0, -1.0, 1.0, 0, 0.0, 0.0, 0.0, true},
+            // C=1, x=[-1,1], scale=[-1,1], no bias
+            {-1.0, 1.0, -1.0, 1.0, 1, 0.0, 0.0, (gamma(1) / 2.0) + 5.0 * u},
+            // C=10, x=[-1,1], scale=[-1,1], no bias
+            {-1.0, 1.0, -1.0, 1.0, 10, 0.0, 0.0, (gamma(10) / 2.0) + 5.0 * u},
+            // C=10, x=[-1000,1000], scale=[-1000,1000], no bias
+            {-1000.0,
+             1000.0,
+             -1000.0,
+             1000.0,
+             10,
+             0.0,
+             0.0,
+             (gamma(10) / 2.0) * 1000.0 + 5.0 * u * 1000.0},
+            // C=3, x=[-1,1], scale=[-1,1], bias=[-0.5,0.5]
+            {-1.0, 1.0, -1.0, 1.0, 3, -0.5, 0.5, (gamma(3) / 2.0) + 5.0 * u + 0.5 * u}};
+}
+
+// Float / Double / Float (Input casting error: inputEpsilon(double) < epsilon(float))
+// accTol = gamma * sumAbsProductBound + sumAbsProductBound * epsilon
+template <>
+std::vector<RMSNormFwdToleranceTestCase>
+    getRMSNormFwdToleranceTestCases<TypeTriple<float, double, float>>()
+{
+    auto u = static_cast<double>(std::numeric_limits<float>::epsilon());
+    auto gamma = [&](int64_t c) { return computeGamma(static_cast<uint64_t>(c), u); };
+    return {// nChannels = 0 => throws
+            {-1.0, 1.0, -1.0, 1.0, 0, 0.0, 0.0, 0.0, true},
+            // C=1
+            {-1.0, 1.0, -1.0, 1.0, 1, 0.0, 0.0, ((gamma(1) + u) / 2.0) + 5.0 * u},
+            // C=10
+            {-1.0, 1.0, -1.0, 1.0, 10, 0.0, 0.0, ((gamma(10) + u) / 2.0) + 5.0 * u},
+            // Zero input: x=0, all terms vanish
+            {0.0, 0.0, -1.0, 1.0, 10, 0.0, 0.0, 0.0}};
+}
+
+// Half / Float / Float (Output casting error: outputEpsilon(half=2^-10) > epsilon(float=2^-23))
+template <>
+std::vector<RMSNormFwdToleranceTestCase>
+    getRMSNormFwdToleranceTestCases<TypeTriple<half, float, float>>()
+{
+    auto u = static_cast<double>(std::numeric_limits<float>::epsilon());
+    auto uHalf = static_cast<double>(std::numeric_limits<half>::epsilon());
+    auto gamma = [&](int64_t c) { return computeGamma(static_cast<uint64_t>(c), u); };
+    return {// nChannels = 0 => throws
+            {-1.0, 1.0, -1.0, 1.0, 0, 0.0, 0.0, 0.0, true},
+            // C=1
+            {-1.0, 1.0, -1.0, 1.0, 1, 0.0, 0.0, (gamma(1) / 2.0) + 5.0 * u + 1.0 * uHalf},
+            // C=10
+            {-1.0, 1.0, -1.0, 1.0, 10, 0.0, 0.0, (gamma(10) / 2.0) + 5.0 * u + 1.0 * uHalf},
+            // Zero input: output cast term from maxOutputMagnitude=0 vanishes
+            {0.0, 0.0, -1.0, 1.0, 10, 0.0, 0.0, 0.0}};
+}
+
+// Half / Half / Half
+// computeGamma selects linear vs statistical based on nU threshold (0.01).
+// half epsilon = 2^-10.  C=1: nU=0.00195<0.01 -> linear.  C=10: nU=0.0195>=0.01 -> statistical.
+template <>
+std::vector<RMSNormFwdToleranceTestCase>
+    getRMSNormFwdToleranceTestCases<TypeTriple<half, half, half>>()
+{
+    auto u = static_cast<double>(std::numeric_limits<half>::epsilon());
+    auto gamma = [&](int64_t c) { return computeGamma(static_cast<uint64_t>(c), u); };
+    return {// nChannels = 0 => throws
+            {-1.0, 1.0, -1.0, 1.0, 0, 0.0, 0.0, 0.0, true},
+            // C=1: gamma via computeGamma (linear at this nU)
+            {-1.0, 1.0, -1.0, 1.0, 1, 0.0, 0.0, (gamma(1) / 2.0) + 5.0 * u},
+            // C=10: gamma via computeGamma (statistical at this nU)
+            {-1.0, 1.0, -1.0, 1.0, 10, 0.0, 0.0, (gamma(10) / 2.0) + 5.0 * u},
+            // Zero input: all terms vanish
+            {0.0, 0.0, -1.0, 1.0, 10, 0.0, 0.0, 0.0}};
+}
+
+// Bfloat16 / Float / Float (Output casting error: outputEpsilon(bf16=2^-7) > epsilon(float=2^-23))
+template <>
+std::vector<RMSNormFwdToleranceTestCase>
+    getRMSNormFwdToleranceTestCases<TypeTriple<bfloat16, float, float>>()
+{
+    auto u = static_cast<double>(std::numeric_limits<float>::epsilon());
+    auto uBf16 = static_cast<double>(std::numeric_limits<bfloat16>::epsilon());
+    auto gamma = [&](int64_t c) { return computeGamma(static_cast<uint64_t>(c), u); };
+    return {// nChannels = 0 => throws
+            {-1.0, 1.0, -1.0, 1.0, 0, 0.0, 0.0, 0.0, true},
+            // C=1
+            {-1.0, 1.0, -1.0, 1.0, 1, 0.0, 0.0, (gamma(1) / 2.0) + 5.0 * u + 1.0 * uBf16},
+            // C=10
+            {-1.0, 1.0, -1.0, 1.0, 10, 0.0, 0.0, (gamma(10) / 2.0) + 5.0 * u + 1.0 * uBf16},
+            // Zero input: output cast from maxOutputMagnitude=0 vanishes
+            {0.0, 0.0, -1.0, 1.0, 10, 0.0, 0.0, 0.0}};
+}
+
+// Bfloat16 / Bfloat16 / Bfloat16
+// bf16 epsilon = 2^-7.  C=1: nU=0.0156>=0.01 -> statistical.
+template <>
+std::vector<RMSNormFwdToleranceTestCase>
+    getRMSNormFwdToleranceTestCases<TypeTriple<bfloat16, bfloat16, bfloat16>>()
+{
+    auto u = static_cast<double>(std::numeric_limits<bfloat16>::epsilon());
+    auto gamma = [&](int64_t c) { return computeGamma(static_cast<uint64_t>(c), u); };
+    return {// nChannels = 0 => throws
+            {-1.0, 1.0, -1.0, 1.0, 0, 0.0, 0.0, 0.0, true},
+            // C=1
+            {-1.0, 1.0, -1.0, 1.0, 1, 0.0, 0.0, (gamma(1) / 2.0) + 5.0 * u},
+            // C=10
+            {-1.0, 1.0, -1.0, 1.0, 10, 0.0, 0.0, (gamma(10) / 2.0) + 5.0 * u},
+            // Zero input: all terms vanish
+            {0.0, 0.0, -1.0, 1.0, 10, 0.0, 0.0, 0.0}};
+}
+
+template <typename Out, typename In, typename Comp>
+class TestCalculateRMSNormFwdTolerance
+    : public ::testing::TestWithParam<RMSNormFwdToleranceTestCase>
+{
+protected:
+    void verifyTolerance()
+    {
+        const auto& params = GetParam();
+
+        if(params.expectThrow)
+        {
+            EXPECT_THROW((calculateRMSNormFwdTolerance<Out, In, Comp>(params.xMin,
+                                                                      params.xMax,
+                                                                      params.scaleMin,
+                                                                      params.scaleMax,
+                                                                      params.nChannels,
+                                                                      params.biasMin,
+                                                                      params.biasMax)),
+                         std::invalid_argument);
+        }
+        else
+        {
+            auto tol = calculateRMSNormFwdTolerance<Out, In, Comp>(params.xMin,
+                                                                   params.xMax,
+                                                                   params.scaleMin,
+                                                                   params.scaleMax,
+                                                                   params.nChannels,
+                                                                   params.biasMin,
+                                                                   params.biasMax);
+
+            auto expected = static_cast<float>(params.expectedTolerance);
+
+            EXPECT_NEAR(
+                tol, expected, std::max(expected * 0.01f, std::numeric_limits<float>::min()));
+        }
+    }
+};
+
+using TestCalculateRMSNormFwdToleranceFp32 = TestCalculateRMSNormFwdTolerance<float, float, float>;
+TEST_P(TestCalculateRMSNormFwdToleranceFp32, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalculateRMSNormFwdToleranceFp32,
+    ::testing::ValuesIn(getRMSNormFwdToleranceTestCases<TypeTriple<float, float, float>>()));
+
+using TestCalculateRMSNormFwdToleranceInputDouble
+    = TestCalculateRMSNormFwdTolerance<float, double, float>;
+TEST_P(TestCalculateRMSNormFwdToleranceInputDouble, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalculateRMSNormFwdToleranceInputDouble,
+    ::testing::ValuesIn(getRMSNormFwdToleranceTestCases<TypeTriple<float, double, float>>()));
+
+using TestCalculateRMSNormFwdToleranceComputeFloatFp16
+    = TestCalculateRMSNormFwdTolerance<half, float, float>;
+TEST_P(TestCalculateRMSNormFwdToleranceComputeFloatFp16, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalculateRMSNormFwdToleranceComputeFloatFp16,
+    ::testing::ValuesIn(getRMSNormFwdToleranceTestCases<TypeTriple<half, float, float>>()));
+
+using TestCalculateRMSNormFwdToleranceFp16 = TestCalculateRMSNormFwdTolerance<half, half, half>;
+TEST_P(TestCalculateRMSNormFwdToleranceFp16, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalculateRMSNormFwdToleranceFp16,
+    ::testing::ValuesIn(getRMSNormFwdToleranceTestCases<TypeTriple<half, half, half>>()));
+
+using TestCalculateRMSNormFwdToleranceComputeFloatBfp16
+    = TestCalculateRMSNormFwdTolerance<bfloat16, float, float>;
+TEST_P(TestCalculateRMSNormFwdToleranceComputeFloatBfp16, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalculateRMSNormFwdToleranceComputeFloatBfp16,
+    ::testing::ValuesIn(getRMSNormFwdToleranceTestCases<TypeTriple<bfloat16, float, float>>()));
+
+using TestCalculateRMSNormFwdToleranceBfp16
+    = TestCalculateRMSNormFwdTolerance<bfloat16, bfloat16, bfloat16>;
+TEST_P(TestCalculateRMSNormFwdToleranceBfp16, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalculateRMSNormFwdToleranceBfp16,
+    ::testing::ValuesIn(
+        getRMSNormFwdToleranceTestCases<TypeTriple<bfloat16, bfloat16, bfloat16>>()));
+
+// Test that calculateRMSNormFwdTolerance catches simulated wrong outputs
+TEST(TestCalculateRMSNormFwdTolerance, DetectsFailure)
+{
+    // C=100, x=[-1,1], scale=[-1,1]
+    const std::vector<int64_t> dims = {1, 1, 10, 10};
+    const std::vector<int64_t> strides = {100, 100, 10, 1};
+
+    auto baseline = hipdnn_data_sdk::utilities::createTensor(
+        hipdnn_data_sdk::data_objects::DataType::FLOAT, dims, strides);
+    auto actualPassing = hipdnn_data_sdk::utilities::createTensor(
+        hipdnn_data_sdk::data_objects::DataType::FLOAT, dims, strides);
+    auto actualFailing = hipdnn_data_sdk::utilities::createTensor(
+        hipdnn_data_sdk::data_objects::DataType::FLOAT, dims, strides);
+
+    baseline->fillTensorWithValue(1.0f);
+    actualPassing->fillTensorWithValue(1.000001f); // Small error (1e-6 < tol ~1.25e-5)
+    actualFailing->fillTensorWithValue(1.2f); // Large error
+
+    auto tol = calculateRMSNormFwdTolerance<float, float, float>(-1.0, 1.0, -1.0, 1.0, 100);
+
+    // For FP32, C=100: tolerance should be small (dominated by nonlinear ops term)
+    EXPECT_LT(tol, 0.01f);
+    EXPECT_GT(tol, 1e-6f);
+
+    auto validator = hipdnn_test_sdk::utilities::createAllCloseValidator(
+        hipdnn_data_sdk::data_objects::DataType::FLOAT, tol, 0);
+
+    bool valid = validator->allClose(*baseline, *actualPassing);
+    EXPECT_TRUE(valid);
+
+    valid = validator->allClose(*baseline, *actualFailing);
+    EXPECT_FALSE(valid);
+}
+
+// Test that calculateRMSNormFwdTolerance throws when gamma >= 0.5
+TEST(TestCalculateRMSNormFwdTolerance, ThrowsOnSingularity)
+{
+    // For float, epsilon = 2^-23 ~ 1.19e-7.
+    // computeGamma switches to statistical at nU >= 0.01.
+    // C=5,000,000: nU = 2*5e6*2^-23 ~ 1.19 >= 0.01 -> statistical.
+    // gamma = 6 * sqrt(2*5e6) * 2^-23 ~ 6 * 3162 * 1.19e-7 ~ 0.00226 < 0.5 (won't throw).
+    // Need much larger C for gamma >= 0.5 with float statistical bound.
+    // gamma = 6 * sqrt(2C) * u >= 0.5 -> C >= (0.5 / (6*u))^2 / 2
+    // C >= (0.5 / (6 * 1.19e-7))^2 / 2 ~ 2.93e11. Use 3e11.
+    EXPECT_THROW(
+        (calculateRMSNormFwdTolerance<float, float, float>(-1.0, 1.0, -1.0, 1.0, 300000000000LL)),
+        std::overflow_error);
+
+    // For bfloat16, epsilon = 2^-7.  gamma >= 0.5 at much smaller C.
+    // gamma = 6*sqrt(2C)*u >= 0.5 -> C >= (0.5/(6*2^-7))^2/2 ~ 68.3. Use C=100.
+    EXPECT_THROW(
+        (calculateRMSNormFwdTolerance<bfloat16, bfloat16, bfloat16>(-1.0, 1.0, -1.0, 1.0, 100)),
+        std::overflow_error);
+
+    // For half, epsilon = 2^-10.  gamma >= 0.5 -> C >= (0.5/(6*2^-10))^2/2 ~ 4370. Use C=5000.
+    EXPECT_THROW((calculateRMSNormFwdTolerance<half, half, half>(-1.0, 1.0, -1.0, 1.0, 5000)),
+                 std::overflow_error);
+
+    // float/double/float uses float epsilon -> same threshold as float/float/float
+    EXPECT_THROW(
+        (calculateRMSNormFwdTolerance<float, double, float>(-1.0, 1.0, -1.0, 1.0, 300000000000LL)),
+        std::overflow_error);
+}
+
+// Test that calculateRMSNormFwdTolerance throws when tolerance exceeds OutputType max
+TEST(TestCalculateRMSNormFwdTolerance, ThrowsOnOutputOverflow)
+{
+    // OutputType = half (max approx 65504)
+    // Use very large scale to push tolerance above half max.
+    // C=10, x=[-1,1], scale=[-1e8,1e8]
+    // output cast term: maxAbsScale * uHalf = 1e8 * 2^-10 ~ 97656 >> 65504
+    EXPECT_THROW((calculateRMSNormFwdTolerance<half, float, float>(-1.0, 1.0, -1e8, 1e8, 10)),
+                 std::overflow_error);
+
+    // half/half/half with very large scale: propagated tolerance exceeds half max (65504).
+    // C=10, x=[-1000,1000], scale=[-1e7,1e7]:
+    // gamma(10) ~ 0.0262, tol ~ gamma/2 * 1e7 + 5 * 2^-10 * 1e7 ~ 1.8e5 > 65504
+    EXPECT_THROW((calculateRMSNormFwdTolerance<half, half, half>(-1000, 1000, -1e7, 1e7, 10)),
+                 std::overflow_error);
+}
+
+// Test zero input (x=0) produces a valid small tolerance
+TEST(TestCalculateRMSNormFwdTolerance, ZeroInput)
+{
+    // When x=0, maxAbsX=0, sumAbsProductBound=0, accTol=0
+    // propagatedTolerance = 0 + 0 + maxAbsBias * epsilon
+    auto tol = calculateRMSNormFwdTolerance<float, float, float>(0.0, 0.0, -1.0, 1.0, 10);
+    EXPECT_EQ(tol, 0.0f);
+
+    // With bias (float)
+    auto tolBias
+        = calculateRMSNormFwdTolerance<float, float, float>(0.0, 0.0, -1.0, 1.0, 10, -0.5, 0.5);
+    EXPECT_GT(tolBias, 0.0f);
+
+    // Zero input with bfloat16 output casting: outputEpsilon(bf16) > epsilon(float), but
+    // maxOutputMagnitude=0, so output cast term also vanishes
+    auto tolBf16 = calculateRMSNormFwdTolerance<bfloat16, float, float>(0.0, 0.0, -1.0, 1.0, 10);
+    EXPECT_EQ(tolBf16, 0.0f);
+
+    // Zero input with bias and half output: bias term + output cast of bias
+    auto uFloat = static_cast<double>(std::numeric_limits<float>::epsilon());
+    auto uHalf = static_cast<double>(std::numeric_limits<half>::epsilon());
+    auto tolHalfBias
+        = calculateRMSNormFwdTolerance<half, float, float>(0.0, 0.0, -1.0, 1.0, 10, -0.5, 0.5);
+    // Expected: maxAbsBias * epsilon + maxOutputMagnitude * outputEpsilon
+    //         = 0.5 * uFloat + 0.5 * uHalf
+    auto expectedHalfBias = static_cast<float>(0.5 * uFloat + 0.5 * uHalf);
+    EXPECT_NEAR(tolHalfBias, expectedHalfBias, 1e-10f);
+}
+
+// Sanity check: tolerance scaling behavior with increasing C.
+// For small C with FP32, computeGamma uses linear bound -> dominant term ~ C * u
+// For BF16, computeGamma uses statistical bound -> dominant term ~ sqrt(C) * u
+TEST(TestCalculateRMSNormFwdTolerance, ToleranceScalesWithChannels)
+{
+    // FP32: tolerance should grow roughly linearly with C (gamma/2 ~ C*u)
+    auto tolFp32C1 = calculateRMSNormFwdTolerance<float, float, float>(-1.0, 1.0, -1.0, 1.0, 1);
+    auto tolFp32C10 = calculateRMSNormFwdTolerance<float, float, float>(-1.0, 1.0, -1.0, 1.0, 10);
+    auto tolFp32C100 = calculateRMSNormFwdTolerance<float, float, float>(-1.0, 1.0, -1.0, 1.0, 100);
+
+    EXPECT_LT(tolFp32C1, tolFp32C10) << "FP32: C=10 should have higher tolerance than C=1";
+    EXPECT_LT(tolFp32C10, tolFp32C100) << "FP32: C=100 should have higher tolerance than C=10";
+
+    // Ratio check: C=100 vs C=1 (use wider spread so gamma term dominates the constant 5u)
+    auto ratioFp32 = static_cast<double>(tolFp32C100) / static_cast<double>(tolFp32C1);
+    EXPECT_GT(ratioFp32, 10.0) << "FP32: ratio C100/C1 should reflect ~C growth";
+
+    // BF16 (statistical): tolerance should grow ~ sqrt(C)
+    // C=100 exceeds gamma >= 0.5 for bf16 (gamma ~ 0.663), so use C=50 as upper bound
+    auto tolBf16C1
+        = calculateRMSNormFwdTolerance<bfloat16, bfloat16, bfloat16>(-1.0, 1.0, -1.0, 1.0, 1);
+    auto tolBf16C10
+        = calculateRMSNormFwdTolerance<bfloat16, bfloat16, bfloat16>(-1.0, 1.0, -1.0, 1.0, 10);
+    auto tolBf16C50
+        = calculateRMSNormFwdTolerance<bfloat16, bfloat16, bfloat16>(-1.0, 1.0, -1.0, 1.0, 50);
+
+    EXPECT_LT(tolBf16C1, tolBf16C10) << "BF16: C=10 should have higher tolerance than C=1";
+    EXPECT_LT(tolBf16C10, tolBf16C50) << "BF16: C=50 should have higher tolerance than C=10";
+
+    auto ratioBf16 = static_cast<double>(tolBf16C10) / static_cast<double>(tolBf16C1);
+    EXPECT_GT(ratioBf16, 1.5) << "BF16: ratio C10/C1 should reflect sqrt(C) growth";
+}

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestRMSNormFwdPlan.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestRMSNormFwdPlan.cpp
@@ -10,6 +10,7 @@
 #include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceRMSNorm.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
+#include <hipdnn_test_sdk/utilities/DynamicTolerances.hpp>
 #include <hipdnn_test_sdk/utilities/Seeds.hpp>
 #include <hipdnn_test_sdk/utilities/TestTolerances.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/RMSNormFwdPlan.hpp>
@@ -21,6 +22,7 @@ using namespace hipdnn_data_sdk::utilities;
 using namespace hipdnn_data_sdk::flatbuffer_utilities;
 using namespace ::testing;
 using namespace hipdnn_sdk_test_utils;
+namespace rmsnorm = hipdnn_test_sdk::utilities::rmsnorm;
 
 TEST(TestRMSNormFwdPlan, ExecutePlan)
 {
@@ -64,7 +66,9 @@ TEST(TestRMSNormFwdPlan, ExecutePlan)
     RMSNormFwdPlan<float, float, float, float> fwdPlan(std::move(params));
     fwdPlan.execute(variantPack);
 
-    const float tolerance = 1e-5f;
+    // x in [0, 1], scale in [0, 1], C=3, no bias
+    const float tolerance
+        = rmsnorm::calculateRMSNormFwdTolerance<float, float, float>(0.0, 1.0, 0.0, 1.0, dims[1]);
     const CpuFpReferenceValidation<float> cpuRefOutputValidation(tolerance, tolerance);
     EXPECT_TRUE(cpuRefOutputValidation.allClose(
         *directTensorBundle.tensors[attributes.y_tensor_uid()].get(),
@@ -161,7 +165,9 @@ TEST(TestRMSNormFwdPlan, ExecutePlanWithBias)
     RMSNormFwdPlan<float, float, float, float> fwdPlan(std::move(params));
     fwdPlan.execute(variantPack);
 
-    const float tolerance = 1e-5f;
+    // x in [0, 1], scale in [0, 1], C=3, bias in [-0.5, 0.5]
+    const float tolerance = rmsnorm::calculateRMSNormFwdTolerance<float, float, float>(
+        0.0, 1.0, 0.0, 1.0, dims[1], -0.5, 0.5);
     const CpuFpReferenceValidation<float> cpuRefOutputValidation(tolerance, tolerance);
     EXPECT_TRUE(cpuRefOutputValidation.allClose(
         *directTensorBundle.tensors[attributes.y_tensor_uid()].get(),


### PR DESCRIPTION
## Motivation

Add dynamic tolerance calculation for RMSNorm forward operations, extending the existing `DynamicTolerances.hpp` framework. Unlike conv/matmul where accumulation error maps directly to output error via `gamma * sum`, RMSNorm requires **derivative-based error propagation** through the nonlinear chain (div, sqrt, reciprocal) between accumulation and output. This PR implements that propagation as a conservative, deterministic bound using only max-norm information on the input ranges, without assuming any statistical structure of the data. Tighter RMS-aware bounds are explicitly deferred.

## Technical Details

The output error is built up in `propagatedTolerance`, which accumulates four terms:

```cpp
if(maxAbsX > 0.0)
{
    propagatedTolerance  = (accumulatedTolerance / (2.0 * sumAbsProductBound)) * maxAbsScale;
    propagatedTolerance += NONLINEAR_OPS_UPPER_BOUND * epsilon * maxAbsScale;
}
propagatedTolerance += maxAbsBias * epsilon;
const double maxOutputMagnitude = (maxAbsX > 0.0 ? maxAbsScale : 0.0) + maxAbsBias;
propagatedTolerance += computeOutputCastingError<OutputType, ComputeType>(maxOutputMagnitude);
```

**Propagation term -- `accTol / (2 * sumAbsProductBound) * maxAbsScale`**: The raw accumulation error from summing C squares is `accumulatedTolerance = gamma * sumAbsProductBound`, where `gamma` is selected by `computeGamma(C, u)` -- linear bound when `2*C*u < 0.01`, statistical (6-sigma) bound otherwise. If `InputType` has higher precision than `ComputeType`, an input casting term is added via `computeInputCastingError` (factor 1, not 2 as in conv, because RMSNorm squares a single tensor). This raw error is propagated through the nonlinear chain: since `y = x * invRms * scale` and `|x * invRms| <= 1` (under worst-case `invRms ≈ 1/maxAbsX`), the absolute output error is `accTol / (2 * sumAbsProductBound) * maxAbsScale = gamma/2 * maxAbsScale`.

**Nonlinear ops -- `5 * epsilon * maxAbsScale`**: Per-operation rounding through div, sqrt, reciprocal, and two multiplications. Since `|y| <= maxAbsScale` under the same normalization assumption, each op contributes `epsilon * maxAbsScale`. `NONLINEAR_OPS_UPPER_BOUND = 5` is an upper bound; hardware rsqrt fusion may produce fewer rounding errors in practice.

**Bias -- `maxAbsBias * epsilon`**: Rounding error from the optional bias addition. When absent, `biasMin`/`biasMax` default to 0 and this term vanishes naturally.

**Output casting -- `maxOutputMagnitude * outputEpsilon`**: Where `maxOutputMagnitude = maxAbsScale + maxAbsBias` (since normalization bounds `|x/RMS| <= 1`). When `maxAbsX == 0`, reduces to `maxAbsBias`. Applies only when `OutputType` has lower precision than `ComputeType`.

Safety: throws `overflow_error` if `gamma >= 0.5` (accumulation error exceeds 50% of signal) or if the tolerance exceeds `numeric_limits<OutputType>::max()`.

## Test Plan

**Tolerance formula validation** (`TestDynamicTolerancesRMSNorm.cpp`):
- 7 type combinations tested via parameterized `TEST_P` suites with hand-computed expected values: float/float/float, float/double/float, half/float/float, half/half/half, bfloat16/float/float, bfloat16/bfloat16/bfloat16, float/half/float
- Each suite covers: invalid input (throws), small C, large C, scaled ranges, and bias variants

**Functional validation** (`TestDynamicTolerancesRMSNorm.cpp`):
- `DetectsFailure`: computed tolerance accepts small perturbations, rejects large ones via `allClose`
- `ThrowsOnSingularity`: verifies `gamma >= 0.5` check at extreme C values
- `ThrowsOnOutputOverflow`: verifies overflow check when tolerance exceeds `OutputType::max()`
- `ZeroInput`: `x=0` produces tolerance 0 (no bias) or `max|bias| * u` (with bias)
- `ToleranceScalesWithChannels`: FP32 ratio C100/C1 > 10 (~C growth), BF16 ratio C10/C1 > 1.5 (~sqrt(C) growth, C=50 upper bound)

**Integration tests** (`TestRMSNormFwdPlan.cpp`):
- `ExecutePlan` and `ExecutePlanWithBias` now use `calculateRMSNormFwdTolerance<>()` instead of hardcoded `1e-5f`

