### PR TITLE
[hipSPARSELt] Fix: add null terminator to the return value of hipsparseLtGetArchName()

### DIFF
--- a/projects/hipsparselt/library/src/hcc_detail/hipsparselt.cpp
+++ b/projects/hipsparselt/library/src/hcc_detail/hipsparselt.cpp
@@ -945,8 +945,8 @@ try
 {
     *archName = nullptr;
     auto arch = rocsparselt_internal_get_arch_name();
-    *archName = (char*)malloc(arch.size() * sizeof(char));
-    strncpy(*archName, arch.c_str(), arch.size());
+    *archName = (char*)malloc((arch.size() + 1) * sizeof(char));
+    strcpy(*archName, arch.c_str());
     return HIPSPARSE_STATUS_SUCCESS;
 }
 catch(...)


### PR DESCRIPTION
ASAN detected a heap overflow. The issue was caused by the return value missing a null terminator ('\0')

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
