### PR TITLE
[hipDNN] Add knob frontend lifting (unpacker) for KnobSetting and Knob

### DIFF
--- a/projects/hipdnn/frontend/include/hipdnn_frontend/detail/KnobSettingUnpacker.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/detail/KnobSettingUnpacker.hpp
@@ -1,0 +1,135 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <hipdnn_frontend/Error.hpp>
+#include <hipdnn_frontend/detail/BackendWrapper.hpp>
+#include <hipdnn_frontend/detail/DescriptorUnpackHelpers.hpp>
+#include <hipdnn_frontend/knob/KnobSetting.hpp>
+
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace hipdnn_frontend::detail
+{
+
+/// Unpacks a finalized HIPDNN_BACKEND_KNOB_CHOICE_DESCRIPTOR into a frontend KnobSetting.
+///
+/// This is the inverse of createKnobSettingDescriptor() in KnobPacker.hpp.
+/// Reads the knob ID and polymorphic value from the backend descriptor via
+/// getAttribute and reconstructs a frontend KnobSetting.
+///
+/// @param knobDesc A finalized knob choice backend descriptor
+/// @param outSetting The KnobSetting to populate
+/// @return Error on failure, empty Error on success
+[[nodiscard]] inline Error unpackKnobSettingDescriptor(hipdnnBackendDescriptor_t knobDesc,
+                                                       KnobSetting& outSetting)
+{
+    // Read knob ID string
+    std::string knobId;
+    HIPDNN_CHECK_ERROR(getDescriptorAttrString(
+        knobDesc, HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE_EXT, knobId, "knob setting knob ID"));
+
+    if(knobId.empty())
+    {
+        return {ErrorCode::INVALID_VALUE, "Knob setting descriptor has empty knob ID"};
+    }
+
+    // Determine the value type by querying the default_value_type attribute.
+    // The KnobSettingDescriptor stores a polymorphic value (int64, double, or string).
+    // We need to determine its type first, then read the appropriate value.
+    //
+    // We attempt int64 first; if that fails, try double; then string.
+    // This approach works because getAttribute will succeed for the type that was set.
+    KnobValueVariant value;
+
+    // Try reading as int64
+    {
+        int64_t intVal = 0;
+        auto status = hipdnnBackend()->backendGetAttribute(knobDesc,
+                                                            HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE_EXT,
+                                                            HIPDNN_TYPE_INT64,
+                                                            1,
+                                                            nullptr,
+                                                            &intVal);
+        if(status == HIPDNN_STATUS_SUCCESS)
+        {
+            value = intVal;
+            outSetting = KnobSetting(std::move(knobId), std::move(value));
+            return {};
+        }
+    }
+
+    // Try reading as double
+    {
+        double doubleVal = 0.0;
+        auto status = hipdnnBackend()->backendGetAttribute(knobDesc,
+                                                            HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE_EXT,
+                                                            HIPDNN_TYPE_DOUBLE,
+                                                            1,
+                                                            nullptr,
+                                                            &doubleVal);
+        if(status == HIPDNN_STATUS_SUCCESS)
+        {
+            value = doubleVal;
+            outSetting = KnobSetting(std::move(knobId), std::move(value));
+            return {};
+        }
+    }
+
+    // Try reading as string (CHAR)
+    {
+        std::string strVal;
+        auto err = getDescriptorAttrString(
+            knobDesc, HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE_EXT, strVal, "knob setting value (string)");
+        if(err.is_good())
+        {
+            value = std::move(strVal);
+            outSetting = KnobSetting(std::move(knobId), std::move(value));
+            return {};
+        }
+    }
+
+    return {ErrorCode::HIPDNN_BACKEND_ERROR,
+            "Failed to read knob value from knob setting descriptor for knob '" + knobId + "'"};
+}
+
+/// Unpacks an array of knob choice descriptors from a parent descriptor.
+///
+/// @param parentDesc The parent descriptor (e.g., engine config) containing knob choices
+/// @param attrName The attribute name for the knob choices array
+/// @param outSettings Output vector of KnobSettings
+/// @return Error on failure, empty Error on success
+[[nodiscard]] inline Error
+    unpackKnobSettingsFromDescriptor(hipdnnBackendDescriptor_t parentDesc,
+                                     hipdnnBackendAttributeName_t attrName,
+                                     std::vector<KnobSetting>& outSettings)
+{
+    auto [knobDescs, err] = getDescriptorAttrDescArray(parentDesc, attrName, "knob choices");
+    if(err.is_bad())
+    {
+        return err;
+    }
+
+    outSettings.clear();
+    outSettings.reserve(knobDescs.size());
+
+    for(size_t i = 0; i < knobDescs.size(); ++i)
+    {
+        KnobSetting setting("", KnobValueVariant{int64_t{0}});
+        auto unpackErr = unpackKnobSettingDescriptor(knobDescs[i].get(), setting);
+        if(unpackErr.is_bad())
+        {
+            return {unpackErr.code,
+                    "Failed to unpack knob setting at index " + std::to_string(i) + ": "
+                        + unpackErr.get_message()};
+        }
+        outSettings.push_back(std::move(setting));
+    }
+
+    return {};
+}
+
+} // namespace hipdnn_frontend::detail

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/detail/KnobUnpacker.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/detail/KnobUnpacker.hpp
@@ -1,0 +1,372 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <hipdnn_frontend/Error.hpp>
+#include <hipdnn_frontend/detail/BackendWrapper.hpp>
+#include <hipdnn_frontend/detail/DescriptorUnpackHelpers.hpp>
+#include <hipdnn_frontend/detail/ScopedHipdnnBackendDescriptor.hpp>
+#include <hipdnn_frontend/knob/Knob.hpp>
+#include <hipdnn_frontend/knob/KnobConstraint.hpp>
+#include <hipdnn_frontend/knob/KnobSetting.hpp>
+
+#include <optional>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace hipdnn_frontend::detail
+{
+
+/// Unpacks a finalized HIPDNN_BACKEND_KNOB_INFO_DESCRIPTOR into a frontend Knob.
+///
+/// This lifts knob metadata from a backend KnobDescriptor by reading each
+/// attribute via the C-API getAttribute pattern. It reconstructs the frontend
+/// Knob with its ID, description, default value, deprecation flag, and
+/// constraints by round-tripping through flatbuffer serialization.
+///
+/// @param knobDesc A finalized knob info backend descriptor
+/// @return Pair of Error and Knob; on error, the Knob should be ignored.
+///         Uses Knob::tryFromFlatbuffer internally.
+[[nodiscard]] inline std::pair<Error, Knob>
+    unpackKnobDescriptor(hipdnnBackendDescriptor_t knobDesc)
+{
+    namespace fb = hipdnn_data_sdk::data_objects;
+
+    // Read knob ID
+    std::string knobId;
+    auto err = getDescriptorAttrString(
+        knobDesc, HIPDNN_ATTR_KNOB_INFO_TYPE_EXT, knobId, "knob info ID");
+    if(err.is_bad())
+    {
+        return {err, Knob::tryFromFlatbuffer({nullptr, 0}).second};
+    }
+
+    if(knobId.empty())
+    {
+        return {{ErrorCode::INVALID_VALUE, "Knob info descriptor has empty knob ID"},
+                Knob::tryFromFlatbuffer({nullptr, 0}).second};
+    }
+
+    // Read description
+    std::string description;
+    err = getDescriptorAttrString(
+        knobDesc, HIPDNN_ATTR_KNOB_INFO_DESCRIPTION_EXT, description, "knob info description");
+    if(err.is_bad())
+    {
+        return {err, Knob::tryFromFlatbuffer({nullptr, 0}).second};
+    }
+
+    // Read deprecated flag
+    bool deprecated = false;
+    err = getDescriptorAttrScalar(knobDesc,
+                                   HIPDNN_ATTR_KNOB_INFO_DEPRECATED_EXT,
+                                   HIPDNN_TYPE_BOOLEAN,
+                                   deprecated,
+                                   "knob info deprecated flag");
+    if(err.is_bad())
+    {
+        return {err, Knob::tryFromFlatbuffer({nullptr, 0}).second};
+    }
+
+    // Read the default value type first
+    int64_t defaultValueTypeRaw = 0;
+    err = getDescriptorAttrScalar(knobDesc,
+                                   HIPDNN_ATTR_KNOB_INFO_DEFAULT_VALUE_TYPE_EXT,
+                                   HIPDNN_TYPE_INT64,
+                                   defaultValueTypeRaw,
+                                   "knob info default value type");
+    if(err.is_bad())
+    {
+        return {err, Knob::tryFromFlatbuffer({nullptr, 0}).second};
+    }
+
+    const auto defaultValueType
+        = static_cast<hipdnnBackendAttributeType_t>(defaultValueTypeRaw);
+
+    // Build a KnobT that we will serialize to flatbuffer for round-tripping
+    // through Knob::tryFromFlatbuffer (since Knob's constructor is private).
+    fb::KnobT knobT;
+    knobT.knob_id = knobId;
+    knobT.description = description;
+    knobT.deprecated = deprecated;
+
+    // Read default value based on type and set it on the KnobT
+    switch(defaultValueType)
+    {
+    case HIPDNN_TYPE_INT64:
+    {
+        int64_t intVal = 0;
+        err = getDescriptorAttrScalar(knobDesc,
+                                       HIPDNN_ATTR_KNOB_INFO_DEFAULT_VALUE_EXT,
+                                       HIPDNN_TYPE_INT64,
+                                       intVal,
+                                       "knob info default value (int64)");
+        if(err.is_bad())
+        {
+            return {err, Knob::tryFromFlatbuffer({nullptr, 0}).second};
+        }
+        fb::IntValueT intValue;
+        intValue.value = intVal;
+        knobT.default_value.Set(intValue);
+        break;
+    }
+    case HIPDNN_TYPE_DOUBLE:
+    {
+        double doubleVal = 0.0;
+        err = getDescriptorAttrScalar(knobDesc,
+                                       HIPDNN_ATTR_KNOB_INFO_DEFAULT_VALUE_EXT,
+                                       HIPDNN_TYPE_DOUBLE,
+                                       doubleVal,
+                                       "knob info default value (double)");
+        if(err.is_bad())
+        {
+            return {err, Knob::tryFromFlatbuffer({nullptr, 0}).second};
+        }
+        fb::FloatValueT floatValue;
+        floatValue.value = doubleVal;
+        knobT.default_value.Set(floatValue);
+        break;
+    }
+    case HIPDNN_TYPE_CHAR:
+    {
+        std::string strVal;
+        err = getDescriptorAttrString(
+            knobDesc,
+            HIPDNN_ATTR_KNOB_INFO_DEFAULT_VALUE_EXT,
+            strVal,
+            "knob info default value (string)");
+        if(err.is_bad())
+        {
+            return {err, Knob::tryFromFlatbuffer({nullptr, 0}).second};
+        }
+        fb::StringValueT stringValue;
+        stringValue.value = std::move(strVal);
+        knobT.default_value.Set(std::move(stringValue));
+        break;
+    }
+    default:
+        return {{ErrorCode::INVALID_VALUE,
+                 "Knob '" + knobId + "' has unknown default value type: "
+                     + std::to_string(defaultValueTypeRaw)},
+                Knob::tryFromFlatbuffer({nullptr, 0}).second};
+    }
+
+    // Read constraint fields based on default value type and set them on KnobT
+    switch(defaultValueType)
+    {
+    case HIPDNN_TYPE_INT64:
+    {
+        std::optional<int64_t> minVal;
+        err = getDescriptorAttrOptionalScalar(knobDesc,
+                                               HIPDNN_ATTR_KNOB_INFO_MINIMUM_VALUE_EXT,
+                                               HIPDNN_TYPE_INT64,
+                                               minVal,
+                                               "knob info min value (int64)");
+        if(err.is_bad())
+        {
+            return {err, Knob::tryFromFlatbuffer({nullptr, 0}).second};
+        }
+
+        std::optional<int64_t> maxVal;
+        err = getDescriptorAttrOptionalScalar(knobDesc,
+                                               HIPDNN_ATTR_KNOB_INFO_MAXIMUM_VALUE_EXT,
+                                               HIPDNN_TYPE_INT64,
+                                               maxVal,
+                                               "knob info max value (int64)");
+        if(err.is_bad())
+        {
+            return {err, Knob::tryFromFlatbuffer({nullptr, 0}).second};
+        }
+
+        std::optional<int64_t> stride;
+        err = getDescriptorAttrOptionalScalar(knobDesc,
+                                               HIPDNN_ATTR_KNOB_INFO_STRIDE_EXT,
+                                               HIPDNN_TYPE_INT64,
+                                               stride,
+                                               "knob info stride");
+        if(err.is_bad())
+        {
+            return {err, Knob::tryFromFlatbuffer({nullptr, 0}).second};
+        }
+
+        std::vector<int64_t> validValuesVec;
+        err = getDescriptorAttrVec(knobDesc,
+                                    HIPDNN_ATTR_KNOB_INFO_VALID_VALUES_INT_EXT,
+                                    validValuesVec,
+                                    "knob info valid values (int64)");
+        if(err.is_bad())
+        {
+            return {err, Knob::tryFromFlatbuffer({nullptr, 0}).second};
+        }
+
+        if(minVal.has_value() || maxVal.has_value() || stride.has_value()
+           || !validValuesVec.empty())
+        {
+            fb::IntConstraintT intConstraint;
+            intConstraint.min_value = minVal.value_or(0);
+            intConstraint.max_value = maxVal.value_or(0);
+            intConstraint.step = stride.value_or(1);
+            intConstraint.valid_values = std::move(validValuesVec);
+            knobT.constraint.Set(std::move(intConstraint));
+        }
+        break;
+    }
+    case HIPDNN_TYPE_DOUBLE:
+    {
+        std::optional<double> minVal;
+        err = getDescriptorAttrOptionalScalar(knobDesc,
+                                               HIPDNN_ATTR_KNOB_INFO_MINIMUM_VALUE_EXT,
+                                               HIPDNN_TYPE_DOUBLE,
+                                               minVal,
+                                               "knob info min value (double)");
+        if(err.is_bad())
+        {
+            return {err, Knob::tryFromFlatbuffer({nullptr, 0}).second};
+        }
+
+        std::optional<double> maxVal;
+        err = getDescriptorAttrOptionalScalar(knobDesc,
+                                               HIPDNN_ATTR_KNOB_INFO_MAXIMUM_VALUE_EXT,
+                                               HIPDNN_TYPE_DOUBLE,
+                                               maxVal,
+                                               "knob info max value (double)");
+        if(err.is_bad())
+        {
+            return {err, Knob::tryFromFlatbuffer({nullptr, 0}).second};
+        }
+
+        if(minVal.has_value() || maxVal.has_value())
+        {
+            fb::FloatConstraintT floatConstraint;
+            floatConstraint.min_value = minVal.value_or(0.0);
+            floatConstraint.max_value = maxVal.value_or(0.0);
+            knobT.constraint.Set(floatConstraint);
+        }
+        break;
+    }
+    case HIPDNN_TYPE_CHAR:
+    {
+        std::optional<int32_t> stringMaxLength;
+        err = getDescriptorAttrOptionalScalar(knobDesc,
+                                               HIPDNN_ATTR_KNOB_INFO_STRING_MAX_LENGTH_EXT,
+                                               HIPDNN_TYPE_INT32,
+                                               stringMaxLength,
+                                               "knob info string max length");
+        if(err.is_bad())
+        {
+            return {err, Knob::tryFromFlatbuffer({nullptr, 0}).second};
+        }
+
+        // Read valid values string - uses the raw C-API since the format
+        // is a null-separated buffer
+        std::vector<std::string> validValuesList;
+        {
+            int64_t count = 0;
+            auto countStatus = hipdnnBackend()->backendGetAttribute(
+                knobDesc,
+                HIPDNN_ATTR_KNOB_INFO_VALID_VALUES_STRING_EXT,
+                HIPDNN_TYPE_CHAR,
+                0,
+                &count,
+                nullptr);
+
+            if(countStatus == HIPDNN_STATUS_SUCCESS && count > 0)
+            {
+                std::vector<char> buffer(static_cast<size_t>(count));
+                int64_t actualCount = 0;
+                auto getStatus = hipdnnBackend()->backendGetAttribute(
+                    knobDesc,
+                    HIPDNN_ATTR_KNOB_INFO_VALID_VALUES_STRING_EXT,
+                    HIPDNN_TYPE_CHAR,
+                    count,
+                    &actualCount,
+                    buffer.data());
+
+                if(getStatus == HIPDNN_STATUS_SUCCESS && actualCount > 0)
+                {
+                    // Parse null-separated string buffer
+                    const char* data = buffer.data();
+                    const char* end = data + actualCount;
+                    while(data < end)
+                    {
+                        std::string val(data);
+                        if(!val.empty())
+                        {
+                            validValuesList.push_back(std::move(val));
+                        }
+                        data += std::strlen(data) + 1;
+                    }
+                }
+            }
+        }
+
+        if(stringMaxLength.has_value() || !validValuesList.empty())
+        {
+            fb::StringConstraintT stringConstraint;
+            stringConstraint.max_length = stringMaxLength.value_or(0);
+            stringConstraint.valid_values = std::move(validValuesList);
+            knobT.constraint.Set(std::move(stringConstraint));
+        }
+        break;
+    }
+    default:
+        break;
+    }
+
+    // Serialize to flatbuffer and use the existing factory method.
+    // This round-trip ensures all validation in tryFromFlatbuffer is applied.
+    flatbuffers::FlatBufferBuilder builder;
+    builder.Finish(fb::Knob::Pack(builder, &knobT));
+
+    hipdnnBackendFlatbufferData_t fbData;
+    fbData.ptr = builder.GetBufferPointer();
+    fbData.size = builder.GetSize();
+
+    return Knob::tryFromFlatbuffer(fbData);
+}
+
+/// Unpacks knob info descriptors from a backend engine descriptor via the
+/// C-API descriptor path (HIPDNN_ATTR_ENGINECFG_KNOB_CHOICES as descriptors).
+///
+/// This is the C-API-based alternative to the flatbuffer path used by
+/// getKnobsForEngine() in Knob.hpp.
+///
+/// @param engineDesc A finalized engine backend descriptor
+/// @param outKnobs Output vector of Knob objects
+/// @return Error on failure, empty Error on success
+[[nodiscard]] inline Error unpackKnobsFromDescriptors(hipdnnBackendDescriptor_t engineDesc,
+                                                       std::vector<Knob>& outKnobs)
+{
+    auto [knobDescs, err]
+        = getDescriptorAttrDescArray(engineDesc,
+                                     HIPDNN_ATTR_KNOB_INFO_SERIALIZED_VALUE_EXT,
+                                     "knob info descriptors");
+    if(err.is_bad())
+    {
+        // The attribute may not support descriptor-based retrieval; this is expected
+        // when the backend only supports flatbuffer-based knob info.
+        outKnobs.clear();
+        return err;
+    }
+
+    outKnobs.clear();
+    outKnobs.reserve(knobDescs.size());
+
+    for(size_t i = 0; i < knobDescs.size(); ++i)
+    {
+        auto [knobErr, knob] = unpackKnobDescriptor(knobDescs[i].get());
+        if(knobErr.is_bad())
+        {
+            return {knobErr.code,
+                    "Failed to unpack knob info at index " + std::to_string(i) + ": "
+                        + knobErr.get_message()};
+        }
+        outKnobs.push_back(std::move(knob));
+    }
+
+    return {};
+}
+
+} // namespace hipdnn_frontend::detail

--- a/projects/hipdnn/frontend/tests/CMakeLists.txt
+++ b/projects/hipdnn/frontend/tests/CMakeLists.txt
@@ -50,6 +50,8 @@ add_executable(
     TestIncompatibleBackendWrapper.cpp
     TestINode.cpp
     TestKnob.cpp
+    TestKnobSettingUnpacker.cpp
+    TestKnobUnpacker.cpp
     TestLayernormAttributes.cpp
     TestLayerNormNode.cpp
     TestMatmulAttributes.cpp

--- a/projects/hipdnn/frontend/tests/TestKnobSettingUnpacker.cpp
+++ b/projects/hipdnn/frontend/tests/TestKnobSettingUnpacker.cpp
@@ -1,0 +1,370 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <hipdnn_frontend/detail/KnobPacker.hpp>
+#include <hipdnn_frontend/detail/KnobSettingUnpacker.hpp>
+#include <hipdnn_frontend/knob/KnobSetting.hpp>
+
+#include "fake_backend/BackendTestMatchers.hpp"
+#include "fake_backend/MockHipdnnBackend.hpp"
+
+using namespace hipdnn_frontend;
+using namespace hipdnn_frontend::detail;
+using namespace hipdnn_frontend::test;
+using namespace ::testing;
+
+namespace
+{
+
+class TestKnobSettingUnpacker : public ::testing::Test
+{
+protected:
+    std::shared_ptr<Mock_hipdnn_backend> _mockBackend;
+
+    void SetUp() override
+    {
+        _mockBackend = std::make_shared<Mock_hipdnn_backend>();
+        IHipdnnBackend::setInstance(_mockBackend);
+    }
+    void TearDown() override
+    {
+        IHipdnnBackend::resetInstance();
+        _mockBackend.reset();
+    }
+};
+
+// ============================================================================
+// unpackKnobSettingDescriptor tests
+// ============================================================================
+
+TEST_F(TestKnobSettingUnpacker, UnpackIntKnobSetting)
+{
+    auto fakeDesc = reinterpret_cast<hipdnnBackendDescriptor_t>(0x1234);
+
+    // Mock reading knob ID string
+    // First call: size query (count only)
+    EXPECT_CALL(*_mockBackend,
+                backendGetAttribute(fakeDesc,
+                                    HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE_EXT,
+                                    HIPDNN_TYPE_CHAR,
+                                    0,
+                                    _,
+                                    nullptr))
+        .WillOnce(DoAll(SetArgPointee<4>(14), Return(HIPDNN_STATUS_SUCCESS)));
+
+    // Second call: actual data
+    const std::string knobId = "test.int_knob";
+    EXPECT_CALL(*_mockBackend,
+                backendGetAttribute(fakeDesc,
+                                    HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE_EXT,
+                                    HIPDNN_TYPE_CHAR,
+                                    14,
+                                    _,
+                                    NotNull()))
+        .WillOnce(DoAll(
+            SetArgPointee<4>(14),
+            Invoke([&knobId](hipdnnBackendDescriptor_t,
+                             hipdnnBackendAttributeName_t,
+                             hipdnnBackendAttributeType_t,
+                             int64_t,
+                             int64_t*,
+                             void* out) {
+                std::memcpy(out, knobId.c_str(), knobId.size() + 1);
+            }),
+            Return(HIPDNN_STATUS_SUCCESS)));
+
+    // Mock reading value as int64 (first attempt succeeds)
+    EXPECT_CALL(*_mockBackend,
+                backendGetAttribute(fakeDesc,
+                                    HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE_EXT,
+                                    HIPDNN_TYPE_INT64,
+                                    1,
+                                    _,
+                                    NotNull()))
+        .WillOnce(DoAll(
+            Invoke([](hipdnnBackendDescriptor_t,
+                      hipdnnBackendAttributeName_t,
+                      hipdnnBackendAttributeType_t,
+                      int64_t,
+                      int64_t*,
+                      void* out) { *static_cast<int64_t*>(out) = 42; }),
+            Return(HIPDNN_STATUS_SUCCESS)));
+
+    KnobSetting setting("", KnobValueVariant{int64_t{0}});
+    auto err = unpackKnobSettingDescriptor(fakeDesc, setting);
+
+    ASSERT_TRUE(err.is_good()) << err.get_message();
+    EXPECT_EQ(setting.knobId(), knobId);
+
+    auto* intVal = std::get_if<int64_t>(&setting.value());
+    ASSERT_NE(intVal, nullptr);
+    EXPECT_EQ(*intVal, 42);
+}
+
+TEST_F(TestKnobSettingUnpacker, UnpackDoubleKnobSetting)
+{
+    auto fakeDesc = reinterpret_cast<hipdnnBackendDescriptor_t>(0x1234);
+
+    // Mock reading knob ID
+    EXPECT_CALL(*_mockBackend,
+                backendGetAttribute(fakeDesc,
+                                    HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE_EXT,
+                                    HIPDNN_TYPE_CHAR,
+                                    0,
+                                    _,
+                                    nullptr))
+        .WillOnce(DoAll(SetArgPointee<4>(16), Return(HIPDNN_STATUS_SUCCESS)));
+
+    const std::string knobId = "test.float_knob";
+    EXPECT_CALL(*_mockBackend,
+                backendGetAttribute(fakeDesc,
+                                    HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE_EXT,
+                                    HIPDNN_TYPE_CHAR,
+                                    16,
+                                    _,
+                                    NotNull()))
+        .WillOnce(DoAll(
+            SetArgPointee<4>(16),
+            Invoke([&knobId](hipdnnBackendDescriptor_t,
+                             hipdnnBackendAttributeName_t,
+                             hipdnnBackendAttributeType_t,
+                             int64_t,
+                             int64_t*,
+                             void* out) {
+                std::memcpy(out, knobId.c_str(), knobId.size() + 1);
+            }),
+            Return(HIPDNN_STATUS_SUCCESS)));
+
+    // Int64 attempt fails
+    EXPECT_CALL(*_mockBackend,
+                backendGetAttribute(fakeDesc,
+                                    HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE_EXT,
+                                    HIPDNN_TYPE_INT64,
+                                    1,
+                                    _,
+                                    NotNull()))
+        .WillOnce(Return(HIPDNN_STATUS_BAD_PARAM));
+
+    // Double attempt succeeds
+    EXPECT_CALL(*_mockBackend,
+                backendGetAttribute(fakeDesc,
+                                    HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE_EXT,
+                                    HIPDNN_TYPE_DOUBLE,
+                                    1,
+                                    _,
+                                    NotNull()))
+        .WillOnce(DoAll(
+            Invoke([](hipdnnBackendDescriptor_t,
+                      hipdnnBackendAttributeName_t,
+                      hipdnnBackendAttributeType_t,
+                      int64_t,
+                      int64_t*,
+                      void* out) { *static_cast<double*>(out) = 3.14; }),
+            Return(HIPDNN_STATUS_SUCCESS)));
+
+    KnobSetting setting("", KnobValueVariant{int64_t{0}});
+    auto err = unpackKnobSettingDescriptor(fakeDesc, setting);
+
+    ASSERT_TRUE(err.is_good()) << err.get_message();
+    EXPECT_EQ(setting.knobId(), knobId);
+
+    auto* doubleVal = std::get_if<double>(&setting.value());
+    ASSERT_NE(doubleVal, nullptr);
+    EXPECT_DOUBLE_EQ(*doubleVal, 3.14);
+}
+
+TEST_F(TestKnobSettingUnpacker, UnpackStringKnobSetting)
+{
+    auto fakeDesc = reinterpret_cast<hipdnnBackendDescriptor_t>(0x1234);
+
+    // Mock reading knob ID
+    EXPECT_CALL(*_mockBackend,
+                backendGetAttribute(fakeDesc,
+                                    HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE_EXT,
+                                    HIPDNN_TYPE_CHAR,
+                                    0,
+                                    _,
+                                    nullptr))
+        .WillOnce(DoAll(SetArgPointee<4>(17), Return(HIPDNN_STATUS_SUCCESS)));
+
+    const std::string knobId = "test.string_knob";
+    EXPECT_CALL(*_mockBackend,
+                backendGetAttribute(fakeDesc,
+                                    HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE_EXT,
+                                    HIPDNN_TYPE_CHAR,
+                                    17,
+                                    _,
+                                    NotNull()))
+        .WillOnce(DoAll(
+            SetArgPointee<4>(17),
+            Invoke([&knobId](hipdnnBackendDescriptor_t,
+                             hipdnnBackendAttributeName_t,
+                             hipdnnBackendAttributeType_t,
+                             int64_t,
+                             int64_t*,
+                             void* out) {
+                std::memcpy(out, knobId.c_str(), knobId.size() + 1);
+            }),
+            Return(HIPDNN_STATUS_SUCCESS)));
+
+    // Int64 attempt fails
+    EXPECT_CALL(*_mockBackend,
+                backendGetAttribute(fakeDesc,
+                                    HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE_EXT,
+                                    HIPDNN_TYPE_INT64,
+                                    1,
+                                    _,
+                                    NotNull()))
+        .WillOnce(Return(HIPDNN_STATUS_BAD_PARAM));
+
+    // Double attempt fails
+    EXPECT_CALL(*_mockBackend,
+                backendGetAttribute(fakeDesc,
+                                    HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE_EXT,
+                                    HIPDNN_TYPE_DOUBLE,
+                                    1,
+                                    _,
+                                    NotNull()))
+        .WillOnce(Return(HIPDNN_STATUS_BAD_PARAM));
+
+    // String attempt: size query
+    const std::string expectedValue = "accurate";
+    EXPECT_CALL(*_mockBackend,
+                backendGetAttribute(fakeDesc,
+                                    HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE_EXT,
+                                    HIPDNN_TYPE_CHAR,
+                                    0,
+                                    _,
+                                    nullptr))
+        .WillOnce(DoAll(SetArgPointee<4>(static_cast<int64_t>(expectedValue.size() + 1)),
+                        Return(HIPDNN_STATUS_SUCCESS)));
+
+    // String attempt: read data
+    EXPECT_CALL(*_mockBackend,
+                backendGetAttribute(fakeDesc,
+                                    HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE_EXT,
+                                    HIPDNN_TYPE_CHAR,
+                                    static_cast<int64_t>(expectedValue.size() + 1),
+                                    _,
+                                    NotNull()))
+        .WillOnce(DoAll(
+            SetArgPointee<4>(static_cast<int64_t>(expectedValue.size() + 1)),
+            Invoke([&expectedValue](hipdnnBackendDescriptor_t,
+                                    hipdnnBackendAttributeName_t,
+                                    hipdnnBackendAttributeType_t,
+                                    int64_t,
+                                    int64_t*,
+                                    void* out) {
+                std::memcpy(out, expectedValue.c_str(), expectedValue.size() + 1);
+            }),
+            Return(HIPDNN_STATUS_SUCCESS)));
+
+    KnobSetting setting("", KnobValueVariant{int64_t{0}});
+    auto err = unpackKnobSettingDescriptor(fakeDesc, setting);
+
+    ASSERT_TRUE(err.is_good()) << err.get_message();
+    EXPECT_EQ(setting.knobId(), knobId);
+
+    auto* strVal = std::get_if<std::string>(&setting.value());
+    ASSERT_NE(strVal, nullptr);
+    EXPECT_EQ(*strVal, expectedValue);
+}
+
+TEST_F(TestKnobSettingUnpacker, UnpackFailsWithEmptyKnobId)
+{
+    auto fakeDesc = reinterpret_cast<hipdnnBackendDescriptor_t>(0x1234);
+
+    // Mock reading empty knob ID: size query returns 0
+    EXPECT_CALL(*_mockBackend,
+                backendGetAttribute(fakeDesc,
+                                    HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE_EXT,
+                                    HIPDNN_TYPE_CHAR,
+                                    0,
+                                    _,
+                                    nullptr))
+        .WillOnce(DoAll(SetArgPointee<4>(0), Return(HIPDNN_STATUS_SUCCESS)));
+
+    KnobSetting setting("", KnobValueVariant{int64_t{0}});
+    auto err = unpackKnobSettingDescriptor(fakeDesc, setting);
+
+    EXPECT_TRUE(err.is_bad());
+    EXPECT_NE(err.get_message().find("empty knob ID"), std::string::npos);
+}
+
+TEST_F(TestKnobSettingUnpacker, UnpackFailsWhenAllValueTypesUnsupported)
+{
+    auto fakeDesc = reinterpret_cast<hipdnnBackendDescriptor_t>(0x1234);
+
+    // Mock reading knob ID
+    EXPECT_CALL(*_mockBackend,
+                backendGetAttribute(fakeDesc,
+                                    HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE_EXT,
+                                    HIPDNN_TYPE_CHAR,
+                                    0,
+                                    _,
+                                    nullptr))
+        .WillOnce(DoAll(SetArgPointee<4>(10), Return(HIPDNN_STATUS_SUCCESS)));
+
+    const std::string knobId = "bad.knob";
+    EXPECT_CALL(*_mockBackend,
+                backendGetAttribute(fakeDesc,
+                                    HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE_EXT,
+                                    HIPDNN_TYPE_CHAR,
+                                    10,
+                                    _,
+                                    NotNull()))
+        .WillOnce(DoAll(
+            SetArgPointee<4>(10),
+            Invoke([&knobId](hipdnnBackendDescriptor_t,
+                             hipdnnBackendAttributeName_t,
+                             hipdnnBackendAttributeType_t,
+                             int64_t,
+                             int64_t*,
+                             void* out) {
+                std::memcpy(out, knobId.c_str(), knobId.size() + 1);
+            }),
+            Return(HIPDNN_STATUS_SUCCESS)));
+
+    // All value type reads fail
+    EXPECT_CALL(*_mockBackend,
+                backendGetAttribute(fakeDesc,
+                                    HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE_EXT,
+                                    HIPDNN_TYPE_INT64,
+                                    _,
+                                    _,
+                                    _))
+        .WillOnce(Return(HIPDNN_STATUS_BAD_PARAM));
+
+    EXPECT_CALL(*_mockBackend,
+                backendGetAttribute(fakeDesc,
+                                    HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE_EXT,
+                                    HIPDNN_TYPE_DOUBLE,
+                                    _,
+                                    _,
+                                    _))
+        .WillOnce(Return(HIPDNN_STATUS_BAD_PARAM));
+
+    // String size query fails
+    EXPECT_CALL(*_mockBackend,
+                backendGetAttribute(fakeDesc,
+                                    HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE_EXT,
+                                    HIPDNN_TYPE_CHAR,
+                                    0,
+                                    _,
+                                    nullptr))
+        .WillOnce(Return(HIPDNN_STATUS_BAD_PARAM));
+
+    // getLastErrorString for the error message
+    EXPECT_CALL(*_mockBackend, getLastErrorString(_, _)).Times(AnyNumber());
+
+    KnobSetting setting("", KnobValueVariant{int64_t{0}});
+    auto err = unpackKnobSettingDescriptor(fakeDesc, setting);
+
+    EXPECT_TRUE(err.is_bad());
+    EXPECT_NE(err.get_message().find("Failed to read knob value"), std::string::npos);
+}
+
+} // anonymous namespace

--- a/projects/hipdnn/frontend/tests/TestKnobUnpacker.cpp
+++ b/projects/hipdnn/frontend/tests/TestKnobUnpacker.cpp
@@ -1,0 +1,486 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <hipdnn_frontend/detail/KnobUnpacker.hpp>
+#include <hipdnn_frontend/knob/Knob.hpp>
+#include <hipdnn_frontend/knob/KnobConstraint.hpp>
+
+#include "fake_backend/BackendTestMatchers.hpp"
+#include "fake_backend/MockHipdnnBackend.hpp"
+
+using namespace hipdnn_frontend;
+using namespace hipdnn_frontend::detail;
+using namespace hipdnn_frontend::test;
+using namespace ::testing;
+
+namespace
+{
+
+class TestKnobUnpacker : public ::testing::Test
+{
+protected:
+    std::shared_ptr<Mock_hipdnn_backend> _mockBackend;
+
+    void SetUp() override
+    {
+        _mockBackend = std::make_shared<Mock_hipdnn_backend>();
+        IHipdnnBackend::setInstance(_mockBackend);
+    }
+    void TearDown() override
+    {
+        IHipdnnBackend::resetInstance();
+        _mockBackend.reset();
+    }
+
+    // Helper: mock reading a string attribute via the size-query + data-read pattern
+    void mockStringAttr(hipdnnBackendDescriptor_t desc,
+                        hipdnnBackendAttributeName_t attrName,
+                        const std::string& value)
+    {
+        // Size query (count only, nullptr data)
+        EXPECT_CALL(*_mockBackend,
+                    backendGetAttribute(desc, attrName, HIPDNN_TYPE_CHAR, 0, _, nullptr))
+            .WillOnce(DoAll(SetArgPointee<4>(static_cast<int64_t>(value.size() + 1)),
+                            Return(HIPDNN_STATUS_SUCCESS)));
+
+        // Data read
+        EXPECT_CALL(*_mockBackend,
+                    backendGetAttribute(desc,
+                                        attrName,
+                                        HIPDNN_TYPE_CHAR,
+                                        static_cast<int64_t>(value.size() + 1),
+                                        _,
+                                        NotNull()))
+            .WillOnce(DoAll(
+                SetArgPointee<4>(static_cast<int64_t>(value.size() + 1)),
+                Invoke([value](hipdnnBackendDescriptor_t,
+                               hipdnnBackendAttributeName_t,
+                               hipdnnBackendAttributeType_t,
+                               int64_t,
+                               int64_t*,
+                               void* out) { std::memcpy(out, value.c_str(), value.size() + 1); }),
+                Return(HIPDNN_STATUS_SUCCESS)));
+    }
+
+    // Helper: mock reading a scalar attribute
+    template <typename T>
+    void mockScalarAttr(hipdnnBackendDescriptor_t desc,
+                        hipdnnBackendAttributeName_t attrName,
+                        hipdnnBackendAttributeType_t attrType,
+                        T value)
+    {
+        EXPECT_CALL(*_mockBackend,
+                    backendGetAttribute(desc, attrName, attrType, 1, _, NotNull()))
+            .WillOnce(DoAll(
+                Invoke([value](hipdnnBackendDescriptor_t,
+                               hipdnnBackendAttributeName_t,
+                               hipdnnBackendAttributeType_t,
+                               int64_t,
+                               int64_t*,
+                               void* out) { *static_cast<T*>(out) = value; }),
+                Return(HIPDNN_STATUS_SUCCESS)));
+    }
+
+    // Helper: mock an optional scalar attribute that is present
+    template <typename T>
+    void mockOptionalScalarAttr(hipdnnBackendDescriptor_t desc,
+                                hipdnnBackendAttributeName_t attrName,
+                                hipdnnBackendAttributeType_t attrType,
+                                T value)
+    {
+        // Count query (returns 1 = present)
+        EXPECT_CALL(*_mockBackend,
+                    backendGetAttribute(desc, attrName, attrType, 0, _, nullptr))
+            .WillOnce(DoAll(SetArgPointee<4>(1), Return(HIPDNN_STATUS_SUCCESS)));
+
+        // Value read
+        mockScalarAttr(desc, attrName, attrType, value);
+    }
+
+    // Helper: mock an optional scalar attribute that is absent
+    void mockOptionalScalarAbsent(hipdnnBackendDescriptor_t desc,
+                                  hipdnnBackendAttributeName_t attrName,
+                                  hipdnnBackendAttributeType_t attrType)
+    {
+        EXPECT_CALL(*_mockBackend,
+                    backendGetAttribute(desc, attrName, attrType, 0, _, nullptr))
+            .WillOnce(DoAll(SetArgPointee<4>(0), Return(HIPDNN_STATUS_SUCCESS)));
+    }
+
+    // Helper: mock int64 vector attribute (empty)
+    void mockEmptyVecAttr(hipdnnBackendDescriptor_t desc,
+                          hipdnnBackendAttributeName_t attrName)
+    {
+        // Count query returns 0
+        EXPECT_CALL(*_mockBackend,
+                    backendGetAttribute(desc, attrName, HIPDNN_TYPE_INT64, 0, _, nullptr))
+            .WillOnce(DoAll(SetArgPointee<4>(0), Return(HIPDNN_STATUS_SUCCESS)));
+    }
+};
+
+// ============================================================================
+// unpackKnobDescriptor tests
+// ============================================================================
+
+TEST_F(TestKnobUnpacker, UnpackIntKnobWithConstraints)
+{
+    auto fakeDesc = reinterpret_cast<hipdnnBackendDescriptor_t>(0x5678);
+
+    // Mock: knob ID
+    mockStringAttr(fakeDesc, HIPDNN_ATTR_KNOB_INFO_TYPE_EXT, "test.int_knob");
+
+    // Mock: description
+    mockStringAttr(fakeDesc, HIPDNN_ATTR_KNOB_INFO_DESCRIPTION_EXT, "An integer knob");
+
+    // Mock: deprecated flag
+    mockScalarAttr<bool>(
+        fakeDesc, HIPDNN_ATTR_KNOB_INFO_DEPRECATED_EXT, HIPDNN_TYPE_BOOLEAN, false);
+
+    // Mock: default value type = INT64
+    mockScalarAttr<int64_t>(fakeDesc,
+                            HIPDNN_ATTR_KNOB_INFO_DEFAULT_VALUE_TYPE_EXT,
+                            HIPDNN_TYPE_INT64,
+                            static_cast<int64_t>(HIPDNN_TYPE_INT64));
+
+    // Mock: default value = 50
+    mockScalarAttr<int64_t>(
+        fakeDesc, HIPDNN_ATTR_KNOB_INFO_DEFAULT_VALUE_EXT, HIPDNN_TYPE_INT64, 50);
+
+    // Mock: int constraints (min=0, max=100, stride=10)
+    mockOptionalScalarAttr<int64_t>(
+        fakeDesc, HIPDNN_ATTR_KNOB_INFO_MINIMUM_VALUE_EXT, HIPDNN_TYPE_INT64, 0);
+    mockOptionalScalarAttr<int64_t>(
+        fakeDesc, HIPDNN_ATTR_KNOB_INFO_MAXIMUM_VALUE_EXT, HIPDNN_TYPE_INT64, 100);
+    mockOptionalScalarAttr<int64_t>(
+        fakeDesc, HIPDNN_ATTR_KNOB_INFO_STRIDE_EXT, HIPDNN_TYPE_INT64, 10);
+
+    // Mock: valid values (empty)
+    mockEmptyVecAttr(fakeDesc, HIPDNN_ATTR_KNOB_INFO_VALID_VALUES_INT_EXT);
+
+    auto [err, knob] = unpackKnobDescriptor(fakeDesc);
+
+    ASSERT_TRUE(err.is_good()) << err.get_message();
+    EXPECT_EQ(knob.knobId(), "test.int_knob");
+    EXPECT_EQ(knob.description(), "An integer knob");
+    EXPECT_FALSE(knob.isDeprecated());
+    EXPECT_EQ(knob.valueType(), KnobValueType::INT64);
+
+    auto* defaultVal = std::get_if<int64_t>(&knob.defaultValue());
+    ASSERT_NE(defaultVal, nullptr);
+    EXPECT_EQ(*defaultVal, 50);
+
+    // Check constraint
+    ASSERT_NE(knob.constraint(), nullptr);
+    auto* intConstraint = dynamic_cast<const IntConstraint*>(knob.constraint());
+    ASSERT_NE(intConstraint, nullptr);
+    EXPECT_EQ(intConstraint->getMinValue(), 0);
+    EXPECT_EQ(intConstraint->getMaxValue(), 100);
+    EXPECT_EQ(intConstraint->getStep(), 10);
+}
+
+TEST_F(TestKnobUnpacker, UnpackFloatKnobWithConstraints)
+{
+    auto fakeDesc = reinterpret_cast<hipdnnBackendDescriptor_t>(0x5678);
+
+    mockStringAttr(fakeDesc, HIPDNN_ATTR_KNOB_INFO_TYPE_EXT, "test.float_knob");
+    mockStringAttr(fakeDesc, HIPDNN_ATTR_KNOB_INFO_DESCRIPTION_EXT, "A float knob");
+    mockScalarAttr<bool>(
+        fakeDesc, HIPDNN_ATTR_KNOB_INFO_DEPRECATED_EXT, HIPDNN_TYPE_BOOLEAN, false);
+
+    // Default value type = DOUBLE
+    mockScalarAttr<int64_t>(fakeDesc,
+                            HIPDNN_ATTR_KNOB_INFO_DEFAULT_VALUE_TYPE_EXT,
+                            HIPDNN_TYPE_INT64,
+                            static_cast<int64_t>(HIPDNN_TYPE_DOUBLE));
+
+    // Default value = 0.5
+    mockScalarAttr<double>(
+        fakeDesc, HIPDNN_ATTR_KNOB_INFO_DEFAULT_VALUE_EXT, HIPDNN_TYPE_DOUBLE, 0.5);
+
+    // Float constraints: min=0.0, max=1.0
+    mockOptionalScalarAttr<double>(
+        fakeDesc, HIPDNN_ATTR_KNOB_INFO_MINIMUM_VALUE_EXT, HIPDNN_TYPE_DOUBLE, 0.0);
+    mockOptionalScalarAttr<double>(
+        fakeDesc, HIPDNN_ATTR_KNOB_INFO_MAXIMUM_VALUE_EXT, HIPDNN_TYPE_DOUBLE, 1.0);
+
+    auto [err, knob] = unpackKnobDescriptor(fakeDesc);
+
+    ASSERT_TRUE(err.is_good()) << err.get_message();
+    EXPECT_EQ(knob.knobId(), "test.float_knob");
+    EXPECT_EQ(knob.valueType(), KnobValueType::FLOAT64);
+
+    auto* defaultVal = std::get_if<double>(&knob.defaultValue());
+    ASSERT_NE(defaultVal, nullptr);
+    EXPECT_DOUBLE_EQ(*defaultVal, 0.5);
+
+    ASSERT_NE(knob.constraint(), nullptr);
+    auto* floatConstraint = dynamic_cast<const FloatConstraint*>(knob.constraint());
+    ASSERT_NE(floatConstraint, nullptr);
+    EXPECT_DOUBLE_EQ(floatConstraint->getMinValue(), 0.0);
+    EXPECT_DOUBLE_EQ(floatConstraint->getMaxValue(), 1.0);
+}
+
+TEST_F(TestKnobUnpacker, UnpackStringKnobWithValidValues)
+{
+    auto fakeDesc = reinterpret_cast<hipdnnBackendDescriptor_t>(0x5678);
+
+    mockStringAttr(fakeDesc, HIPDNN_ATTR_KNOB_INFO_TYPE_EXT, "test.string_knob");
+    mockStringAttr(fakeDesc, HIPDNN_ATTR_KNOB_INFO_DESCRIPTION_EXT, "A string knob");
+    mockScalarAttr<bool>(
+        fakeDesc, HIPDNN_ATTR_KNOB_INFO_DEPRECATED_EXT, HIPDNN_TYPE_BOOLEAN, false);
+
+    // Default value type = CHAR
+    mockScalarAttr<int64_t>(fakeDesc,
+                            HIPDNN_ATTR_KNOB_INFO_DEFAULT_VALUE_TYPE_EXT,
+                            HIPDNN_TYPE_INT64,
+                            static_cast<int64_t>(HIPDNN_TYPE_CHAR));
+
+    // Default value = "fast"
+    mockStringAttr(fakeDesc, HIPDNN_ATTR_KNOB_INFO_DEFAULT_VALUE_EXT, "fast");
+
+    // String constraints: max length = 20
+    mockOptionalScalarAttr<int32_t>(
+        fakeDesc, HIPDNN_ATTR_KNOB_INFO_STRING_MAX_LENGTH_EXT, HIPDNN_TYPE_INT32, 20);
+
+    // Valid values string: "fast\0accurate\0balanced\0"
+    const std::string validValBuf = std::string("fast") + '\0' + "accurate" + '\0' + "balanced" + '\0';
+    const auto validValBufLen = static_cast<int64_t>(validValBuf.size());
+
+    // Size query
+    EXPECT_CALL(*_mockBackend,
+                backendGetAttribute(fakeDesc,
+                                    HIPDNN_ATTR_KNOB_INFO_VALID_VALUES_STRING_EXT,
+                                    HIPDNN_TYPE_CHAR,
+                                    0,
+                                    _,
+                                    nullptr))
+        .WillOnce(DoAll(SetArgPointee<4>(validValBufLen), Return(HIPDNN_STATUS_SUCCESS)));
+
+    // Data read
+    EXPECT_CALL(*_mockBackend,
+                backendGetAttribute(fakeDesc,
+                                    HIPDNN_ATTR_KNOB_INFO_VALID_VALUES_STRING_EXT,
+                                    HIPDNN_TYPE_CHAR,
+                                    validValBufLen,
+                                    _,
+                                    NotNull()))
+        .WillOnce(DoAll(
+            SetArgPointee<4>(validValBufLen),
+            Invoke([&validValBuf](hipdnnBackendDescriptor_t,
+                                  hipdnnBackendAttributeName_t,
+                                  hipdnnBackendAttributeType_t,
+                                  int64_t,
+                                  int64_t*,
+                                  void* out) {
+                std::memcpy(out, validValBuf.data(), validValBuf.size());
+            }),
+            Return(HIPDNN_STATUS_SUCCESS)));
+
+    auto [err, knob] = unpackKnobDescriptor(fakeDesc);
+
+    ASSERT_TRUE(err.is_good()) << err.get_message();
+    EXPECT_EQ(knob.knobId(), "test.string_knob");
+    EXPECT_EQ(knob.valueType(), KnobValueType::STRING);
+
+    auto* defaultVal = std::get_if<std::string>(&knob.defaultValue());
+    ASSERT_NE(defaultVal, nullptr);
+    EXPECT_EQ(*defaultVal, "fast");
+
+    ASSERT_NE(knob.constraint(), nullptr);
+    auto* strConstraint = dynamic_cast<const StringConstraint*>(knob.constraint());
+    ASSERT_NE(strConstraint, nullptr);
+    EXPECT_EQ(strConstraint->getMaxLength(), 20);
+
+    const auto& validValues = strConstraint->getValidValues();
+    EXPECT_EQ(validValues.size(), 3u);
+    EXPECT_NE(validValues.find("fast"), validValues.end());
+    EXPECT_NE(validValues.find("accurate"), validValues.end());
+    EXPECT_NE(validValues.find("balanced"), validValues.end());
+}
+
+TEST_F(TestKnobUnpacker, UnpackDeprecatedKnob)
+{
+    auto fakeDesc = reinterpret_cast<hipdnnBackendDescriptor_t>(0x5678);
+
+    mockStringAttr(fakeDesc, HIPDNN_ATTR_KNOB_INFO_TYPE_EXT, "test.deprecated_knob");
+    mockStringAttr(fakeDesc, HIPDNN_ATTR_KNOB_INFO_DESCRIPTION_EXT, "A deprecated knob");
+
+    // Deprecated = true
+    mockScalarAttr<bool>(
+        fakeDesc, HIPDNN_ATTR_KNOB_INFO_DEPRECATED_EXT, HIPDNN_TYPE_BOOLEAN, true);
+
+    // Default value type = INT64
+    mockScalarAttr<int64_t>(fakeDesc,
+                            HIPDNN_ATTR_KNOB_INFO_DEFAULT_VALUE_TYPE_EXT,
+                            HIPDNN_TYPE_INT64,
+                            static_cast<int64_t>(HIPDNN_TYPE_INT64));
+    // Default value = 0
+    mockScalarAttr<int64_t>(
+        fakeDesc, HIPDNN_ATTR_KNOB_INFO_DEFAULT_VALUE_EXT, HIPDNN_TYPE_INT64, 0);
+
+    // No constraints
+    mockOptionalScalarAbsent(
+        fakeDesc, HIPDNN_ATTR_KNOB_INFO_MINIMUM_VALUE_EXT, HIPDNN_TYPE_INT64);
+    mockOptionalScalarAbsent(
+        fakeDesc, HIPDNN_ATTR_KNOB_INFO_MAXIMUM_VALUE_EXT, HIPDNN_TYPE_INT64);
+    mockOptionalScalarAbsent(fakeDesc, HIPDNN_ATTR_KNOB_INFO_STRIDE_EXT, HIPDNN_TYPE_INT64);
+    mockEmptyVecAttr(fakeDesc, HIPDNN_ATTR_KNOB_INFO_VALID_VALUES_INT_EXT);
+
+    auto [err, knob] = unpackKnobDescriptor(fakeDesc);
+
+    ASSERT_TRUE(err.is_good()) << err.get_message();
+    EXPECT_EQ(knob.knobId(), "test.deprecated_knob");
+    EXPECT_TRUE(knob.isDeprecated());
+}
+
+TEST_F(TestKnobUnpacker, UnpackKnobWithNoConstraintsGetsEmptyConstraint)
+{
+    auto fakeDesc = reinterpret_cast<hipdnnBackendDescriptor_t>(0x5678);
+
+    mockStringAttr(fakeDesc, HIPDNN_ATTR_KNOB_INFO_TYPE_EXT, "test.unconstrained");
+    mockStringAttr(fakeDesc, HIPDNN_ATTR_KNOB_INFO_DESCRIPTION_EXT, "Unconstrained knob");
+    mockScalarAttr<bool>(
+        fakeDesc, HIPDNN_ATTR_KNOB_INFO_DEPRECATED_EXT, HIPDNN_TYPE_BOOLEAN, false);
+
+    mockScalarAttr<int64_t>(fakeDesc,
+                            HIPDNN_ATTR_KNOB_INFO_DEFAULT_VALUE_TYPE_EXT,
+                            HIPDNN_TYPE_INT64,
+                            static_cast<int64_t>(HIPDNN_TYPE_INT64));
+    mockScalarAttr<int64_t>(
+        fakeDesc, HIPDNN_ATTR_KNOB_INFO_DEFAULT_VALUE_EXT, HIPDNN_TYPE_INT64, 42);
+
+    // All optional constraints absent
+    mockOptionalScalarAbsent(
+        fakeDesc, HIPDNN_ATTR_KNOB_INFO_MINIMUM_VALUE_EXT, HIPDNN_TYPE_INT64);
+    mockOptionalScalarAbsent(
+        fakeDesc, HIPDNN_ATTR_KNOB_INFO_MAXIMUM_VALUE_EXT, HIPDNN_TYPE_INT64);
+    mockOptionalScalarAbsent(fakeDesc, HIPDNN_ATTR_KNOB_INFO_STRIDE_EXT, HIPDNN_TYPE_INT64);
+    mockEmptyVecAttr(fakeDesc, HIPDNN_ATTR_KNOB_INFO_VALID_VALUES_INT_EXT);
+
+    auto [err, knob] = unpackKnobDescriptor(fakeDesc);
+
+    ASSERT_TRUE(err.is_good()) << err.get_message();
+    ASSERT_NE(knob.constraint(), nullptr);
+
+    auto* emptyConstraint = dynamic_cast<const EmptyConstraint*>(knob.constraint());
+    EXPECT_NE(emptyConstraint, nullptr)
+        << "Expected EmptyConstraint but got: " << knob.constraint()->toString();
+}
+
+TEST_F(TestKnobUnpacker, UnpackFailsWithEmptyKnobId)
+{
+    auto fakeDesc = reinterpret_cast<hipdnnBackendDescriptor_t>(0x5678);
+
+    // Mock: knob ID size query returns 0
+    EXPECT_CALL(*_mockBackend,
+                backendGetAttribute(fakeDesc,
+                                    HIPDNN_ATTR_KNOB_INFO_TYPE_EXT,
+                                    HIPDNN_TYPE_CHAR,
+                                    0,
+                                    _,
+                                    nullptr))
+        .WillOnce(DoAll(SetArgPointee<4>(0), Return(HIPDNN_STATUS_SUCCESS)));
+
+    auto [err, knob] = unpackKnobDescriptor(fakeDesc);
+
+    EXPECT_TRUE(err.is_bad());
+    EXPECT_NE(err.get_message().find("empty knob ID"), std::string::npos);
+}
+
+TEST_F(TestKnobUnpacker, UnpackFailsWithUnknownValueType)
+{
+    auto fakeDesc = reinterpret_cast<hipdnnBackendDescriptor_t>(0x5678);
+
+    mockStringAttr(fakeDesc, HIPDNN_ATTR_KNOB_INFO_TYPE_EXT, "test.bad_type");
+    mockStringAttr(fakeDesc, HIPDNN_ATTR_KNOB_INFO_DESCRIPTION_EXT, "Bad type knob");
+    mockScalarAttr<bool>(
+        fakeDesc, HIPDNN_ATTR_KNOB_INFO_DEPRECATED_EXT, HIPDNN_TYPE_BOOLEAN, false);
+
+    // Default value type = some unknown type (9999)
+    mockScalarAttr<int64_t>(fakeDesc,
+                            HIPDNN_ATTR_KNOB_INFO_DEFAULT_VALUE_TYPE_EXT,
+                            HIPDNN_TYPE_INT64,
+                            9999);
+
+    auto [err, knob] = unpackKnobDescriptor(fakeDesc);
+
+    EXPECT_TRUE(err.is_bad());
+    EXPECT_NE(err.get_message().find("unknown default value type"), std::string::npos);
+}
+
+TEST_F(TestKnobUnpacker, UnpackIntKnobWithValidValues)
+{
+    auto fakeDesc = reinterpret_cast<hipdnnBackendDescriptor_t>(0x5678);
+
+    mockStringAttr(fakeDesc, HIPDNN_ATTR_KNOB_INFO_TYPE_EXT, "test.valid_values_knob");
+    mockStringAttr(fakeDesc, HIPDNN_ATTR_KNOB_INFO_DESCRIPTION_EXT, "Knob with valid values");
+    mockScalarAttr<bool>(
+        fakeDesc, HIPDNN_ATTR_KNOB_INFO_DEPRECATED_EXT, HIPDNN_TYPE_BOOLEAN, false);
+
+    mockScalarAttr<int64_t>(fakeDesc,
+                            HIPDNN_ATTR_KNOB_INFO_DEFAULT_VALUE_TYPE_EXT,
+                            HIPDNN_TYPE_INT64,
+                            static_cast<int64_t>(HIPDNN_TYPE_INT64));
+    mockScalarAttr<int64_t>(
+        fakeDesc, HIPDNN_ATTR_KNOB_INFO_DEFAULT_VALUE_EXT, HIPDNN_TYPE_INT64, 8);
+
+    // No min/max/stride
+    mockOptionalScalarAbsent(
+        fakeDesc, HIPDNN_ATTR_KNOB_INFO_MINIMUM_VALUE_EXT, HIPDNN_TYPE_INT64);
+    mockOptionalScalarAbsent(
+        fakeDesc, HIPDNN_ATTR_KNOB_INFO_MAXIMUM_VALUE_EXT, HIPDNN_TYPE_INT64);
+    mockOptionalScalarAbsent(fakeDesc, HIPDNN_ATTR_KNOB_INFO_STRIDE_EXT, HIPDNN_TYPE_INT64);
+
+    // Valid values: {8, 16, 32, 64}
+    std::vector<int64_t> validValues = {8, 16, 32, 64};
+    // Count query
+    EXPECT_CALL(*_mockBackend,
+                backendGetAttribute(fakeDesc,
+                                    HIPDNN_ATTR_KNOB_INFO_VALID_VALUES_INT_EXT,
+                                    HIPDNN_TYPE_INT64,
+                                    0,
+                                    _,
+                                    nullptr))
+        .WillOnce(DoAll(SetArgPointee<4>(static_cast<int64_t>(validValues.size())),
+                        Return(HIPDNN_STATUS_SUCCESS)));
+
+    // Data read
+    EXPECT_CALL(*_mockBackend,
+                backendGetAttribute(fakeDesc,
+                                    HIPDNN_ATTR_KNOB_INFO_VALID_VALUES_INT_EXT,
+                                    HIPDNN_TYPE_INT64,
+                                    static_cast<int64_t>(validValues.size()),
+                                    _,
+                                    NotNull()))
+        .WillOnce(DoAll(
+            SetArgPointee<4>(static_cast<int64_t>(validValues.size())),
+            Invoke([&validValues](hipdnnBackendDescriptor_t,
+                                  hipdnnBackendAttributeName_t,
+                                  hipdnnBackendAttributeType_t,
+                                  int64_t,
+                                  int64_t*,
+                                  void* out) {
+                std::memcpy(out, validValues.data(), validValues.size() * sizeof(int64_t));
+            }),
+            Return(HIPDNN_STATUS_SUCCESS)));
+
+    auto [err, knob] = unpackKnobDescriptor(fakeDesc);
+
+    ASSERT_TRUE(err.is_good()) << err.get_message();
+
+    ASSERT_NE(knob.constraint(), nullptr);
+    auto* intConstraint = dynamic_cast<const IntConstraint*>(knob.constraint());
+    ASSERT_NE(intConstraint, nullptr);
+
+    const auto& vv = intConstraint->getValidValues();
+    EXPECT_EQ(vv.size(), 4u);
+    EXPECT_NE(vv.find(8), vv.end());
+    EXPECT_NE(vv.find(16), vv.end());
+    EXPECT_NE(vv.find(32), vv.end());
+    EXPECT_NE(vv.find(64), vv.end());
+}
+
+} // anonymous namespace


### PR DESCRIPTION
## Motivation

Enable lifting backend knob descriptors back to frontend Knob/KnobSetting objects via the C-API, completing the round-trip path for knob configuration.

## Technical Details

Add `KnobSettingUnpacker.hpp` to lift `HIPDNN_BACKEND_KNOB_CHOICE_DESCRIPTOR` back to frontend `KnobSetting`, handling polymorphic values (int64, double, string) by attempting each type in order. Add `KnobUnpacker.hpp` to lift `HIPDNN_BACKEND_KNOB_INFO_DESCRIPTOR` back to frontend `Knob` with full metadata including ID, description, deprecated flag, default value, and constraints. The `KnobUnpacker` round-trips through flatbuffer serialization to use `Knob::tryFromFlatbuffer()` since `Knob` has a private constructor.

Knob and KnobSetting lifting are bundled in one PR because they are tightly coupled.

## Test Plan

- [x] Build with clang-tidy passes
- [x] 13 new unit tests pass (5 `KnobSetting` + 8 `Knob`)
- [x] Full frontend test suite (1479 tests) passes
- [x] Full unit-check (6 suites) passes

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.