### PR TITLE
[hipDNN] Change HIPDNN_REGISTER_ENGINE() to have one parameter with legacy support for two parameters.

### DIFF
--- a/dnn-providers/miopen-provider/MiopenContainer.cpp
+++ b/dnn-providers/miopen-provider/MiopenContainer.cpp
@@ -24,11 +24,11 @@ namespace miopen_plugin
 // 2. Detect hash collisions with other formally-registered engines
 //
 // Example for new engines:
-// HIPDNN_REGISTER_ENGINE(MY_CUSTOM_ENGINE, "MY_CUSTOM_ENGINE")
-// HIPDNN_REGISTER_ENGINE(MY_OTHER_ENGINE, "MY_OTHER_ENGINE")
+// HIPDNN_REGISTER_ENGINE(MY_CUSTOM_ENGINE)
+// HIPDNN_REGISTER_ENGINE(MY_OTHER_ENGINE)
 //
 // Note: MIOPEN_ENGINE is already registered in EngineNames.hpp via
-// HIPDNN_REGISTER_ENGINE(MIOPEN_ENGINE, "MIOPEN_ENGINE"), so we can use
+// HIPDNN_REGISTER_ENGINE(MIOPEN_ENGINE), so we can use
 // the MIOPEN_ENGINE_NAME and MIOPEN_ENGINE_ID constants directly from there.
 // ============================================================================
 

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/EngineNames.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/EngineNames.hpp
@@ -129,14 +129,40 @@ struct EngineRegistrar
     }
 };
 
-// Macro that defines engine and automatically registers it
-#define HIPDNN_REGISTER_ENGINE(name)                                                    \
+/// @cond INTERNAL
+#define DETAIL_HIPDNN_REGISTER_ENGINE_1(name)                                           \
     inline constexpr const char* name##_NAME = #name;                                   \
     inline const int64_t name##_ID = hipdnn_data_sdk::utilities::engineNameToId(#name); \
     inline const hipdnn_data_sdk::utilities::EngineRegistrar name##_registrar{#name};
 
+#define DETAIL_HIPDNN_REGISTER_ENGINE_2(name, displayName)                                    \
+    inline constexpr const char* name##_NAME = displayName;                                   \
+    inline const int64_t name##_ID = hipdnn_data_sdk::utilities::engineNameToId(displayName); \
+    inline const hipdnn_data_sdk::utilities::EngineRegistrar name##_registrar{displayName};
+
+#define DETAIL_HIPDNN_GET_REGISTER_ENGINE_MACRO(_1, _2, NAME, ...) NAME
+/// @endcond
+
+/**
+ * @def HIPDNN_REGISTER_ENGINE
+ * @brief Macro that defines an engine and automatically registers it.
+ *
+ * Supports 1 or 2 arguments:
+ * - `HIPDNN_REGISTER_ENGINE(MyEngine)` → identifier: `MyEngine`, name: `"MyEngine"`
+ * - `HIPDNN_REGISTER_ENGINE(MyEngine, "MyEngine")` → identifier: `MyEngine`, name: `"MyEngine"`
+ *
+ * The single-parameter form should be used whenever possible for simplicity.
+ *
+ * @param name The identifier used for generated constants (e.g., `name_NAME`, `name_ID`)
+ * @param displayName (optional) Custom string name for the engine. Defaults to stringified `name`.
+ */
+#define HIPDNN_REGISTER_ENGINE(...)                                                            \
+    DETAIL_HIPDNN_GET_REGISTER_ENGINE_MACRO(                                                   \
+        __VA_ARGS__, DETAIL_HIPDNN_REGISTER_ENGINE_2, DETAIL_HIPDNN_REGISTER_ENGINE_1, unused) \
+    (__VA_ARGS__)
+
 ////////////////////////////////////////////////////////////////////////////////////////////
-// Define all engines using the macro
+// Define all engines using the HIPDNN_REGISTER_ENGINE() macro.
 // Note: Once an engine is named here, it should never be renamed.  Renaming an engine will
 // change the generated uint64_t ID.
 ////////////////////////////////////////////////////////////////////////////////////////////

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/EngineNames.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/EngineNames.hpp
@@ -130,24 +130,25 @@ struct EngineRegistrar
 };
 
 // Macro that defines engine and automatically registers it
-#define HIPDNN_REGISTER_ENGINE(name, value)                 \
-    inline constexpr const char* name##_NAME = value;       \
-    inline const int64_t name##_ID = engineNameToId(value); \
-    inline const EngineRegistrar name##_registrar{value};
+#define HIPDNN_REGISTER_ENGINE(name)                                                    \
+    inline constexpr const char* name##_NAME = #name;                                   \
+    inline const int64_t name##_ID = hipdnn_data_sdk::utilities::engineNameToId(#name); \
+    inline const hipdnn_data_sdk::utilities::EngineRegistrar name##_registrar{#name};
 
-//Note: Once an engine is named here, it should never be renamed.  Renaming an engine will
-// change the generated uint64_t ID.
-
+////////////////////////////////////////////////////////////////////////////////////////////
 // Define all engines using the macro
+// Note: Once an engine is named here, it should never be renamed.  Renaming an engine will
+// change the generated uint64_t ID.
+////////////////////////////////////////////////////////////////////////////////////////////
 // NOLINTBEGIN(bugprone-throwing-static-initialization) collision detection requires throw
-HIPDNN_REGISTER_ENGINE(FUSILLI_ENGINE, "FUSILLI_ENGINE")
 
-HIPDNN_REGISTER_ENGINE(HIPBLASLT_ENGINE, "HIPBLASLT_ENGINE")
+HIPDNN_REGISTER_ENGINE(FUSILLI_ENGINE)
+HIPDNN_REGISTER_ENGINE(HIP_KERNEL_ENGINE)
+HIPDNN_REGISTER_ENGINE(HIPBLASLT_ENGINE)
+HIPDNN_REGISTER_ENGINE(MIOPEN_ENGINE)
+HIPDNN_REGISTER_ENGINE(MIOPEN_ENGINE_DETERMINISTIC)
 
-HIPDNN_REGISTER_ENGINE(MIOPEN_ENGINE, "MIOPEN_ENGINE")
-HIPDNN_REGISTER_ENGINE(MIOPEN_ENGINE_DETERMINISTIC, "MIOPEN_ENGINE_DETERMINISTIC")
 // NOLINTEND(bugprone-throwing-static-initialization)
-
-HIPDNN_REGISTER_ENGINE(HIP_KERNEL_ENGINE, "HIP_KERNEL_ENGINE")
+////////////////////////////////////////////////////////////////////////////////////////////
 
 } // namespace hipdnn_data_sdk::utilities

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/EngineNames.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/EngineNames.hpp
@@ -135,10 +135,10 @@ struct EngineRegistrar
     inline const int64_t name##_ID = hipdnn_data_sdk::utilities::engineNameToId(#name); \
     inline const hipdnn_data_sdk::utilities::EngineRegistrar name##_registrar{#name};
 
-#define DETAIL_HIPDNN_REGISTER_ENGINE_2(name, displayName)                                    \
-    inline constexpr const char* name##_NAME = displayName;                                   \
-    inline const int64_t name##_ID = hipdnn_data_sdk::utilities::engineNameToId(displayName); \
-    inline const hipdnn_data_sdk::utilities::EngineRegistrar name##_registrar{displayName};
+#define DETAIL_HIPDNN_REGISTER_ENGINE_2(name, value)                                    \
+    inline constexpr const char* name##_NAME = value;                                   \
+    inline const int64_t name##_ID = hipdnn_data_sdk::utilities::engineNameToId(value); \
+    inline const hipdnn_data_sdk::utilities::EngineRegistrar name##_registrar{value};
 
 #define DETAIL_HIPDNN_GET_REGISTER_ENGINE_MACRO(_1, _2, NAME, ...) NAME
 /// @endcond
@@ -154,7 +154,7 @@ struct EngineRegistrar
  * The single-parameter form should be used whenever possible for simplicity.
  *
  * @param name The identifier used for generated constants (e.g., `name_NAME`, `name_ID`)
- * @param displayName (optional) Custom string name for the engine. Defaults to stringified `name`.
+ * @param value (optional) Custom string name for the engine. Defaults to stringified `name`.
  */
 #define HIPDNN_REGISTER_ENGINE(...)                                                            \
     DETAIL_HIPDNN_GET_REGISTER_ENGINE_MACRO(                                                   \

--- a/projects/hipdnn/data_sdk/tests/utilities/TestEngineNames.cpp
+++ b/projects/hipdnn/data_sdk/tests/utilities/TestEngineNames.cpp
@@ -10,6 +10,20 @@
 
 using namespace hipdnn_data_sdk::utilities;
 
+// Test engines defined with the macro to verify expansion
+// These use unique names to avoid collision with production engines
+namespace test_macro_expansion
+{
+// Single-argument form: identifier and display name are the same
+HIPDNN_REGISTER_ENGINE(TEST_MACRO_SINGLE_ARG_ENGINE)
+
+// Two-argument form: identifier differs from display name
+HIPDNN_REGISTER_ENGINE(TEST_MACRO_DUAL_ARG_ENGINE, "CustomDisplayName")
+
+// Two-argument form where identifier and display name happen to match (like MIOPEN_ENGINE)
+HIPDNN_REGISTER_ENGINE(TEST_MACRO_MATCHING_ARGS_ENGINE, "TEST_MACRO_MATCHING_ARGS_ENGINE")
+} // namespace test_macro_expansion
+
 class TestEngineNames : public ::testing::Test
 {
 };
@@ -150,4 +164,61 @@ TEST_F(TestEngineNames, EnsureAllEngineNameToIdsBehaveTheSame)
         EXPECT_EQ(engineIdCString, engineIdString);
         EXPECT_EQ(engineIdCString, engineIdStringView);
     }
+}
+
+TEST_F(TestEngineNames, MacroSingleArgGeneratesCorrectName)
+{
+    // Single-argument form: _NAME should be the stringified identifier
+    EXPECT_STREQ(test_macro_expansion::TEST_MACRO_SINGLE_ARG_ENGINE_NAME,
+                 "TEST_MACRO_SINGLE_ARG_ENGINE");
+}
+
+TEST_F(TestEngineNames, MacroSingleArgGeneratesCorrectId)
+{
+    // Single-argument form: _ID should be computed from the stringified identifier
+    EXPECT_EQ(test_macro_expansion::TEST_MACRO_SINGLE_ARG_ENGINE_ID,
+              engineNameToId("TEST_MACRO_SINGLE_ARG_ENGINE"));
+}
+
+TEST_F(TestEngineNames, MacroSingleArgRegistersEngine)
+{
+    // Single-argument form: engine should be registered with the stringified identifier
+    EXPECT_TRUE(isEngineNameRegistered("TEST_MACRO_SINGLE_ARG_ENGINE"));
+    EXPECT_EQ(getEngineNameFromId(test_macro_expansion::TEST_MACRO_SINGLE_ARG_ENGINE_ID),
+              "TEST_MACRO_SINGLE_ARG_ENGINE");
+}
+
+TEST_F(TestEngineNames, MacroDualArgGeneratesCorrectName)
+{
+    // Two-argument form: _NAME should be the custom display name, not the identifier
+    EXPECT_STREQ(test_macro_expansion::TEST_MACRO_DUAL_ARG_ENGINE_NAME, "CustomDisplayName");
+}
+
+TEST_F(TestEngineNames, MacroDualArgGeneratesCorrectId)
+{
+    // Two-argument form: _ID should be computed from the custom display name
+    EXPECT_EQ(test_macro_expansion::TEST_MACRO_DUAL_ARG_ENGINE_ID,
+              engineNameToId("CustomDisplayName"));
+    // Verify it's NOT computed from the identifier
+    EXPECT_NE(test_macro_expansion::TEST_MACRO_DUAL_ARG_ENGINE_ID,
+              engineNameToId("TEST_MACRO_DUAL_ARG_ENGINE"));
+}
+
+TEST_F(TestEngineNames, MacroDualArgRegistersWithDisplayName)
+{
+    // Two-argument form: engine should be registered with the display name, not the identifier
+    EXPECT_TRUE(isEngineNameRegistered("CustomDisplayName"));
+    EXPECT_FALSE(isEngineNameRegistered("TEST_MACRO_DUAL_ARG_ENGINE"));
+    EXPECT_EQ(getEngineNameFromId(test_macro_expansion::TEST_MACRO_DUAL_ARG_ENGINE_ID),
+              "CustomDisplayName");
+}
+
+TEST_F(TestEngineNames, MacroMatchingArgsEquivalentToSingleArg)
+{
+    // Two-argument form with matching args should behave the same as single-argument form
+    EXPECT_STREQ(test_macro_expansion::TEST_MACRO_MATCHING_ARGS_ENGINE_NAME,
+                 "TEST_MACRO_MATCHING_ARGS_ENGINE");
+    EXPECT_EQ(test_macro_expansion::TEST_MACRO_MATCHING_ARGS_ENGINE_ID,
+              engineNameToId("TEST_MACRO_MATCHING_ARGS_ENGINE"));
+    EXPECT_TRUE(isEngineNameRegistered("TEST_MACRO_MATCHING_ARGS_ENGINE"));
 }

--- a/projects/hipdnn/docs/PluginDevelopment.md
+++ b/projects/hipdnn/docs/PluginDevelopment.md
@@ -126,7 +126,7 @@ To add your engine name to the official registry:
 
 2. **Add to Registry**: Submit a PR to add your engine name to [`data_sdk/include/hipdnn_data_sdk/utilities/EngineNames.hpp`](../data_sdk/include/hipdnn_data_sdk/utilities/EngineNames.hpp):
    ```cpp
-   HIPDNN_REGISTER_ENGINE(MY_NEW_ENGINE, "MY_NEW_ENGINE")
+   HIPDNN_REGISTER_ENGINE(MY_NEW_ENGINE)
    ```
 
 3. **Test Locally First**: You can use unregistered names during development - they'll generate a warning but work correctly

--- a/projects/hipdnn/docs/rfcs/0003_EngineIdDesign.md
+++ b/projects/hipdnn/docs/rfcs/0003_EngineIdDesign.md
@@ -124,16 +124,16 @@ struct EngineRegistrar {
 };
 
 // Macro that defines engine and automatically registers it
-#define HIPDNN_REGISTER_ENGINE(name, value) \
-    inline constexpr const char* name = value; \
-    inline constexpr const int64_t name##_id = hipdnn_data_sdk::engineNameToId(value); \
-    inline const EngineRegistrar name##_registrar{value};
+#define HIPDNN_REGISTER_ENGINE(name) \
+    inline constexpr const char* name##_NAME = value; \
+    inline const int64_t name##_ID = hipdnn_data_sdk::utilities::engineNameToId(#name); \
+    inline const hipdnn_data_sdk::utilities::EngineRegistrar name##_registrar{#name};
 
 // Define all engines using the macro, name and value should match.
-HIPDNN_REGISTER_ENGINE(MIOPEN_PLUGIN, "MIOPEN_PLUGIN")
-HIPDNN_REGISTER_ENGINE(VENDOR_FAST_CONV, "VENDOR_FAST_CONV")
-HIPDNN_REGISTER_ENGINE(CPU_REFERENCE_ENGINE, "CPU_REFERENCE_ENGINE")
-HIPDNN_REGISTER_ENGINE(EXAMPLE_PLUGIN_RENAME_THIS, "EXAMPLE_PLUGIN_RENAME_THIS")
+HIPDNN_REGISTER_ENGINE(MIOPEN_PLUGIN)
+HIPDNN_REGISTER_ENGINE(VENDOR_FAST_CONV)
+HIPDNN_REGISTER_ENGINE(CPU_REFERENCE_ENGINE)
+HIPDNN_REGISTER_ENGINE(EXAMPLE_PLUGIN_RENAME_THIS)
 
 } // namespace hipdnn_plugin_sdk::engine_names
 

--- a/projects/hipdnn/docs/user-guides/how-to/develop-plugins.rst
+++ b/projects/hipdnn/docs/user-guides/how-to/develop-plugins.rst
@@ -83,7 +83,7 @@ hipDNN uses a deterministic hash-based system for managing engine IDs. This syst
 The engine ID system ensures globally unique identifiers across all plugins.
 
 When creating a new engine, select a unique descriptive name.
-During development, add the ``HIPDNN_REGISTER_ENGINE(MY_CUSTOM_ENGINE, "MY_CUSTOME_ENGINE")`` macro to a source file in your project.
+During development, add the ``HIPDNN_REGISTER_ENGINE(MY_CUSTOM_ENGINE)`` macro to a source file in your project.
 This verifies that the new plugin name doesn't conflict with plugin names from the official distribution and creates variables that can be used to retrieve the unique ID for this engine.
 
 Benefits
@@ -105,7 +105,7 @@ Use engine IDs
   // such as MY_CUSTOM_ENGINE_ID for this engine.
   using hipdnn_data_sdk::utilities::engineNameToId;
   using hipdnn_data_sdk::utilities::EngineRegistrar;
-  HIPDNN_REGISTER_ENGINE(MY_CUSTOM_ENGINE, "MY_CUSTOM_ENGINE")
+  HIPDNN_REGISTER_ENGINE(MY_CUSTOM_ENGINE)
 
   class MyCustomEngine : public hipdnn_plugin_sdk::IEngine< ... >
   {
@@ -125,7 +125,7 @@ To add your engine name to the official registry, submit a GitHub pull request t
 
 .. code:: cpp
 
-  HIPDNN_REGISTER_ENGINE(MY_CUSTOM_ENGINE, "MY_CUSTOM_ENGINE")
+  HIPDNN_REGISTER_ENGINE(MY_CUSTOM_ENGINE)
 
 Test it locally. You can use unregistered names during development, but you'll need to remove the ``HIPDNN_REGISTER_ENGINE()`` macro from your plugin before it's added to the official registry.
 

--- a/projects/hipdnn/docs/user-guides/how-to/develop-plugins.rst
+++ b/projects/hipdnn/docs/user-guides/how-to/develop-plugins.rst
@@ -103,8 +103,6 @@ Use engine IDs
 
   // This macro registers the engine name and creates helper variables
   // such as MY_CUSTOM_ENGINE_ID for this engine.
-  using hipdnn_data_sdk::utilities::engineNameToId;
-  using hipdnn_data_sdk::utilities::EngineRegistrar;
   HIPDNN_REGISTER_ENGINE(MY_CUSTOM_ENGINE)
 
   class MyCustomEngine : public hipdnn_plugin_sdk::IEngine< ... >


### PR DESCRIPTION
## Motivation

The two parameters are typically the same; use macro syntax to derive the two forms of the macro parameters from a single parameter. Still supports two parameters for exceptional situations.

Also add namespaces to classes and functions called in the macro so it can be used outside of the namespace blocks.

Added doxygen doc block and macro unit tests.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

CI tests pass.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
