### PR TITLE
[hipsparelt] Delete spurious rIdx_ loop for hipsparselt failed tests

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
@@ -1030,39 +1030,37 @@ class LocalReadMFMA(LocalRead):
                                                 #vgprIdx = (vIdx*numVgpr+i)*ceil(tP["bpeDS"]*kernel["MIInputPerThread%s"%tc] / writer.states.bpr)*min(writer.states.bpr//tP["bpeDS"],vectorWidth)
                                                 if kernel["MIInputPerThread%s"%tc] == 4:
                                                     vgprOffset = 0
-                                                    for rIdx_ in range(0, numReadsPerUnroll*miInputGroup):
-                                                        for elementIdx in range(0, numSplitMetadata+1):
-                                                            if elementIdx >= writer.states.bpr:
-                                                                break
-                                                            # since the number of input thread is 4, so will alwasy be D0, D1, D2, D3
-                                                            packCodeT.add(VPermB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx+elementIdx)), \
-                                                                            src0=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, 1, i+vIdx*numVgpr)), \
-                                                                            src1=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, 0, i+vIdx*numVgpr)), \
-                                                                            src2=sgpr("PackKFor%sV%u"%(tPackM, elementIdx)), \
-                                                                            comment="1 select K=%u%u for vector=%u"%(0, 1, elementIdx)))
-                                                            packCodeT.add(VPermB32(dst=vgpr("PackTemp"), \
-                                                                            src0=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, 3, i+vIdx*numVgpr)), \
-                                                                            src1=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, 2, i+vIdx*numVgpr)), \
-                                                                            src2=sgpr("PackKFor%sV%u"%(tPackM, elementIdx)), \
-                                                                            comment="1 select K=%u%u for vector=%u"%(2, 3, elementIdx)))
-                                                            packCodeT.add(VLShiftLeftOrB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx+elementIdx)), \
-                                                                            src0=vgpr("PackTemp"), shiftHex=16, \
-                                                                            src1=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx+elementIdx)), \
-                                                                            comment="pack two half Vgpr to one Vgpr"))
-                                                            vgprOffset += 1
+                                                    for elementIdx in range(0, numSplitMetadata+1):
+                                                        if elementIdx >= writer.states.bpr:
+                                                            break
+                                                        # since the number of input thread is 4, so will alwasy be D0, D1, D2, D3
+                                                        packCodeT.add(VPermB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx+elementIdx)), \
+                                                                        src0=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, 1, i+vIdx*numVgpr)), \
+                                                                        src1=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, 0, i+vIdx*numVgpr)), \
+                                                                        src2=sgpr("PackKFor%sV%u"%(tPackM, vgprOffset)), \
+                                                                        comment="1 select K=%u%u for vector=%u"%(0, 1, vgprOffset)))
+                                                        packCodeT.add(VPermB32(dst=vgpr("PackTemp"), \
+                                                                        src0=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, 3, i+vIdx*numVgpr)), \
+                                                                        src1=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, 2, i+vIdx*numVgpr)), \
+                                                                        src2=sgpr("PackKFor%sV%u"%(tPackM, vgprOffset)), \
+                                                                        comment="1 select K=%u%u for vector=%u"%(2, 3, vgprOffset)))
+                                                        packCodeT.add(VLShiftLeftOrB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx+elementIdx)), \
+                                                                        src0=vgpr("PackTemp"), shiftHex=16, \
+                                                                        src1=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx+elementIdx)), \
+                                                                        comment="pack two half Vgpr to one Vgpr"))
+                                                        vgprOffset += 1
                                                 elif kernel["MIInputPerThread%s"%tc] == 2:
                                                     vgprOffset = 0
-                                                    for rIdx_ in range(0, numReadsPerUnroll*miInputGroup):
-                                                        for elementIdx in range(0, numSplitMetadata+1):
-                                                            if elementIdx >= writer.states.bpr:
-                                                                break
-                                                            # since the number of input thread is 2, so will alwasy be D0 and D1
-                                                            packCodeT.add(VPermB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx+elementIdx)), \
-                                                                                    src0=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, 1, i+vIdx*numVgpr)), \
-                                                                                    src1=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, 0, i+vIdx*numVgpr)), \
-                                                                                    src2=sgpr("PackKFor%sV%u"%(tPackM, elementIdx)), \
-                                                                                    comment="select K=%u%u for vector=%u"%(0, 1, elementIdx)))
-                                                            vgprOffset += 1
+                                                    for elementIdx in range(0, numSplitMetadata+1):
+                                                        if elementIdx >= writer.states.bpr:
+                                                            break
+                                                        # since the number of input thread is 2, so will alwasy be D0 and D1
+                                                        packCodeT.add(VPermB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx+elementIdx)), \
+                                                                                src0=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, 1, i+vIdx*numVgpr)), \
+                                                                                src1=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, 0, i+vIdx*numVgpr)), \
+                                                                                src2=sgpr("PackKFor%sV%u"%(tPackM, vgprOffset)), \
+                                                                                comment="select K=%u%u for vector=%u"%(0, 1, vgprOffset)))
+                                                        vgprOffset += 1
                                                 elif kernel["MIInputPerThread%s"%tc] == 1:
                                                     vgprIdx_ = vgprIdx+vIdx*(numSplitMetadata+1)
                                                     packCodeT.add(VMovB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx_)), src=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, 0, i+vIdx*numVgpr))))

--- a/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
@@ -1062,17 +1062,17 @@ class LocalReadMFMA(LocalRead):
                                                                                 comment="select K=%u%u for vector=%u"%(0, 1, vgprOffset)))
                                                         vgprOffset += 1
                                                 elif kernel["MIInputPerThread%s"%tc] == 1:
-                                                    vgprIdx_ = vgprIdx+vIdx*(numSplitMetadata+1)
-                                                    packCodeT.add(VMovB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx_)), src=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, 0, i+vIdx*numVgpr))))
-                                                    for elementIdx in range(1, numSplitMetadata+1):
+                                                    destVgpr_ = vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, grIdx%(kernel["MIInputPerThread%s"%tc]), vIdx*numVgpr + i))
+                                                    bitShift = 0
+                                                    for elementIdx in range(0, numSplitMetadata+1):
+                                                        # go to next vgpr
                                                         if elementIdx >= writer.states.bpr:
                                                             break
-                                                        packCodeT.add(VMovB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx_ + elementIdx)), src=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, 0, i+vIdx*numVgpr)), \
-                                                                            comment="another VGPR storing lshr 8-bit value %d %d" %(vgprIdx, elementIdx)))
-                                                        packCodeT.add(VLShiftRightB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx_+elementIdx)), \
-                                                                                    shiftHex=hex(8*elementIdx), \
-                                                                                    src=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx_+elementIdx)), \
-                                                                                    comment="ValuMetadata Vpgr >> 8"))
+                                                        comment_ = "another VGPR storing lshr %d-bit value %d %d" %(bitShift, vgprIdx, elementIdx) if bitShift != 0 else ""
+                                                        packCodeT.add(VMovB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx+elementIdx)), src=destVgpr_, comment=comment_))
+                                                        if bitShift != 0:
+                                                            packCodeT.add(VLShiftRightB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx+elementIdx)), shiftHex=hex(bitShift), src=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx+elementIdx)), comment="ValuMetadata Vpgr >> %d" % bitShift))
+                                                        bitShift += 8
                                                 else:
                                                     assert False
                                             elif tP["isM"]:

--- a/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
@@ -1062,7 +1062,7 @@ class LocalReadMFMA(LocalRead):
                                                                                 comment="select K=%u%u for vector=%u"%(0, 1, vgprOffset)))
                                                         vgprOffset += 1
                                                 elif kernel["MIInputPerThread%s"%tc] == 1:
-                                                    destVgpr_ = vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, grIdx%(kernel["MIInputPerThread%s"%tc]), vIdx*numVgpr + i))
+                                                    destVgpr_ = vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, rIdx%(kernel["MIInputPerThread%s"%tc]), vIdx*numVgpr + i))
                                                     bitShift = 0
                                                     for elementIdx in range(0, numSplitMetadata+1):
                                                         # go to next vgpr


### PR DESCRIPTION
## Motivation
- Fix all hipsparselt-test failed test in rhel && gfx950
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
- delete the extra `for rIdx_ loop` in LocalRead.py for the assembly
<img width="1805" height="681" alt="image" src="https://github.com/user-attachments/assets/d633bd82-a291-43c2-a9c6-d99276a5335d" />

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
- test script: `./build/release/hipsparselt-install/bin/hipsparselt-test --gtest_output=xml --gtest_color=yes --gtest_filter=*quick* `
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
- All passed
<img width="1212" height="250" alt="image" src="https://github.com/user-attachments/assets/797091e6-2bb1-4262-9513-5220ff6b3122" />

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
