### PR TITLE
[CK][CK_Tile] Revert PR 5181

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -180,11 +180,6 @@
 /projects/rocthrust/**/.readthedocs.yaml            @ROCm/prims-rands-reviewers @ROCm/prims-docs-reviewers
 /projects/rocthrust/docs/                           @ROCm/prims-rands-reviewers @ROCm/prims-docs-reviewers
 
-/projects/composablekernel/**/*.md                  @ROCm/prims-rands-reviewers @ROCm/ck-docs-reviewers
-/projects/composablekernel/**/*.rst                 @ROCm/prims-rands-reviewers @ROCm/ck-docs-reviewers
-/projects/composablekernel/**/.readthedocs.yaml     @ROCm/prims-rands-reviewers @ROCm/ck-docs-reviewers
-/projects/composablekernel/docs/                    @ROCm/prims-rands-reviewers @ROCm/ck-docs-reviewers
-
 /shared/tensile/**/*.md                             @ROCm/tensile-reviewers @ROCm/tensile-docs-reviewers
 /shared/tensile/**/*.rst                            @ROCm/tensile-reviewers @ROCm/tensile-docs-reviewers
 /shared/tensile/**/.readthedocs.yaml                @ROCm/tensile-reviewers @ROCm/tensile-docs-reviewers


### PR DESCRIPTION
## Motivation

This PR reverts the changes in https://github.com/ROCm/rocm-libraries/pull/5181, which modified the code owners file to include specific groups to review certain CK-related documentation. One such group was prims-rands-reviewers. However, this change requires prims-rands-reviewers to approve any PR that alters CK-related docs, which will increase the time it takes for CK changes to be merged. As a temporary solution, we have opted to revert this PR.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
