### PR TITLE
[hip-kernel-provider] Cleanup and add isChannelLastLayout utility

### DIFF
--- a/dnn-providers/hip-kernel-provider/README.md
+++ b/dnn-providers/hip-kernel-provider/README.md
@@ -31,7 +31,22 @@ HipKernelEngine
 
 ## Building
 
-This plugin should be built as a standalone plugin. To build the plugin, first install hipDNN on the system and then follow these steps:
+This plugin is built as a standalone project outside of the main hipDNN build. It depends on the hipDNN SDK packages (`hipdnn_data_sdk` and `hipdnn_plugin_sdk`), which must be available on the system before building.
+
+The SDK packages can come from either:
+
+- **Building hipDNN from source** (in the `projects/hipdnn` directory of this repository): build hipDNN and run `ninja install` to install the SDK packages. Note that the `CMAKE_INSTALL_PREFIX` may need to be set when configuring the hipDNN CMake project if ROCm was not installed to the default `/opt/rocm` on your system.
+- **A ROCm or TheRock installation** that includes hipDNN: the SDK packages are installed as part of the install.
+
+Either approach works as long as the installed SDK version is compatible with the plugin version being built.
+
+> **Avoiding header conflicts:** If you have hipDNN installed system-wide (e.g., from ROCm or TheRock) and also build hipDNN from source in the repository, the two sets of headers may conflict. To avoid this, use `CMAKE_PREFIX_PATH` to point at exactly the installation you intend to use:
+>
+> ```bash
+> cmake -GNinja -DCMAKE_PREFIX_PATH=<path-to-hipdnn-install> -DCMAKE_CXX_COMPILER=<path-to-amdclang>/clang++ ..
+> ```
+
+### Steps
 
 1. Navigate to the `dnn-providers/hip-kernel-provider` directory.
 2. Make a build directory using `mkdir build && cd build`.
@@ -40,9 +55,9 @@ This plugin should be built as a standalone plugin. To build the plugin, first i
 
 ### Build Requirements
 
-- hipDNN installed (via `ninja install` from hipDNN build)
+- hipDNN SDK packages installed (`hipdnn_data_sdk`, `hipdnn_plugin_sdk`)
 - ROCm with HIP and HIPRTC
-- CMake 3.16+
+- CMake 3.25+
 - Ninja build system
 - C++17 compatible compiler (amdclang++ recommended)
 

--- a/dnn-providers/hip-kernel-provider/src/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/src/CMakeLists.txt
@@ -16,9 +16,6 @@ add_library(
     engines/plans/BatchnormFwdInferencePlan.cpp
     engines/plans/BatchnormApplicabilityChecks.cpp
 )
-target_compile_definitions(
-    hip_kernel_provider_impl PRIVATE COMPONENT_NAME="hip_kernel_provider"
-)
 target_include_directories(hip_kernel_provider_impl PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_BINARY_DIR}
@@ -36,13 +33,11 @@ add_clang_tidy_custom_target()
 
 # Static library for unit tests to link against (provides access to internal implementation)
 add_library(hip_kernel_provider_private STATIC $<TARGET_OBJECTS:hip_kernel_provider_impl>)
-target_compile_definitions(hip_kernel_provider_private PRIVATE COMPONENT_NAME="hip_kernel_provider")
 target_include_directories(hip_kernel_provider_private PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(hip_kernel_provider_private PUBLIC hipdnn_data_sdk hipdnn_plugin_sdk hiprtc::hiprtc)
 
 # hip_kernel_provider - SHARED library (the actual plugin)
 add_library(hip_kernel_provider SHARED $<TARGET_OBJECTS:hip_kernel_provider_impl>)
-target_compile_definitions(hip_kernel_provider PRIVATE COMPONENT_NAME="hip_kernel_provider")
 target_link_libraries(hip_kernel_provider PRIVATE hipdnn_data_sdk hipdnn_plugin_sdk hiprtc::hiprtc hip::host)
 
 if(NOT WIN32)

--- a/dnn-providers/hip-kernel-provider/src/HipKernelUtils.cpp
+++ b/dnn-providers/hip-kernel-provider/src/HipKernelUtils.cpp
@@ -3,6 +3,7 @@
 
 #include "HipKernelUtils.hpp"
 
+#include <hipdnn_data_sdk/utilities/Tensor.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 
 namespace hip_kernel_provider::hip_kernel_utils
@@ -39,6 +40,59 @@ const hipdnn_data_sdk::data_objects::TensorAttributes& findTensorAttributes(
     throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_INTERNAL_ERROR,
                                                    "Failed to find tensor with UID in tensorMap: "
                                                        + std::to_string(uid));
+}
+
+bool isChannelLastLayout(const hipdnn_data_sdk::data_objects::TensorAttributes* tensor)
+{
+    const auto* strides = tensor->strides();
+    const auto* dims = tensor->dims();
+    const size_t numDims = dims->size();
+
+    // Extract stride order from strides
+    std::vector<int64_t> stridesVec(strides->begin(), strides->end());
+    std::vector<int64_t> strideOrder = hipdnn_data_sdk::utilities::extractStrideOrder(stridesVec);
+
+    // Compare against known layouts
+    if(numDims == 4)
+    {
+        const auto layoutNchw = hipdnn_data_sdk::utilities::TensorLayout::NCHW;
+        const auto layoutNhwc = hipdnn_data_sdk::utilities::TensorLayout::NHWC;
+
+        if(strideOrder == layoutNhwc.strideOrder)
+        {
+            return true;
+        }
+        if(strideOrder == layoutNchw.strideOrder)
+        {
+            return false;
+        }
+        throw hipdnn_plugin_sdk::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+            "Unsupported tensor layout for 4D tensor. Only NCHW and NHWC are supported.");
+    }
+
+    if(numDims == 5)
+    {
+        const auto layoutNcdhw = hipdnn_data_sdk::utilities::TensorLayout::NCDHW;
+        const auto layoutNdhwc = hipdnn_data_sdk::utilities::TensorLayout::NDHWC;
+
+        if(strideOrder == layoutNdhwc.strideOrder)
+        {
+            return true;
+        }
+        if(strideOrder == layoutNcdhw.strideOrder)
+        {
+            return false;
+        }
+        throw hipdnn_plugin_sdk::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+            "Unsupported tensor layout for 5D tensor. Only NCDHW and NDHWC are supported.");
+    }
+
+    throw hipdnn_plugin_sdk::HipdnnPluginException(
+        HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+        "Tensor must be 4D or 5D for layout detection. Got " + std::to_string(numDims)
+            + "D tensor.");
 }
 
 } // namespace hip_kernel_provider::hip_kernel_utils

--- a/dnn-providers/hip-kernel-provider/src/HipKernelUtils.hpp
+++ b/dnn-providers/hip-kernel-provider/src/HipKernelUtils.hpp
@@ -19,4 +19,7 @@ const hipdnn_data_sdk::data_objects::TensorAttributes& findTensorAttributes(
     const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     int64_t uid);
+
+bool isChannelLastLayout(const hipdnn_data_sdk::data_objects::TensorAttributes* tensor);
+
 }

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/BatchnormFwdInferencePlan.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/BatchnormFwdInferencePlan.cpp
@@ -153,8 +153,7 @@ void BatchnormFwdInferencePlan::compile(const IKernelCompiler& kernelCompiler,
 
     auto inCstride = static_cast<unsigned int>(h * w);
 
-    // Detect layout: NHWC has C dimension (index 1) with stride 1, NCHW has stride H*W
-    bool isLayoutNhwc = (xStrides->Get(1) == 1);
+    bool isLayoutNhwc = hip_kernel_utils::isChannelLastLayout(_inferenceParams.x());
 
     // Calculate vector size based on layout
     auto vectorsize = computeVectorSize(isLayoutNhwc, c, inCstride);

--- a/dnn-providers/hip-kernel-provider/src/hip/HipUtils.hpp
+++ b/dnn-providers/hip-kernel-provider/src/hip/HipUtils.hpp
@@ -20,7 +20,7 @@ namespace hip_kernel_provider
         if(status != hipSuccess)                                               \
         {                                                                      \
             throw hipdnn_plugin_sdk::HipdnnPluginException(                    \
-                HIPDNN_PLUGIN_STATUS_ALLOC_FAILED,                             \
+                HIPDNN_PLUGIN_STATUS_INTERNAL_ERROR,                           \
                 std::string(#call) + " failed: " + hipGetErrorString(status)); \
         }                                                                      \
     } while(0)
@@ -33,7 +33,7 @@ namespace hip_kernel_provider
         if(status != HIPRTC_SUCCESS)                                              \
         {                                                                         \
             throw hipdnn_plugin_sdk::HipdnnPluginException(                       \
-                HIPDNN_PLUGIN_STATUS_ALLOC_FAILED,                                \
+                HIPDNN_PLUGIN_STATUS_INTERNAL_ERROR,                              \
                 std::string(#call) + " failed: " + hiprtcGetErrorString(status)); \
         }                                                                         \
     } while(0)

--- a/dnn-providers/hip-kernel-provider/src/tests/TestHipKernelUtils.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/TestHipKernelUtils.cpp
@@ -8,10 +8,48 @@
 #include "HipKernelUtils.hpp"
 
 #include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_data_sdk/utilities/Tensor.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 
 using namespace hip_kernel_provider::hip_kernel_utils;
+
+namespace
+{
+
+/// Creates a minimal flatbuffer graph containing a single tensor with the given dims and strides.
+/// Returns the FlatBufferBuilder that owns the buffer.
+flatbuffers::FlatBufferBuilder createSingleTensorGraph(const std::vector<int64_t>& dims,
+                                                       const std::vector<int64_t>& strides)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "tensor", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims));
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+    return builder;
+}
+
+/// Extracts the TensorAttributes pointer (UID 1) from a single-tensor graph.
+const hipdnn_data_sdk::data_objects::TensorAttributes*
+    getTensor(const hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper& graph)
+{
+    return graph.getTensorMap().at(1);
+}
+
+} // namespace
 
 // ============================================================================
 // findDeviceBuffer
@@ -98,4 +136,92 @@ TEST(TestFindTensorAttributes, ThrowsWhenMapIsEmpty)
     std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*> emptyMap;
 
     EXPECT_THROW(findTensorAttributes(emptyMap, 1), hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+// ============================================================================
+// isChannelLastLayout - 4D
+// ============================================================================
+
+TEST(TestIsChannelLastLayout, ReturnsTrueForNhwc4D)
+{
+    std::vector<int64_t> dims = {1, 3, 224, 224};
+    auto strides = hipdnn_data_sdk::utilities::generateStrides(
+        dims, hipdnn_data_sdk::utilities::TensorLayout::NHWC.strideOrder);
+
+    auto builder = createSingleTensorGraph(dims, strides);
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    EXPECT_TRUE(isChannelLastLayout(getTensor(graph)));
+}
+
+TEST(TestIsChannelLastLayout, ReturnsFalseForNchw4D)
+{
+    std::vector<int64_t> dims = {1, 3, 224, 224};
+    auto strides = hipdnn_data_sdk::utilities::generateStrides(
+        dims, hipdnn_data_sdk::utilities::TensorLayout::NCHW.strideOrder);
+
+    auto builder = createSingleTensorGraph(dims, strides);
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    EXPECT_FALSE(isChannelLastLayout(getTensor(graph)));
+}
+
+// ============================================================================
+// isChannelLastLayout - 5D
+// ============================================================================
+
+TEST(TestIsChannelLastLayout, ReturnsTrueForNdhwc5D)
+{
+    std::vector<int64_t> dims = {1, 3, 8, 224, 224};
+    auto strides = hipdnn_data_sdk::utilities::generateStrides(
+        dims, hipdnn_data_sdk::utilities::TensorLayout::NDHWC.strideOrder);
+
+    auto builder = createSingleTensorGraph(dims, strides);
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    EXPECT_TRUE(isChannelLastLayout(getTensor(graph)));
+}
+
+TEST(TestIsChannelLastLayout, ReturnsFalseForNcdhw5D)
+{
+    std::vector<int64_t> dims = {1, 3, 8, 224, 224};
+    auto strides = hipdnn_data_sdk::utilities::generateStrides(
+        dims, hipdnn_data_sdk::utilities::TensorLayout::NCDHW.strideOrder);
+
+    auto builder = createSingleTensorGraph(dims, strides);
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    EXPECT_FALSE(isChannelLastLayout(getTensor(graph)));
+}
+
+// ============================================================================
+// isChannelLastLayout - error cases
+// ============================================================================
+
+TEST(TestIsChannelLastLayout, ThrowsFor3DTensor)
+{
+    std::vector<int64_t> dims = {1, 3, 224};
+    std::vector<int64_t> strides = {672, 224, 1};
+
+    auto builder = createSingleTensorGraph(dims, strides);
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    EXPECT_THROW(isChannelLastLayout(getTensor(graph)), hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+TEST(TestIsChannelLastLayout, ThrowsFor6DTensor)
+{
+    std::vector<int64_t> dims = {1, 3, 4, 8, 224, 224};
+    std::vector<int64_t> strides = {4816896, 1605632, 401408, 50176, 224, 1};
+
+    auto builder = createSingleTensorGraph(dims, strides);
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    EXPECT_THROW(isChannelLastLayout(getTensor(graph)), hipdnn_plugin_sdk::HipdnnPluginException);
 }


### PR DESCRIPTION
## Motivation

Clean up some things from a previous PR in a new PR thats easier to review

## Technical Details

Remove unused COMPONENT_NAME compile definitions that were never consumed by the plugin SDK (which checks HIPDNN_COMPONENT_NAME instead). Add isChannelLastLayout() to HipKernelUtils for stride-order-based layout detection and use it in BatchnormFwdInferencePlan. Update README to clarify SDK dependency sourcing and header conflict avoidance. Fix HipUtils error status codes from ALLOC_FAILED to INTERNAL_ERROR.

Changes:
- Remove dead COMPONENT_NAME compile definitions from CMakeLists.txt
- Add isChannelLastLayout() to HipKernelUtils.hpp/cpp using extractStrideOrder
- Replace inline stride heuristic in BatchnormFwdInferencePlan with isChannelLastLayout
- Add 6 unit tests for isChannelLastLayout (4D/5D layouts + error cases)
- Clarify README building section: SDK sources, header conflicts, cmake version
- Fix HIP_CHECK/HIPRTC_CHECK macros to use INTERNAL_ERROR status

Copied from PR #5548 (excluding CODEOWNERS and labeler changes).

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
