### PR TITLE
[hipblaslt] Correct OCP E4M3 NaN/Inf checks in hipblaslt_float8.h

### DIFF
--- a/projects/hipblaslt/clients/common/include/testing_auxiliary.hpp
+++ b/projects/hipblaslt/clients/common/include/testing_auxiliary.hpp
@@ -1842,8 +1842,11 @@ void testing_aux_auxiliary_func(const Arguments& arg)
     ASSERT_TRUE(hipblaslt_isnan(arg_hipblaslt_bf8_fnuz));
 
     hipblaslt_f8 arg_hipblaslt_f8;
-    arg_hipblaslt_f8.__x = 0x80;
+    arg_hipblaslt_f8.__x = 0x7f;
     ASSERT_TRUE(hipblaslt_isnan(arg_hipblaslt_f8));
+    arg_hipblaslt_f8.__x = 0x80;
+    ASSERT_FALSE(hipblaslt_isnan(arg_hipblaslt_f8));
+    ASSERT_TRUE(arg_hipblaslt_f8.is_zero());
 
     hipblaslt_bf8 arg_hipblaslt_bf8;
     arg_hipblaslt_bf8.__x = 0x7d;
@@ -1858,52 +1861,136 @@ void testing_aux_auxiliary_func(const Arguments& arg)
 
 void testing_aux_float8_func(const Arguments& arg)
 {
-    // Test hipblaslt_float8
-    _Float16          f16 = 2.0;
-    hipblaslt_f8_fnuz f8_fnuz_data(f16);
-    ASSERT_TRUE(f16 == static_cast<_Float16>(f8_fnuz_data));
-    f8_fnuz_data.__x = 0x00;
-    ASSERT_TRUE(f8_fnuz_data.is_zero());
-    f8_fnuz_data.__x = 0x80;
-    ASSERT_TRUE(f8_fnuz_data.is_inf());
-    hipblaslt_f8_fnuz f8_fnuz_data_copy;
-    f8_fnuz_data_copy = f8_fnuz_data;
-    ASSERT_TRUE(f8_fnuz_data_copy.__x == f8_fnuz_data.__x);
+    _Float16 f16 = 2.0;
 
-    // Test hipblaslt_f8
-    hipblaslt_f8 f8_data(f16);
-    ASSERT_TRUE(f16 == static_cast<_Float16>(f8_data));
-    f8_data.__x = 0x00;
-    ASSERT_TRUE(f8_data.is_zero());
-    f8_data.__x = 0x80;
-    ASSERT_TRUE(f8_data.is_inf());
-    hipblaslt_f8 f8_data_copy;
-    f8_data_copy = f8_data;
-    ASSERT_TRUE(f8_data_copy.__x == f8_data.__x);
+    // hipblaslt_f8_fnuz (FNUZ E4M3): zero only 0x00; 0x80 is NaN (is_inf matches for legacy API).
+    {
+        hipblaslt_f8_fnuz v(f16);
+        ASSERT_TRUE(f16 == static_cast<_Float16>(v));
 
-    // Test hipblaslt_bf8_fnuz
-    hipblaslt_bf8_fnuz bf8_fnuz_data(f16);
-    ASSERT_TRUE(f16 == static_cast<_Float16>(bf8_fnuz_data));
-    bf8_fnuz_data.__x = 0x00;
-    ASSERT_TRUE(bf8_fnuz_data.is_zero());
-    bf8_fnuz_data.__x = 0x80;
-    ASSERT_TRUE(bf8_fnuz_data.is_inf());
-    hipblaslt_bf8_fnuz bf8_fnuz_data_copy;
-    bf8_fnuz_data_copy = bf8_fnuz_data;
-    ASSERT_TRUE(bf8_fnuz_data_copy.__x == bf8_fnuz_data.__x);
+        v.__x = 0x00;
+        ASSERT_TRUE(v.is_zero());
+        ASSERT_FALSE(v.is_nan());
+        ASSERT_FALSE(v.is_inf());
 
-    // Test hipblaslt_bf8
-    hipblaslt_bf8 bf8_data(f16);
-    ASSERT_TRUE(f16 == static_cast<_Float16>(bf8_data));
-    bf8_data.__x = 0x00;
-    ASSERT_TRUE(bf8_data.is_zero());
-    bf8_data.__x = 0xff;
-    ASSERT_TRUE(bf8_data.is_nan());
-    bf8_data.__x = 0xfc;
-    ASSERT_TRUE(bf8_data.is_inf());
-    hipblaslt_bf8 bf8_data_copy;
-    bf8_data_copy = bf8_data;
-    ASSERT_TRUE(bf8_data_copy.__x == bf8_data.__x);
+        v.__x = 0x80;
+        ASSERT_FALSE(v.is_zero());
+        ASSERT_TRUE(v.is_nan());
+        ASSERT_TRUE(v.is_inf());
+        ASSERT_TRUE(hipblaslt_isnan(v));
+
+        v.__x = 0x38;
+        ASSERT_FALSE(v.is_zero());
+        ASSERT_FALSE(v.is_nan());
+        ASSERT_FALSE(v.is_inf());
+
+        hipblaslt_f8_fnuz c;
+        c = v;
+        ASSERT_TRUE(c.__x == v.__x);
+    }
+
+    // hipblaslt_f8 (OCP E4M3): ±0 = 0x00/0x80; canonical NaN = 0x7f/0xff; no Inf.
+    {
+        hipblaslt_f8 v(f16);
+        ASSERT_TRUE(f16 == static_cast<_Float16>(v));
+
+        v.__x = 0x00;
+        ASSERT_TRUE(v.is_zero());
+        ASSERT_FALSE(v.is_nan());
+        ASSERT_FALSE(v.is_inf());
+
+        v.__x = 0x80;
+        ASSERT_TRUE(v.is_zero());
+        ASSERT_FALSE(v.is_nan());
+        ASSERT_FALSE(v.is_inf());
+
+        v.__x = 0x7f;
+        ASSERT_FALSE(v.is_zero());
+        ASSERT_TRUE(v.is_nan());
+        ASSERT_FALSE(v.is_inf());
+        ASSERT_TRUE(hipblaslt_isnan(v));
+
+        v.__x = 0xff;
+        ASSERT_FALSE(v.is_zero());
+        ASSERT_TRUE(v.is_nan());
+        ASSERT_FALSE(v.is_inf());
+
+        v.__x = 0x2a;
+        ASSERT_FALSE(v.is_zero());
+        ASSERT_FALSE(v.is_nan());
+        ASSERT_FALSE(v.is_inf());
+
+        hipblaslt_f8 c = v;
+        ASSERT_TRUE(c.__x == v.__x);
+    }
+
+    // hipblaslt_bf8_fnuz (FNUZ E5M2): same sentinel pattern as f8_fnuz.
+    {
+        hipblaslt_bf8_fnuz v(f16);
+        ASSERT_TRUE(f16 == static_cast<_Float16>(v));
+
+        v.__x = 0x00;
+        ASSERT_TRUE(v.is_zero());
+        ASSERT_FALSE(v.is_nan());
+        ASSERT_FALSE(v.is_inf());
+
+        v.__x = 0x80;
+        ASSERT_FALSE(v.is_zero());
+        ASSERT_TRUE(v.is_nan());
+        ASSERT_TRUE(v.is_inf());
+        ASSERT_TRUE(hipblaslt_isnan(v));
+
+        v.__x = 0x14;
+        ASSERT_FALSE(v.is_zero());
+        ASSERT_FALSE(v.is_nan());
+        ASSERT_FALSE(v.is_inf());
+
+        hipblaslt_bf8_fnuz c = v;
+        ASSERT_TRUE(c.__x == v.__x);
+    }
+
+    // hipblaslt_bf8 (OCP E5M2): ±0; Inf 0x7c/0xfc; NaN when exp=max and mantissa non-zero.
+    {
+        hipblaslt_bf8 v(f16);
+        ASSERT_TRUE(f16 == static_cast<_Float16>(v));
+
+        v.__x = 0x00;
+        ASSERT_TRUE(v.is_zero());
+        ASSERT_FALSE(v.is_nan());
+        ASSERT_FALSE(v.is_inf());
+
+        v.__x = 0x80;
+        ASSERT_TRUE(v.is_zero());
+        ASSERT_FALSE(v.is_nan());
+        ASSERT_FALSE(v.is_inf());
+
+        v.__x = 0x7c;
+        ASSERT_FALSE(v.is_zero());
+        ASSERT_FALSE(v.is_nan());
+        ASSERT_TRUE(v.is_inf());
+
+        v.__x = 0xfc;
+        ASSERT_FALSE(v.is_zero());
+        ASSERT_FALSE(v.is_nan());
+        ASSERT_TRUE(v.is_inf());
+
+        for(int b : {0x7d, 0x7e, 0x7f, 0xfd, 0xfe, 0xff})
+        {
+            v.__x = static_cast<decltype(v.__x)>(b);
+            ASSERT_FALSE(v.is_zero());
+            ASSERT_TRUE(v.is_nan());
+            ASSERT_FALSE(v.is_inf());
+            ASSERT_TRUE(hipblaslt_isnan(v));
+        }
+
+        v.__x = 0x08;
+        ASSERT_FALSE(v.is_zero());
+        ASSERT_FALSE(v.is_nan());
+        ASSERT_FALSE(v.is_inf());
+
+        hipblaslt_bf8 c = v;
+        ASSERT_TRUE(c.__x == v.__x);
+    }
 
     // namespace std functions
     // Test hipblaslt_f8_fnuz sin function

--- a/projects/hipblaslt/library/include/hipblaslt/hipblaslt_float8.h
+++ b/projects/hipblaslt/library/include/hipblaslt/hipblaslt_float8.h
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc.
+ * Copyright (C) 2024-2026 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -78,19 +78,19 @@ struct HIPBLASLT_EXPORT hipblaslt_f8_fnuz: public __hip_fp8_e4m3_fnuz
         return _Float16(float(*this));
     }
 
-    // check for zero
+    // check for zero — FNUZ E4M3: only 0x00; 0x80 is the non-finite sentinel (see is_nan / is_inf).
     inline HIP_HOST_DEVICE bool is_zero() const
     {
         return __x == 0x00;
     }
 
-    // check for nan
+    // FNUZ E4M3: encoding 0x80 is NaN (AMD __hip_fp8_e4m3_fnuz convention; no infinities).
     inline HIP_HOST_DEVICE bool is_nan() const
     {
         return __x == 0x80;
     }
 
-    // check for inf
+    // Legacy / test API: same bit pattern as is_nan; there is no separate Inf code in this format.
     inline HIP_HOST_DEVICE bool is_inf() const
     {
         return __x == 0x80;
@@ -130,16 +130,23 @@ struct HIPBLASLT_EXPORT hipblaslt_f8: public __hip_fp8_e4m3
 #endif
     }
 
-    // check for zero
+    // check for zero — OCP E4M3: signed zero S.0000.000 → +0 = 0x00, -0 = 0x80.
     inline HIP_HOST_DEVICE bool is_zero() const
     {
-        return __x == 0x00;
+        return __x == 0x00 || __x == 0x80;
     }
 
-    // check for nan (OCP E4M3: exp and mantissa all 1s; no infinities)
+    // OCP E4M3: canonical NaN is exp=1111 and mantissa=111 → 0x7f / 0xff; mask drops sign.
+    // ±0 (0x00/0x80) are not NaN: (0x80 & 0x7f) != 0x7f.
     inline HIP_HOST_DEVICE bool is_nan() const
     {
         return (__x & 0x7f) == 0x7f;
+    }
+
+    // OCP E4M3 does not define infinities (unlike E5M2).
+    inline HIP_HOST_DEVICE bool is_inf() const
+    {
+        return false;
     }
 
     // assignment overloading only from the same F8 types
@@ -173,19 +180,19 @@ struct HIPBLASLT_EXPORT hipblaslt_bf8_fnuz: public __hip_fp8_e5m2_fnuz
         return _Float16(float(*this));
     }
 
-    // check for zero
+    // check for zero — FNUZ E5M2: only 0x00; 0x80 is non-finite (see is_nan).
     inline HIP_HOST_DEVICE bool is_zero() const
     {
-        return (__x == 0x00 || __x == 0x80);
+        return __x == 0x00;
     }
 
-    // check for nan
+    // FNUZ E5M2: encoding 0x80 is NaN (same sentinel as f8_fnuz path; see __hip_fp8_e5m2_fnuz).
     inline HIP_HOST_DEVICE bool is_nan() const
     {
         return __x == 0x80;
     }
 
-    // check for inf: no inf, so checking nan?
+    // Legacy / test API: same as is_nan; no distinct Inf encoding in this wrapper.
     inline HIP_HOST_DEVICE bool is_inf() const
     {
         return __x == 0x80;
@@ -227,20 +234,19 @@ struct HIPBLASLT_EXPORT hipblaslt_bf8: public __hip_fp8_e5m2
 #endif
     }
 
-    // check for zero
+    // check for zero — OCP E5M2: signed zero S.00000.00 → +0 = 0x00, -0 = 0x80.
     inline HIP_HOST_DEVICE bool is_zero() const
     {
         return __x == 0x00 || __x == 0x80;
     }
 
-    // check for nan
+    // OCP E5M2 (S EEEEE MM): NaN iff exp==31 and mantissa!=00; Inf iff exp==31 and mantissa==00 (0x7c / 0xfc).
     inline HIP_HOST_DEVICE bool is_nan() const
     {
         return (__x == 0x7d) || (__x == 0x7e) || (__x == 0x7f) ||
         (__x == 0xfd) || (__x == 0xfe) || (__x == 0xff);
     }
 
-    // check for inf
     inline HIP_HOST_DEVICE bool is_inf() const
     {
         return (__x == 0x7c) || (__x == 0xfc);

--- a/projects/hipblaslt/library/include/hipblaslt/hipblaslt_float8.h
+++ b/projects/hipblaslt/library/include/hipblaslt/hipblaslt_float8.h
@@ -136,16 +136,10 @@ struct HIPBLASLT_EXPORT hipblaslt_f8: public __hip_fp8_e4m3
         return __x == 0x00;
     }
 
-    // check for nan
+    // check for nan (OCP E4M3: exp and mantissa all 1s; no infinities)
     inline HIP_HOST_DEVICE bool is_nan() const
     {
-        return __x == 0x80;
-    }
-
-    // check for inf
-    inline HIP_HOST_DEVICE bool is_inf() const
-    {
-        return __x == 0x80;
+        return (__x & 0x7f) == 0x7f;
     }
 
     // assignment overloading only from the same F8 types

--- a/projects/hipblaslt/library/include/hipblaslt/hipblaslt_float8.h
+++ b/projects/hipblaslt/library/include/hipblaslt/hipblaslt_float8.h
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2024-2026 Advanced Micro Devices, Inc.
+ * Copyright (C) 2019-2026 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
- is_nan: use (x & 0x7f) == 0x7f
- is_inf: return false (no infinity in OCP E4M3)

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
OCP FP8 E4M3 (hipblaslt_f8) had is_nan() and is_inf() implemented like FNUZ (e.g. 0x80), which does not match the OCP / OFP8 encoding. That misclassifies real OCP NaNs (0x7f / 0xff) and wrongly treats 0x80 as NaN/Inf. This PR corrects those predicates so host/device checks match the OCP spec and align with ROCm’s hip_fp8_ocp_is_nan / hip_fp8_ocp_is_inf behavior.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
hipblaslt_f8::is_nan() -> Use ( __x & 0x7f ) == 0x7f (exponent and mantissa all ones; sign ignored), per OCP E4M3.
hipblaslt_f8::is_inf() -> OCP E4M3 does not define infinity, return false.
No change to FNUZ types (hipblaslt_f8_fnuz, hipblaslt_bf8_fnuz) or OCP E5M2 (hipblaslt_bf8), which were already consistent with their formats.

Relevant reference: ROCm amd_hip_fp8.h (hip_fp8_ocp_is_nan / hip_fp8_ocp_is_inf). OFP8: [opencomputeproject/FP8](https://github.com/opencomputeproject/FP8).

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

- hipblaslt-test locallly

## Test Result

<!-- Briefly summarize test outcomes. -->
`[----------] Global test environment tear-down
[==========] 40809 tests from 11 test suites ran. (4595530 ms total)
[  PASSED  ] 40809 tests.
hipBLASLt version: 100202
hipBLASLt git version: 
command line: ./build/release/clients/hipblaslt-test `

## Related Tickets:
- https://amd-hub.atlassian.net/browse/ROCM-1579