### PR TITLE
[hipsparselt] Restore to develop logic and fix mistakenly used PackKForMV

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
@@ -635,12 +635,6 @@ class LocalReadMFMA(LocalRead):
         needPack |= (kernel["ConvertAfterDS"] and (tP["bpe"] != tP["bpeDS"]))
         needPack |= kernel["UseF32XEmulation"]
 
-        # Metadata pack SGPR prefix: "M" when both 16-bit (A/B) and 8-bit (metadata) packing coexist
-        # Must match tPackM logic in KernelWriterAssembly.py
-        tPackM = ""
-        if (kernel["ProblemType"]["MacDataTypeA"].isHalf() or kernel["ProblemType"]["MacDataTypeA"].isBFloat16()):
-            if (writer.states.lrvwTileA > 1 or writer.states.lrvwTileB > 1) and writer.states.lrvwTileMetadata > 1:
-                tPackM = "M"
         pack     = Module("pack%s_I%s"%(tc,iui))
         packPre = Module("pack%s_I%s Pre"%(tc,iui))
 
@@ -1015,6 +1009,16 @@ class LocalReadMFMA(LocalRead):
                                     isHigh8Bits = 0
                                     isHigh16Bits = 0
                                     numElementPerReg = int(writer.states.bpr//tP["bpe"])
+
+                                    needPackK16  = False
+                                    needPackK8Lw = False
+                                    if kernel["ProblemType"]["MacDataTypeA"].isHalf() or kernel["ProblemType"]["MacDataTypeA"].isBFloat16():
+                                        if writer.states.lrvwTileA > 1 or writer.states.lrvwTileB > 1:
+                                            needPackK16 = True
+                                        if writer.states.lrvwTileMetadata > 1:
+                                            needPackK8Lw = True
+
+                                    tPackM = "M" if needPackK16 and needPackK8Lw else ""
                                     if needPack or numSplitMetadata:
                                         destVgpr = vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, grIdx%(kernel["MIInputPerThread%s"%tc]), vIdx*numVgpr), numVgpr)
                                     if grIdx == numReadsPerUnroll*miInputGroup-1:
@@ -1079,7 +1083,7 @@ class LocalReadMFMA(LocalRead):
                                                     packCodeT.add(VPermB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx+elementIdx+vIdx*2)), \
                                                                         src0=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, vgprOffset*2 + 1 , i+vIdx*numVgpr)), \
                                                                         src1=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, vgprOffset*2, i+vIdx*numVgpr)), \
-                                                                        src2=sgpr("PackKFor%sV%u"%(tPackM, elementIdx % 2)), \
+                                                                        src2=sgpr("PackKForV%u"%(elementIdx % 2)), \
                                                                         comment="select K=%u%u for vector=%u"%(vgprOffset*2+1, vgprOffset*2, elementIdx)))
                                                     vgprOffset += (1 if elementIdx % 2 == 1 else 0)
                                             elif kernel["ProblemType"]["MacDataTypeA"].isHalf() or kernel["MFMA_BF16_1K"] or kernel["ProblemType"]["MacDataTypeA"].isBFloat16():
@@ -1088,7 +1092,7 @@ class LocalReadMFMA(LocalRead):
                                                     for elementIdx in range(0, int(tP["bpe"]*kernel["MIInputPerThread%s"%tc]//writer.states.bpr)):
                                                         packCodeT.add(VPermB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx+vgprOffset)), \
                                                                             src0=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, elementIdx*numElementPerReg+1, i+vIdx*numVgpr)), \
-                                                                            src1=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, elementIdx*numElementPerReg, i+vIdx*numVgpr)), src2=sgpr("PackKFor%sV%u"%(tPackM, vectorIdx)), \
+                                                                            src1=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, elementIdx*numElementPerReg, i+vIdx*numVgpr)), src2=sgpr("PackKForV%u"%(vectorIdx)), \
                                                                             comment="select K=%u%u for vector=%u"%(elementIdx*numElementPerReg,  elementIdx*numElementPerReg+1, vectorIdx)))
                                                         vgprOffset += 1
                                             elif kernel["ProblemType"]["MacDataTypeA"].isInt8() or kernel["ProblemType"]["MacDataTypeA"].is8bitFloat():
@@ -1101,12 +1105,12 @@ class LocalReadMFMA(LocalRead):
                                                         packCodeT.add(VPermB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx+vgprOffset)), \
                                                                             src0=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, elementIdx*numElementPerReg+1, i+vIdx*numVgpr)), \
                                                                             src1=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, elementIdx*numElementPerReg, i+vIdx*numVgpr)), \
-                                                                            src2=sgpr("PackKFor%sV%u"%(tPackM, vectorIdx)), \
+                                                                            src2=sgpr("PackKForV%u"%(vectorIdx)), \
                                                                             comment="select K=%u%u for vector=%u"%(elementIdx*4,  elementIdx*4+1, vectorIdx)))
                                                         packCodeT.add(VPermB32(dst=vgpr("PackTemp"), \
                                                                             src0=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, elementIdx*numElementPerReg+3, i+vIdx*numVgpr)), \
                                                                             src1=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, elementIdx*numElementPerReg+2, i+vIdx*numVgpr)), \
-                                                                            src2=sgpr("PackKFor%sV%u"%(tPackM, vectorIdx)), \
+                                                                            src2=sgpr("PackKForV%u"%(vectorIdx)), \
                                                                             comment="select K=%u%u for vector=%u"%(elementIdx*4+2,  elementIdx*4+3, vectorIdx)))
                                                         packCodeT.add(VLShiftLeftOrB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx + vgprOffset)),
                                                                                     src0=vgpr("PackTemp"), \


### PR DESCRIPTION
## Motivation
- Continuing fixing the hipsparselt-test failed test

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
- As the kernel shows, it misuses the PackKForMV
<img width="2033" height="387" alt="image" src="https://github.com/user-attachments/assets/b45c5ab9-e293-44ba-b82a-ab2bd8cf9ba8" />
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
- hipsparselt-test: `TENSILE_DB=0x8000 ./build/release/hipsparselt-install/bin/hipsparselt-test --gtest_output=xml --gtest_color=yes '--gtest_filter=*quick*'`
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
<img width="874" height="605" alt="image" src="https://github.com/user-attachments/assets/2c2d2c48-7be6-4505-8ad3-557c8416a7a2" />

From 750 failed test -> 260
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
