### PR TITLE
[MIOpen] Removed -Wno-float-equal and fixed the warnings associated with it

### DIFF
--- a/projects/miopen/cmake/EnableCompilerWarnings.cmake
+++ b/projects/miopen/cmake/EnableCompilerWarnings.cmake
@@ -52,7 +52,6 @@ set(__clang_cxx_compile_options
     -Wno-exit-time-destructors
     -Wno-extra-semi
     -Wno-extra-semi-stmt
-    -Wno-float-conversion
     -Wno-gnu-anonymous-struct
     -Wno-gnu-zero-variadic-macro-arguments
     -Wno-missing-prototypes
@@ -78,7 +77,6 @@ set(__clang_cxx_compile_options
     -Wno-microsoft-enum-value
     -Wno-language-extension-token
     -Wno-c++11-narrowing
-    -Wno-float-equal
     -Wno-redundant-parens
     -Wno-format-nonliteral
     -Wno-unused-template

--- a/projects/miopen/driver/adam_driver.hpp
+++ b/projects/miopen/driver/adam_driver.hpp
@@ -96,7 +96,7 @@ void mloAdamRunHost(miopenTensorDescriptor_t paramDesc,
         if(is_amp)
             grad *= inv_grad_scale;
 
-        if(!miopen::float_equal(weight_decay, 0))
+        if(!miopen::float_equal_sentinel(weight_decay, 0))
         {
             if(adamw)
                 param *= one_minus_lr_by_weight_decay;

--- a/projects/miopen/driver/adam_driver.hpp
+++ b/projects/miopen/driver/adam_driver.hpp
@@ -34,6 +34,7 @@
 
 #include "../test/verify.hpp"
 
+#include <miopen/float_equal.hpp>
 #include <miopen/ford.hpp>
 #include <miopen/miopen.h>
 #include <miopen/tensor.hpp>
@@ -95,7 +96,7 @@ void mloAdamRunHost(miopenTensorDescriptor_t paramDesc,
         if(is_amp)
             grad *= inv_grad_scale;
 
-        if(weight_decay != 0)
+        if(!miopen::float_equal(weight_decay, 0))
         {
             if(adamw)
                 param *= one_minus_lr_by_weight_decay;

--- a/projects/miopen/driver/cat_driver.hpp
+++ b/projects/miopen/driver/cat_driver.hpp
@@ -335,7 +335,7 @@ int CatDriver<Tgpu, Tref>::VerifyForward()
     const auto error     = miopen::rms_range(outhost, out);
     const char* pRefType = use_multithread ? "multi-threaded" : "single-threaded";
 
-    if(!std::isfinite(error) || !miopen::float_equal(error, 0))
+    if(!std::isfinite(error) || !miopen::float_equal_sentinel(error, 0))
     {
         std::cout << "Forward Cat FAILED against " << pRefType << " CPU reference: " << error
                   << " > 0" << std::endl;

--- a/projects/miopen/driver/cat_driver.hpp
+++ b/projects/miopen/driver/cat_driver.hpp
@@ -14,6 +14,7 @@
 #include <cstdlib>
 #include <memory>
 #include <miopen/miopen.h>
+#include <miopen/float_equal.hpp>
 #include <miopen/tensor.hpp>
 #include <numeric>
 #include <vector>
@@ -334,7 +335,7 @@ int CatDriver<Tgpu, Tref>::VerifyForward()
     const auto error     = miopen::rms_range(outhost, out);
     const char* pRefType = use_multithread ? "multi-threaded" : "single-threaded";
 
-    if(!std::isfinite(error) || error != 0)
+    if(!std::isfinite(error) || !miopen::float_equal(error, 0))
     {
         std::cout << "Forward Cat FAILED against " << pRefType << " CPU reference: " << error
                   << " > 0" << std::endl;

--- a/projects/miopen/src/include/miopen/float_equal.hpp
+++ b/projects/miopen/src/include/miopen/float_equal.hpp
@@ -59,6 +59,31 @@ struct float_equal_fn
 
 static constexpr float_equal_fn float_equal{};
 
+/// Special case for comparing with a sentinel value
+struct float_equal_sentinel_fn
+{
+    template <class T>
+    static bool apply(T x, T y)
+    {
+// In this case we have to ignore this warning, because we intend to compare with the exact value
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wfloat-equal"
+        bool equals_sentinel = x == y;
+#pragma clang diagnostic pop
+
+        return std::isfinite(static_cast<double>(x)) and std::isfinite(static_cast<double>(y)) and
+               equals_sentinel;
+    }
+
+    template <class T, class U>
+    bool operator()(T x, U y) const
+    {
+        return float_equal_sentinel_fn::apply<common_type<T, U>>(x, y);
+    }
+};
+
+static constexpr float_equal_sentinel_fn float_equal_sentinel{};
+
 } // namespace miopen
 
 #endif

--- a/projects/miopen/src/include/miopen/utility/modified_z.hpp
+++ b/projects/miopen/src/include/miopen/utility/modified_z.hpp
@@ -30,6 +30,7 @@
 #include <algorithm>
 #include <numeric>
 #include <miopen/errors.hpp>
+#include <miopen/float_equal.hpp>
 
 namespace miopen {
 
@@ -94,7 +95,7 @@ std::vector<T> modifiedZScores(const std::vector<T>& sortedData)
     T mad                             = median(absolute_deviation);
 
     // If MAD is 0, then we cannot calcualte the ModifiedZScore
-    if(mad == T{0})
+    if(miopen::float_equal(mad, T{0}))
     {
         return std::vector<T>(sortedData.size(), 0);
     }

--- a/projects/miopen/src/include/miopen/utility/modified_z.hpp
+++ b/projects/miopen/src/include/miopen/utility/modified_z.hpp
@@ -95,7 +95,7 @@ std::vector<T> modifiedZScores(const std::vector<T>& sortedData)
     T mad                             = median(absolute_deviation);
 
     // If MAD is 0, then we cannot calcualte the ModifiedZScore
-    if(miopen::float_equal(mad, T{0}))
+    if(miopen::float_equal_sentinel(mad, T{0}))
     {
         return std::vector<T>(sortedData.size(), 0);
     }

--- a/projects/miopen/test/cpu_adam.hpp
+++ b/projects/miopen/test/cpu_adam.hpp
@@ -83,7 +83,7 @@ void cpu_adam(tensor<T1>& params,
             const float bias_correction1 = 1.0 - pow(beta1, step);
             const float bias_correction2 = 1.0 - pow(beta2, step);
 
-            if(!miopen::float_equal(weight_decay, 0.f))
+            if(!miopen::float_equal_sentinel(weight_decay, 0.f))
             {
                 if(adamw)
                     param *= one_minus_lr_by_weight_decay;

--- a/projects/miopen/test/cpu_adam.hpp
+++ b/projects/miopen/test/cpu_adam.hpp
@@ -28,6 +28,8 @@
 
 #include "tensor_holder.hpp"
 
+#include <miopen/float_equal.hpp>
+
 template <typename T1, typename T2>
 void cpu_adam(tensor<T1>& params,
               tensor<T2>& grads,
@@ -81,7 +83,7 @@ void cpu_adam(tensor<T1>& params,
             const float bias_correction1 = 1.0 - pow(beta1, step);
             const float bias_correction2 = 1.0 - pow(beta2, step);
 
-            if(weight_decay != 0)
+            if(!miopen::float_equal(weight_decay, 0.f))
             {
                 if(adamw)
                     param *= one_minus_lr_by_weight_decay;

--- a/projects/miopen/test/gtest/tensor_2d_lite_ocl_hip.cpp
+++ b/projects/miopen/test/gtest/tensor_2d_lite_ocl_hip.cpp
@@ -258,7 +258,7 @@ protected:
     {
         auto error = miopen::rms_range(tensC_ocl, tensC_hip);
         EXPECT_TRUE(miopen::float_equal_sentinel(error, 0.f))
-            << "GPU outputs do not match each other. Error: " << error;
+            << "OCL and HIP GPU outputs are expected to be identical. Error: " << error;
     }
 
     void TearDown() override

--- a/projects/miopen/test/gtest/tensor_2d_lite_ocl_hip.cpp
+++ b/projects/miopen/test/gtest/tensor_2d_lite_ocl_hip.cpp
@@ -257,7 +257,7 @@ protected:
     void verify()
     {
         auto error = miopen::rms_range(tensC_ocl, tensC_hip);
-        EXPECT_TRUE(miopen::float_equal(error, 0.f))
+        EXPECT_TRUE(miopen::float_equal_sentinel(error, 0.f))
             << "GPU outputs do not match each other. Error: " << error;
     }
 

--- a/projects/miopen/test/gtest/tensor_2d_lite_ocl_hip.cpp
+++ b/projects/miopen/test/gtest/tensor_2d_lite_ocl_hip.cpp
@@ -257,7 +257,8 @@ protected:
     void verify()
     {
         auto error = miopen::rms_range(tensC_ocl, tensC_hip);
-        EXPECT_TRUE(error == 0) << "GPU outputs do not match each other. Error: " << error;
+        EXPECT_TRUE(miopen::float_equal(error, 0.f))
+            << "GPU outputs do not match each other. Error: " << error;
     }
 
     void TearDown() override

--- a/projects/miopen/test/gtest/tensor_4d_generic_ocl_hip.cpp
+++ b/projects/miopen/test/gtest/tensor_4d_generic_ocl_hip.cpp
@@ -483,14 +483,14 @@ protected:
     {
         auto error = miopen::rms_range(tensC_ocl, tensC_hip);
         EXPECT_TRUE(miopen::float_equal_sentinel(error, 0))
-            << "GPU outputs do not match each other. Error: " << error;
+            << "OCL and HIP GPU outputs are expected to be identical. Error: " << error;
     }
 
     void verifyCPU()
     {
         auto error = miopen::rms_range(tensC_hip, tensC_cpu);
         EXPECT_TRUE(miopen::float_equal_sentinel(error, 0))
-            << "GPU outputs do not match each other. Error: " << error;
+            << "OCL and HIP GPU outputs are expected to be identical. Error: " << error;
     }
 
     void TearDown() override

--- a/projects/miopen/test/gtest/tensor_4d_generic_ocl_hip.cpp
+++ b/projects/miopen/test/gtest/tensor_4d_generic_ocl_hip.cpp
@@ -482,14 +482,14 @@ protected:
     void verify()
     {
         auto error = miopen::rms_range(tensC_ocl, tensC_hip);
-        EXPECT_TRUE(miopen::float_equal(error, 0))
+        EXPECT_TRUE(miopen::float_equal_sentinel(error, 0))
             << "GPU outputs do not match each other. Error: " << error;
     }
 
     void verifyCPU()
     {
         auto error = miopen::rms_range(tensC_hip, tensC_cpu);
-        EXPECT_TRUE(miopen::float_equal(error, 0))
+        EXPECT_TRUE(miopen::float_equal_sentinel(error, 0))
             << "GPU outputs do not match each other. Error: " << error;
     }
 

--- a/projects/miopen/test/gtest/tensor_4d_generic_ocl_hip.cpp
+++ b/projects/miopen/test/gtest/tensor_4d_generic_ocl_hip.cpp
@@ -482,13 +482,15 @@ protected:
     void verify()
     {
         auto error = miopen::rms_range(tensC_ocl, tensC_hip);
-        EXPECT_TRUE(error == 0) << "GPU outputs do not match each other. Error: " << error;
+        EXPECT_TRUE(miopen::float_equal(error, 0))
+            << "GPU outputs do not match each other. Error: " << error;
     }
 
     void verifyCPU()
     {
         auto error = miopen::rms_range(tensC_hip, tensC_cpu);
-        EXPECT_TRUE(error == 0) << "GPU outputs do not match each other. Error: " << error;
+        EXPECT_TRUE(miopen::float_equal(error, 0))
+            << "GPU outputs do not match each other. Error: " << error;
     }
 
     void TearDown() override

--- a/projects/miopen/test/gtest/tensor_fwd_bias_generic_ocl_hip.cpp
+++ b/projects/miopen/test/gtest/tensor_fwd_bias_generic_ocl_hip.cpp
@@ -400,7 +400,7 @@ protected:
     {
         auto error = miopen::rms_range(tensC_ocl, tensC_hip);
         EXPECT_TRUE(miopen::float_equal_sentinel(error, 0))
-            << "GPU outputs do not match each other. Error: " << error;
+            << "OCL and HIP GPU outputs are expected to be identical. Error: " << error;
     }
 
     void TearDown() override

--- a/projects/miopen/test/gtest/tensor_fwd_bias_generic_ocl_hip.cpp
+++ b/projects/miopen/test/gtest/tensor_fwd_bias_generic_ocl_hip.cpp
@@ -399,7 +399,7 @@ protected:
     void verify() // verify if the output tensors are same
     {
         auto error = miopen::rms_range(tensC_ocl, tensC_hip);
-        EXPECT_TRUE(miopen::float_equal(error, 0))
+        EXPECT_TRUE(miopen::float_equal_sentinel(error, 0))
             << "GPU outputs do not match each other. Error: " << error;
     }
 

--- a/projects/miopen/test/gtest/tensor_fwd_bias_generic_ocl_hip.cpp
+++ b/projects/miopen/test/gtest/tensor_fwd_bias_generic_ocl_hip.cpp
@@ -399,7 +399,8 @@ protected:
     void verify() // verify if the output tensors are same
     {
         auto error = miopen::rms_range(tensC_ocl, tensC_hip);
-        EXPECT_TRUE(error == 0) << "GPU outputs do not match each other. Error: " << error;
+        EXPECT_TRUE(miopen::float_equal(error, 0))
+            << "GPU outputs do not match each other. Error: " << error;
     }
 
     void TearDown() override

--- a/projects/miopen/test/gtest/tensor_fwd_bias_ocl_hip.cpp
+++ b/projects/miopen/test/gtest/tensor_fwd_bias_ocl_hip.cpp
@@ -331,7 +331,7 @@ protected:
     void verify()
     {
         auto error = miopen::rms_range(tensC_ocl, tensC_hip);
-        EXPECT_TRUE(miopen::float_equal(error, 0))
+        EXPECT_TRUE(miopen::float_equal_sentinel(error, 0))
             << "GPU outputs do not match each other. Error: " << error;
     }
 

--- a/projects/miopen/test/gtest/tensor_fwd_bias_ocl_hip.cpp
+++ b/projects/miopen/test/gtest/tensor_fwd_bias_ocl_hip.cpp
@@ -331,7 +331,8 @@ protected:
     void verify()
     {
         auto error = miopen::rms_range(tensC_ocl, tensC_hip);
-        EXPECT_TRUE(error == 0) << "GPU outputs do not match each other. Error: " << error;
+        EXPECT_TRUE(miopen::float_equal(error, 0))
+            << "GPU outputs do not match each other. Error: " << error;
     }
 
     void TearDown() override

--- a/projects/miopen/test/gtest/tensor_fwd_bias_ocl_hip.cpp
+++ b/projects/miopen/test/gtest/tensor_fwd_bias_ocl_hip.cpp
@@ -332,7 +332,7 @@ protected:
     {
         auto error = miopen::rms_range(tensC_ocl, tensC_hip);
         EXPECT_TRUE(miopen::float_equal_sentinel(error, 0))
-            << "GPU outputs do not match each other. Error: " << error;
+            << "OCL and HIP GPU outputs are expected to be identical. Error: " << error;
     }
 
     void TearDown() override

--- a/projects/miopen/test/gtest/unit_conv_solver_tests.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_tests.cpp
@@ -27,6 +27,7 @@
 
 #include <miopen/miopen.h>
 #include <miopen/errors.hpp>
+#include <miopen/float_equal.hpp>
 
 #include "gtest_common.hpp"
 #include "unit_conv_solver.hpp"
@@ -98,7 +99,7 @@ TEST(CPU_UnitConvSolverToleranceTests_NONE, testSetAllUnique)
             {
                 for(auto tt : types)
                 {
-                    if(val == tol.Get(gg, tt))
+                    if(miopen::float_equal(val, tol.Get(gg, tt)))
                     {
                         matches.push_back({gg, tt});
                     }

--- a/projects/miopen/test/verify.hpp
+++ b/projects/miopen/test/verify.hpp
@@ -139,6 +139,18 @@ struct square_diff_fn
 };
 static constexpr square_diff_fn square_diff{};
 
+template <class T, std::enable_if_t<!std::is_floating_point_v<T>, bool> = true>
+bool equal_values(T const& lhs, T const& rhs)
+{
+    return lhs == rhs;
+}
+
+template <class T, std::enable_if_t<std::is_floating_point_v<T>, bool> = true>
+bool equal_values(T const& lhs, T const& rhs)
+{
+    return miopen::float_equal(lhs, rhs);
+}
+
 template <class R1>
 bool range_empty(R1&& r1)
 {
@@ -151,7 +163,7 @@ auto range_distance(R1&& r1) MIOPEN_RETURNS(std::distance(r1.begin(), r1.end()))
 template <class T>
 bool range_zero(const std::vector<T>& r)
 {
-    return std::all_of(r.begin(), r.end(), [](T x) { return x == T(); });
+    return std::all_of(r.begin(), r.end(), [](T x) { return equal_values(x, T()); });
 }
 
 template <class T>

--- a/projects/miopen/test/verify.hpp
+++ b/projects/miopen/test/verify.hpp
@@ -148,7 +148,7 @@ bool equal_values(T const& lhs, T const& rhs)
 template <class T, std::enable_if_t<std::is_floating_point_v<T>, bool> = true>
 bool equal_values(T const& lhs, T const& rhs)
 {
-    return miopen::float_equal(lhs, rhs);
+    return miopen::float_equal_sentinel(lhs, rhs);
 }
 
 template <class R1>


### PR DESCRIPTION
## Motivation

This is a part of an ongoing task of removing many ignored warnings from CMake scripts and fixed everything that was ignored. In this case. `-Wno-float-equal`

## Technical Details

I think, it's pretty self-explanatory: remove ignored warning from CMake scripts, then fix everything that became affected by it

part of efforts to fix https://github.com/ROCm/rocm-libraries/issues/4646

## Test Plan

Building the project, observing the warnings are gone

## Test Result

This PR check should be sufficient

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
