### PR TITLE
[rocBLAS] adds transpose only tuned kernels

### DIFF
--- a/projects/rocblas/CHANGELOG.md
+++ b/projects/rocblas/CHANGELOG.md
@@ -3,6 +3,11 @@
 rocBLAS documentation is available at
 [https://rocm.docs.amd.com/projects/rocBLAS/en/latest/index.html](https://rocm.docs.amd.com/projects/rocBLAS/en/latest/index.html).
 
+## rocBLAS 5.4.0
+
+### Optimized
+* Improved the performance of Level 3 geam for pure transpose scale use cases.
+
 ## rocBLAS 5.3.0
 
 ### Added

--- a/projects/rocblas/clients/gtest/geam_gtest.yaml
+++ b/projects/rocblas/clients/gtest/geam_gtest.yaml
@@ -22,6 +22,7 @@ Definitions:
 
   - &large_matrix_size_range
     - { M:   192, N:   193, lda:   194, ldb:   195, ldc:   196 }
+    - { M:   192, N:   192, lda:   192, ldb:   192, ldc:   192 }
     - { M:   640, N:   641, lda:   960, ldb:   961, ldc:   962 }
     - { M:  1001, N:  1000, lda:  1003, ldb:  1002, ldc:  1001 }
 
@@ -51,6 +52,7 @@ Definitions:
 
   - &large_complex_alpha_beta_range
     - { alpha:  1, beta:  2, alphai:  3, betai:  4 }
+    - { alpha:  1, beta:  0, alphai:  5, betai:  0 }
 
   - &huge_complex_alpha_beta_range
     - { alpha:  4, beta:  3, alphai:  2, betai:  1 }
@@ -212,7 +214,6 @@ Tests:
   transA_transB: *transA_transB_range
   matrix_size: *large_matrix_size_range
   alpha_beta: *large_alpha_beta_range
-  pointer_mode_device: false
 
 - name: geam_large_complex
   category: pre_checkin
@@ -221,7 +222,7 @@ Tests:
   transA_transB: *transA_transB_range
   matrix_size: *large_matrix_size_range
   alpha_beta: *large_complex_alpha_beta_range
-  pointer_mode_device: false
+  pointer_mode_device: false # more kernels for host only 
 
 - name: geam_batched_large_complex
   category: pre_checkin
@@ -231,7 +232,7 @@ Tests:
   matrix_size: *large_matrix_size_range
   alpha_beta: *large_complex_alpha_beta_range
   batch_count: [ 2 ]
-  pointer_mode_host: false
+  pointer_mode_device: false
 
 - name: geam_strided_batched_large_complex
   category: pre_checkin
@@ -242,7 +243,6 @@ Tests:
   alpha_beta: *large_complex_alpha_beta_range
   stride_scale: [ 2 ]
   batch_count: [ 2 ]
-  pointer_mode_host: false
 
 - name: geam_huge
   category: nightly

--- a/projects/rocblas/library/src/blas3/rocblas_geam_kernels.cpp
+++ b/projects/rocblas/library/src/blas3/rocblas_geam_kernels.cpp
@@ -259,8 +259,6 @@ rocblas_geam_transpose_tiled_device(rocblas_operation transA,
         for(int j = 0; j < TILE_SIZE; j += TY_SIZE)
         {
             auto a_val = (ty + j >= cols || tx >= rows) ? T(0) : A[tx + (ty + j) * lda];
-            //auto a_val
-            //= (ty + j >= cols || tx >= rows || alpha == T(0)) ? T(0) : A[tx + (ty + j) * lda];
 
             if(transA == rocblas_operation_conjugate_transpose)
                 a_val = conj(a_val);
@@ -549,8 +547,8 @@ rocblas_status rocblas_geam_launcher(rocblas_handle    handle,
 
         if(pointer_mode == rocblas_pointer_mode_host && !*alpha && transB != rocblas_operation_none)
         {
-            // beta == 0
-            // Pure transpose C = alpha * op(B).
+            // alpha == 0
+            // Pure transpose C = beta * op(B).
             static constexpr int TILE_SIZE = 32;
             static constexpr int TY_SIZE   = 8; // 4 iterations per tile
 
@@ -642,7 +640,7 @@ rocblas_status rocblas_geam_launcher(rocblas_handle    handle,
         if(pointer_mode == rocblas_pointer_mode_host && !*beta && transA != rocblas_operation_none)
         {
             // beta == 0
-            // Pure transpose C = alpha * op(B).
+            // Pure transpose C = alpha * op(A).
             static constexpr int TILE_SIZE = 32;
             static constexpr int TY_SIZE   = 8; // 4 iterations per tile
 
@@ -845,7 +843,7 @@ rocblas_status rocblas_geam_launcher(rocblas_handle    handle,
         }
         else if(transB != rocblas_operation_none)
         {
-            // beta == 0
+            // alpha == 0
             // Pure transpose C = beta * op(B).
             static constexpr int TILE_SIZE = 32;
             static constexpr int TY_SIZE   = 8; // 4 iterations per tile

--- a/projects/rocblas/library/src/blas3/rocblas_geam_kernels.cpp
+++ b/projects/rocblas/library/src/blas3/rocblas_geam_kernels.cpp
@@ -208,6 +208,89 @@ rocblas_geam_2matrix_device(rocblas_operation transA,
 #endif
 }
 
+// Tiled transpose with padded shared memory for coalesced reads/writes and no bank conflicts.
+// C = alpha * op(A); tile is TILE_SIZE x (TILE_SIZE + PAD) to avoid shared-memory bank conflicts.
+template <int TILE_SIZE, int TY_SIZE, typename T, typename TScal, typename TConstPtr, typename TPtr>
+ROCBLAS_KERNEL(TILE_SIZE* TILE_SIZE)
+rocblas_geam_transpose_tiled_device(rocblas_operation transA,
+                                    rocblas_int       m,
+                                    rocblas_int       n,
+                                    TScal             alpha_device_host,
+                                    TConstPtr         Aa,
+                                    rocblas_stride    offset_a,
+                                    int64_t           lda,
+                                    rocblas_stride    stride_a,
+                                    TPtr              Ca,
+                                    rocblas_stride    offset_c,
+                                    int64_t           ldc,
+                                    rocblas_stride    stride_c,
+                                    rocblas_int       batch_count)
+{
+
+    // only used for transpose so input_rows is n
+    // alpha zero is handled in other kernel as just setting all to zero
+
+    int input_rows  = n; // transA == rocblas_operation_none ? m : n;
+    int num_blocksx = (input_rows - 1) / TILE_SIZE + 1; // input has transpose args
+    int blkx        = blockIdx.x % num_blocksx;
+    int blky        = blockIdx.x / num_blocksx;
+
+    const int bx = blkx * TILE_SIZE;
+    const int by = blky * TILE_SIZE;
+    const int tx = bx + threadIdx.x;
+    const int ty = by + threadIdx.y;
+
+    __shared__ T tile[TILE_SIZE][TILE_SIZE + 1];
+
+    uint32_t batch = blockIdx.z;
+
+#if DEVICE_GRID_YZ_16BIT
+    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    {
+#endif
+
+#define rows n
+#define cols m
+
+        T     alpha = load_scalar(alpha_device_host); // alpha is non zero and on host
+        auto* A     = load_ptr_batch(Aa, batch, offset_a, stride_a);
+        auto* C     = load_ptr_batch(Ca, batch, offset_c, stride_c);
+
+        for(int j = 0; j < TILE_SIZE; j += TY_SIZE)
+        {
+            auto a_val = (ty + j >= cols || tx >= rows) ? T(0) : A[tx + (ty + j) * lda];
+            //auto a_val
+            //= (ty + j >= cols || tx >= rows || alpha == T(0)) ? T(0) : A[tx + (ty + j) * lda];
+
+            if(transA == rocblas_operation_conjugate_transpose)
+                a_val = conj(a_val);
+            tile[threadIdx.y + j][threadIdx.x] = alpha * a_val;
+        }
+
+        __syncthreads();
+
+        int dstcol = bx + threadIdx.y; // transpose block offset
+        int dstrow = by + threadIdx.x;
+
+        if(dstrow < m)
+        {
+            for(int j = 0; j < TILE_SIZE; j += TY_SIZE)
+            {
+                if(dstcol + j < n)
+                {
+                    C[dstrow + (dstcol + j) * ldc] = tile[threadIdx.x][threadIdx.y + j];
+                }
+            }
+        }
+
+#undef rows
+#undef cols
+
+#if DEVICE_GRID_YZ_16BIT
+    }
+#endif
+}
+
 // special cases where: lda=ldb=ldc=m && transA==transB=none so matrices
 // are contiguous, there are no transposes, and therefore matrices
 // can be treated as contiguous vectors
@@ -464,7 +547,41 @@ rocblas_status rocblas_geam_launcher(rocblas_handle    handle,
         dim3 geam_grid(blocksX, 1, batches);
         dim3 geam_threads(GEAM_DIM_X, GEAM_DIM_Y);
 
-        if(pointer_mode == rocblas_pointer_mode_host)
+        if(pointer_mode == rocblas_pointer_mode_host && !*alpha && transB != rocblas_operation_none)
+        {
+            // beta == 0
+            // Pure transpose C = alpha * op(B).
+            static constexpr int TILE_SIZE = 32;
+            static constexpr int TY_SIZE   = 8; // 4 iterations per tile
+
+            rocblas_int num_blocksx = (m - 1) / TILE_SIZE + 1;
+            rocblas_int num_blocksy = (n - 1) / TILE_SIZE + 1;
+            rocblas_int blocks      = num_blocksx * num_blocksy;
+
+            dim3 tiled_grid(blocks, 1, batches);
+            dim3 tiled_threads(TILE_SIZE, TY_SIZE);
+
+            using T_elt = std::remove_cv_t<std::remove_pointer_t<TScal>>;
+            ROCBLAS_LAUNCH_KERNEL((rocblas_geam_transpose_tiled_device<TILE_SIZE, TY_SIZE, T_elt>),
+                                  tiled_grid,
+                                  tiled_threads,
+                                  0,
+                                  rocblas_stream,
+                                  transB,
+                                  m,
+                                  n,
+                                  *beta,
+                                  B,
+                                  offset_b,
+                                  ldb,
+                                  stride_b,
+                                  C,
+                                  offset_c,
+                                  ldc,
+                                  stride_c,
+                                  batch_count);
+        }
+        else if(pointer_mode == rocblas_pointer_mode_host)
         {
             ROCBLAS_LAUNCH_KERNEL((rocblas_geam_inplace_device<GEAM_DIM_X, GEAM_DIM_Y>),
                                   geam_grid,
@@ -522,7 +639,41 @@ rocblas_status rocblas_geam_launcher(rocblas_handle    handle,
         dim3 geam_grid(blocksX, 1, batches);
         dim3 geam_threads(GEAM_DIM_X, GEAM_DIM_Y);
 
-        if(pointer_mode == rocblas_pointer_mode_host)
+        if(pointer_mode == rocblas_pointer_mode_host && !*beta && transA != rocblas_operation_none)
+        {
+            // beta == 0
+            // Pure transpose C = alpha * op(B).
+            static constexpr int TILE_SIZE = 32;
+            static constexpr int TY_SIZE   = 8; // 4 iterations per tile
+
+            rocblas_int num_blocksx = (m - 1) / TILE_SIZE + 1;
+            rocblas_int num_blocksy = (n - 1) / TILE_SIZE + 1;
+            rocblas_int blocks      = num_blocksx * num_blocksy;
+
+            dim3 tiled_grid(blocks, 1, batches);
+            dim3 tiled_threads(TILE_SIZE, TY_SIZE);
+
+            using T_elt = std::remove_cv_t<std::remove_pointer_t<TScal>>;
+            ROCBLAS_LAUNCH_KERNEL((rocblas_geam_transpose_tiled_device<TILE_SIZE, TY_SIZE, T_elt>),
+                                  tiled_grid,
+                                  tiled_threads,
+                                  0,
+                                  rocblas_stream,
+                                  transA,
+                                  m,
+                                  n,
+                                  *alpha,
+                                  A,
+                                  offset_a,
+                                  lda,
+                                  stride_a,
+                                  C,
+                                  offset_c,
+                                  ldc,
+                                  stride_c,
+                                  batch_count);
+        }
+        else if(pointer_mode == rocblas_pointer_mode_host)
         {
             ROCBLAS_LAUNCH_KERNEL((rocblas_geam_inplace_device<GEAM_DIM_X, GEAM_DIM_Y>),
                                   geam_grid,
@@ -569,7 +720,7 @@ rocblas_status rocblas_geam_launcher(rocblas_handle    handle,
     }
     else if(pointer_mode == rocblas_pointer_mode_host && !*beta)
     {
-        if(m == lda && transA == rocblas_operation_none && m == ldc)
+        if(transA == rocblas_operation_none && m == lda && m == ldc)
         {
             // beta == 0
             // special case: A, C are processed as vectors because
@@ -593,6 +744,40 @@ rocblas_status rocblas_geam_launcher(rocblas_handle    handle,
                                   stride_a,
                                   C,
                                   offset_c,
+                                  stride_c,
+                                  batch_count);
+        }
+        else if(transA != rocblas_operation_none)
+        {
+            // beta == 0
+            // Pure transpose C = alpha * op(A).
+            static constexpr int TILE_SIZE = 32;
+            static constexpr int TY_SIZE   = 8; // 4 iterations per tile
+
+            rocblas_int num_blocksx = (m - 1) / TILE_SIZE + 1;
+            rocblas_int num_blocksy = (n - 1) / TILE_SIZE + 1;
+            rocblas_int blocks      = num_blocksx * num_blocksy;
+
+            dim3 geam_grid(blocks, 1, batches);
+            dim3 geam_threads(TILE_SIZE, TY_SIZE);
+
+            using T_elt = std::remove_cv_t<std::remove_pointer_t<TScal>>;
+            ROCBLAS_LAUNCH_KERNEL((rocblas_geam_transpose_tiled_device<TILE_SIZE, TY_SIZE, T_elt>),
+                                  geam_grid,
+                                  geam_threads,
+                                  0,
+                                  rocblas_stream,
+                                  transA,
+                                  m,
+                                  n,
+                                  *alpha,
+                                  A,
+                                  offset_a,
+                                  lda,
+                                  stride_a,
+                                  C,
+                                  offset_c,
+                                  ldc,
                                   stride_c,
                                   batch_count);
         }
@@ -631,7 +816,7 @@ rocblas_status rocblas_geam_launcher(rocblas_handle    handle,
     }
     else if(rocblas_pointer_mode_host == pointer_mode && !*alpha)
     {
-        if(m == ldb && transB == rocblas_operation_none && m == ldc)
+        if(transB == rocblas_operation_none && m == ldb && m == ldc)
         {
             // alpha == 0
             // special case: B, C are processed as vectors because
@@ -655,6 +840,40 @@ rocblas_status rocblas_geam_launcher(rocblas_handle    handle,
                                   stride_b,
                                   C,
                                   offset_c,
+                                  stride_c,
+                                  batch_count);
+        }
+        else if(transB != rocblas_operation_none)
+        {
+            // beta == 0
+            // Pure transpose C = beta * op(B).
+            static constexpr int TILE_SIZE = 32;
+            static constexpr int TY_SIZE   = 8; // 4 iterations per tile
+
+            rocblas_int num_blocksx = (m - 1) / TILE_SIZE + 1;
+            rocblas_int num_blocksy = (n - 1) / TILE_SIZE + 1;
+            rocblas_int blocks      = num_blocksx * num_blocksy;
+
+            dim3 geam_grid(blocks, 1, batches);
+            dim3 geam_threads(TILE_SIZE, TY_SIZE);
+
+            using T_elt = std::remove_cv_t<std::remove_pointer_t<TScal>>;
+            ROCBLAS_LAUNCH_KERNEL((rocblas_geam_transpose_tiled_device<TILE_SIZE, TY_SIZE, T_elt>),
+                                  geam_grid,
+                                  geam_threads,
+                                  0,
+                                  rocblas_stream,
+                                  transB,
+                                  m,
+                                  n,
+                                  *beta,
+                                  B,
+                                  offset_b,
+                                  ldb,
+                                  stride_b,
+                                  C,
+                                  offset_c,
+                                  ldc,
                                   stride_c,
                                   batch_count);
         }


### PR DESCRIPTION
This pull request introduces a performance optimization for the Level 3 GEAM (General Matrix Addition) operation in rocBLAS, specifically targeting cases where a pure transpose and scaling are performed. It adds a new optimized tiled transpose kernel, updates the GEAM launcher logic to leverage this kernel for relevant use cases, and expands test coverage for these scenarios.

Performance and kernel improvements:

* Added a new `rocblas_geam_transpose_tiled_device` kernel to optimize pure transpose and scale operations by using shared memory tiling for improved memory access patterns and reduced bank conflicts.
* Updated the `rocblas_geam_launcher` function to detect pure transpose scenarios (when one of the scaling factors is zero and a transpose is requested) and dispatch the new optimized kernel, both for alpha and beta cases. This includes handling for both A and B matrix transposes, and for batched operations. 

Test coverage and configuration:

* Expanded the `large_matrix_size_range` and `large_complex_alpha_beta_range` in `geam_gtest.yaml` to include new test cases that specifically target pure transpose and scale scenarios, ensuring the new kernel is exercised. 
* Adjusted test pointer mode and test definitions to better reflect the new kernel's coverage and to clarify host/device pointer mode distinctions for large and complex tests. 

Documentation:

* Added a changelog entry for rocBLAS 5.4.0, highlighting the improved performance for Level 3 GEAM in pure transpose scale use cases.

