### PR TITLE
[MIOpen][WORKAROUND] Disable Winograd Fury for gfx1103

### DIFF
--- a/projects/miopen/src/solver/conv/conv_wino_fury_RxS.cpp
+++ b/projects/miopen/src/solver/conv/conv_wino_fury_RxS.cpp
@@ -38,6 +38,9 @@
 
 #define WORKAROUND_SWDEV_453577 1
 
+// Workaround for an HSA_STATUS_ERROR_INVALID_ISA error encountered on gfx1103
+#define WORKAROUND_ISSUE_3044 1
+
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_AMD_WINOGRAD_FURY_RXS_F2X3)
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_AMD_WINOGRAD_FURY_RXS_F3X2)
 
@@ -389,6 +392,10 @@ bool ConvWinoFuryRxSCommon<Winodata, Winofilter>::IsApplicable(const ExecutionCo
     // All gfx11/gfx12 ASICs are supported
     if(!(StartsWith(dev_name, "gfx11") || StartsWith(dev_name, "gfx12")))
         return false;
+#if WORKAROUND_ISSUE_3044
+    if(dev_name == "gfx1103")
+        return false;
+#endif
 
     if(!(problem.GetKernelStrideH() == 1 && problem.GetKernelStrideW() == 1))
         return false;


### PR DESCRIPTION
## Motivation

A dispatch of Fury kernel on gfx1103 leads to HSA_STATUS_ERROR_INVALID_ISA error. The kernel is blocking benchmarking and testing on gfx1103. We disable it until a solution is found. The original issue https://github.com/ROCm/TheRock/issues/3044

## Technical Details

A proper `#define` for the workaround is created and used for wrapping (`#if..#end`) the code.

## Test Plan

CI should be passed.

## Test Result

- [x] CI

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
