### PR TITLE
[rocm-libraries] Fixing CMake lint pre-commit check that fails on Windows

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -1,3 +1,5 @@
+import platform
+
 with section("parse"):
     additional_commands = {
         "rocm_create_package": {
@@ -20,4 +22,7 @@ with section("markup"):
     first_comment_is_literal = True
 
 with section("lint"):
-    disabled_codes = ["C0103", "C0301", "C0327", "W0106"]
+    # Disable line ending check (C0327) on Windows where CRLF is expected
+    disabled_codes = ["C0103", "C0301", "W0106"]
+    if platform.system() == "Windows":
+        disabled_codes.append("C0327")

--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -20,4 +20,4 @@ with section("markup"):
     first_comment_is_literal = True
 
 with section("lint"):
-    disabled_codes = ["C0103", "C0301", "W0106"]
+    disabled_codes = ["C0103", "C0301", "C0327", "W0106"]


### PR DESCRIPTION
## Motivation
A developer using pre-commit on a Windows machine will frequently run into an error whenever CMakeLists.txt get changed, that the line endings are wrong.  And yes, they don't match Linux (CRLF vs. LF).  However, git manages that for you OOTB, and you don't really need to worry about it.

## Technical Details
- Eliminate line-ending warnings in Windows

## Test Plan
- Tested on Windows with `pre-commit run --files ./projects/hipdnn/CMakeLists.txt`

## Test Result
- CMake lint no longer complains

## Submission Checklist
- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
