### PR TITLE
[hipDNN] Fix flaky ValidateSortsNodesTopologically test

### DIFF
--- a/projects/hipdnn/frontend/tests/TestGraph.cpp
+++ b/projects/hipdnn/frontend/tests/TestGraph.cpp
@@ -3495,12 +3495,12 @@ TEST_F(TestGraph, ValidateSortsNodesTopologically)
     auto sortedSubnodesDueToGraphConstructionOrderCopy = graph.getPrivateGraphSubnodes();
 
     auto& subNodes = graph.getPrivateGraphSubnodes();
-    // Randomize the node order to mess it up
-    std::random_device rd;
-    std::mt19937 gen(rd());
-    std::shuffle(subNodes.begin(), subNodes.end(), gen);
+    // Deterministically scramble the node order.
+    // std::shuffle was flaky — it could randomly produce the original order.
+    std::swap(subNodes.front(), subNodes.back());
+    std::swap(subNodes[1], subNodes[subNodes.size() - 2]);
 
-    //verify for sure the nodes arent sorted.
+    // Verify the nodes are no longer in the original order.
     bool notSortedAnymore = false;
     for(size_t i = 0; i < subNodes.size(); i++)
     {


### PR DESCRIPTION
## Summary
- Replace `std::shuffle` with deterministic `std::swap` calls in `ValidateSortsNodesTopologically` to fix flaky test
- The random shuffle could occasionally produce the original sorted order, causing the unsorted assertion to fail
- Deterministic swaps (first↔last, second↔second-to-last) guarantee the node order always differs from the original

## Test plan
- [x] Verify `ValidateSortsNodesTopologically` passes consistently (no more random failures)
- [x] Run full frontend test suite: `hipdnn_frontend_tests --gtest_filter="TestGraph.*"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)