### PR TITLE
bf16 WrW convolution: inter-batch accumulation in bf16 fix

### DIFF
--- a/projects/miopen/src/gemm_v2.cpp
+++ b/projects/miopen/src/gemm_v2.cpp
@@ -925,6 +925,117 @@ miopenStatus_t CallGemm(const Handle& handle,
     return miopenStatusUnknownError;
 }
 
+miopenStatus_t CallGemm(const Handle& handle,
+                        GemmDescriptor gemm_desc,
+                        ConstData_t A,
+                        std::size_t a_offset,
+                        ConstData_t B,
+                        std::size_t b_offset,
+                        Data_t C,
+                        std::size_t c_offset,
+                        GemmBackend_t gemm_backend,
+                        miopenDataType_t cType)
+{
+    // If C/D type matches A/B type, delegate to the standard overload
+    if(cType == gemm_desc.dataType)
+        return CallGemm(handle, gemm_desc, A, a_offset, B, b_offset, C, c_offset, gemm_backend);
+
+    MIOPEN_LOG_I2("gemm_desc: " << gemm_desc << " cType: " << GetDataType(cType));
+
+    gemm_backend = enforce_gemm_backend(gemm_backend);
+
+    if(!gemm_desc.isColMajor)
+    {
+        gemm_desc.isColMajor = !gemm_desc.isColMajor;
+        std::swap(A, B);
+        std::swap(a_offset, b_offset);
+        std::swap(gemm_desc.a_cast_type, gemm_desc.b_cast_type);
+        std::swap(gemm_desc.transA, gemm_desc.transB);
+        std::swap(gemm_desc.m, gemm_desc.n);
+        std::swap(gemm_desc.lda, gemm_desc.ldb);
+    }
+
+    switch(gemm_backend)
+    {
+    case GemmBackend_t::nogemmbackend: return miopenStatusNotImplemented;
+    case GemmBackend_t::rocblas: {
+#if MIOPEN_USE_ROCBLAS
+        MIOPEN_LOG_I2("rocBLAS mixed-precision C/D");
+
+        HipEventPtr start = nullptr;
+        HipEventPtr stop  = nullptr;
+        if(handle.IsProfilingEnabled())
+        {
+            ProfilingRecordStart(handle, start, stop);
+        }
+        rocblas_atomics_mode cur_mode =
+            rocblas_atomics_mode::rocblas_atomics_allowed;
+        if(gemm_desc.deterministic)
+            cur_mode = DisableRocblasAtomics(handle);
+
+        rocblas_status rb_status = rocblas_status::rocblas_status_internal_error;
+
+        // Currently only bf16 A/B with fp32 C/D is supported
+        if(gemm_desc.dataType == miopenBFloat16 && cType == miopenFloat)
+        {
+            float alpha = gemm_desc.alpha;
+            float beta  = gemm_desc.beta;
+
+            rb_status = miopen_rocblas_gemm_ex(
+                handle,
+                gemm_desc,
+                gemm_desc.transA ? rocblas_operation_transpose : rocblas_operation_none,
+                gemm_desc.transB ? rocblas_operation_transpose : rocblas_operation_none,
+                gemm_desc.m,
+                gemm_desc.n,
+                gemm_desc.k,
+                &alpha,
+                static_cast<const rocblas_bfloat16*>(A) + a_offset,
+                rocblas_datatype::rocblas_datatype_bf16_r,
+                gemm_desc.lda,
+                static_cast<const rocblas_bfloat16*>(B) + b_offset,
+                rocblas_datatype::rocblas_datatype_bf16_r,
+                gemm_desc.ldb,
+                &beta,
+                static_cast<const float*>(C) + c_offset,
+                rocblas_datatype::rocblas_datatype_f32_r,
+                gemm_desc.ldc,
+                static_cast<float*>(C) + c_offset,
+                rocblas_datatype::rocblas_datatype_f32_r,
+                gemm_desc.ldc,
+                rocBlasComputeType(gemm_desc),
+                rocblas_gemm_algo::rocblas_gemm_algo_standard,
+                0,
+                0);
+        }
+        else
+        {
+            MIOPEN_THROW(miopenStatusInternalError,
+                         "CallGemm with cType: unsupported dataType/cType combination");
+        }
+
+        if(handle.IsProfilingEnabled())
+            ProfilingRecordStop(handle, start, stop);
+
+        if(rb_status != rocblas_status::rocblas_status_success)
+            MIOPEN_THROW(miopenStatusInternalError, "rocBlas error encountered");
+
+        if(gemm_desc.deterministic)
+            SetRocblasAtomics(handle, cur_mode);
+        return miopenStatusSuccess;
+#else
+        return miopenStatusNotImplemented;
+#endif
+    }
+    case GemmBackend_t::hipblaslt: {
+        MIOPEN_THROW(miopenStatusInternalError,
+                     "CallGemm with cType: hipblaslt backend not supported");
+    }
+    }
+
+    return miopenStatusUnknownError;
+}
+
 miopenStatus_t CallGemmStridedBatched(const Handle& handle,
                                       GemmDescriptor gemm_desc,
                                       ConstData_t A,
@@ -1208,6 +1319,124 @@ miopenStatus_t CallGemmStridedBatched(const Handle& handle,
 #else
         return miopenStatusNotImplemented;
 #endif
+    }
+    }
+
+    return miopenStatusUnknownError;
+}
+
+miopenStatus_t CallGemmStridedBatched(const Handle& handle,
+                                      GemmDescriptor gemm_desc,
+                                      ConstData_t A,
+                                      std::size_t a_offset,
+                                      ConstData_t B,
+                                      std::size_t b_offset,
+                                      Data_t C,
+                                      std::size_t c_offset,
+                                      GemmBackend_t gemm_backend,
+                                      miopenDataType_t cType)
+{
+    // If C/D type matches A/B type, delegate to the standard overload
+    if(cType == gemm_desc.dataType)
+        return CallGemmStridedBatched(
+            handle, gemm_desc, A, a_offset, B, b_offset, C, c_offset, gemm_backend);
+
+    MIOPEN_LOG_I2("gemm_desc: " << gemm_desc << " cType: " << GetDataType(cType));
+
+    gemm_backend = enforce_gemm_backend(gemm_backend);
+
+    if(!gemm_desc.isColMajor)
+    {
+        gemm_desc.isColMajor = !gemm_desc.isColMajor;
+        std::swap(A, B);
+        std::swap(a_offset, b_offset);
+        std::swap(gemm_desc.a_cast_type, gemm_desc.b_cast_type);
+        std::swap(gemm_desc.transA, gemm_desc.transB);
+        std::swap(gemm_desc.m, gemm_desc.n);
+        std::swap(gemm_desc.lda, gemm_desc.ldb);
+        std::swap(gemm_desc.strideA, gemm_desc.strideB);
+    }
+
+    switch(gemm_backend)
+    {
+    case GemmBackend_t::nogemmbackend: return miopenStatusNotImplemented;
+    case GemmBackend_t::rocblas: {
+#if MIOPEN_USE_ROCBLAS
+        MIOPEN_LOG_I2("rocBLAS mixed-precision C/D (strided batched)");
+
+        HipEventPtr start = nullptr;
+        HipEventPtr stop  = nullptr;
+        if(handle.IsProfilingEnabled())
+        {
+            ProfilingRecordStart(handle, start, stop);
+        }
+        rocblas_atomics_mode cur_mode =
+            rocblas_atomics_mode::rocblas_atomics_allowed;
+        if(gemm_desc.deterministic)
+            cur_mode = DisableRocblasAtomics(handle);
+
+        rocblas_status rb_status = rocblas_status::rocblas_status_internal_error;
+
+        // Currently only bf16 A/B with fp32 C/D is supported
+        if(gemm_desc.dataType == miopenBFloat16 && cType == miopenFloat)
+        {
+            float alpha = gemm_desc.alpha;
+            float beta  = gemm_desc.beta;
+
+            rb_status = miopen_rocblas_gemm_strided_batched_ex(
+                handle.rhandle().get(),
+                gemm_desc.transA ? rocblas_operation_transpose : rocblas_operation_none,
+                gemm_desc.transB ? rocblas_operation_transpose : rocblas_operation_none,
+                gemm_desc.m,
+                gemm_desc.n,
+                gemm_desc.k,
+                &alpha,
+                static_cast<const rocblas_bfloat16*>(A) + a_offset,
+                rocblas_datatype::rocblas_datatype_bf16_r,
+                gemm_desc.lda,
+                gemm_desc.strideA,
+                static_cast<const rocblas_bfloat16*>(B) + b_offset,
+                rocblas_datatype::rocblas_datatype_bf16_r,
+                gemm_desc.ldb,
+                gemm_desc.strideB,
+                &beta,
+                static_cast<const float*>(C) + c_offset,
+                rocblas_datatype::rocblas_datatype_f32_r,
+                gemm_desc.ldc,
+                gemm_desc.strideC,
+                static_cast<float*>(C) + c_offset,
+                rocblas_datatype::rocblas_datatype_f32_r,
+                gemm_desc.ldc,
+                gemm_desc.strideC,
+                gemm_desc.batch_count,
+                rocblas_datatype::rocblas_datatype_f32_r,
+                rocblas_gemm_algo::rocblas_gemm_algo_standard,
+                0,
+                0);
+        }
+        else
+        {
+            MIOPEN_THROW(miopenStatusInternalError,
+                         "CallGemmStridedBatched with cType: unsupported dataType/cType combination");
+        }
+
+        if(handle.IsProfilingEnabled())
+            ProfilingRecordStop(handle, start, stop);
+
+        if(rb_status != rocblas_status::rocblas_status_success)
+            MIOPEN_THROW(miopenStatusInternalError, "rocBlas error encountered");
+
+        if(gemm_desc.deterministic)
+            SetRocblasAtomics(handle, cur_mode);
+
+        return miopenStatusSuccess;
+#else
+        return miopenStatusNotImplemented;
+#endif
+    }
+    case GemmBackend_t::hipblaslt: {
+        MIOPEN_THROW(miopenStatusInternalError,
+                     "CallGemmStridedBatched with cType: hipblaslt backend not supported");
     }
     }
 

--- a/projects/miopen/src/gemm_v2.cpp
+++ b/projects/miopen/src/gemm_v2.cpp
@@ -968,8 +968,7 @@ miopenStatus_t CallGemm(const Handle& handle,
         {
             ProfilingRecordStart(handle, start, stop);
         }
-        rocblas_atomics_mode cur_mode =
-            rocblas_atomics_mode::rocblas_atomics_allowed;
+        rocblas_atomics_mode cur_mode = rocblas_atomics_mode::rocblas_atomics_allowed;
         if(gemm_desc.deterministic)
             cur_mode = DisableRocblasAtomics(handle);
 
@@ -1370,8 +1369,7 @@ miopenStatus_t CallGemmStridedBatched(const Handle& handle,
         {
             ProfilingRecordStart(handle, start, stop);
         }
-        rocblas_atomics_mode cur_mode =
-            rocblas_atomics_mode::rocblas_atomics_allowed;
+        rocblas_atomics_mode cur_mode = rocblas_atomics_mode::rocblas_atomics_allowed;
         if(gemm_desc.deterministic)
             cur_mode = DisableRocblasAtomics(handle);
 
@@ -1416,8 +1414,9 @@ miopenStatus_t CallGemmStridedBatched(const Handle& handle,
         }
         else
         {
-            MIOPEN_THROW(miopenStatusInternalError,
-                         "CallGemmStridedBatched with cType: unsupported dataType/cType combination");
+            MIOPEN_THROW(
+                miopenStatusInternalError,
+                "CallGemmStridedBatched with cType: unsupported dataType/cType combination");
         }
 
         if(handle.IsProfilingEnabled())

--- a/projects/miopen/src/gemm_v2.cpp
+++ b/projects/miopen/src/gemm_v2.cpp
@@ -933,8 +933,8 @@ miopenStatus_t CallGemm(const Handle& handle,
                         std::size_t b_offset,
                         Data_t C,
                         std::size_t c_offset,
-                        GemmBackend_t gemm_backend,
-                        miopenDataType_t cType)
+                        miopenDataType_t cType,
+                        GemmBackend_t gemm_backend)
 {
     // If C/D type matches A/B type, delegate to the standard overload
     if(cType == gemm_desc.dataType)
@@ -1332,8 +1332,8 @@ miopenStatus_t CallGemmStridedBatched(const Handle& handle,
                                       std::size_t b_offset,
                                       Data_t C,
                                       std::size_t c_offset,
-                                      GemmBackend_t gemm_backend,
-                                      miopenDataType_t cType)
+                                      miopenDataType_t cType,
+                                      GemmBackend_t gemm_backend)
 {
     // If C/D type matches A/B type, delegate to the standard overload
     if(cType == gemm_desc.dataType)

--- a/projects/miopen/src/include/miopen/gemm_v2.hpp
+++ b/projects/miopen/src/include/miopen/gemm_v2.hpp
@@ -127,6 +127,19 @@ miopenStatus_t CallGemm(const Handle& handle,
                         std::size_t c_offset,
                         GemmBackend_t gemm_backend = GemmBackend_t::rocblas);
 
+// Overload with explicit C/D data type (e.g. bf16 A/B with fp32 C/D accumulation)
+MIOPEN_EXPORT
+miopenStatus_t CallGemm(const Handle& handle,
+                        GemmDescriptor gemm_desc,
+                        ConstData_t A,
+                        std::size_t a_offset,
+                        ConstData_t B,
+                        std::size_t b_offset,
+                        Data_t C,
+                        std::size_t c_offset,
+                        GemmBackend_t gemm_backend,
+                        miopenDataType_t cType);
+
 MIOPEN_EXPORT
 miopenStatus_t CallGemmStridedBatched(const Handle& handle,
                                       GemmDescriptor gemm_desc,
@@ -137,6 +150,19 @@ miopenStatus_t CallGemmStridedBatched(const Handle& handle,
                                       Data_t C,
                                       std::size_t c_offset,
                                       GemmBackend_t gemm_backend = GemmBackend_t::rocblas);
+
+// Overload with explicit C/D data type (e.g. bf16 A/B with fp32 C/D accumulation)
+MIOPEN_EXPORT
+miopenStatus_t CallGemmStridedBatched(const Handle& handle,
+                                      GemmDescriptor gemm_desc,
+                                      ConstData_t A,
+                                      std::size_t a_offset,
+                                      ConstData_t B,
+                                      std::size_t b_offset,
+                                      Data_t C,
+                                      std::size_t c_offset,
+                                      GemmBackend_t gemm_backend,
+                                      miopenDataType_t cType);
 
 miopenStatus_t
 CallGemmStridedBatchedSequential(const Handle& handle,

--- a/projects/miopen/src/include/miopen/gemm_v2.hpp
+++ b/projects/miopen/src/include/miopen/gemm_v2.hpp
@@ -137,8 +137,8 @@ miopenStatus_t CallGemm(const Handle& handle,
                         std::size_t b_offset,
                         Data_t C,
                         std::size_t c_offset,
-                        GemmBackend_t gemm_backend,
-                        miopenDataType_t cType);
+                        miopenDataType_t cType,
+                        GemmBackend_t gemm_backend = GemmBackend_t::rocblas);
 
 MIOPEN_EXPORT
 miopenStatus_t CallGemmStridedBatched(const Handle& handle,
@@ -161,8 +161,8 @@ miopenStatus_t CallGemmStridedBatched(const Handle& handle,
                                       std::size_t b_offset,
                                       Data_t C,
                                       std::size_t c_offset,
-                                      GemmBackend_t gemm_backend,
-                                      miopenDataType_t cType);
+                                      miopenDataType_t cType,
+                                      GemmBackend_t gemm_backend = GemmBackend_t::rocblas);
 
 miopenStatus_t
 CallGemmStridedBatchedSequential(const Handle& handle,

--- a/projects/miopen/src/solver/conv/gemm_wrw.cpp
+++ b/projects/miopen/src/solver/conv/gemm_wrw.cpp
@@ -353,10 +353,9 @@ size_t GemmWrwUniversal::GetWorkspaceSize(const ExecutionContext& context,
                          conv.group_count;
 
     // For bf16: extra workspace for fp32 accumulation buffer (same shape as dw)
-    const auto xDesc  = problem.GetOut();
-    const auto in_n   = xDesc.GetLengths()[0];
-    const auto need_fp32_accum =
-        (dyDesc.GetType() == miopenBFloat16) && (in_n > 1);
+    const auto xDesc           = problem.GetOut();
+    const auto in_n            = xDesc.GetLengths()[0];
+    const auto need_fp32_accum = (dyDesc.GetType() == miopenBFloat16) && (in_n > 1);
     const auto fp32_accum_size =
         need_fp32_accum ? GetTypeSize(miopenFloat) * dwDesc.GetElementSize() : std::size_t{0};
     // Use padded layout: im2col buffer at offset 0, fp32 accum buffer at offset ws_size
@@ -367,7 +366,7 @@ size_t GemmWrwUniversal::GetWorkspaceSize(const ExecutionContext& context,
     if(total_ws_size > handle.GetMaxMemoryAllocSize())
     {
         MIOPEN_LOG_I2("GemmWrwUniversal: " << total_ws_size << " > "
-                                            << handle.GetMaxMemoryAllocSize());
+                                           << handle.GetMaxMemoryAllocSize());
         return 0;
     }
     return total_ws_size;
@@ -469,13 +468,13 @@ ConvSolution GemmWrwUniversal::GetSolution(const ExecutionContext& context,
     const auto wei_k          = dwDesc.GetLengths()[0];
 
     // bf16: accumulate in fp32 workspace when batch_size > 1
-    const auto data_type       = dyDesc.GetType();
-    const auto use_fp32_accum  = (data_type == miopenBFloat16) && (in_n > 1);
-    const auto lowp_quant      = conv.lowp_quant;
-    const auto dw_lengths      = dwDesc.GetLengths();
-    const auto dw_strides      = dwDesc.GetStrides();
+    const auto data_type      = dyDesc.GetType();
+    const auto use_fp32_accum = (data_type == miopenBFloat16) && (in_n > 1);
+    const auto lowp_quant     = conv.lowp_quant;
+    const auto dw_lengths     = dwDesc.GetLengths();
+    const auto dw_strides     = dwDesc.GetStrides();
     // im2col workspace size (before padding/alignment)
-    const auto im2col_ws_size  = [&]() {
+    const auto im2col_ws_size = [&]() {
         const auto wei_c = dwDesc.GetLengths()[1];
         const auto out_sp =
             dyDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dims);
@@ -553,8 +552,7 @@ ConvSolution GemmWrwUniversal::GetSolution(const ExecutionContext& context,
             Data_t accum_buf = dw;
             if(use_fp32_accum)
             {
-                accum_buf = static_cast<Data_t>(
-                    static_cast<char*>(workspace) + fp32_accum_offset);
+                accum_buf = static_cast<Data_t>(static_cast<char*>(workspace) + fp32_accum_offset);
                 TensorDescriptor fp32Desc(miopenFloat, dw_lengths, dw_strides);
                 SetTensor(handle, fp32Desc, accum_buf, &zero);
             }

--- a/projects/miopen/src/solver/conv/gemm_wrw.cpp
+++ b/projects/miopen/src/solver/conv/gemm_wrw.cpp
@@ -342,15 +342,15 @@ size_t GemmWrwUniversal::GetWorkspaceSize(const ExecutionContext& context,
     const auto wei_c = dwDesc.GetLengths()[1];
 
     auto ws_size = GetTypeSize(dyDesc.GetType()) * wei_c *
-                    std::accumulate(out_spatial.begin(),
-                                    out_spatial.end(),
-                                    std::size_t(1),
-                                    std::multiplies<std::size_t>()) *
-                    std::accumulate(wei_spatial.begin(),
-                                    wei_spatial.end(),
-                                    std::size_t(1),
-                                    std::multiplies<std::size_t>()) *
-                    conv.group_count;
+                   std::accumulate(out_spatial.begin(),
+                                   out_spatial.end(),
+                                   std::size_t(1),
+                                   std::multiplies<std::size_t>()) *
+                   std::accumulate(wei_spatial.begin(),
+                                   wei_spatial.end(),
+                                   std::size_t(1),
+                                   std::multiplies<std::size_t>()) *
+                   conv.group_count;
 
     // For bf16: extra workspace for fp32 accumulation buffer (same shape as dw)
     const auto xDesc           = problem.GetOut();
@@ -366,8 +366,7 @@ size_t GemmWrwUniversal::GetWorkspaceSize(const ExecutionContext& context,
 
     if(ws_size > handle.GetMaxMemoryAllocSize())
     {
-        MIOPEN_LOG_I2("GemmWrwUniversal: " << ws_size << " > "
-                                           << handle.GetMaxMemoryAllocSize());
+        MIOPEN_LOG_I2("GemmWrwUniversal: " << ws_size << " > " << handle.GetMaxMemoryAllocSize());
         return 0;
     }
     return ws_size;

--- a/projects/miopen/src/solver/conv/gemm_wrw.cpp
+++ b/projects/miopen/src/solver/conv/gemm_wrw.cpp
@@ -341,35 +341,36 @@ size_t GemmWrwUniversal::GetWorkspaceSize(const ExecutionContext& context,
         dwDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
     const auto wei_c = dwDesc.GetLengths()[1];
 
-    const auto ws_size = GetTypeSize(dyDesc.GetType()) * wei_c *
-                         std::accumulate(out_spatial.begin(),
-                                         out_spatial.end(),
-                                         std::size_t(1),
-                                         std::multiplies<std::size_t>()) *
-                         std::accumulate(wei_spatial.begin(),
-                                         wei_spatial.end(),
-                                         std::size_t(1),
-                                         std::multiplies<std::size_t>()) *
-                         conv.group_count;
+    auto ws_size = GetTypeSize(dyDesc.GetType()) * wei_c *
+                    std::accumulate(out_spatial.begin(),
+                                    out_spatial.end(),
+                                    std::size_t(1),
+                                    std::multiplies<std::size_t>()) *
+                    std::accumulate(wei_spatial.begin(),
+                                    wei_spatial.end(),
+                                    std::size_t(1),
+                                    std::multiplies<std::size_t>()) *
+                    conv.group_count;
 
     // For bf16: extra workspace for fp32 accumulation buffer (same shape as dw)
     const auto xDesc           = problem.GetOut();
     const auto in_n            = xDesc.GetLengths()[0];
     const auto need_fp32_accum = (dyDesc.GetType() == miopenBFloat16) && (in_n > 1);
-    const auto fp32_accum_size =
-        need_fp32_accum ? GetTypeSize(miopenFloat) * dwDesc.GetElementSize() : std::size_t{0};
-    // Use padded layout: im2col buffer at offset 0, fp32 accum buffer at offset ws_size
-    // (aligned to 256 bytes)
-    const auto total_ws_size =
-        need_fp32_accum ? ((ws_size + 255) & ~std::size_t{255}) + fp32_accum_size : ws_size;
-
-    if(total_ws_size > handle.GetMaxMemoryAllocSize())
+    if(need_fp32_accum)
     {
-        MIOPEN_LOG_I2("GemmWrwUniversal: " << total_ws_size << " > "
+        const auto fp32_accum_size = GetTypeSize(miopenFloat) * dwDesc.GetElementSize();
+        // Use padded layout: im2col buffer at offset 0, fp32 accum buffer at offset ws_size
+        // (aligned to 256 bytes)
+        ws_size = ((ws_size + 255) & ~std::size_t{255}) + fp32_accum_size;
+    }
+
+    if(ws_size > handle.GetMaxMemoryAllocSize())
+    {
+        MIOPEN_LOG_I2("GemmWrwUniversal: " << ws_size << " > "
                                            << handle.GetMaxMemoryAllocSize());
         return 0;
     }
-    return total_ws_size;
+    return ws_size;
 #else
     std::ignore = context;
     std::ignore = problem;
@@ -597,7 +598,6 @@ ConvSolution GemmWrwUniversal::GetSolution(const ExecutionContext& context,
                                                         0,
                                                         accum_buf,
                                                         0,
-                                                        GemmBackend_t::rocblas,
                                                         miopenFloat);
                     }
                     else
@@ -626,7 +626,6 @@ ConvSolution GemmWrwUniversal::GetSolution(const ExecutionContext& context,
                                           0,
                                           accum_buf,
                                           0,
-                                          GemmBackend_t::rocblas,
                                           miopenFloat);
                     }
                     else

--- a/projects/miopen/src/solver/conv/gemm_wrw.cpp
+++ b/projects/miopen/src/solver/conv/gemm_wrw.cpp
@@ -352,12 +352,25 @@ size_t GemmWrwUniversal::GetWorkspaceSize(const ExecutionContext& context,
                                          std::multiplies<std::size_t>()) *
                          conv.group_count;
 
-    if(ws_size > handle.GetMaxMemoryAllocSize())
+    // For bf16: extra workspace for fp32 accumulation buffer (same shape as dw)
+    const auto xDesc  = problem.GetOut();
+    const auto in_n   = xDesc.GetLengths()[0];
+    const auto need_fp32_accum =
+        (dyDesc.GetType() == miopenBFloat16) && (in_n > 1);
+    const auto fp32_accum_size =
+        need_fp32_accum ? GetTypeSize(miopenFloat) * dwDesc.GetElementSize() : std::size_t{0};
+    // Use padded layout: im2col buffer at offset 0, fp32 accum buffer at offset ws_size
+    // (aligned to 256 bytes)
+    const auto total_ws_size =
+        need_fp32_accum ? ((ws_size + 255) & ~std::size_t{255}) + fp32_accum_size : ws_size;
+
+    if(total_ws_size > handle.GetMaxMemoryAllocSize())
     {
-        MIOPEN_LOG_I2("GemmWrwUniversal: " << ws_size << " > " << handle.GetMaxMemoryAllocSize());
+        MIOPEN_LOG_I2("GemmWrwUniversal: " << total_ws_size << " > "
+                                            << handle.GetMaxMemoryAllocSize());
         return 0;
     }
-    return ws_size;
+    return total_ws_size;
 #else
     std::ignore = context;
     std::ignore = problem;
@@ -455,6 +468,30 @@ ConvSolution GemmWrwUniversal::GetSolution(const ExecutionContext& context,
     const auto in_c           = xDesc.GetLengths()[1];
     const auto wei_k          = dwDesc.GetLengths()[0];
 
+    // bf16: accumulate in fp32 workspace when batch_size > 1
+    const auto data_type       = dyDesc.GetType();
+    const auto use_fp32_accum  = (data_type == miopenBFloat16) && (in_n > 1);
+    const auto lowp_quant      = conv.lowp_quant;
+    const auto dw_lengths      = dwDesc.GetLengths();
+    const auto dw_strides      = dwDesc.GetStrides();
+    // im2col workspace size (before padding/alignment)
+    const auto im2col_ws_size  = [&]() {
+        const auto wei_c = dwDesc.GetLengths()[1];
+        const auto out_sp =
+            dyDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dims);
+        const auto wei_sp =
+            dwDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dims);
+        return GetTypeSize(data_type) * wei_c *
+               std::accumulate(
+                   out_sp.begin(), out_sp.end(), std::size_t(1), std::multiplies<std::size_t>()) *
+               std::accumulate(
+                   wei_sp.begin(), wei_sp.end(), std::size_t(1), std::multiplies<std::size_t>()) *
+               conv.group_count;
+    }();
+    // Offset to fp32 accumulation buffer within workspace (256-byte aligned)
+    const auto fp32_accum_offset =
+        use_fp32_accum ? ((im2col_ws_size + 255) & ~std::size_t{255}) : std::size_t{0};
+
     const auto in_spatial_ =
         xDesc.GetLengths() | std::views::drop(2) | std::views::take(conv.GetSpatialDimension());
     const auto wei_spatial_ =
@@ -510,9 +547,24 @@ ConvSolution GemmWrwUniversal::GetSolution(const ExecutionContext& context,
 
             // Zeroing out the output buffer
             float zero = 0.0f;
-            SetTensor(handle, dwDesc_, dw, &zero);
-
             float time = 0;
+
+            // For bf16 with batch > 1: accumulate into fp32 workspace, then cast
+            Data_t accum_buf = dw;
+            if(use_fp32_accum)
+            {
+                accum_buf = static_cast<Data_t>(
+                    static_cast<char*>(workspace) + fp32_accum_offset);
+                TensorDescriptor fp32Desc(miopenFloat, dw_lengths, dw_strides);
+                SetTensor(handle, fp32Desc, accum_buf, &zero);
+            }
+            else
+            {
+                SetTensor(handle, dwDesc_, dw, &zero);
+            }
+
+            if(handle.IsProfilingEnabled())
+                time += handle.GetKernelTime();
 
             for(std::size_t i = 0; i < in_n; i++)
             {
@@ -537,34 +589,76 @@ ConvSolution GemmWrwUniversal::GetSolution(const ExecutionContext& context,
 
                 if(group_count > 1)
                 {
-                    status = CallGemmStridedBatched(handle,
-                                                    gemm_desc,
-                                                    dy,
-                                                    out_offset,
-                                                    workspace,
-                                                    0,
-                                                    dw,
-                                                    0,
-                                                    GemmBackend_t::rocblas);
+                    if(use_fp32_accum)
+                    {
+                        status = CallGemmStridedBatched(handle,
+                                                        gemm_desc,
+                                                        dy,
+                                                        out_offset,
+                                                        workspace,
+                                                        0,
+                                                        accum_buf,
+                                                        0,
+                                                        GemmBackend_t::rocblas,
+                                                        miopenFloat);
+                    }
+                    else
+                    {
+                        status = CallGemmStridedBatched(handle,
+                                                        gemm_desc,
+                                                        dy,
+                                                        out_offset,
+                                                        workspace,
+                                                        0,
+                                                        dw,
+                                                        0,
+                                                        GemmBackend_t::rocblas);
+                    }
                 }
                 else
                 {
-                    // dw = dy * transpose(Im2Col(x))
-                    status = CallGemm(handle,
-                                      gemm_desc,
-                                      dy,
-                                      out_offset,
-                                      workspace,
-                                      0,
-                                      dw,
-                                      0,
-                                      GemmBackend_t::rocblas);
+                    if(use_fp32_accum)
+                    {
+                        // dw = dy * transpose(Im2Col(x))  -- accumulated in fp32
+                        status = CallGemm(handle,
+                                          gemm_desc,
+                                          dy,
+                                          out_offset,
+                                          workspace,
+                                          0,
+                                          accum_buf,
+                                          0,
+                                          GemmBackend_t::rocblas,
+                                          miopenFloat);
+                    }
+                    else
+                    {
+                        // dw = dy * transpose(Im2Col(x))
+                        status = CallGemm(handle,
+                                          gemm_desc,
+                                          dy,
+                                          out_offset,
+                                          workspace,
+                                          0,
+                                          dw,
+                                          0,
+                                          GemmBackend_t::rocblas);
+                    }
                 }
 
                 if(status != miopenStatusSuccess)
                     MIOPEN_THROW("GemmWrw1x1_stride1 execution failure.");
 
                 // Update times for both the kernels
+                if(handle.IsProfilingEnabled())
+                    time += handle.GetKernelTime();
+            }
+
+            // Cast fp32 accumulation buffer back to bf16
+            if(use_fp32_accum)
+            {
+                TensorDescriptor fp32Desc(miopenFloat, dw_lengths, dw_strides);
+                CastTensor(handle, &lowp_quant, false, fp32Desc, accum_buf, dwDesc_, dw, 0, 0);
                 if(handle.IsProfilingEnabled())
                     time += handle.GetKernelTime();
             }


### PR DESCRIPTION
## Motivation

During investigating PR912 CI failed on 3 tests, using gfx942:
      test_conv2d
      test_conv2d_find2
      test_immed_conv2d

All 236 individual failures are bf16 backward-weights convolutions.

Soure of error:
In GemmWrwUniversal::GetSolution (gemm_wrw.cpp, line ~435), weight gradients are accumulated across batches by calling CallGemm with beta=1.0 directly into a bf16 dw buffer.
With batch size > 1, each GEMM adds its result to the bf16 output buffer, loosing valuable precision.

## Technical Details

Applied solution is to use fp32 to accumulate while do the rest of compute in bf16. Since this is just inter-batch communication, no major regression should happen.

## Test Plan

To reproduce the failing tests, the tightened error checking path had to be included from PR912. After applying the above fix (while keeping the tightened error check), all CI tests passed. Since this PR is fixing only GemmWrwUniversal, the changes from PR912 were removed when the review process started here.

## Test Result

All tests are passing

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
