### PR TITLE
Fix: propagate YAML param type-mismatch warnings across joblib worker processes

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/ClientWriter.py
+++ b/projects/hipblaslt/tensilelite/Tensile/ClientWriter.py
@@ -128,14 +128,15 @@ def main(config, assembler: Assembler, cCompiler: str, isaInfoMap, outputPath: P
   printSolutionRejectionReason = True
   printIndexAssignmentInfo = False
   for logicFileName in logicFiles:
-    (scheduleName, _, problemType, _, exactLogic, newLibrary) \
-        = LibraryIO.parseLibraryLogicFile(logicFileName,
-                                          assembler,
-                                          splitGSU,
-                                          printSolutionRejectionReason,
-                                          printIndexAssignmentInfo,
-                                          isaInfoMap,
-                                          globalParameters["LazyLibraryLoading"])
+    logic = LibraryIO.parseLibraryLogicFile(logicFileName,
+                                            assembler,
+                                            splitGSU,
+                                            printSolutionRejectionReason,
+                                            printIndexAssignmentInfo,
+                                            isaInfoMap,
+                                            globalParameters["LazyLibraryLoading"])
+    scheduleName, problemType, exactLogic, newLibrary = \
+        logic.schedule, logic.problemType, logic.exactLogic, logic.library
     functions.append((scheduleName, problemType))
     functionNames.append("tensile_%s" % (problemType))
     problemSizes = ProblemSizesMock(exactLogic) if exactLogic else ProblemSizesMockDummy()

--- a/projects/hipblaslt/tensilelite/Tensile/LibraryIO.py
+++ b/projects/hipblaslt/tensilelite/Tensile/LibraryIO.py
@@ -32,6 +32,7 @@ from Tensile.Common import printExit, printWarning, print2, \
 from Tensile.Common.TimingInstrumentation import timing_context
 from Tensile.Common.Architectures import gfxToIsa
 from Tensile.SolutionStructs import Solution, ProblemSizes
+from Tensile.SolutionStructs.Solution import getTypeMismatchCollector, resetTypeMismatchCollector
 from Tensile.SolutionStructs.Problem import ProblemType, problemTypeToEnum
 
 from typing import IO, NamedTuple, List, Dict, Optional
@@ -325,6 +326,7 @@ class LibraryLogic(NamedTuple):
     solutions: list
     exactLogic: list
     library: SolutionLibrary.MasterSolutionLibrary
+    typeMismatches: dict = {}
 
 def parseLibraryLogicFile(
         filename,
@@ -435,7 +437,9 @@ def parseLibraryLogicData(
                          )
         return solutionObject
 
+    resetTypeMismatchCollector()
     solutions = [solutionStateToSolution(solutionState, assembler, isaInfoMap) for solutionState in data["Solutions"]]
+    typeMismatches = getTypeMismatchCollector()
 
     newLibrary, _ = SolutionLibrary.MasterSolutionLibrary.FromOriginalState(
         data,
@@ -450,7 +454,7 @@ def parseLibraryLogicData(
     )
 
     return LibraryLogic(data["ScheduleName"], data["ArchitectureName"], problemType, solutions, \
-            data.get("ExactLogic"), newLibrary)
+            data.get("ExactLogic"), newLibrary, typeMismatches)
 
 
 def parseLibraryLogicList(data, srcFile="?"):

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -99,6 +99,31 @@ def resetTypeMismatchCollector():
   _typeMismatchCollector.clear()
 
 
+def getTypeMismatchCollector():
+  """Return a copy of the current collector state.
+
+  Used by worker processes to return their collected mismatch data to the
+  main process after parallel YAML parsing.
+  """
+  return {k: {"count": v["count"], "values": set(v["values"]), "files": set(v["files"])}
+          for k, v in _typeMismatchCollector.items()}
+
+
+def mergeTypeMismatchCollector(data):
+  """Merge mismatch data returned from a worker process into the main collector.
+
+  Args:
+      data: A dict in the same format as ``_typeMismatchCollector``, as
+            returned by ``getTypeMismatchCollector()`` in a worker process.
+  """
+  for key, entry in data.items():
+    if key not in _typeMismatchCollector:
+      _typeMismatchCollector[key] = {"count": 0, "values": set(), "files": set()}
+    _typeMismatchCollector[key]["count"] += entry["count"]
+    _typeMismatchCollector[key]["values"] |= entry["values"]
+    _typeMismatchCollector[key]["files"] |= entry["files"]
+
+
 def validateParameterTypes(state, srcFile=""):
   """Validate that every solution parameter has the correct Python type.
 
@@ -139,18 +164,24 @@ def validateParameterTypes(state, srcFile=""):
         entry["files"].add(srcFile)
 
 
-def printTypeMismatchSummary():
-  """Print a summary of all collected type mismatches to stderr.
+def printTypeMismatchSummary(numFiles=0):
+  """Print a summary of all collected type mismatches.
 
-  If no mismatches have been collected, this function prints nothing and
-  returns 0.  Otherwise it emits a WARNING block to stderr with one line
-  per unique (parameter, actual_type) combination showing the count,
-  observed values, and expected type.
+  If no mismatches have been collected, prints a confirmation message
+  showing how many files were checked cleanly, and returns 0.  Otherwise
+  it emits a WARNING block with one line per unique (parameter,
+  actual_type) combination showing the count, observed values, and
+  expected type.
+
+  Args:
+      numFiles: Total number of YAML logic files that were checked.
 
   Returns:
       int: The total number of individual mismatches (0 if clean).
   """
   if not _typeMismatchCollector:
+    if numFiles > 0:
+      print(f"Checked {numFiles} YAML logic files - no type mismatches found.", flush=True)
     return 0
 
   totalCount = sum(e["count"] for e in _typeMismatchCollector.values())
@@ -174,7 +205,7 @@ def printTypeMismatchSummary():
     valuesStr = ", ".join(sorted(entry["values"]))
     lines.append(
       f"  {paramName}: found {actualType} in {entry['count']} solutions "
-      f"(values: {valuesStr}) — expected {expectedStr}"
+      f"(values: {valuesStr}) - expected {expectedStr}"
     )
 
   lines.append("-----------------------------------------------------------")
@@ -183,7 +214,7 @@ def printTypeMismatchSummary():
   lines.append("  Fix these to prevent future build failures.")
   lines.append("===========================================================")
 
-  print("\n".join(lines), file=sys.stderr)
+  print("\n".join(lines), flush=True)
   return totalCount
 
 

--- a/projects/hipblaslt/tensilelite/Tensile/TensileCreateLibrary/Run.py
+++ b/projects/hipblaslt/tensilelite/Tensile/TensileCreateLibrary/Run.py
@@ -68,7 +68,7 @@ from Tensile.KernelWriterBase import (
 )
 from Tensile.SolutionLibrary import MasterSolutionLibrary
 from Tensile.SolutionStructs import Solution
-from Tensile.SolutionStructs.Solution import printTypeMismatchSummary
+from Tensile.SolutionStructs.Solution import mergeTypeMismatchCollector, printTypeMismatchSummary
 from Tensile.Toolchain.Assembly import makeAssemblyToolchain, buildAssemblyCodeObjectFiles
 from Tensile.Toolchain.Source import makeSourceToolchain, buildSourceCodeObjectFiles
 from Tensile.Toolchain.Validators import (
@@ -653,7 +653,8 @@ def generateLogicDataAndSolutions(logicFiles, args, assembler: Assembler, isaInf
     for library in ParallelMap2(
         LibraryIO.parseLibraryLogicFile, fIter, "Loading Logics...", return_as="generator_unordered"
     ):
-        _, architectureName, _, _, _, newLibrary = library
+        _, architectureName, _, _, _, newLibrary, typeMismatches = library
+        mergeTypeMismatchCollector(typeMismatches)
 
         if architectureName == "":
             continue
@@ -666,7 +667,7 @@ def generateLogicDataAndSolutions(logicFiles, args, assembler: Assembler, isaInf
 
     # After all YAML files have been parsed and Solution objects created,
     # print a summary of any type mismatches that were collected.
-    printTypeMismatchSummary()
+    printTypeMismatchSummary(len(logicFiles))
 
     # Sort masterLibraries to make global soln index values deterministic
     solnReIndex = 0

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_validateParameterTypes.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_validateParameterTypes.py
@@ -295,58 +295,65 @@ class TestPrintTypeMismatchSummary:
         result = printTypeMismatchSummary()
         assert result == 3
 
-    def test_outputs_warning_to_stderr(self, capsys):
-        """Summary should be printed to stderr, not stdout."""
+    def test_outputs_warning_to_stdout(self, capsys):
+        """Summary should be printed to stdout so it appears in build logs."""
         validateParameterTypes({"UseCustomMainLoopSchedule": False}, srcFile="test.yaml")
         printTypeMismatchSummary()
         captured = capsys.readouterr()
-        assert captured.out == ""
-        assert "WARNING" in captured.err
+        assert captured.err == ""
+        assert "WARNING" in captured.out
 
     def test_output_contains_param_name(self, capsys):
         validateParameterTypes({"UseCustomMainLoopSchedule": False})
         printTypeMismatchSummary()
         captured = capsys.readouterr()
-        assert "UseCustomMainLoopSchedule" in captured.err
+        assert "UseCustomMainLoopSchedule" in captured.out
 
     def test_output_contains_actual_type(self, capsys):
         validateParameterTypes({"UseCustomMainLoopSchedule": False})
         printTypeMismatchSummary()
         captured = capsys.readouterr()
-        assert "bool" in captured.err
+        assert "bool" in captured.out
 
     def test_output_contains_expected_type(self, capsys):
         validateParameterTypes({"UseCustomMainLoopSchedule": False})
         printTypeMismatchSummary()
         captured = capsys.readouterr()
-        assert "int" in captured.err
+        assert "int" in captured.out
 
     def test_output_contains_solution_count(self, capsys):
         validateParameterTypes({"UseCustomMainLoopSchedule": False}, srcFile="a.yaml")
         validateParameterTypes({"UseCustomMainLoopSchedule": True}, srcFile="b.yaml")
         printTypeMismatchSummary()
         captured = capsys.readouterr()
-        assert "2 solutions" in captured.err
+        assert "2 solutions" in captured.out
 
     def test_output_contains_file_count(self, capsys):
         validateParameterTypes({"UseCustomMainLoopSchedule": False}, srcFile="a.yaml")
         validateParameterTypes({"UseCustomMainLoopSchedule": True}, srcFile="b.yaml")
         printTypeMismatchSummary()
         captured = capsys.readouterr()
-        assert "2 files" in captured.err
+        assert "2 files" in captured.out
 
     def test_output_contains_fix_message(self, capsys):
         validateParameterTypes({"UseCustomMainLoopSchedule": False})
         printTypeMismatchSummary()
         captured = capsys.readouterr()
-        assert "Fix these to prevent future build failures" in captured.err
+        assert "Fix these to prevent future build failures" in captured.out
 
-    def test_no_output_when_clean(self, capsys):
-        """When there are no mismatches, nothing should be printed."""
+    def test_no_output_when_clean_no_files(self, capsys):
+        """When there are no mismatches and no files, nothing should be printed."""
         printTypeMismatchSummary()
         captured = capsys.readouterr()
         assert captured.out == ""
         assert captured.err == ""
+
+    def test_clean_message_when_no_mismatches(self, capsys):
+        """When files were checked but no mismatches found, print confirmation."""
+        printTypeMismatchSummary(numFiles=42)
+        captured = capsys.readouterr()
+        assert "42" in captured.out
+        assert "no type mismatches found" in captured.out
 
     def test_multiple_param_types_in_output(self, capsys):
         """Multiple different mismatched params should all appear in output."""
@@ -354,5 +361,5 @@ class TestPrintTypeMismatchSummary:
         validateParameterTypes({"BufferLoad": 0})
         printTypeMismatchSummary()
         captured = capsys.readouterr()
-        assert "UseCustomMainLoopSchedule" in captured.err
-        assert "BufferLoad" in captured.err
+        assert "UseCustomMainLoopSchedule" in captured.out
+        assert "BufferLoad" in captured.out


### PR DESCRIPTION
## Problem

`validateParameterTypes` accumulates type mismatches (e.g. bool used where int
is expected) into a module-level dict `_typeMismatchCollector` in
`SolutionStructs/Solution.py`, and `printTypeMismatchSummary` is meant to print
a human-readable WARNING at the end of `TensileCreateLibrary`.

Two bugs prevented this from working:

1. **Parallel isolation** – `TensileCreateLibrary` parses YAML logic files via
   `ParallelMap2`, which uses `joblib.Parallel` with the loky backend (separate
   processes). Module-level state is not shared across process boundaries, so
   all mismatches collected inside worker processes were silently discarded; the
   main process collector remained empty and `printTypeMismatchSummary` produced
   no output.

2. **stderr vs stdout** – Even after fixing (1), output was written to
   `sys.stderr`. Because CMake's `USES_TERMINAL` directive gives the subprocess
   direct terminal access, `| tee` in the install script only captures stdout;
   stderr output bypassed the log file entirely.

## Solution

* **`SolutionStructs/Solution.py`**: Add `getTypeMismatchCollector()` (returns
  a deep copy of the worker's collector) and `mergeTypeMismatchCollector(data)`
  (merges a worker copy into the main-process collector). Change
  `printTypeMismatchSummary` to print to `sys.stdout` with `flush=True` so
  output is captured by `| tee` and appears in build logs.

* **`LibraryIO.py`**: Add a `typeMismatches: dict = {}` field to the
  `LibraryLogic` NamedTuple. In `parseLibraryLogicData`, reset the collector
  before parsing solutions and capture it afterwards, storing the result in the
  new field so it travels back to the main process with the return value.

* Print a confirmation message ("Checked N YAML logic files — no type
  mismatches found.") when all files are clean, so the build log always
  contains evidence that the check ran.

* **`TensileCreateLibrary/Run.py`**: After each `parseLibraryLogicFile` result
  is returned by the generator, unpack `typeMismatches` and call
  `mergeTypeMismatchCollector`. After the loop, call `printTypeMismatchSummary`
  once so the aggregated WARNING appears in the build output.

* **`Tests/unit/test_validateParameterTypes.py`**: Update eight tests that
  asserted output on `captured.err` to assert on `captured.out`, matching the
  new stdout destination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)