### PR TITLE
Workaround for running full instead of standard

### DIFF
--- a/projects/miopen/test/gtest/test_categories.yaml
+++ b/projects/miopen/test/gtest/test_categories.yaml
@@ -244,8 +244,6 @@ test_categories:
     description: "Complete test suite - (target: hours+)"
     test_patterns: *positive_patterns
 
-    exclude:
-
     test_files:
       # All test files in the suite
       - "*.cpp"

--- a/projects/miopen/test/gtest/test_categories.yaml
+++ b/projects/miopen/test/gtest/test_categories.yaml
@@ -242,13 +242,7 @@ test_categories:
 
   full:
     description: "Complete test suite - (target: hours+)"
-    test_patterns:
-      # Everything - all test suite prefixes
-      - "Smoke/*"
-      - "Full/*"
-      - "Perf/*"
-      - "Unit/*"
-      - "*"
+    test_patterns: *positive_patterns
 
     exclude:
 
@@ -258,6 +252,39 @@ test_categories:
       - "gtest/*.cpp"
       
     exclude:
+      # Excluding slower tests for faster PR validation
+      - "*DeepBench*"
+      - "*MIOpenTestConv*"
+      - "Full/GPU_Reduce_FP64*"
+      - "Full/GPU_BNOCLFWDTrainSerialRun3D_BFP16*"
+      - "Full/GPU_Lrn_FP32*"
+      - "Full/GPU_Lrn_FP16*"
+      - "Full/GPU_BNOCLInferSerialRun3D_BFP16*"
+      - "Smoke/GPU_BNOCLFWDTrainLarge2D_BFP16*"
+      - "Smoke/GPU_BNOCLInferLarge2D_BFP16*"
+      - "Full/GPU_BNOCLBWDSerialRun3D_BFP16*"
+      - "Smoke/GPU_BNOCLBWDLarge2D_BFP16*"
+      - "Full/GPU_UnitTestActivationDescriptor_FP32*"
+      - "Full/GPU_UnitTestActivationDescriptor_FP16*"
+      - "Smoke/GPU_BNOCLBWDLargeFusedActivation2D_BFP16*"
+      - "Smoke/GPU_BNOCLBWDLargeFusedActivation2D_FP16*"
+      - "Full/GPU_ConvGrpBiasActivInfer_BFP16*"
+      - "Full/GPU_ConvGrpBiasActivInfer_FP32*"
+      - "Full/GPU_ConvGrpBiasActivInfer_FP16*"
+      - "Full/GPU_ConvGrpActivInfer_BFP16*"
+      - "Full/GPU_ConvGrpActivInfer_FP32*"
+      - "Full/GPU_ConvGrpActivInfer_FP16*"
+      - "Full/GPU_ConvGrpBiasActivInfer3D_BFP16*"
+      - "Full/GPU_ConvGrpBiasActivInfer3D_FP32*"
+      - "Full/GPU_ConvGrpBiasActivInfer3D_FP16*"
+      - "Full/GPU_ConvGrpActivInfer3D_BFP16*"
+      - "Full/GPU_ConvGrpActivInfer3D_FP32*"
+      - "Full/GPU_ConvGrpActivInfer3D_FP16*"
+      - "Smoke/GPU_UnitTestConvSolverHipImplicitGemmV4R1Fwd_BFP16.ConvHipImplicitGemmV4R1Fwd/0"
+      - "Full/GPU_MIOpenDriverConv2dTransTest*"
+      - "Full/GPU_MIOpenDriverRegressionBigTensorTest_FP32"
+      - "*GPU_TestMhaFind20_FP32*" #rocm-1016 fixed in develop. Re-enable once bumped
+      - "*GPU_TestMhaFind20_FP16*" #rocm-1016 fixed in develop. Re-enable once bumped
       # Only exclude explicitly disabled tests
       - "*DISABLED*"
     


### PR DESCRIPTION
## Motivation

Unblock miopen CI since we don't maintain full yet, our tests intended for PRs are in standard.
Will address why PRs won't pick up standard in another PR.
## Technical Details

copying standard tests to full

## Test Plan

miopen runs the selected suites meant for PRs and passing.
No inclusions of tests that are outside standard such as: Full/GPU_LSTM_FP64
## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
