### PR TITLE
feat(rocprim): add typetrait definitions for '__hip_bfloat16'

### DIFF
--- a/projects/rocprim/CHANGELOG.md
+++ b/projects/rocprim/CHANGELOG.md
@@ -4,6 +4,10 @@ Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projec
 
 ## rocPRIM 4.4.0 for ROCm 7.13
 
+### Added
+
+* Added type trait definitions for `__hip_bfloat16`. This should resolve issues where this type did not work with radix-based algorithms.
+
 ### Changed
 
 * Building benchmarks on Windows is not currently possible because of the dependency on AMD SMI. 

--- a/projects/rocprim/rocprim/include/rocprim/type_traits.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/type_traits.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -1154,15 +1154,23 @@ struct get
     /// float, double);
     constexpr bool is_build_in() const
     {
-        return std::is_same<T, bool>::value || std::is_same<T, char>::value
-               || std::is_same<T, unsigned char>::value || std::is_same<T, short>::value
-               || std::is_same<T, unsigned short>::value || std::is_same<T, int>::value
-               || std::is_same<T, unsigned int>::value || std::is_same<T, long long>::value
-               || std::is_same<T, unsigned long long>::value
-               || std::is_same<T, rocprim::int128_t>::value
-               || std::is_same<T, rocprim::uint128_t>::value
-               || std::is_same<T, rocprim::half>::value || std::is_same<T, float>::value
-               || std::is_same<T, rocprim::bfloat16>::value || std::is_same<T, double>::value;
+        return ::rocprim::detail::variadic_list<
+            bool,
+            char,
+            unsigned char,
+            short,
+            unsigned short,
+            int,
+            unsigned int,
+            long long,
+            unsigned long long,
+            float,
+            double,
+            rocprim::int128_t,
+            rocprim::uint128_t,
+            rocprim::half,
+            rocprim::bfloat16,
+            __hip_bfloat16>::any([](auto t) { return std::is_same_v<decltype(t), T>; });
     }
 
     /// \brief If `T` is fundamental type, then returns `false`.
@@ -1270,6 +1278,24 @@ struct traits::define<double>
 template<>
 struct traits::define<rocprim::bfloat16>
 {
+    /// \brief Trait `is_arithmetic` for this type
+    using is_arithmetic = traits::is_arithmetic::values<true>;
+    /// \brief Trait `number_format` for this type
+    using number_format
+        = traits::number_format::values<traits::number_format::kind::floating_point_type>;
+    /// \brief Trait `float_bit_mask` for this type
+    using float_bit_mask = traits::float_bit_mask::values<uint16_t, 0x8000, 0x7F80, 0x007F>;
+};
+
+/// \brief This is the definition of traits of `__hip_bfloat16`
+/// HIP arithmetic type
+template<>
+struct traits::define<__hip_bfloat16>
+{
+    // Note: __hip_bfloat16 is included from <hip/hip_bf16.h> whilst rocprim::bfloat16
+    // (hip_bfloat16) is included from <hip/hip_bfloat16.h>. These two types are
+    // distinctly different!
+
     /// \brief Trait `is_arithmetic` for this type
     using is_arithmetic = traits::is_arithmetic::values<true>;
     /// \brief Trait `number_format` for this type

--- a/projects/rocprim/rocprim/include/rocprim/type_traits_functions.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/type_traits_functions.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -273,8 +273,7 @@ struct is_tuple_of_references<::rocprim::tuple<Args...>>
 private:
     template<size_t Index>
     ROCPRIM_HOST_DEVICE
-    static constexpr
-        typename std::enable_if<(Index < sizeof...(Args)), bool>::type is_tuple_of_references_impl()
+    static constexpr std::enable_if_t<(Index < sizeof...(Args)), bool> is_tuple_of_references_impl()
     {
         using tuple_t   = ::rocprim::tuple<Args...>;
         using element_t = ::rocprim::tuple_element_t<Index, tuple_t>;
@@ -283,7 +282,7 @@ private:
 
     template<size_t Index>
     ROCPRIM_HOST_DEVICE
-    static constexpr typename std::enable_if<(Index == sizeof...(Args)), bool>::type
+    static constexpr std::enable_if_t<(Index == sizeof...(Args)), bool>
         is_tuple_of_references_impl()
     {
         return true;
@@ -543,14 +542,33 @@ template<typename T>
 struct word_type<const volatile T> : word_type<T>
 {};
 
-} // namespace detail
-
-namespace detail
-{
 template<typename Destination, typename Source>
 constexpr bool is_valid_bit_cast
     = sizeof(Destination) == sizeof(Source) && std::is_trivially_copyable<Destination>::value
       && std::is_trivially_copyable<Source>::value;
+
+/// \brief Utility to apply functions over multiple types.
+template<class... Ts>
+struct variadic_list
+{
+    /// \brief Applies predicate `f` over `Ts` and returns if any is true.
+    template<class F>
+    static constexpr bool any(F f)
+    {
+        return (f(Ts{}) || ...);
+    }
+
+    /// \brief Applies predicate `f` over `Ts` type and returns if all is true.
+    template<class F>
+    static constexpr bool all(F f)
+    {
+        return (f(Ts{}) && ...);
+    }
+};
+static_assert(variadic_list<short, int>::all([](auto t)
+                                             { return std::is_integral_v<decltype(t)>; }));
+static_assert(variadic_list<float, int>::any([](auto t)
+                                             { return std::is_integral_v<decltype(t)>; }));
 } // namespace detail
 
 END_ROCPRIM_NAMESPACE

--- a/projects/rocprim/rocprim/include/rocprim/types.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/types.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -23,6 +23,8 @@
 
 #include <type_traits>
 
+#include <hip/hip_bf16.h>
+#include <hip/hip_bfloat16.h>
 #include <hip/hip_vector_types.h>
 
 // Meta configuration for rocPRIM

--- a/projects/rocprim/scripts/copyright-date/check-copyright.sh
+++ b/projects/rocprim/scripts/copyright-date/check-copyright.sh
@@ -73,6 +73,9 @@ fi
 # Current year
 year="$(date +%Y)"
 
+# Change working directory to git root
+cd "$(git rev-parse --show-toplevel)"
+
 # Enable rename detection with full matches only, this skips copyright checks for file name only
 # changes.
 diff_opts=(-z --name-only '--diff-filter=MA' '--find-renames=100%')

--- a/projects/rocprim/test/rocprim/test_radix_key_codec.cpp
+++ b/projects/rocprim/test/rocprim/test_radix_key_codec.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -57,6 +57,12 @@ std::ostream& operator<<(std::ostream& os, const extract_digit_params& params)
     sstream << "{ start: " << params.start << ", radix_bits: " << params.radix_bits
             << ", expected_result: 0x" << std::hex << params.expected_result << " }";
     return os << sstream.str();
+}
+
+inline std::ostream& operator<<(std::ostream& stream, const __hip_bfloat16& value)
+{
+    stream << static_cast<float>(value);
+    return stream;
 }
 
 class RadixKeyCodecTest : public ::testing::TestWithParam<extract_digit_params>
@@ -321,7 +327,8 @@ using TypedRadixKeyCodecTestTypes
                        TypedRadixKeyCodecTestParams<rocprim::half>,
                        TypedRadixKeyCodecTestParams<rocprim::bfloat16>,
                        TypedRadixKeyCodecTestParams<float>,
-                       TypedRadixKeyCodecTestParams<double>>;
+                       TypedRadixKeyCodecTestParams<double>,
+                       TypedRadixKeyCodecTestParams<__hip_bfloat16>>;
 
 TYPED_TEST_SUITE(TypedRadixKeyCodecTest, TypedRadixKeyCodecTestTypes);
 

--- a/projects/rocprim/test/rocprim/test_type_traits_interface.cpp
+++ b/projects/rocprim/test/rocprim/test_type_traits_interface.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -138,8 +138,12 @@ class RocprimFloatingPointTests : public ::testing::Test
 public:
     using input_type = Params;
 };
-using FloatingPointTypeTestParams = ::testing::
-    Types<rocprim::half, rocprim::bfloat16, float, double, type_traits_test::custom_float_type>;
+using FloatingPointTypeTestParams = ::testing::Types<rocprim::half,
+                                                     rocprim::bfloat16,
+                                                     float,
+                                                     double,
+                                                     type_traits_test::custom_float_type,
+                                                     __hip_bfloat16>;
 
 template<class Params>
 class RocprimIntegralTests : public ::testing::Test

--- a/projects/rocprim/test/rocprim/test_utils_data_generation.hpp
+++ b/projects/rocprim/test/rocprim/test_utils_data_generation.hpp
@@ -365,8 +365,9 @@ auto make_distribution(U min, V max)
 {
     if constexpr(rocprim::is_floating_point<T>::value)
     {
-        using dis_type = typename std::conditional<std::is_same<rocprim::half, T>::value
-                                                       || std::is_same<rocprim::bfloat16, T>::value,
+        using dis_type = typename std::conditional<std::is_same_v<rocprim::half, T>
+                                                       || std::is_same_v<rocprim::bfloat16, T>
+                                                       || std::is_same_v<__hip_bfloat16, T>,
                                                    float,
                                                    T>::type;
         return std::uniform_real_distribution<dis_type>(static_cast<dis_type>(min),

--- a/projects/rocprim/test/rocprim/test_utils_data_generation.hpp
+++ b/projects/rocprim/test/rocprim/test_utils_data_generation.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -147,6 +147,37 @@ public:
         return bfloat16(std::numeric_limits<float>::signaling_NaN());
     };
 };
+
+template<>
+struct numeric_limits<__hip_bfloat16> : std::numeric_limits<__hip_bfloat16>
+{
+public:
+    static inline __hip_bfloat16 max()
+    {
+        return __hip_bfloat16(std::numeric_limits<float>::max() * 0.998);
+    };
+    static inline __hip_bfloat16 min()
+    {
+        return __hip_bfloat16(std::numeric_limits<float>::min());
+    };
+    static inline __hip_bfloat16 lowest()
+    {
+        return __hip_bfloat16(std::numeric_limits<float>::lowest() * 0.998);
+    };
+    static inline __hip_bfloat16 infinity()
+    {
+        return __hip_bfloat16(std::numeric_limits<float>::infinity());
+    };
+    static inline __hip_bfloat16 quiet_NaN()
+    {
+        return __hip_bfloat16(std::numeric_limits<float>::quiet_NaN());
+    };
+    static inline __hip_bfloat16 signaling_NaN()
+    {
+        return __hip_bfloat16(std::numeric_limits<float>::signaling_NaN());
+    };
+};
+
 // End of extended numeric_limits
 
 END_ROCPRIM_NAMESPACE


### PR DESCRIPTION
## Motivation

Closes https://github.com/ROCm/rocm-libraries/issues/5325.

## Technical Details

* Adds type trait definitions for `__hip_bfloat16` (included via `<hip/hip_bf16.h>`).
* Adds utility to fold predicates over variadic list, since the `... || std::is_same_v<...`-construct is really ugly.
* Updates test
* Updates copyright checker script because I got annoyed.

This is implemented by copying the trait definitons for `hip_bfloat16` (i.e. `rocprim::bfloat16`) to a new specialization for `__hip_bfloat16`. No new type alias for `__hip_bfloat16` will be provided as investigating the performance differences between the two types is currently out-of-scope.

## Test Plan

Tests have been modified to include this type.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
