### PR TITLE
[MIOpen][HOTFIX] Fix applicability tests

### DIFF
--- a/projects/miopen/src/solver/conv/conv_wino_fury_RxS.cpp
+++ b/projects/miopen/src/solver/conv/conv_wino_fury_RxS.cpp
@@ -394,7 +394,18 @@ bool ConvWinoFuryRxSCommon<Winodata, Winofilter>::IsApplicable(const ExecutionCo
         return false;
 #if WORKAROUND_ISSUE_3044
     if(dev_name == "gfx1103")
-        return false;
+    {
+        if constexpr(IS2X3)
+        {
+            if(!env::enabled(MIOPEN_DEBUG_AMD_WINOGRAD_FURY_RXS_F2X3))
+                return false;
+        }
+        if constexpr(IS3X2)
+        {
+            if(!env::enabled(MIOPEN_DEBUG_AMD_WINOGRAD_FURY_RXS_F3X2))
+                return false;
+        }
+    }
 #endif
 
     if(!(problem.GetKernelStrideH() == 1 && problem.GetKernelStrideW() == 1))

--- a/projects/miopen/test/gtest/unit_conv_solver.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver.cpp
@@ -295,6 +295,11 @@ void UnitTestConvSolverParams::SetTolerance(Gpu gpu, miopenDataType_t type, floa
     tolerances.Set(gpu, type, value);
 }
 
+void UnitTestConvSolverParams::ExcludeDevice(std::string_view name)
+{
+    excluded_devices.emplace(name);
+}
+
 std::ostream& operator<<(std::ostream& os, const UnitTestConvSolverParams& p)
 {
     os << "(";
@@ -854,6 +859,10 @@ void UnitTestConvSolverBase::SetUpImpl(const UnitTestConvSolverParams& params)
     {
         GTEST_SKIP();
     }
+    else if(params.excluded_devices.count(get_handle().GetDeviceName()) > 0)
+    {
+        GTEST_SKIP();
+    }
     else if(params.check_xnack_disabled && get_handle_xnack())
     {
         GTEST_SKIP();
@@ -892,7 +901,8 @@ void UnitTestConvSolverDevApplicabilityBase::RunTestImpl(
     const auto all_known_devs = GetAllKnownDevices();
     for(const auto& [dev, dev_descr] : all_known_devs)
     {
-        const auto supported = IsDeviceSupported(params.supported_devs, dev);
+        const auto supported = IsDeviceSupported(params.supported_devs, dev)
+                               && params.excluded_devices.count(dev_descr.name) == 0;
         // std::cout << "Test " << dev_descr << " (supported: " << supported << ")" << std::endl;
 
         auto handle    = MockHandle{dev_descr, params.check_xnack_disabled};

--- a/projects/miopen/test/gtest/unit_conv_solver.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver.cpp
@@ -901,8 +901,8 @@ void UnitTestConvSolverDevApplicabilityBase::RunTestImpl(
     const auto all_known_devs = GetAllKnownDevices();
     for(const auto& [dev, dev_descr] : all_known_devs)
     {
-        const auto supported = IsDeviceSupported(params.supported_devs, dev)
-                               && params.excluded_devices.count(dev_descr.name) == 0;
+        const auto supported = IsDeviceSupported(params.supported_devs, dev) &&
+                               params.excluded_devices.count(dev_descr.name) == 0;
         // std::cout << "Test " << dev_descr << " (supported: " << supported << ")" << std::endl;
 
         auto handle    = MockHandle{dev_descr, params.check_xnack_disabled};

--- a/projects/miopen/test/gtest/unit_conv_solver.hpp
+++ b/projects/miopen/test/gtest/unit_conv_solver.hpp
@@ -25,6 +25,7 @@
  *******************************************************************************/
 #pragma once
 
+#include <set>
 #include <unordered_map>
 
 #include <miopen/conv/solvers.hpp>
@@ -152,6 +153,7 @@ struct UnitTestConvSolverParams
     void CheckXnackDisabled();
     void SetConvAttrFp16Alt(uint64_t value);
     void SetTolerance(Gpu gpu, miopenDataType_t type, float value);
+    void ExcludeDevice(std::string_view name);
 
     friend std::ostream& operator<<(std::ostream& os, const UnitTestConvSolverParams& p);
 
@@ -163,6 +165,7 @@ struct UnitTestConvSolverParams
     std::size_t tuning_iterations_max;
     std::optional<uint64_t> conv_attr_fp16_alt;
     Tolerances tolerances;
+    std::set<std::string, std::less<>> excluded_devices;
 };
 
 class UnitTestConvSolverBase

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvWinoFuryRxS.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvWinoFuryRxS.cpp
@@ -57,6 +57,7 @@ const auto& GetTestParams()
     static const auto params = [] {
         auto p = miopen::unit_tests::UnitTestConvSolverParams(Gpu::gfx110X | Gpu::gfx120X |
                                                               Gpu::gfx115X);
+        p.ExcludeDevice("gfx1103"); // WORKAROUND_ISSUE_3044
         return p;
     }();
     return params;


### PR DESCRIPTION
## Motivation

- #5763 ignored gfx1103 in the applicability tests for Fury solver and it was OK because it wasn't in all-devices list. It was revealed as a bug by #5522 which added gfx1103 to the list, but the PRs were tested independently and were merged almost simultaneously
- The opportunity to enable the solver by force with `MIOPEN_DEBUG_AMD_WINOGRAD_FURY_RXS_F2X3=1` environment variable wasn't provided

## Technical Details

A list of excluded devices has been introduced in `UnitTestConvSolverParams`. It allows to track the supported devices individually rather than by their ISA.

## Test Plan

CI should be passed

## Test Result

- [ ] CI

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
