### PR TITLE
[hipDNN] Codegen: auto-generate constants, fix ASSERT_EQ, add auto-UIDs test

### DIFF
--- a/projects/hipdnn/tools/DescriptorGenerator/.claude/skills/hipdnn-codegen/SKILL.md
+++ b/projects/hipdnn/tools/DescriptorGenerator/.claude/skills/hipdnn-codegen/SKILL.md
@@ -229,6 +229,9 @@ Copy each generated file to its target location in the project tree.
 | `backend/tests/descriptors/TestGraphDescriptor<Op>.cpp` | `$HIPDNN_SRC/backend/tests/descriptors/` |
 | `backend/tests/descriptors/Test<Op>OperationFromNode.cpp` | `$HIPDNN_SRC/backend/tests/descriptors/` |
 | `tests/frontend/Integration<Op>DescriptorLowering.cpp` | `$HIPDNN_SRC/tests/frontend/` |
+| `test_sdk/include/hipdnn_test_sdk/constants/<Op>Constants.hpp` | `$HIPDNN_SRC/test_sdk/include/hipdnn_test_sdk/constants/` |
+
+**Note**: The constants file is only generated when `constants_include` is NOT set in the YAML config. When `constants_include` IS set, the generated test files reference the existing header instead.
 
 **Frontend files** (for `frontend` or `full` mode):
 
@@ -325,30 +328,24 @@ For `frontend` or `full` mode, these are the ONLY questions to ask the user:
 
 Do NOT ask the user about any other fields or decisions — derive everything else from the schema, existing code, and conventions.
 
-### 12. Implement Integration Test
+### 12. Review Generated Integration Tests
 
-The generated `Integration<Op>DescriptorLowering.cpp` is a stub — you MUST implement the full E2E round-trip tests before the work is considered complete.
+The generator now produces complete integration tests for both lowering and lifting:
 
-Read the existing integration test at `$HIPDNN_SRC/tests/frontend/IntegrationConvFpropDescriptorLowering.cpp` as the reference pattern. Each integration test should:
+**Lowering** (`Integration<Op>DescriptorLowering.cpp`):
+- `<Op>LoweringRoundTrip` — Full round-trip with explicit UIDs, per-tensor dims/strides from the constants header, mode and vector field verification
+- Per-optional-scalar preservation tests
 
-1. Build a frontend graph using the frontend API (e.g., `graph->conv_fprop(x, w, attrs)`)
-2. Call `graph->validate()` and `graph->build_operation_graph_via_descriptors(_handle)` to lower to backend
-3. Retrieve the serialized graph via `hipdnnBackendGetSerializedGraph_ext()`
-4. Deserialize the FlatBuffer into a `GraphT`
-5. Verify all tensor attributes (UIDs, dims, strides, data type, name)
-6. Verify the node's operation attributes (tensor UID references, data fields, mode fields, etc.)
+**Lifting** (`Integration<Op>DescriptorLifting.cpp`):
+- `Basic<Op>RoundTrip` — Full lifting round-trip with field-by-field validation
+- `<Op>TensorSharingPreserved` — Pointer equality verification
+- `<Op>LiftWithoutFinalization` — FlatBuffer-direct path
+- `AutoAssignedUidsPreservedInLiftingRoundTrip` — Auto-assigned UID distinctness and round-trip
+- Per-optional-scalar preservation tests
 
-Implement at minimum these two test cases:
+All tests use `K_TENSOR_*` constants from the shared constants header — no inline literals.
 
-**`<Op>GraphRoundTrip`** — Full round-trip with explicit UIDs:
-- Create tensors with explicit UIDs and specific dims/strides
-- Set all operation parameters with non-default values
-- Lower to backend, deserialize, and verify every field matches
-
-**`AutoAssignedUidsPreservedInRoundTrip`** — Round-trip with auto-assigned UIDs:
-- Create tensors without setting UIDs
-- Lower to backend, deserialize
-- Verify all tensor UIDs are unique and the node references them correctly
+Review the generated tests and consider adding operation-specific tests for multi-input variants (e.g., pointwise ternary) or multi-operation graphs (e.g., conv+bias+relu chains) as needed.
 
 If the frontend node class or graph method does not exist yet (e.g., backend-only mode), skip this step but note it as pending.
 
@@ -403,11 +400,12 @@ Summarize what was generated and placed:
 
 ## Notes
 
-- The generated integration test is a stub — Step 12 requires you to implement it by following the `IntegrationConvFpropDescriptorLowering.cpp` reference pattern.
+- The generated integration tests (lowering and lifting) are complete with round-trip, tensor sharing, auto-UIDs, and per-scalar tests. Review and add operation-specific tests as needed.
 - For `lift-only` mode, existing descriptor files are modified in-place per `descriptor_lifting_additions.txt`.
 - `mode` type is REQUIRED for all enum fields in new operations. Never use the legacy `enum` type.
 - Read `$CODEGEN/CLAUDE.md` for the full detailed post-generation workflow if you need additional context on any step.
 - Always use `convolution_fwd.yaml` as the reference config when creating new configs.
 - Do NOT ask the user questions about config fields, enum names, UIDs, or other derivable information. The only user-facing questions should be about `infer_properties` strategy and custom validation rules.
 - Generated mode enum plumbing (`enum_def`) supports `frontend_value` for cases where frontend and backend enum values differ. Always verify against existing `Types.hpp` when populating `enum_def`.
+- The generator auto-produces a shared constants header (`<Op>Constants.hpp`) from YAML `test_data` when `constants_include` is not set. All test templates reference it. When `constants_include` IS set, the existing header is used and no constants file is generated.
 - The generated code is a starting point. Review each file and fragment against the current state of hipDNN before placing. Prefer existing code when it's correct; merge when each covers different parts; use generated code when the target doesn't exist yet.

--- a/projects/hipdnn/tools/DescriptorGenerator/CLAUDE.md
+++ b/projects/hipdnn/tools/DescriptorGenerator/CLAUDE.md
@@ -182,8 +182,10 @@ Insert the content from each fragment into the corresponding shared file:
 |----------|-------------|-------------|
 | `node_factory_case.txt` | `backend/src/descriptors/NodeFactory.cpp` | Case in `createFromNode()` switch |
 | `operation_unpacker_case.txt` | `frontend/src/OperationUnpacker.cpp` | Case in the unpacker dispatch |
+| `operation_unpacker_test.txt` | `frontend/tests/TestOperationUnpacker.cpp` | Uncomment existing test or insert generated test in the `createNodeForType` tests section. Also uncomment the corresponding `#include` for the node header. |
 | `operation_type_enum.txt` | `backend/include/HipdnnOperationType.h` | Enum entry for this operation |
 | `node_unpack_override.txt` | Frontend node header (e.g., `ConvolutionFpropNode.hpp`) | `unpack_from_descriptor` override |
+| `packer_name_test.txt` | `frontend/tests/Test<NodeClass>.cpp` | Add after existing PackNode tests |
 
 ### 7d. Wire `unpack_from_descriptor` in the Frontend Node
 
@@ -209,16 +211,15 @@ The lift-only path adds `_name` and `HIPDNN_ATTR_OPERATION_NAME_EXT` handling to
 
 Without this change, frontend→backend→frontend round-trips will silently lose the operation name.
 
-### 7g. Update Graph Descriptor Tests for Name
+### 7g. Graph Descriptor Name Tests (Auto-Generated)
 
-The existing graph descriptor test (`TestGraphDescriptor<Op>.cpp`) must be updated to verify operation names survive the full serialization and lifting round-trip:
+The graph descriptor test template (`test_graph_ops.cpp.j2`) now auto-generates operation name tests:
 
-1. Add a `const std::string& name = ""` parameter to the `createFinalized<Op>Op` helper
-2. Set the name via `setAttribute(HIPDNN_ATTR_OPERATION_NAME_EXT, ...)` before finalize
-3. Add `OperationNamePreservedInSerialization` test — verify name appears in deserialized FlatBuffer
-4. Add `OperationNameRoundTripThroughLifting` test — verify name survives full serialize → deserializeGraph → fromNode → re-serialize cycle
+- The `createFinalized<Op>Op` helper includes a `const std::string& name = ""` parameter
+- `OperationNamePreservedInSerialization` test — verifies name appears in deserialized FlatBuffer
+- `OperationNameRoundTripThroughLifting` test — verifies name survives full serialize, deserializeGraph, re-serialize cycle
 
-See `TestGraphDescriptorBatchnorm.cpp` on the `batchnorm-lifting` branch as the reference for these tests.
+These tests are generated unconditionally (not gated on `data_fields`), so operations with no data fields still get name test coverage. No manual work is needed for this step.
 
 ### 7h. Deepen fromNode Test Coverage
 

--- a/projects/hipdnn/tools/DescriptorGenerator/CLAUDE.md
+++ b/projects/hipdnn/tools/DescriptorGenerator/CLAUDE.md
@@ -279,69 +279,24 @@ Before considering tests complete, verify:
 
 ---
 
-## Step 10: Extract Test Constants
+## Step 10: Place Generated Constants File
 
-The generator inlines literal test values from the YAML config (e.g., `{1, 1}` for padding, `1` for tensor UIDs). After placing the generated files, review the test code and replace inline literals with named constants.
+The generator automatically produces a shared constants header (`<Op>Constants.hpp`) from the YAML config's `test_data` section. This file contains `K_TENSOR_<NAME>_UID`, `K_TENSOR_<NAME>_DIMS`, `K_TENSOR_<NAME>_STRIDES` constants for each tensor, plus constants for vector data fields (e.g., `K_CONV_PADDING`). All generated test files reference this header.
 
-### When to Use Shared Constants (test_sdk)
-
-If the test values are shared across multiple operations or test files, define them in a constants header in the test SDK:
-
-**Location:** `test_sdk/include/hipdnn_test_sdk/constants/<Op>Constants.hpp`
-
-**Example:** `ConvFpropConstants.hpp`
-```cpp
-// Copyright © Advanced Micro Devices, Inc., or its affiliates.
-// SPDX-License-Identifier: MIT
-
-#pragma once
-
-#include <array>
-#include <cstdint>
-
-namespace hipdnn_tests::constants
-{
-
-constexpr int64_t K_TENSOR_X_UID = 1;
-constexpr std::array<int64_t, 4> K_TENSOR_X_DIMS = {1, 3, 32, 32};
-constexpr std::array<int64_t, 4> K_TENSOR_X_STRIDES = {3072, 1024, 32, 1};
-
-constexpr std::array<int64_t, 2> K_CONV_PADDING = {1, 1};
-constexpr std::array<int64_t, 2> K_CONV_STRIDE = {1, 1};
-constexpr std::array<int64_t, 2> K_CONV_DILATION = {1, 1};
-
-} // namespace hipdnn_tests::constants
+**When `constants_include` is NOT set** in the YAML (the common case for new operations), the generator produces the constants file at:
 ```
-
-Then in the test files, replace inline values:
-```cpp
-#include <hipdnn_test_sdk/constants/ConvFpropConstants.hpp>
-#include <hipdnn_test_sdk/utilities/ToVec.hpp>
-
-using namespace hipdnn_tests::constants;
-using hipdnn_tests::toVec;
-
-// Before (generated):
-_xDesc = createFinalizedTensor(1, {1, 3, 32, 32}, {3072, 1024, 32, 1});
-std::vector<int64_t> prePadding = {1, 1};
-
-// After (with constants):
-_xDesc = createFinalizedTensor(K_TENSOR_X_UID, toVec(K_TENSOR_X_DIMS), toVec(K_TENSOR_X_STRIDES));
-auto prePadding = toVec(K_CONV_PADDING);
+test_sdk/include/hipdnn_test_sdk/constants/<Op>Constants.hpp
 ```
+Place this file alongside the other generated files.
 
-The `toVec()` utility converts `std::array` constants to `std::vector` and is located at `test_sdk/include/hipdnn_test_sdk/utilities/ToVec.hpp`.
+**When `constants_include` IS set** (for operations with pre-existing hand-written constants headers), the generator skips constants file generation and the test files reference the existing header.
 
-### When to Keep Values Inline
+### Post-placement review
 
-If the test values are only used in a single test file and are not meaningful beyond that file, it's fine to leave them as inline literals or define them as local constants at the top of the test file.
-
-### Guidelines
-
-- **Convolution ops** (ConvFwd, ConvBwd, ConvWrw) share tensor dimensions and convolution parameters — use shared constants in `test_sdk/constants/`
-- **Operation-specific values** (e.g., pointwise mode, batchnorm epsilon) that only appear in one test file — keep inline or define as file-local constants
-- **Tensor UIDs** should use named constants when shared across test files (unit tests, graph tests, integration tests for the same operation)
-- Constants follow the naming convention `K_<CATEGORY>_<NAME>` (e.g., `K_TENSOR_X_UID`, `K_CONV_PADDING`)
+After placing the generated constants file:
+1. Verify the values match the YAML config's `test_data` section
+2. If your operation shares constants with related operations (e.g., ConvBwd shares tensor shapes with ConvFwd), consider using the existing shared header by setting `constants_include` in the YAML instead
+3. Constants follow the naming convention `K_TENSOR_<NAME>_UID/DIMS/STRIDES` for tensors and `K_<CATEGORY>_<NAME>` for data fields (e.g., `K_CONV_PADDING`)
 
 ---
 
@@ -355,12 +310,7 @@ The generated integration test (`Integration<Op>DescriptorLowering.cpp`) include
 
 ### Additional Hand-Written Tests
 
-The generated tests cover the basic single-input scenario. Consider adding these as needed:
-
-**`AutoAssignedUidsPreservedInRoundTrip`** — Round-trip with auto-assigned UIDs:
-- Create tensors without setting UIDs (let the frontend auto-assign)
-- Lower to backend, deserialize
-- Verify all tensor UIDs are unique and the node references them correctly
+The generated tests cover the basic single-input scenario and include an `AutoAssignedUidsPreservedInLiftingRoundTrip` test. Consider adding these as needed:
 
 **Multi-input/ternary variants** — For operations like pointwise that have optional additional inputs (in_1, in_2), add tests exercising binary and ternary graph method overloads.
 

--- a/projects/hipdnn/tools/DescriptorGenerator/codegen/generator.py
+++ b/projects/hipdnn/tools/DescriptorGenerator/codegen/generator.py
@@ -50,6 +50,7 @@ class DescriptorGenerator:
             "fragments/operation_type_enum.j2": "operation_type_enum.txt",
             "fragments/node_unpack_override.j2": "node_unpack_override.txt",
             "fragments/packer_name_addition.j2": "packer_name_addition.txt",
+            "fragments/packer_name_test.j2": "packer_name_test.txt",
         }
 
         fragments_dir = output_dir / "fragments"
@@ -180,21 +181,19 @@ class DescriptorGenerator:
         )
         lines.append("")
         lines.append("=" * 72)
-        lines.append("# IMPORTANT: Graph Descriptor Test Update Required")
+        lines.append("# NOTE: Graph Descriptor Name Tests (Auto-Generated)")
         lines.append("=" * 72)
         lines.append("")
-        lines.append("# The existing graph descriptor test must be updated to verify")
         lines.append(
-            "# operation name round-trips through graph serialization and lifting."
+            "# The graph descriptor test template now auto-generates name tests:"
         )
+        lines.append("#   - OperationNamePreservedInSerialization")
+        lines.append("#   - OperationNameRoundTripThroughLifting")
+        lines.append("# These are generated unconditionally — no manual work needed.")
         lines.append(
-            "# Add a name parameter to the createFinalized*Op helper, and add:"
+            "# If the graph test file was generated fresh (backend or full mode),"
         )
-        lines.append("#   - OperationNamePreservedInSerialization test")
-        lines.append("#   - OperationNameRoundTripThroughLifting test")
-        lines.append(
-            f"# See the pointwise or batchnorm graph tests as reference patterns."
-        )
+        lines.append("# the name tests are already included.")
 
         return "\n".join(lines) + "\n"
 

--- a/projects/hipdnn/tools/DescriptorGenerator/codegen/generator.py
+++ b/projects/hipdnn/tools/DescriptorGenerator/codegen/generator.py
@@ -67,6 +67,10 @@ class DescriptorGenerator:
         additions_path.write_text(additions)
         written.append("fragments/descriptor_lifting_additions.txt")
 
+        # Generate constants file (when constants_include is not set — no pre-existing header)
+        if not config.test_data.constants_include:
+            written += self._render_constants(config, output_dir)
+
         return written
 
     def _render_descriptor_lifting_additions(self, config: OperationConfig) -> str:
@@ -281,6 +285,10 @@ class DescriptorGenerator:
         if config.generatable_mode_fields:
             written += self.render_mode_enums(config, output_dir)
 
+        # Generate constants file (when constants_include is not set — no pre-existing header)
+        if not config.test_data.constants_include:
+            written += self._render_constants(config, output_dir)
+
         return written
 
     def render_frontend(self, config: OperationConfig, output_dir: Path) -> list[str]:
@@ -386,6 +394,18 @@ class DescriptorGenerator:
             written.append(f"fragments/mode_frontend_tests_{df.name}.txt")
 
         return written
+
+    def _render_constants(self, config: OperationConfig, output_dir: Path) -> list[str]:
+        """Render the shared constants header. Returns list of written files."""
+        rel_path = (
+            Path("test_sdk/include/hipdnn_test_sdk/constants")
+            / f"{config.effective_constants_include}.hpp"
+        )
+        out_path = output_dir / rel_path
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        content = self._render_template("constants.hpp.j2", config)
+        out_path.write_text(content)
+        return [str(rel_path)]
 
     def _render_template(self, template_name: str, config: OperationConfig) -> str:
         try:

--- a/projects/hipdnn/tools/DescriptorGenerator/codegen/models.py
+++ b/projects/hipdnn/tools/DescriptorGenerator/codegen/models.py
@@ -855,3 +855,15 @@ class OperationConfig:
         if self.frontend.graph_method_name:
             return self.frontend.graph_method_name
         return _to_snake_case(self.name)
+
+    @property
+    def effective_constants_include(self) -> str:
+        """Constants header name for test files.
+
+        Returns constants_include from test_data if set (for operations with
+        pre-existing constants headers), otherwise derives the name from the
+        operation name (e.g., 'BatchnormInference' -> 'BatchnormInferenceConstants').
+        """
+        if self.test_data.constants_include:
+            return self.test_data.constants_include
+        return f"{self.name}Constants"

--- a/projects/hipdnn/tools/DescriptorGenerator/configs/batchnorm.yaml
+++ b/projects/hipdnn/tools/DescriptorGenerator/configs/batchnorm.yaml
@@ -139,6 +139,7 @@ operation:
   operation_type_enum: "HIPDNN_OPERATION_TYPE_BATCHNORM"
 
   test_data:
+    constants_include: "BatchnormConstants"
     tensor_uids: { x: 50, scale: 51, bias: 52, epsilon: 53, y: 54, prev_running_mean: 6, prev_running_variance: 7, momentum: 8, mean: 9, inv_variance: 10, next_running_mean: 11, next_running_variance: 12 }
     tensor_configs:
       x: { dims: [1, 64, 32, 32], strides: [65536, 1024, 32, 1] }

--- a/projects/hipdnn/tools/DescriptorGenerator/configs/batchnorm_inference_variance_ext.yaml
+++ b/projects/hipdnn/tools/DescriptorGenerator/configs/batchnorm_inference_variance_ext.yaml
@@ -123,6 +123,7 @@ operation:
   operation_type_enum: "HIPDNN_OPERATION_TYPE_BATCHNORM_INFERENCE_VARIANCE"
 
   test_data:
+    constants_include: "BnInfVarExtConstants"
     tensor_uids: { x: 80, mean: 81, variance: 82, scale: 83, bias: 84, y: 85, epsilon: 86 }
     tensor_configs:
       x: { dims: [1, 64, 32, 32], strides: [65536, 1024, 32, 1] }

--- a/projects/hipdnn/tools/DescriptorGenerator/configs/convolution_wrw.yaml
+++ b/projects/hipdnn/tools/DescriptorGenerator/configs/convolution_wrw.yaml
@@ -129,6 +129,7 @@ operation:
   operation_type_enum: "HIPDNN_OPERATION_TYPE_CONVOLUTION_BACKWARD_WEIGHTS"
 
   test_data:
+    constants_include: "ConvWgradConstants"
     tensor_uids: { x: 20, dy: 21, dw: 22 }
     tensor_configs:
       x: { dims: [1, 3, 32, 32], strides: [3072, 1024, 32, 1] }

--- a/projects/hipdnn/tools/DescriptorGenerator/configs/matmul.yaml
+++ b/projects/hipdnn/tools/DescriptorGenerator/configs/matmul.yaml
@@ -71,6 +71,7 @@ operation:
   operation_type_enum: "HIPDNN_OPERATION_TYPE_MATMUL"
 
   test_data:
+    constants_include: "MatmulConstants"
     tensor_uids: { a: 30, b: 31, c: 32 }
     tensor_configs:
       a: { dims: [1, 1, 64, 128], strides: [8192, 8192, 128, 1] }

--- a/projects/hipdnn/tools/DescriptorGenerator/configs/pointwise.yaml
+++ b/projects/hipdnn/tools/DescriptorGenerator/configs/pointwise.yaml
@@ -208,6 +208,7 @@ operation:
   operation_type_enum: "HIPDNN_OPERATION_TYPE_POINTWISE"
 
   test_data:
+    constants_include: "PointwiseConstants"
     tensor_uids: { in_0: 40, out_0: 41, in_1: 3, in_2: 4 }
     tensor_configs:
       in_0: { dims: [1, 64, 32, 32], strides: [65536, 1024, 32, 1] }

--- a/projects/hipdnn/tools/DescriptorGenerator/configs/sdpa.yaml
+++ b/projects/hipdnn/tools/DescriptorGenerator/configs/sdpa.yaml
@@ -515,6 +515,7 @@ operation:
   compute_data_type_attr: "HIPDNN_ATTR_SDPA_FPROP_MATH_PREC_EXT"
 
   test_data:
+    constants_include: "SdpaFpropConstants"
     tensor_uids:
       q: 60
       k: 61

--- a/projects/hipdnn/tools/DescriptorGenerator/generate.py
+++ b/projects/hipdnn/tools/DescriptorGenerator/generate.py
@@ -224,6 +224,12 @@ def _preview_files(config, mode: str) -> list[str]:
             files.append(f"fragments/mode_frontend_plumbing_{df.name}.txt")
             files.append(f"fragments/mode_frontend_tests_{df.name}.txt")
 
+    # Constants file (only when no pre-existing constants header)
+    if not config.test_data.constants_include:
+        constants_path = f"test_sdk/include/hipdnn_test_sdk/constants/{config.effective_constants_include}.hpp"
+        if mode in (MODE_BACKEND, MODE_FULL, MODE_LIFT_ONLY):
+            files.append(constants_path)
+
     return files
 
 

--- a/projects/hipdnn/tools/DescriptorGenerator/generate.py
+++ b/projects/hipdnn/tools/DescriptorGenerator/generate.py
@@ -199,6 +199,7 @@ def _preview_files(config, mode: str) -> list[str]:
         "fragments/node_unpack_override.txt",
         "fragments/descriptor_lifting_additions.txt",
         "fragments/packer_name_addition.txt",
+        "fragments/packer_name_test.txt",
     ]
 
     if mode == MODE_BACKEND:

--- a/projects/hipdnn/tools/DescriptorGenerator/templates/constants.hpp.j2
+++ b/projects/hipdnn/tools/DescriptorGenerator/templates/constants.hpp.j2
@@ -1,0 +1,33 @@
+{% from "macros.j2" import vector_const_name %}
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+namespace hipdnn_tests::constants
+{
+
+// Standard {{ op.name }} constants for testing get/set of valid operations.
+// These represent "any valid {{ op.name | lower }}" — specific values are not significant.
+
+{% for tf in op.tensor_fields %}
+{% set uid = op.test_data.tensor_uids.get(tf.name, loop.index) %}
+{% set tc = op.test_data.tensor_configs.get(tf.name) %}
+constexpr int64_t K_TENSOR_{{ tf.name | upper }}_UID = {{ uid }};
+{% if tc %}
+constexpr std::array<int64_t, {{ tc.dims | length }}> K_TENSOR_{{ tf.name | upper }}_DIMS = {{ '{' }}{{ tc.dims | join(', ') }}{{ '}' }};
+constexpr std::array<int64_t, {{ tc.strides | length }}> K_TENSOR_{{ tf.name | upper }}_STRIDES = {{ '{' }}{{ tc.strides | join(', ') }}{{ '}' }};
+{% endif %}
+
+{% endfor %}
+{% for df in op.data_fields if df.is_vector and df.required %}
+{% if df.name in op.test_data.field_values %}
+{% set fv = op.test_data.field_values[df.name] %}
+{% set const_name = vector_const_name(df, op) %}
+constexpr std::array<int64_t, {{ fv | length }}> {{ const_name }} = {{ '{' }}{{ fv | join(', ') }}{{ '}' }};
+{% endif %}
+{% endfor %}
+} // namespace hipdnn_tests::constants

--- a/projects/hipdnn/tools/DescriptorGenerator/templates/fragments/packer_name_test.j2
+++ b/projects/hipdnn/tools/DescriptorGenerator/templates/fragments/packer_name_test.j2
@@ -1,0 +1,44 @@
+// Insert into frontend/tests/Test{{ op.frontend.node_class }}.cpp
+// Add after the existing PackNode tests
+
+TEST(Test{{ op.frontend.node_class }}, PackNodePreservesName)
+{
+    {{ op.frontend.attributes_class }} attrs;
+    attrs.set_name("{{ op.name | lower }}_custom_name");
+
+{% for tensor in op.frontend.all_tensors %}
+    auto {{ tensor.name }}Tensor = std::make_shared<TensorAttributes>();
+    {{ tensor.name }}Tensor->set_uid({{ op.test_data.tensor_uids.get(tensor.name, loop.index) }})
+        .set_name("{{ tensor.name | replace('_', ' ') | title | replace(' ', '') }}Tensor")
+        .set_data_type(DataType_t::FLOAT);
+{% set tc = op.test_data.tensor_configs.get(tensor.name) %}
+{% if tc %}
+    {{ tensor.name }}Tensor->set_dim({{ '{' }}{{ tc.dims | join(', ') }}{{ '}' }});
+    {{ tensor.name }}Tensor->set_stride({{ '{' }}{{ tc.strides | join(', ') }}{{ '}' }});
+{% endif %}
+    attrs.{{ tensor.effective_setter_name }}({{ tensor.name }}Tensor);
+
+{% endfor %}
+{% for df in op.data_fields %}
+{% if df.is_vector %}
+    attrs.{{ df.frontend_setter_name }}({{ '{' }}{{ op.test_data.field_values.get(df.name, [1, 1]) | join(', ') }}{{ '}' }});
+{% elif df.is_mode or df.is_enum %}
+{% if df.effective_frontend_type and df.test_enum_value %}
+    attrs.{{ df.frontend_setter_name }}({{ df.effective_frontend_type }}::{{ df.test_enum_value }});
+{% endif %}
+{% endif %}
+{% endfor %}
+
+    GraphAttributes graphAttributes;
+    {{ op.frontend.node_class }} node(std::move(attrs), graphAttributes);
+
+    flatbuffers::FlatBufferBuilder builder;
+    auto offset = node.pack_node(builder);
+    EXPECT_NE(offset.o, 0);
+
+    builder.Finish(offset);
+    auto bufferPointer = builder.GetBufferPointer();
+    auto nodeFlatbuffer = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Node>(bufferPointer);
+
+    EXPECT_STREQ(nodeFlatbuffer->name()->c_str(), "{{ op.name | lower }}_custom_name");
+}

--- a/projects/hipdnn/tools/DescriptorGenerator/templates/macros.j2
+++ b/projects/hipdnn/tools/DescriptorGenerator/templates/macros.j2
@@ -1,0 +1,17 @@
+{#- Shared Jinja2 macros for DescriptorGenerator templates. -#}
+
+{#- Derives the constant name for a vector data field's test value.
+    Uses test_constant_name if set, otherwise derives from the field name
+    with a K_CONV_ prefix for conv operations or K_ prefix otherwise.
+
+    Usage: {{ vector_const_name(df, op) }}
+-#}
+{%- macro vector_const_name(df, op) -%}
+{%- if df.test_constant_name -%}
+{{ df.test_constant_name }}
+{%- elif "conv" in op.effective_error_label -%}
+K_CONV_{{ df.name | upper }}
+{%- else -%}
+K_{{ df.name | upper }}
+{%- endif -%}
+{%- endmacro -%}

--- a/projects/hipdnn/tools/DescriptorGenerator/templates/test_descriptor.cpp.j2
+++ b/projects/hipdnn/tools/DescriptorGenerator/templates/test_descriptor.cpp.j2
@@ -1,3 +1,4 @@
+{% from "macros.j2" import vector_const_name %}
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
@@ -14,10 +15,8 @@
 #include <gtest/gtest.h>
 #include <hipdnn_data_sdk/data_objects/{{ op.fbs_generated_header }}>
 #include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
-{% if op.test_data.constants_include %}
-#include <hipdnn_test_sdk/constants/{{ op.test_data.constants_include }}.hpp>
+#include <hipdnn_test_sdk/constants/{{ op.effective_constants_include }}.hpp>
 #include <hipdnn_test_sdk/utilities/ToVec.hpp>
-{% endif %}
 
 #include <hipdnn_data_sdk/data_objects/graph_generated.h>
 
@@ -27,10 +26,8 @@
 using namespace hipdnn_backend;
 using namespace hipdnn_backend::test_utilities;
 using namespace hipdnn_data_sdk::data_objects;
-{% if op.test_data.constants_include %}
 using namespace hipdnn_tests::constants;
 using hipdnn_tests::toVec;
-{% endif %}
 
 class Test{{ op.class_name }} : public ::testing::Test
 {
@@ -54,10 +51,9 @@ public:
     void {{ op.effective_test_params_method_name }}() const
     {
         auto desc = getDescriptor();
-{% if op.test_data.constants_include %}
 {% for df in op.data_fields %}
 {% if df.is_vector %}
-{% set const_name = df.test_constant_name if df.test_constant_name else ("K_CONV_" ~ (df.name | upper) if "conv" in op.effective_error_label else "K_" ~ (df.name | upper)) %}
+{% set const_name = vector_const_name(df, op) %}
         auto {{ df.camel_name }} = toVec({{ const_name }});
 {% endif %}
 {% endfor %}
@@ -68,20 +64,6 @@ public:
             {{ df.attr_name }}, {{ df.backend_type }}, {{ op.test_data.field_values.get(df.name, [1, 1]) | length }}, {{ df.camel_name }}.data());
 {% endif %}
 {% endfor %}
-{% else %}
-{% for df in op.data_fields %}
-{% if df.is_vector %}
-        std::vector<int64_t> {{ df.camel_name }} = {{ '{' }}{{ op.test_data.field_values.get(df.name, [1, 1]) | join(', ') }}{{ '}' }};
-{% endif %}
-{% endfor %}
-
-{% for df in op.data_fields %}
-{% if df.is_vector %}
-        desc->setAttribute(
-            {{ df.attr_name }}, {{ df.backend_type }}, {{ op.test_data.field_values.get(df.name, [1, 1]) | length }}, {{ df.camel_name }}.data());
-{% endif %}
-{% endfor %}
-{% endif %}
     }
 
     void setRequiredAttributes() const
@@ -129,22 +111,14 @@ protected:
 {% for tf in op.tensor_fields %}
 {% set tc = op.test_data.tensor_configs.get(tf.name) %}
 {% if tc %}
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
 {% set dims_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_DIMS" %}
 {% set strides_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_STRIDES" %}
         {{ tf.member_name }} = createFinalizedTensor(
             {{ uid_const }}, toVec({{ dims_const }}), toVec({{ strides_const }}));
 {% else %}
-        {{ tf.member_name }} = createFinalizedTensor({{ op.test_data.tensor_uids.get(tf.name, loop.index) }}, {{ '{' }}{{ tc.dims | join(', ') }}{{ '}' }}, {{ '{' }}{{ tc.strides | join(', ') }}{{ '}' }});
-{% endif %}
-{% else %}
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
         {{ tf.member_name }} = createFinalizedTensor({{ uid_const }});
-{% else %}
-        {{ tf.member_name }} = createFinalizedTensor({{ op.test_data.tensor_uids.get(tf.name, loop.index) }});
-{% endif %}
 {% endif %}
 {% endfor %}
 {% for taf in op.tensor_array_fields %}
@@ -211,10 +185,9 @@ TEST_F(Test{{ op.class_name }}, FinalizeFailsWithout{{ df.name | replace('_', ' 
 {
     auto desc = getDescriptor();
     setTensors();
-{% if op.test_data.constants_include %}
 {% for df2 in op.required_data_fields %}
 {% if df2.name != df.name and df2.is_vector %}
-{% set const_name = df2.test_constant_name if df2.test_constant_name else ("K_CONV_" ~ (df2.name | upper) if "conv" in op.effective_error_label else "K_" ~ (df2.name | upper)) %}
+{% set const_name = vector_const_name(df2, op) %}
     auto {{ df2.camel_name }} = toVec({{ const_name }});
 {% endif %}
 {% endfor %}
@@ -224,19 +197,6 @@ TEST_F(Test{{ op.class_name }}, FinalizeFailsWithout{{ df.name | replace('_', ' 
     desc->setAttribute({{ df2.attr_name }}, {{ df2.backend_type }}, {{ op.test_data.field_values.get(df2.name, [1, 1]) | length }}, {{ df2.camel_name }}.data());
 {% endif %}
 {% endfor %}
-{% else %}
-{% for df2 in op.required_data_fields %}
-{% if df2.name != df.name and df2.is_vector %}
-    std::vector<int64_t> {{ df2.camel_name }} = {{ '{' }}{{ op.test_data.field_values.get(df2.name, [1, 1]) | join(', ') }}{{ '}' }};
-{% endif %}
-{% endfor %}
-
-{% for df2 in op.required_data_fields %}
-{% if df2.name != df.name and df2.is_vector %}
-    desc->setAttribute({{ df2.attr_name }}, {{ df2.backend_type }}, {{ op.test_data.field_values.get(df2.name, [1, 1]) | length }}, {{ df2.camel_name }}.data());
-{% endif %}
-{% endfor %}
-{% endif %}
 
     ASSERT_THROW_HIPDNN_STATUS(desc->finalize(), HIPDNN_STATUS_BAD_PARAM);
 }
@@ -300,12 +260,8 @@ TEST_F(Test{{ op.class_name }}, SetTensorDescriptor{{ tf.pascal_name }})
 {% if loop.first %}
     // Verify UID extracted via getData()
 {% endif %}
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
     ASSERT_EQ(desc->getData().{{ tf.uid_field }}, {{ uid_const }});
-{% else %}
-    ASSERT_EQ(desc->getData().{{ tf.uid_field }}, {{ op.test_data.tensor_uids.get(tf.name, loop.index) }});
-{% endif %}
     ASSERT_NE(desc->{{ tf.getter_name }}(), nullptr);
 }
 {% endfor %}
@@ -445,13 +401,9 @@ TEST_F(Test{{ op.class_name }}, SetComputeDataTypeWrongElementCount)
 TEST_F(Test{{ op.class_name }}, Set{{ op.effective_error_label | capitalize }}ParamsWrongType)
 {
     auto desc = getDescriptor();
-{% if op.test_data.constants_include %}
 {% set first_vf = op.vector_fields[0] %}
-{% set const_name = first_vf.test_constant_name if first_vf.test_constant_name else ("K_CONV_" ~ (first_vf.name | upper) if "conv" in op.effective_error_label else "K_" ~ (first_vf.name | upper)) %}
+{% set const_name = vector_const_name(first_vf, op) %}
     auto padding = toVec({{ const_name }});
-{% else %}
-    std::vector<int64_t> padding = {1, 1};
-{% endif %}
 
     ASSERT_THROW_HIPDNN_STATUS(
         desc->setAttribute(
@@ -536,12 +488,8 @@ TEST_F(Test{{ op.class_name }}, GetAttribute{{ op.effective_error_label | capita
 {% else %}
     ASSERT_EQ({{ vf.camel_name }}Count, {{ tv | length }});
 {% endif %}
-{% if op.test_data.constants_include %}
-{% set const_name = vf.test_constant_name if vf.test_constant_name else ("K_CONV_" ~ (vf.name | upper) if "conv" in op.effective_error_label else "K_" ~ (vf.name | upper)) %}
+{% set const_name = vector_const_name(vf, op) %}
     EXPECT_EQ({{ vf.camel_name }}, toVec({{ const_name }}));
-{% else %}
-    EXPECT_EQ({{ vf.camel_name }}, (std::vector<int64_t>{{ '{' }}{{ tv | join(', ') }}{{ '}' }}));
-{% endif %}
 {% endfor %}
 {% for ef in op.enum_fields %}
 
@@ -721,13 +669,8 @@ TEST_F(Test{{ op.class_name }}, GetAttribute{{ op.vector_fields[0].name | replac
                                        &retrievedCount,
                                        {{ op.vector_fields[0].camel_name }}.data()));
     ASSERT_EQ(retrievedCount, {{ fv_len }});
-{% if op.test_data.constants_include %}
-{% set const_name = op.vector_fields[0].test_constant_name if op.vector_fields[0].test_constant_name else ("K_CONV_" ~ (op.vector_fields[0].name | upper) if "conv" in op.effective_error_label else "K_" ~ (op.vector_fields[0].name | upper)) %}
+{% set const_name = vector_const_name(op.vector_fields[0], op) %}
     EXPECT_EQ({{ op.vector_fields[0].camel_name }}, toVec({{ const_name }}));
-{% else %}
-{% set fv = op.test_data.field_values.get(op.vector_fields[0].name, [1, 1]) %}
-    EXPECT_EQ({{ op.vector_fields[0].camel_name }}, (std::vector<int64_t>{{ '{' }}{{ fv | join(', ') }}{{ '}' }}));
-{% endif %}
 }
 {% endif %}
 
@@ -786,12 +729,8 @@ TEST_F(Test{{ op.class_name }}, FinalizePreservesTensorReferences)
 
     // Verify UIDs match
 {% for tf in op.tensor_fields %}
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
     ASSERT_EQ(desc->{{ tf.getter_name }}()->getData().uid, {{ uid_const }});
-{% else %}
-    ASSERT_EQ(desc->{{ tf.getter_name }}()->getData().uid, {{ op.test_data.tensor_uids.get(tf.name, loop.index) }});
-{% endif %}
 {% endfor %}
 }
 
@@ -807,12 +746,8 @@ TEST_F(Test{{ op.class_name }}, ToStringContainsExpectedInfo)
     std::string str = desc->toString();
     ASSERT_NE(str.find("{{ op.class_name }}"), std::string::npos);
 {% for tf in op.tensor_fields %}
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
     ASSERT_NE(str.find("{{ tf.name }}_uid=" + std::to_string({{ uid_const }})), std::string::npos);
-{% else %}
-    ASSERT_NE(str.find("{{ tf.name }}_uid={{ op.test_data.tensor_uids.get(tf.name, loop.index) }}"), std::string::npos);
-{% endif %}
 {% endfor %}
 {% if op.has_compute_data_type %}
     ASSERT_NE(str.find("compute_data_type="), std::string::npos);
@@ -831,12 +766,8 @@ TEST_F(Test{{ op.class_name }}, GetTensorDescriptorsReturnsAllTensors)
     auto tensors = desc->getTensorDescriptors();
     ASSERT_EQ(tensors.size(), {{ op.tensor_fields | length }});
 {% for tf in op.tensor_fields %}
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
     ASSERT_EQ(tensors[{{ loop.index0 }}]->getData().uid, {{ uid_const }});
-{% else %}
-    ASSERT_EQ(tensors[{{ loop.index0 }}]->getData().uid, {{ op.test_data.tensor_uids.get(tf.name, loop.index) }});
-{% endif %}
 {% endfor %}
 }
 
@@ -861,21 +792,13 @@ TEST_F(Test{{ op.class_name }}, BuildNodeProducesCorrectNodeT)
     auto* {{ op.effective_build_node_attrs_var }} = node->attributes.As{{ op.fbs_table }}();
     ASSERT_NE({{ op.effective_build_node_attrs_var }}, nullptr);
 {% for tf in op.tensor_fields %}
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
     ASSERT_EQ({{ op.effective_build_node_attrs_var }}->{{ tf.uid_field }}, {{ uid_const }});
-{% else %}
-    ASSERT_EQ({{ op.effective_build_node_attrs_var }}->{{ tf.uid_field }}, {{ op.test_data.tensor_uids.get(tf.name, loop.index) }});
-{% endif %}
 {% endfor %}
 {% for df in op.vector_fields %}
 {% if df.build_node_check %}
-{% if op.test_data.constants_include %}
-{% set const_name = df.test_constant_name if df.test_constant_name else ("K_CONV_" ~ (df.name | upper) if "conv" in op.effective_error_label else "K_" ~ (df.name | upper)) %}
+{% set const_name = vector_const_name(df, op) %}
     EXPECT_EQ({{ op.effective_build_node_attrs_var }}->{{ df.fbs_field }}, toVec({{ const_name }}));
-{% else %}
-    EXPECT_EQ({{ op.effective_build_node_attrs_var }}->{{ df.fbs_field }}, (std::vector<int64_t>{{ '{' }}{{ op.test_data.field_values.get(df.name, [1, 1]) | join(', ') }}{{ '}' }}));
-{% endif %}
 {% endif %}
 {% endfor %}
 {% for ef in op.enum_fields %}
@@ -925,12 +848,8 @@ TEST_F(Test{{ op.class_name }}, TryAsInterfaceReturnsValidGraphOp)
     // Verify the returned interface is the same underlying object
     auto tensors = graphOp->getTensorDescriptors();
     ASSERT_EQ(tensors.size(), {{ op.tensor_fields | length }});
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (op.tensor_fields[0].name | upper) ~ "_UID" %}
     ASSERT_EQ(tensors[0]->getData().uid, {{ uid_const }});
-{% else %}
-    ASSERT_EQ(tensors[0]->getData().uid, {{ op.test_data.tensor_uids.get(op.tensor_fields[0].name, 1) }});
-{% endif %}
 }
 
 TEST_F(Test{{ op.class_name }}, TryAsInterfaceReturnsNullForWrongType)

--- a/projects/hipdnn/tools/DescriptorGenerator/templates/test_from_node.cpp.j2
+++ b/projects/hipdnn/tools/DescriptorGenerator/templates/test_from_node.cpp.j2
@@ -1,3 +1,4 @@
+{% from "macros.j2" import vector_const_name %}
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
@@ -13,10 +14,8 @@
 #include <hipdnn_data_sdk/data_objects/{{ op.fbs_generated_header }}>
 #include <hipdnn_data_sdk/data_objects/graph_generated.h>
 #include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
-{% if op.test_data.constants_include %}
-#include <hipdnn_test_sdk/constants/{{ op.test_data.constants_include }}.hpp>
+#include <hipdnn_test_sdk/constants/{{ op.effective_constants_include }}.hpp>
 #include <hipdnn_test_sdk/utilities/ToVec.hpp>
-{% endif %}
 
 #include <memory>
 #include <optional>
@@ -25,10 +24,8 @@
 
 using namespace hipdnn_backend;
 using namespace hipdnn_data_sdk::data_objects;
-{% if op.test_data.constants_include %}
 using namespace hipdnn_tests::constants;
 using hipdnn_tests::toVec;
-{% endif %}
 
 // =============================================================================
 // {{ op.class_name }}::fromNode() Tests
@@ -44,7 +41,6 @@ protected:
 {% for tf in op.tensor_fields %}
 {% set tc = op.test_data.tensor_configs.get(tf.name) %}
 {% if tc %}
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
 {% set dims_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_DIMS" %}
 {% set strides_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_STRIDES" %}
@@ -56,16 +52,6 @@ protected:
 
         _tensorMap[{{ uid_const }}] = TensorDescriptor::fromFlatBuffer({{ tf.camel_name }}Attrs);
 {% else %}
-        TensorAttributesT {{ tf.camel_name }}Attrs;
-        {{ tf.camel_name }}Attrs.uid = {{ op.test_data.tensor_uids.get(tf.name, loop.index) }};
-        {{ tf.camel_name }}Attrs.data_type = DataType::FLOAT;
-        {{ tf.camel_name }}Attrs.dims = {{ '{' }}{{ tc.dims | join(', ') }}{{ '}' }};
-        {{ tf.camel_name }}Attrs.strides = {{ '{' }}{{ tc.strides | join(', ') }}{{ '}' }};
-
-        _tensorMap[{{ op.test_data.tensor_uids.get(tf.name, loop.index) }}] = TensorDescriptor::fromFlatBuffer({{ tf.camel_name }}Attrs);
-{% endif %}
-{% else %}
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
         TensorAttributesT {{ tf.camel_name }}Attrs;
         {{ tf.camel_name }}Attrs.uid = {{ uid_const }};
@@ -74,15 +60,6 @@ protected:
         {{ tf.camel_name }}Attrs.strides = {1};
 
         _tensorMap[{{ uid_const }}] = TensorDescriptor::fromFlatBuffer({{ tf.camel_name }}Attrs);
-{% else %}
-        TensorAttributesT {{ tf.camel_name }}Attrs;
-        {{ tf.camel_name }}Attrs.uid = {{ op.test_data.tensor_uids.get(tf.name, loop.index) }};
-        {{ tf.camel_name }}Attrs.data_type = DataType::FLOAT;
-        {{ tf.camel_name }}Attrs.dims = {1};
-        {{ tf.camel_name }}Attrs.strides = {1};
-
-        _tensorMap[{{ op.test_data.tensor_uids.get(tf.name, loop.index) }}] = TensorDescriptor::fromFlatBuffer({{ tf.camel_name }}Attrs);
-{% endif %}
 {% endif %}
 {% endfor %}
 {% for taf in op.tensor_array_fields %}
@@ -102,21 +79,13 @@ protected:
     {
         {{ op.fbs_namespace }}::{{ op.fbs_t_type }} attrs;
 {% for tf in op.tensor_fields %}
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
         attrs.{{ tf.uid_field }} = {{ uid_const }};
-{% else %}
-        attrs.{{ tf.uid_field }} = {{ op.test_data.tensor_uids.get(tf.name, loop.index) }};
-{% endif %}
 {% endfor %}
 {% for df in op.data_fields %}
 {% if df.is_vector %}
-{% if op.test_data.constants_include %}
-{% set const_name = df.test_constant_name if df.test_constant_name else ("K_CONV_" ~ (df.name | upper) if "conv" in op.effective_error_label else "K_" ~ (df.name | upper)) %}
+{% set const_name = vector_const_name(df, op) %}
         attrs.{{ df.fbs_field }} = toVec({{ const_name }});
-{% else %}
-        attrs.{{ df.fbs_field }} = {{ '{' }}{{ op.test_data.field_values.get(df.name, [1, 1]) | join(', ') }}{{ '}' }};
-{% endif %}
 {% elif df.is_mode or df.is_enum %}
         attrs.{{ df.fbs_field }} = {{ df.enum_short_type }}::{{ df.test_enum_value }};
 {% elif df.is_scalar %}
@@ -192,12 +161,8 @@ TEST_F(Test{{ op.name }}OperationFromNode, CreatesValidFinalizedDescriptor)
     ASSERT_NE(desc, nullptr);
     ASSERT_TRUE(desc->isFinalized());
     ASSERT_EQ(desc->getType(), {{ op.descriptor_type_enum }});
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (op.tensor_fields[0].name | upper) ~ "_UID" %}
     EXPECT_EQ(desc->getData().{{ op.tensor_fields[0].uid_field }}, {{ uid_const }});
-{% else %}
-    EXPECT_EQ(desc->getData().{{ op.tensor_fields[0].uid_field }}, {{ op.test_data.tensor_uids.get(op.tensor_fields[0].name, 1) }});
-{% endif %}
 }
 
 TEST_F(Test{{ op.name }}OperationFromNode, NodeFactoryDelegatesCorrectly)
@@ -220,20 +185,12 @@ TEST_F(Test{{ op.name }}OperationFromNode, NodeFactoryDelegatesCorrectly)
 
     // Verify all attributes are correctly populated via the delegated path
 {% for tf in op.tensor_fields %}
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
     EXPECT_EQ(desc->getData().{{ tf.uid_field }}, {{ uid_const }});
-{% else %}
-    EXPECT_EQ(desc->getData().{{ tf.uid_field }}, {{ op.test_data.tensor_uids.get(tf.name, loop.index) }});
-{% endif %}
 {% endfor %}
 {% for vf in op.vector_fields %}
-{% if op.test_data.constants_include %}
-{% set const_name = vf.test_constant_name if vf.test_constant_name else ("K_CONV_" ~ (vf.name | upper) if "conv" in op.effective_error_label else "K_" ~ (vf.name | upper)) %}
+{% set const_name = vector_const_name(vf, op) %}
     EXPECT_EQ(desc->getData().{{ vf.fbs_field }}, toVec({{ const_name }}));
-{% else %}
-    EXPECT_EQ(desc->getData().{{ vf.fbs_field }}, (std::vector<int64_t>{{ '{' }}{{ op.test_data.field_values.get(vf.name, [1, 1]) | join(', ') }}{{ '}' }}));
-{% endif %}
 {% endfor %}
 {% for cf in op.mode_fields %}
     EXPECT_EQ(desc->getData().{{ cf.fbs_field }}, {{ cf.enum_short_type }}::{{ cf.test_enum_value }});
@@ -246,22 +203,14 @@ TEST_F(Test{{ op.name }}OperationFromNode, NodeFactoryDelegatesCorrectly)
 {% endif %}
 {% for tf in op.required_tensor_fields %}
 {% if op.test_data.tensor_configs.get(tf.name) %}
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
     EXPECT_EQ(desc->{{ tf.getter_name }}()->getData().uid, {{ uid_const }});
-{% else %}
-    EXPECT_EQ(desc->{{ tf.getter_name }}()->getData().uid, {{ op.test_data.tensor_uids.get(tf.name, loop.index) }});
-{% endif %}
 {% endif %}
 {% endfor %}
 {% for tf in op.optional_tensor_fields %}
 {% if op.test_data.tensor_configs.get(tf.name) %}
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
     EXPECT_EQ(desc->{{ tf.getter_name }}()->getData().uid, {{ uid_const }});
-{% else %}
-    EXPECT_EQ(desc->{{ tf.getter_name }}()->getData().uid, {{ op.test_data.tensor_uids.get(tf.name, loop.index) }});
-{% endif %}
 {% endif %}
 {% endfor %}
 }
@@ -297,12 +246,8 @@ TEST_F(Test{{ op.name }}OperationFromNode, PreservesDataFields)
     auto desc = {{ op.class_name }}::fromNode(node, _tensorMap);
 
 {% for vf in op.vector_fields %}
-{% if op.test_data.constants_include %}
-{% set const_name = vf.test_constant_name if vf.test_constant_name else ("K_CONV_" ~ (vf.name | upper) if "conv" in op.effective_error_label else "K_" ~ (vf.name | upper)) %}
+{% set const_name = vector_const_name(vf, op) %}
     EXPECT_EQ(desc->getData().{{ vf.fbs_field }}, toVec({{ const_name }}));
-{% else %}
-    EXPECT_EQ(desc->getData().{{ vf.fbs_field }}, (std::vector<int64_t>{{ '{' }}{{ op.test_data.field_values.get(vf.name, [1, 1]) | join(', ') }}{{ '}' }}));
-{% endif %}
 {% endfor %}
 {% for ef in op.enum_fields %}
     EXPECT_EQ(desc->getData().{{ ef.fbs_field }}, {{ ef.enum_short_type }}::{{ ef.test_enum_value }});
@@ -321,23 +266,15 @@ TEST_F(Test{{ op.name }}OperationFromNode, SetsTensorReferences)
 {% for tf in op.required_tensor_fields %}
 {% if op.test_data.tensor_configs.get(tf.name) %}
     ASSERT_NE(desc->{{ tf.getter_name }}(), nullptr);
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
     EXPECT_EQ(desc->{{ tf.getter_name }}()->getData().uid, {{ uid_const }});
-{% else %}
-    EXPECT_EQ(desc->{{ tf.getter_name }}()->getData().uid, {{ op.test_data.tensor_uids.get(tf.name, loop.index) }});
-{% endif %}
 {% endif %}
 {% endfor %}
 {% for tf in op.optional_tensor_fields %}
 {% if op.test_data.tensor_configs.get(tf.name) %}
     ASSERT_NE(desc->{{ tf.getter_name }}(), nullptr);
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
     EXPECT_EQ(desc->{{ tf.getter_name }}()->getData().uid, {{ uid_const }});
-{% else %}
-    EXPECT_EQ(desc->{{ tf.getter_name }}()->getData().uid, {{ op.test_data.tensor_uids.get(tf.name, loop.index) }});
-{% endif %}
 {% endif %}
 {% endfor %}
 }
@@ -349,22 +286,14 @@ TEST_F(Test{{ op.name }}OperationFromNode, TensorReferencesMatchTensorMap)
 
 {% for tf in op.required_tensor_fields %}
 {% if op.test_data.tensor_configs.get(tf.name) %}
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
     EXPECT_EQ(desc->{{ tf.getter_name }}(), _tensorMap[{{ uid_const }}]);
-{% else %}
-    EXPECT_EQ(desc->{{ tf.getter_name }}(), _tensorMap[{{ op.test_data.tensor_uids.get(tf.name, loop.index) }}]);
-{% endif %}
 {% endif %}
 {% endfor %}
 {% for tf in op.optional_tensor_fields %}
 {% if op.test_data.tensor_configs.get(tf.name) %}
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
     EXPECT_EQ(desc->{{ tf.getter_name }}(), _tensorMap[{{ uid_const }}]);
-{% else %}
-    EXPECT_EQ(desc->{{ tf.getter_name }}(), _tensorMap[{{ op.test_data.tensor_uids.get(tf.name, loop.index) }}]);
-{% endif %}
 {% endif %}
 {% endfor %}
 }
@@ -378,23 +307,15 @@ TEST_F(Test{{ op.name }}OperationFromNode, SetsTensorReferencesWithFullValues)
 {% set tc = op.test_data.tensor_configs.get(tf.name) %}
 {% if tc %}
     ASSERT_NE(desc->{{ tf.getter_name }}(), nullptr);
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
     EXPECT_EQ(desc->{{ tf.getter_name }}()->getData().uid, {{ uid_const }});
-{% else %}
-    EXPECT_EQ(desc->{{ tf.getter_name }}()->getData().uid, {{ op.test_data.tensor_uids.get(tf.name, loop.index) }});
-{% endif %}
     EXPECT_EQ(desc->{{ tf.getter_name }}()->getData().data_type, DataType::FLOAT);
     EXPECT_EQ(desc->{{ tf.getter_name }}()->getData().dims, (std::vector<int64_t>{{ '{' }}{{ tc.dims | join(', ') }}{{ '}' }}));
     EXPECT_EQ(desc->{{ tf.getter_name }}()->getData().strides, (std::vector<int64_t>{{ '{' }}{{ tc.strides | join(', ') }}{{ '}' }}));
 {% else %}
     ASSERT_NE(desc->{{ tf.getter_name }}(), nullptr);
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
     EXPECT_EQ(desc->{{ tf.getter_name }}()->getData().uid, {{ uid_const }});
-{% else %}
-    EXPECT_EQ(desc->{{ tf.getter_name }}()->getData().uid, {{ op.test_data.tensor_uids.get(tf.name, loop.index) }});
-{% endif %}
     EXPECT_EQ(desc->{{ tf.getter_name }}()->getData().data_type, DataType::FLOAT);
     EXPECT_EQ(desc->{{ tf.getter_name }}()->getData().dims, (std::vector<int64_t>{1}));
     EXPECT_EQ(desc->{{ tf.getter_name }}()->getData().strides, (std::vector<int64_t>{1}));
@@ -405,23 +326,15 @@ TEST_F(Test{{ op.name }}OperationFromNode, SetsTensorReferencesWithFullValues)
 {% set tc = op.test_data.tensor_configs.get(tf.name) %}
 {% if tc %}
     ASSERT_NE(desc->{{ tf.getter_name }}(), nullptr);
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
     EXPECT_EQ(desc->{{ tf.getter_name }}()->getData().uid, {{ uid_const }});
-{% else %}
-    EXPECT_EQ(desc->{{ tf.getter_name }}()->getData().uid, {{ op.test_data.tensor_uids.get(tf.name, loop.index) }});
-{% endif %}
     EXPECT_EQ(desc->{{ tf.getter_name }}()->getData().data_type, DataType::FLOAT);
     EXPECT_EQ(desc->{{ tf.getter_name }}()->getData().dims, (std::vector<int64_t>{{ '{' }}{{ tc.dims | join(', ') }}{{ '}' }}));
     EXPECT_EQ(desc->{{ tf.getter_name }}()->getData().strides, (std::vector<int64_t>{{ '{' }}{{ tc.strides | join(', ') }}{{ '}' }}));
 {% else %}
     ASSERT_NE(desc->{{ tf.getter_name }}(), nullptr);
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
     EXPECT_EQ(desc->{{ tf.getter_name }}()->getData().uid, {{ uid_const }});
-{% else %}
-    EXPECT_EQ(desc->{{ tf.getter_name }}()->getData().uid, {{ op.test_data.tensor_uids.get(tf.name, loop.index) }});
-{% endif %}
     EXPECT_EQ(desc->{{ tf.getter_name }}()->getData().data_type, DataType::FLOAT);
     EXPECT_EQ(desc->{{ tf.getter_name }}()->getData().dims, (std::vector<int64_t>{1}));
     EXPECT_EQ(desc->{{ tf.getter_name }}()->getData().strides, (std::vector<int64_t>{1}));
@@ -433,12 +346,8 @@ TEST_F(Test{{ op.name }}OperationFromNode, SetsTensorReferencesWithFullValues)
 
 TEST_F(Test{{ op.name }}OperationFromNode, FailsWithMissing{{ tf.pascal_name }}Tensor)
 {
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
     _tensorMap.erase({{ uid_const }});
-{% else %}
-    _tensorMap.erase({{ op.test_data.tensor_uids.get(tf.name, loop.index) }});
-{% endif %}
     auto node = createStandardNode();
 
     ASSERT_THROW_HIPDNN_STATUS({{ op.class_name }}::fromNode(node, _tensorMap),
@@ -475,12 +384,8 @@ TEST_F(Test{{ op.name }}OperationFromNode, SucceedsWithOnlyRequiredTensors)
 
 TEST_F(Test{{ op.name }}OperationFromNode, FailsWhenOptional{{ tf.pascal_name }}UidSetButTensorMissing)
 {
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
     _tensorMap.erase({{ uid_const }});
-{% else %}
-    _tensorMap.erase({{ op.test_data.tensor_uids.get(tf.name, loop.index) }});
-{% endif %}
     auto node = createStandardNode();
 
     ASSERT_THROW_HIPDNN_STATUS({{ op.class_name }}::fromNode(node, _tensorMap),
@@ -498,12 +403,8 @@ TEST_F(Test{{ op.name }}OperationFromNode, GetTensorDescriptorsReturnsAllTensors
     ASSERT_EQ(tensors.size(), {{ op.tensor_fields | length }});
 {% for tf in op.tensor_fields %}
 {% if op.test_data.tensor_configs.get(tf.name) %}
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
     EXPECT_EQ(tensors[{{ loop.index0 }}]->getData().uid, {{ uid_const }});
-{% else %}
-    EXPECT_EQ(tensors[{{ loop.index0 }}]->getData().uid, {{ op.test_data.tensor_uids.get(tf.name, loop.index) }});
-{% endif %}
 {% endif %}
 {% endfor %}
 }
@@ -523,20 +424,12 @@ TEST_F(Test{{ op.name }}OperationFromNode, BuildNodeRoundTrip)
     const auto* rebuiltAttrs = rebuiltNode->attributes.As{{ op.fbs_table }}();
     ASSERT_NE(rebuiltAttrs, nullptr);
 {% for tf in op.tensor_fields %}
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
     EXPECT_EQ(rebuiltAttrs->{{ tf.uid_field }}, {{ uid_const }});
-{% else %}
-    EXPECT_EQ(rebuiltAttrs->{{ tf.uid_field }}, {{ op.test_data.tensor_uids.get(tf.name, loop.index) }});
-{% endif %}
 {% endfor %}
 {% for vf in op.vector_fields %}
-{% if op.test_data.constants_include %}
-{% set const_name = vf.test_constant_name if vf.test_constant_name else ("K_CONV_" ~ (vf.name | upper) if "conv" in op.effective_error_label else "K_" ~ (vf.name | upper)) %}
+{% set const_name = vector_const_name(vf, op) %}
     EXPECT_EQ(rebuiltAttrs->{{ vf.fbs_field }}, toVec({{ const_name }}));
-{% else %}
-    EXPECT_EQ(rebuiltAttrs->{{ vf.fbs_field }}, (std::vector<int64_t>{{ '{' }}{{ op.test_data.field_values.get(vf.name, [1, 1]) | join(', ') }}{{ '}' }}));
-{% endif %}
 {% endfor %}
 {% for ef in op.enum_fields %}
     EXPECT_EQ(rebuiltAttrs->{{ ef.fbs_field }}, {{ ef.enum_short_type }}::{{ ef.test_enum_value }});
@@ -620,12 +513,8 @@ TEST_F(Test{{ op.name }}OperationFromNode, GetAttributeWorksAfterFromNode)
                        &{{ vf.camel_name }}Count,
                        {{ vf.camel_name }}.data());
     ASSERT_EQ({{ vf.camel_name }}Count, {{ fv | length }});
-{% if op.test_data.constants_include %}
-{% set const_name = vf.test_constant_name if vf.test_constant_name else ("K_CONV_" ~ (vf.name | upper) if "conv" in op.effective_error_label else "K_" ~ (vf.name | upper)) %}
+{% set const_name = vector_const_name(vf, op) %}
     EXPECT_EQ({{ vf.camel_name }}, toVec({{ const_name }}));
-{% else %}
-    EXPECT_EQ({{ vf.camel_name }}, (std::vector<int64_t>{{ '{' }}{{ fv | join(', ') }}{{ '}' }}));
-{% endif %}
 
 {% endfor %}
 {% if op.has_compute_data_type %}
@@ -659,16 +548,10 @@ TEST_F(Test{{ op.name }}OperationFromNode, GetAttributeWorksAfterFromNode)
                        static_cast<void*>({{ tf.camel_name }}Scoped.getPtr()));
     ASSERT_EQ({{ tf.camel_name }}Count, 1);
     ASSERT_NE({{ tf.camel_name }}Scoped.get(), nullptr);
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
     verifyTensorDescriptor({{ tf.camel_name }}Scoped.get(), {{ uid_const }}, HIPDNN_DATA_FLOAT,
                            {{ '{' }}{{ tc.dims | join(', ') }}{{ '}' }},
                            {{ '{' }}{{ tc.strides | join(', ') }}{{ '}' }});
-{% else %}
-    verifyTensorDescriptor({{ tf.camel_name }}Scoped.get(), {{ op.test_data.tensor_uids.get(tf.name, loop.index) }}, HIPDNN_DATA_FLOAT,
-                           {{ '{' }}{{ tc.dims | join(', ') }}{{ '}' }},
-                           {{ '{' }}{{ tc.strides | join(', ') }}{{ '}' }});
-{% endif %}
 
 {% else %}
     // Verify {{ tf.name }} tensor
@@ -681,14 +564,9 @@ TEST_F(Test{{ op.name }}OperationFromNode, GetAttributeWorksAfterFromNode)
                        static_cast<void*>({{ tf.camel_name }}Scoped.getPtr()));
     ASSERT_EQ({{ tf.camel_name }}Count, 1);
     ASSERT_NE({{ tf.camel_name }}Scoped.get(), nullptr);
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
     verifyTensorDescriptor({{ tf.camel_name }}Scoped.get(), {{ uid_const }}, HIPDNN_DATA_FLOAT,
                            {1}, {1});
-{% else %}
-    verifyTensorDescriptor({{ tf.camel_name }}Scoped.get(), {{ op.test_data.tensor_uids.get(tf.name, loop.index) }}, HIPDNN_DATA_FLOAT,
-                           {1}, {1});
-{% endif %}
 
 {% endif %}
 {% endfor %}
@@ -705,16 +583,10 @@ TEST_F(Test{{ op.name }}OperationFromNode, GetAttributeWorksAfterFromNode)
                        static_cast<void*>({{ tf.camel_name }}Scoped.getPtr()));
     ASSERT_EQ({{ tf.camel_name }}Count, 1);
     ASSERT_NE({{ tf.camel_name }}Scoped.get(), nullptr);
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
     verifyTensorDescriptor({{ tf.camel_name }}Scoped.get(), {{ uid_const }}, HIPDNN_DATA_FLOAT,
                            {{ '{' }}{{ tc.dims | join(', ') }}{{ '}' }},
                            {{ '{' }}{{ tc.strides | join(', ') }}{{ '}' }});
-{% else %}
-    verifyTensorDescriptor({{ tf.camel_name }}Scoped.get(), {{ op.test_data.tensor_uids.get(tf.name, loop.index) }}, HIPDNN_DATA_FLOAT,
-                           {{ '{' }}{{ tc.dims | join(', ') }}{{ '}' }},
-                           {{ '{' }}{{ tc.strides | join(', ') }}{{ '}' }});
-{% endif %}
 
 {% else %}
     // Verify {{ tf.name }} tensor (optional)
@@ -727,14 +599,9 @@ TEST_F(Test{{ op.name }}OperationFromNode, GetAttributeWorksAfterFromNode)
                        static_cast<void*>({{ tf.camel_name }}Scoped.getPtr()));
     ASSERT_EQ({{ tf.camel_name }}Count, 1);
     ASSERT_NE({{ tf.camel_name }}Scoped.get(), nullptr);
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
     verifyTensorDescriptor({{ tf.camel_name }}Scoped.get(), {{ uid_const }}, HIPDNN_DATA_FLOAT,
                            {1}, {1});
-{% else %}
-    verifyTensorDescriptor({{ tf.camel_name }}Scoped.get(), {{ op.test_data.tensor_uids.get(tf.name, loop.index) }}, HIPDNN_DATA_FLOAT,
-                           {1}, {1});
-{% endif %}
 
 {% endif %}
 {% endfor %}

--- a/projects/hipdnn/tools/DescriptorGenerator/templates/test_graph_ops.cpp.j2
+++ b/projects/hipdnn/tools/DescriptorGenerator/templates/test_graph_ops.cpp.j2
@@ -23,6 +23,7 @@
 #include <array>
 #include <memory>
 #include <set>
+#include <string>
 #include <vector>
 
 using namespace hipdnn_backend;
@@ -41,7 +42,8 @@ inline std::unique_ptr<HipdnnBackendDescriptor>
 {% for taf in op.tensor_array_fields %}
                           std::vector<HipdnnBackendDescriptor*> {{ taf.name }}Descs = {}{% if not loop.last %},{% endif %}
 {% endfor %}{% endif %},
-                          hipdnnDataType_t computeType = HIPDNN_DATA_FLOAT)
+                          hipdnnDataType_t computeType = HIPDNN_DATA_FLOAT,
+                          const std::string& name = "")
 {
     auto wrapper = createDescriptor<{{ op.class_name }}>();
     auto desc = wrapper->asDescriptor<{{ op.class_name }}>();
@@ -78,6 +80,14 @@ inline std::unique_ptr<HipdnnBackendDescriptor>
             static_cast<int64_t>({{ taf.name }}Descs.size()), {{ taf.name }}Descs.data());
     }
 {% endfor %}
+
+    if(!name.empty())
+    {
+        desc->setAttribute(HIPDNN_ATTR_OPERATION_NAME_EXT,
+                           HIPDNN_TYPE_CHAR,
+                           static_cast<int64_t>(name.size() + 1),
+                           name.c_str());
+    }
 
     desc->finalize();
     return wrapper;
@@ -483,5 +493,101 @@ TEST_F(TestGraphDescriptor{{ op.name }}, {{ op.name }}AttributesPreserved)
     EXPECT_EQ(graphT->nodes[0]->name, "test_{{ op.name | lower }}");
 }
 {% endif %}
+
+TEST_F(TestGraphDescriptor{{ op.name }}, OperationNamePreservedInSerialization)
+{
+{% for tf in op.tensor_fields %}
+{% set tc = op.test_data.tensor_configs.get(tf.name) %}
+{% if tc %}
+{% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
+{% set dims_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_DIMS" %}
+{% set strides_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_STRIDES" %}
+    auto {{ tf.local_desc_name }} = createFinalizedTensor({{ uid_const }}, toVec({{ dims_const }}), toVec({{ strides_const }}));
+{% else %}
+{% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
+    auto {{ tf.local_desc_name }} = createFinalizedTensor({{ uid_const }});
+{% endif %}
+{% endfor %}
+    auto opDesc = createFinalized{{ op.name }}Op(
+        {% for tf in op.tensor_fields %}{{ tf.local_desc_name }}.get(){% if not loop.last %}, {% endif %}{% endfor %},
+{% if op.has_tensor_array_fields %}
+{% for taf in op.tensor_array_fields %}
+        {}{% if not loop.last %},{% endif %}
+{% endfor %},
+{% endif %}
+        HIPDNN_DATA_FLOAT,
+        "test_{{ op.name | lower }}_name");
+
+    auto desc = getDescriptor();
+    setHandle();
+
+    std::array<HipdnnBackendDescriptor*, 1> ops = {opDesc.get()};
+    desc->setAttribute(
+        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data());
+    desc->finalize();
+
+    auto serialized = desc->getSerializedGraph();
+    auto graphT = UnPackGraph(serialized.ptr);
+
+    ASSERT_EQ(graphT->nodes.size(), 1u);
+    EXPECT_EQ(graphT->nodes[0]->name, "test_{{ op.name | lower }}_name");
+}
+
+TEST_F(TestGraphDescriptor{{ op.name }}, OperationNameRoundTripThroughLifting)
+{
+{% for tf in op.tensor_fields %}
+{% set tc = op.test_data.tensor_configs.get(tf.name) %}
+{% if tc %}
+{% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
+{% set dims_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_DIMS" %}
+{% set strides_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_STRIDES" %}
+    auto {{ tf.local_desc_name }} = createFinalizedTensor({{ uid_const }}, toVec({{ dims_const }}), toVec({{ strides_const }}));
+{% else %}
+{% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
+    auto {{ tf.local_desc_name }} = createFinalizedTensor({{ uid_const }});
+{% endif %}
+{% endfor %}
+    auto opDesc = createFinalized{{ op.name }}Op(
+        {% for tf in op.tensor_fields %}{{ tf.local_desc_name }}.get(){% if not loop.last %}, {% endif %}{% endfor %},
+{% if op.has_tensor_array_fields %}
+{% for taf in op.tensor_array_fields %}
+        {}{% if not loop.last %},{% endif %}
+{% endfor %},
+{% endif %}
+        HIPDNN_DATA_FLOAT,
+        "test_{{ op.name | lower }}_lifting");
+
+    auto desc = getDescriptor();
+    setHandle();
+
+    std::array<HipdnnBackendDescriptor*, 1> ops = {opDesc.get()};
+    desc->setAttribute(
+        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data());
+    desc->finalize();
+
+    // Serialize the graph
+    auto serialized = desc->getSerializedGraph();
+    std::vector<uint8_t> bytes(static_cast<const uint8_t*>(serialized.ptr),
+                               static_cast<const uint8_t*>(serialized.ptr) + serialized.size);
+
+    // Deserialize into a new GraphDescriptor (lifting path)
+    auto liftedWrapper = createDescriptor<GraphDescriptor>();
+    auto liftedDesc = liftedWrapper->asDescriptor<GraphDescriptor>();
+    liftedDesc->deserializeGraph(bytes.data(), bytes.size());
+
+    hipdnnHandle_t handle = &_mockHandle;
+    liftedDesc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE,
+                             HIPDNN_TYPE_HANDLE,
+                             1,
+                             static_cast<const void*>(&handle));
+    liftedDesc->finalize();
+
+    // Re-serialize and verify name survived the round-trip
+    auto reSerialized = liftedDesc->getSerializedGraph();
+    auto graphT = UnPackGraph(reSerialized.ptr);
+
+    ASSERT_EQ(graphT->nodes.size(), 1u);
+    EXPECT_EQ(graphT->nodes[0]->name, "test_{{ op.name | lower }}_lifting");
+}
 
 } // namespace

--- a/projects/hipdnn/tools/DescriptorGenerator/templates/test_graph_ops.cpp.j2
+++ b/projects/hipdnn/tools/DescriptorGenerator/templates/test_graph_ops.cpp.j2
@@ -1,3 +1,4 @@
+{% from "macros.j2" import vector_const_name %}
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
@@ -16,9 +17,7 @@
 #include <hipdnn_data_sdk/data_objects/{{ op.fbs_generated_header }}>
 #include <hipdnn_data_sdk/data_objects/graph_generated.h>
 #include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
-{% if op.test_data.constants_include %}
-#include <hipdnn_test_sdk/constants/{{ op.test_data.constants_include }}.hpp>
-{% endif %}
+#include <hipdnn_test_sdk/constants/{{ op.effective_constants_include }}.hpp>
 #include <hipdnn_test_sdk/utilities/ToVec.hpp>
 
 #include <array>
@@ -29,9 +28,7 @@
 using namespace hipdnn_backend;
 using namespace hipdnn_backend::test_utilities;
 using namespace hipdnn_data_sdk::data_objects;
-{% if op.test_data.constants_include %}
 using namespace hipdnn_tests::constants;
-{% endif %}
 using hipdnn_tests::toVec;
 
 namespace
@@ -55,16 +52,10 @@ inline std::unique_ptr<HipdnnBackendDescriptor>
 {% endfor %}
 {% for df in op.required_data_fields %}
 {% if df.is_vector %}
-{% if op.test_data.constants_include %}
-{% set const_name = df.test_constant_name if df.test_constant_name else ("K_CONV_" ~ (df.name | upper) if "conv" in op.effective_error_label else "K_" ~ (df.name | upper)) %}
+{% set const_name = vector_const_name(df, op) %}
 
     auto {{ df.camel_name }} = toVec({{ const_name }});
     desc->setAttribute({{ df.attr_name }}, {{ df.backend_type }}, static_cast<int64_t>({{ df.camel_name }}.size()), {{ df.camel_name }}.data());
-{% else %}
-
-    std::vector<int64_t> {{ df.camel_name }} = {{ '{' }}{{ op.test_data.field_values.get(df.name, [1, 1]) | join(', ') }}{{ '}' }};
-    desc->setAttribute({{ df.attr_name }}, {{ df.backend_type }}, {{ op.test_data.field_values.get(df.name, [1, 1]) | length }}, {{ df.camel_name }}.data());
-{% endif %}
 {% elif df.is_mode %}
 
     auto {{ df.camel_name }} = {{ df.test_backend_value }};
@@ -200,16 +191,13 @@ TEST_F(TestGraphDescriptor{{ op.name }}, BuildFromSingleOperation)
 {% for tf in op.tensor_fields %}
 {% set tc = op.test_data.tensor_configs.get(tf.name) %}
 {% if tc %}
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
 {% set dims_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_DIMS" %}
 {% set strides_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_STRIDES" %}
     auto {{ tf.local_desc_name }} = createFinalizedTensor({{ uid_const }}, toVec({{ dims_const }}), toVec({{ strides_const }}));
 {% else %}
-    auto {{ tf.local_desc_name }} = createFinalizedTensor({{ op.test_data.tensor_uids.get(tf.name, loop.index) }}, {{ '{' }}{{ tc.dims | join(', ') }}{{ '}' }}, {{ '{' }}{{ tc.strides | join(', ') }}{{ '}' }});
-{% endif %}
-{% else %}
-    auto {{ tf.local_desc_name }} = createFinalizedTensor({{ op.test_data.tensor_uids.get(tf.name, loop.index) }});
+{% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
+    auto {{ tf.local_desc_name }} = createFinalizedTensor({{ uid_const }});
 {% endif %}
 {% endfor %}
     auto opDesc = createFinalized{{ op.name }}Op({% for tf in op.tensor_fields %}{{ tf.local_desc_name }}.get(){% if not loop.last %}, {% endif %}{% endfor %});
@@ -239,7 +227,6 @@ TEST_F(TestGraphDescriptor{{ op.name }}, BuildFromSingleOperation)
 {% for tf in op.tensor_fields %}
 {% set tc = op.test_data.tensor_configs.get(tf.name) %}
 {% if tc %}
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
 {% set dims_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_DIMS" %}
 {% set strides_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_STRIDES" %}
@@ -248,13 +235,6 @@ TEST_F(TestGraphDescriptor{{ op.name }}, BuildFromSingleOperation)
                  toVec({{ dims_const }}),
                  toVec({{ strides_const }}),
                  DataType::FLOAT);
-{% else %}
-    verifyTensor(findTensorByUid(*graphT, {{ op.test_data.tensor_uids.get(tf.name, loop.index) }}),
-                 {{ op.test_data.tensor_uids.get(tf.name, loop.index) }},
-                 {{ '{' }}{{ tc.dims | join(', ') }}{{ '}' }},
-                 {{ '{' }}{{ tc.strides | join(', ') }}{{ '}' }},
-                 DataType::FLOAT);
-{% endif %}
 {% endif %}
 {% endfor %}
 
@@ -265,25 +245,15 @@ TEST_F(TestGraphDescriptor{{ op.name }}, BuildFromSingleOperation)
                       DataType::FLOAT,
 {% endif %}
 {% for tf in op.tensor_fields %}
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
                       {{ uid_const }}{% if not loop.last or op.graph_verifiable_data_fields %},{% endif %}
 
-{% else %}
-                      {{ op.test_data.tensor_uids.get(tf.name, loop.index) }}{% if not loop.last or op.graph_verifiable_data_fields %},{% endif %}
-
-{% endif %}
 {% endfor %}
 {% for df in op.graph_verifiable_data_fields %}
 {% if df.is_vector %}
-{% if op.test_data.constants_include %}
-{% set const_name = df.test_constant_name if df.test_constant_name else ("K_CONV_" ~ (df.name | upper) if "conv" in op.effective_error_label else "K_" ~ (df.name | upper)) %}
+{% set const_name = vector_const_name(df, op) %}
                       toVec({{ const_name }}){% if not loop.last %},{% endif %}
 
-{% else %}
-                      std::vector<int64_t>{{ '{' }}{{ op.test_data.field_values.get(df.name, [1, 1]) | join(', ') }}{{ '}' }}{% if not loop.last %},{% endif %}
-
-{% endif %}
 {% elif df.is_mode %}
                       {{ df.enum_short_type }}::{{ df.test_enum_value }}{% if not loop.last %},{% endif %}
 
@@ -304,12 +274,8 @@ TEST_F(TestGraphDescriptor{{ op.name }}, BuildFromSingleOperation)
 
     // Verify tensor UID references
 {% for tf in op.tensor_fields %}
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
     EXPECT_EQ(attrs->{{ tf.uid_field }}, {{ uid_const }});
-{% else %}
-    EXPECT_EQ(attrs->{{ tf.uid_field }}, {{ op.test_data.tensor_uids.get(tf.name, loop.index) }});
-{% endif %}
 {% endfor %}
 {% endif %}
 {% for taf in op.tensor_array_fields %}
@@ -328,16 +294,13 @@ TEST_F(TestGraphDescriptor{{ op.name }}, ComputeDataTypePreserved)
 {% for tf in op.tensor_fields %}
 {% set tc = op.test_data.tensor_configs.get(tf.name) %}
 {% if tc %}
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
 {% set dims_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_DIMS" %}
 {% set strides_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_STRIDES" %}
     auto {{ tf.local_desc_name }} = createFinalizedTensor({{ uid_const }}, toVec({{ dims_const }}), toVec({{ strides_const }}));
 {% else %}
-    auto {{ tf.local_desc_name }} = createFinalizedTensor({{ op.test_data.tensor_uids.get(tf.name, loop.index) }}, {{ '{' }}{{ tc.dims | join(', ') }}{{ '}' }}, {{ '{' }}{{ tc.strides | join(', ') }}{{ '}' }});
-{% endif %}
-{% else %}
-    auto {{ tf.local_desc_name }} = createFinalizedTensor({{ op.test_data.tensor_uids.get(tf.name, loop.index) }});
+{% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
+    auto {{ tf.local_desc_name }} = createFinalizedTensor({{ uid_const }});
 {% endif %}
 {% endfor %}
     auto opDesc = createFinalized{{ op.name }}Op({% for tf in op.tensor_fields %}{{ tf.local_desc_name }}.get(){% if not loop.last %}, {% endif %}{% endfor %}, HIPDNN_DATA_HALF);
@@ -365,16 +328,13 @@ TEST_F(TestGraphDescriptor{{ op.name }}, BuildWith{{ taf.test_label or taf.name 
 {% for tf in op.tensor_fields %}
 {% set tc = op.test_data.tensor_configs.get(tf.name) %}
 {% if tc %}
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
 {% set dims_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_DIMS" %}
 {% set strides_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_STRIDES" %}
     auto {{ tf.local_desc_name }} = createFinalizedTensor({{ uid_const }}, toVec({{ dims_const }}), toVec({{ strides_const }}));
 {% else %}
-    auto {{ tf.local_desc_name }} = createFinalizedTensor({{ op.test_data.tensor_uids.get(tf.name, loop.index) }}, {{ '{' }}{{ tc.dims | join(', ') }}{{ '}' }}, {{ '{' }}{{ tc.strides | join(', ') }}{{ '}' }});
-{% endif %}
-{% else %}
-    auto {{ tf.local_desc_name }} = createFinalizedTensor({{ op.test_data.tensor_uids.get(tf.name, loop.index) }});
+{% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
+    auto {{ tf.local_desc_name }} = createFinalizedTensor({{ uid_const }});
 {% endif %}
 {% endfor %}
 {% for uid in taf.test_uids %}
@@ -415,21 +375,13 @@ TEST_F(TestGraphDescriptor{{ op.name }}, {{ op.name }}AttributesPreserved)
 {% for tf in op.tensor_fields %}
 {% set tc = op.test_data.tensor_configs.get(tf.name) %}
 {% if tc %}
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
 {% set dims_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_DIMS" %}
 {% set strides_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_STRIDES" %}
     auto {{ tf.local_desc_name }} = createFinalizedTensor({{ uid_const }}, toVec({{ dims_const }}), toVec({{ strides_const }}));
 {% else %}
-    auto {{ tf.local_desc_name }} = createFinalizedTensor({{ op.test_data.tensor_uids.get(tf.name, loop.index) }}, {{ '{' }}{{ tc.dims | join(', ') }}{{ '}' }}, {{ '{' }}{{ tc.strides | join(', ') }}{{ '}' }});
-{% endif %}
-{% else %}
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
     auto {{ tf.local_desc_name }} = createFinalizedTensor({{ uid_const }});
-{% else %}
-    auto {{ tf.local_desc_name }} = createFinalizedTensor({{ op.test_data.tensor_uids.get(tf.name, loop.index) }});
-{% endif %}
 {% endif %}
 {% endfor %}
 
@@ -491,7 +443,6 @@ TEST_F(TestGraphDescriptor{{ op.name }}, {{ op.name }}AttributesPreserved)
 {% for tf in op.tensor_fields %}
 {% set tc = op.test_data.tensor_configs.get(tf.name) %}
 {% if tc %}
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
 {% set dims_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_DIMS" %}
 {% set strides_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_STRIDES" %}
@@ -500,13 +451,6 @@ TEST_F(TestGraphDescriptor{{ op.name }}, {{ op.name }}AttributesPreserved)
                  toVec({{ dims_const }}),
                  toVec({{ strides_const }}),
                  DataType::FLOAT);
-{% else %}
-    verifyTensor(findTensorByUid(*graphT, {{ op.test_data.tensor_uids.get(tf.name, loop.index) }}),
-                 {{ op.test_data.tensor_uids.get(tf.name, loop.index) }},
-                 {{ '{' }}{{ tc.dims | join(', ') }}{{ '}' }},
-                 {{ '{' }}{{ tc.strides | join(', ') }}{{ '}' }},
-                 DataType::FLOAT);
-{% endif %}
 {% endif %}
 {% endfor %}
 
@@ -516,14 +460,9 @@ TEST_F(TestGraphDescriptor{{ op.name }}, {{ op.name }}AttributesPreserved)
                       DataType::FLOAT,
 {% endif %}
 {% for tf in op.tensor_fields %}
-{% if op.test_data.constants_include %}
 {% set uid_const = "K_TENSOR_" ~ (tf.name | upper) ~ "_UID" %}
                       {{ uid_const }}{% if not loop.last or op.graph_verifiable_data_fields %},{% endif %}
 
-{% else %}
-                      {{ op.test_data.tensor_uids.get(tf.name, loop.index) }}{% if not loop.last or op.graph_verifiable_data_fields %},{% endif %}
-
-{% endif %}
 {% endfor %}
 {% for df in op.graph_verifiable_data_fields %}
 {% if df.is_vector %}

--- a/projects/hipdnn/tools/DescriptorGenerator/templates/test_integration.cpp.j2
+++ b/projects/hipdnn/tools/DescriptorGenerator/templates/test_integration.cpp.j2
@@ -1,3 +1,4 @@
+{% from "macros.j2" import vector_const_name %}
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier:  MIT
 
@@ -10,6 +11,7 @@
 #include <hipdnn_data_sdk/data_objects/{{ op.fbs_generated_header }}>
 #include <hipdnn_data_sdk/data_objects/graph_generated.h>
 #include <hipdnn_frontend.hpp>
+#include <hipdnn_test_sdk/constants/{{ op.effective_constants_include }}.hpp>
 #include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
 #include <hipdnn_test_sdk/utilities/ToVec.hpp>
 
@@ -17,6 +19,7 @@
 
 using namespace hipdnn_frontend;
 using namespace hipdnn_frontend::graph;
+using namespace hipdnn_tests::constants;
 using hipdnn_tests::toVec;
 using DataTypeSdk = hipdnn_data_sdk::data_objects::DataType;
 using NodeAttrType = hipdnn_data_sdk::data_objects::NodeAttributes;
@@ -38,18 +41,8 @@ public:
     using Graph::get_raw_graph_descriptor;
 };
 
-// -- Test constants --
-{% for tf in op.tensor_fields %}
-{% set uid = op.test_data.tensor_uids.get(tf.name, loop.index) %}
-constexpr int64_t K_TEST_{{ tf.name | upper }}_UID = {{ uid }};
-{% endfor %}
 {% set first_tensor = op.tensor_fields[0] %}
 {% set first_tc = op.test_data.tensor_configs.get(first_tensor.name) %}
-{% if first_tc %}
-
-constexpr std::array<int64_t, {{ first_tc.dims | length }}> K_TEST_DIMS = {{ '{' }}{{ first_tc.dims | join(', ') }}{{ '}' }};
-constexpr std::array<int64_t, {{ first_tc.strides | length }}> K_TEST_STRIDES = {{ '{' }}{{ first_tc.strides | join(', ') }}{{ '}' }};
-{% endif %}
 
 // Lowers a frontend graph via build_operation_graph_via_descriptors, then
 // retrieves the serialized graph and deserializes it for verification.
@@ -94,24 +87,26 @@ protected:
 {% set rmap = op.frontend_to_tensor_field_map %}
 {% for param in op.frontend.graph_method_params %}
 {% set tf_name = rmap.get(param.tensor_name, param.tensor_name) %}
+{% set tc = op.test_data.tensor_configs.get(tf_name) %}
         auto {{ param.name }} = std::make_shared<TensorAttributes>();
-        {{ param.name }}->set_uid(K_TEST_{{ tf_name | upper }}_UID)
+        {{ param.name }}->set_uid(K_TENSOR_{{ tf_name | upper }}_UID)
             .set_name("{{ param.tensor_name }}")
             .set_data_type(DataType::FLOAT);
-{% if first_tc %}
-        {{ param.name }}->set_dim(toVec(K_TEST_DIMS)).set_stride(toVec(K_TEST_STRIDES));
+{% if tc %}
+        {{ param.name }}->set_dim(toVec(K_TENSOR_{{ tf_name | upper }}_DIMS)).set_stride(toVec(K_TENSOR_{{ tf_name | upper }}_STRIDES));
 {% endif %}
 
 {% endfor %}
 {% if op.frontend.graph_return_type == 'single' %}
 {% set out_name = op.frontend.graph_return_outputs[0] %}
 {% set out_tf_name = rmap.get(out_name, out_name) %}
+{% set out_tc = op.test_data.tensor_configs.get(out_tf_name) %}
         auto {{ out_name }} = graph->{{ op.frontend.graph_method_name }}(
 {% for param in op.frontend.graph_method_params %}
             {{ param.name }},
 {% endfor %}
             attrs);
-        {{ out_name }}->set_uid(K_TEST_{{ out_tf_name | upper }}_UID)
+        {{ out_name }}->set_uid(K_TENSOR_{{ out_tf_name | upper }}_UID)
             .set_output(true)
             .set_name("{{ out_name }}");
 {% endif %}
@@ -164,14 +159,15 @@ TEST_F(Integration{{ op.name }}DescriptorLowering, {{ op.name }}LoweringRoundTri
 {% endif %}
 {% for df in op.data_fields if df.is_vector and df.required %}
 {% if df.name in op.test_data.field_values %}
-    attrs.{{ df.frontend_setter_name }}({{ '{' }}{{ op.test_data.field_values[df.name] | join(', ') }}{{ '}' }});
+{% set const_name = vector_const_name(df, op) %}
+    attrs.{{ df.frontend_setter_name }}(toVec({{ const_name }}));
 {% endif %}
 {% endfor %}
 
     auto graphT = buildAndDeserialize(attrs);
 
     // Verify tensors
-    ASSERT_GE(graphT.tensors.size(), {{ op.required_tensor_fields | length }}u);
+    ASSERT_EQ(graphT.tensors.size(), {{ op.required_tensor_fields | length }}u);
 
     // Verify tensor attributes
     std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributesT*> tensorMap;
@@ -181,12 +177,13 @@ TEST_F(Integration{{ op.name }}DescriptorLowering, {{ op.name }}LoweringRoundTri
     }
 {% for tf in op.required_tensor_fields %}
 {% set tf_upper = tf.name | upper %}
-    ASSERT_NE(tensorMap.count(K_TEST_{{ tf_upper }}_UID), 0u);
-{% if first_tc %}
-    EXPECT_EQ(tensorMap[K_TEST_{{ tf_upper }}_UID]->dims, toVec(K_TEST_DIMS));
-    EXPECT_EQ(tensorMap[K_TEST_{{ tf_upper }}_UID]->strides, toVec(K_TEST_STRIDES));
+{% set tc = op.test_data.tensor_configs.get(tf.name) %}
+    ASSERT_NE(tensorMap.count(K_TENSOR_{{ tf_upper }}_UID), 0u);
+{% if tc %}
+    EXPECT_EQ(tensorMap[K_TENSOR_{{ tf_upper }}_UID]->dims, toVec(K_TENSOR_{{ tf_upper }}_DIMS));
+    EXPECT_EQ(tensorMap[K_TENSOR_{{ tf_upper }}_UID]->strides, toVec(K_TENSOR_{{ tf_upper }}_STRIDES));
 {% endif %}
-    EXPECT_EQ(tensorMap[K_TEST_{{ tf_upper }}_UID]->data_type, DataTypeSdk::FLOAT);
+    EXPECT_EQ(tensorMap[K_TENSOR_{{ tf_upper }}_UID]->data_type, DataTypeSdk::FLOAT);
 {% endfor %}
 
     // Verify operation node
@@ -202,7 +199,7 @@ TEST_F(Integration{{ op.name }}DescriptorLowering, {{ op.name }}LoweringRoundTri
 
     // Verify required tensor UIDs
 {% for tf in op.required_tensor_fields %}
-    EXPECT_EQ(opNode->{{ tf.fbs_field }}, K_TEST_{{ tf.name | upper }}_UID);
+    EXPECT_EQ(opNode->{{ tf.fbs_field }}, K_TENSOR_{{ tf.name | upper }}_UID);
 {% endfor %}
 
     // Verify operation name preserved through lowering
@@ -218,11 +215,9 @@ TEST_F(Integration{{ op.name }}DescriptorLowering, {{ op.name }}LoweringRoundTri
 
 {% for df in op.data_fields if df.is_vector and df.required %}
 {% if df.name in op.test_data.field_values %}
+{% set const_name = vector_const_name(df, op) %}
     // Verify {{ df.name }}
-    {
-        std::vector<int64_t> const expected{{ df.pascal_name }} = {{ '{' }}{{ op.test_data.field_values[df.name] | join(', ') }}{{ '}' }};
-        EXPECT_EQ(opNode->{{ df.fbs_field }}, expected{{ df.pascal_name }});
-    }
+    EXPECT_EQ(opNode->{{ df.fbs_field }}, toVec({{ const_name }}));
 {% endif %}
 {% endfor %}
 }
@@ -250,7 +245,8 @@ TEST_F(Integration{{ op.name }}DescriptorLowering, {{ df.pascal_name }}Preserved
 {% endif %}
 {% for vf in op.data_fields if vf.is_vector and vf.required %}
 {% if vf.name in op.test_data.field_values %}
-    attrs.{{ vf.frontend_setter_name }}({{ '{' }}{{ op.test_data.field_values[vf.name] | join(', ') }}{{ '}' }});
+{% set const_name = vector_const_name(vf, op) %}
+    attrs.{{ vf.frontend_setter_name }}(toVec({{ const_name }}));
 {% endif %}
 {% endfor %}
     attrs.{{ df.frontend_setter_name }}({{ test_val }});

--- a/projects/hipdnn/tools/DescriptorGenerator/templates/test_integration_lifting.cpp.j2
+++ b/projects/hipdnn/tools/DescriptorGenerator/templates/test_integration_lifting.cpp.j2
@@ -1,14 +1,18 @@
+{% from "macros.j2" import vector_const_name %}
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier:  MIT
 
 #include <gtest/gtest.h>
 #include <hip/hip_runtime.h>
+#include <algorithm>
 #include <memory>
+#include <set>
 #include <vector>
 
 #include <hipdnn_frontend.hpp>
 #include <hipdnn_frontend/detail/ScopedHipdnnBackendDescriptor.hpp>
 #include <hipdnn_frontend/node/{{ op.frontend.node_class }}.hpp>
+#include <hipdnn_test_sdk/constants/{{ op.effective_constants_include }}.hpp>
 #include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
 #include <hipdnn_test_sdk/utilities/ToVec.hpp>
 
@@ -16,6 +20,7 @@
 
 using namespace hipdnn_frontend;
 using namespace hipdnn_frontend::graph;
+using namespace hipdnn_tests::constants;
 using hipdnn_tests::toVec;
 
 namespace
@@ -35,18 +40,8 @@ public:
     }
 };
 
-// -- Test constants --
-{% for tf in op.tensor_fields %}
-{% set uid = op.test_data.tensor_uids.get(tf.name, loop.index) %}
-constexpr int64_t K_TEST_{{ tf.name | upper }}_UID = {{ uid }};
-{% endfor %}
 {% set first_tensor = op.tensor_fields[0] %}
 {% set first_tc = op.test_data.tensor_configs.get(first_tensor.name) %}
-{% if first_tc %}
-
-constexpr std::array<int64_t, {{ first_tc.dims | length }}> K_TEST_DIMS = {{ '{' }}{{ first_tc.dims | join(', ') }}{{ '}' }};
-constexpr std::array<int64_t, {{ first_tc.strides | length }}> K_TEST_STRIDES = {{ '{' }}{{ first_tc.strides | join(', ') }}{{ '}' }};
-{% endif %}
 
 {% set non_sentinel = [] %}
 {% if op.mode_fields %}
@@ -95,12 +90,13 @@ protected:
 {% set rmap = op.frontend_to_tensor_field_map %}
 {% for param in op.frontend.graph_method_params %}
 {% set tf_name = rmap.get(param.tensor_name, param.tensor_name) %}
+{% set tc = op.test_data.tensor_configs.get(tf_name) %}
         auto {{ param.name }} = std::make_shared<TensorAttributes>();
-        {{ param.name }}->set_uid(K_TEST_{{ tf_name | upper }}_UID)
+        {{ param.name }}->set_uid(K_TENSOR_{{ tf_name | upper }}_UID)
             .set_name("{{ param.tensor_name }}")
             .set_data_type(DataType::FLOAT);
-{% if first_tc %}
-        {{ param.name }}->set_dim(toVec(K_TEST_DIMS)).set_stride(toVec(K_TEST_STRIDES));
+{% if tc %}
+        {{ param.name }}->set_dim(toVec(K_TENSOR_{{ tf_name | upper }}_DIMS)).set_stride(toVec(K_TENSOR_{{ tf_name | upper }}_STRIDES));
 {% endif %}
 
 {% endfor %}
@@ -114,30 +110,33 @@ protected:
 {% endif %}
 {% for df in op.data_fields if df.is_vector and df.required %}
 {% if df.name in op.test_data.field_values %}
-        attrs.{{ df.frontend_setter_name }}({{ '{' }}{{ op.test_data.field_values[df.name] | join(', ') }}{{ '}' }});
+{% set const_name = vector_const_name(df, op) %}
+        attrs.{{ df.frontend_setter_name }}(toVec({{ const_name }}));
 {% endif %}
 {% endfor %}
 
 {% if op.frontend.graph_return_type == 'single' %}
 {% set out_name = op.frontend.graph_return_outputs[0] %}
 {% set out_tf_name = rmap.get(out_name, out_name) %}
+{% set out_tc = op.test_data.tensor_configs.get(out_tf_name) %}
         auto {{ out_name }} = graph->{{ op.frontend.graph_method_name }}(
 {% for param in op.frontend.graph_method_params %}
             {{ param.name }},
 {% endfor %}
             attrs);
-        {{ out_name }}->set_uid(K_TEST_{{ out_tf_name | upper }}_UID)
+        {{ out_name }}->set_uid(K_TENSOR_{{ out_tf_name | upper }}_UID)
             .set_output(true)
             .set_name("{{ out_name }}");
 {% elif op.frontend.graph_return_type == 'array' %}
 {% set out_name = op.frontend.graph_return_outputs[0] %}
 {% set out_tf_name = rmap.get(out_name, out_name) %}
+{% set out_tc = op.test_data.tensor_configs.get(out_tf_name) %}
         auto results = graph->{{ op.frontend.graph_method_name }}(
 {% for param in op.frontend.graph_method_params %}
             {{ param.name }},
 {% endfor %}
             attrs);
-        results[0]->set_uid(K_TEST_{{ out_tf_name | upper }}_UID)
+        results[0]->set_uid(K_TENSOR_{{ out_tf_name | upper }}_UID)
             .set_output(true)
             .set_name("{{ out_name }}");
 {% endif %}
@@ -175,18 +174,19 @@ TEST_F(Integration{{ op.name }}DescriptorLifting, Basic{{ op.name }}RoundTrip)
 
     // Verify tensors by UID
     auto tensorMap = liftedGraph->getTensorsByUid();
-    ASSERT_GE(tensorMap.size(), {{ op.required_tensor_fields | length }}u);
+    ASSERT_EQ(tensorMap.size(), {{ op.required_tensor_fields | length }}u);
 
 {% for tf in op.required_tensor_fields %}
 {% set tf_upper = tf.name | upper %}
+{% set tc = op.test_data.tensor_configs.get(tf.name) %}
     // Verify {{ tf.name }} tensor
-    ASSERT_NE(tensorMap.count(K_TEST_{{ tf_upper }}_UID), 0u);
-    EXPECT_EQ(tensorMap[K_TEST_{{ tf_upper }}_UID]->get_uid(), K_TEST_{{ tf_upper }}_UID);
-{% if first_tc %}
-    EXPECT_EQ(tensorMap[K_TEST_{{ tf_upper }}_UID]->get_dim(), toVec(K_TEST_DIMS));
-    EXPECT_EQ(tensorMap[K_TEST_{{ tf_upper }}_UID]->get_stride(), toVec(K_TEST_STRIDES));
+    ASSERT_NE(tensorMap.count(K_TENSOR_{{ tf_upper }}_UID), 0u);
+    EXPECT_EQ(tensorMap[K_TENSOR_{{ tf_upper }}_UID]->get_uid(), K_TENSOR_{{ tf_upper }}_UID);
+{% if tc %}
+    EXPECT_EQ(tensorMap[K_TENSOR_{{ tf_upper }}_UID]->get_dim(), toVec(K_TENSOR_{{ tf_upper }}_DIMS));
+    EXPECT_EQ(tensorMap[K_TENSOR_{{ tf_upper }}_UID]->get_stride(), toVec(K_TENSOR_{{ tf_upper }}_STRIDES));
 {% endif %}
-    EXPECT_EQ(tensorMap[K_TEST_{{ tf_upper }}_UID]->get_data_type(), DataType::FLOAT);
+    EXPECT_EQ(tensorMap[K_TENSOR_{{ tf_upper }}_UID]->get_data_type(), DataType::FLOAT);
 
 {% endfor %}
     // Verify sub-node count and type
@@ -206,8 +206,9 @@ TEST_F(Integration{{ op.name }}DescriptorLifting, Basic{{ op.name }}RoundTrip)
 
 {% for df in op.data_fields if df.is_vector and df.required %}
 {% if df.name in op.test_data.field_values %}
+{% set const_name = vector_const_name(df, op) %}
     // Verify {{ df.name }}
-    EXPECT_EQ(opNode->attributes.{{ df.frontend_getter }}, std::vector<int64_t>({{ '{' }}{{ op.test_data.field_values[df.name] | join(', ') }}{{ '}' }}));
+    EXPECT_EQ(opNode->attributes.{{ df.frontend_getter }}, toVec({{ const_name }}));
 {% endif %}
 {% endfor %}
 
@@ -247,8 +248,8 @@ TEST_F(Integration{{ op.name }}DescriptorLifting, {{ op.name }}TensorSharingPres
 {% set ft = tf_map.get(tf.name) %}
 {% if ft %}
     // Verify {{ tf.name }} tensor sharing
-    EXPECT_EQ(opNode->attributes.{{ ft.effective_getter_name }}()->get_uid(), K_TEST_{{ tf.name | upper }}_UID);
-    EXPECT_EQ(tensorMap[K_TEST_{{ tf.name | upper }}_UID].get(),
+    EXPECT_EQ(opNode->attributes.{{ ft.effective_getter_name }}()->get_uid(), K_TENSOR_{{ tf.name | upper }}_UID);
+    EXPECT_EQ(tensorMap[K_TENSOR_{{ tf.name | upper }}_UID].get(),
               opNode->attributes.{{ ft.effective_getter_name }}().get());
 {% endif %}
 {% endfor %}
@@ -299,8 +300,9 @@ TEST_F(Integration{{ op.name }}DescriptorLifting, {{ op.name }}LiftWithoutFinali
 
 {% for df in op.data_fields if df.is_vector and df.required %}
 {% if df.name in op.test_data.field_values %}
+{% set const_name = vector_const_name(df, op) %}
     // Verify {{ df.name }}
-    EXPECT_EQ(opNode->attributes.{{ df.frontend_getter }}, std::vector<int64_t>({{ '{' }}{{ op.test_data.field_values[df.name] | join(', ') }}{{ '}' }}));
+    EXPECT_EQ(opNode->attributes.{{ df.frontend_getter }}, toVec({{ const_name }}));
 {% endif %}
 {% endfor %}
 
@@ -309,14 +311,15 @@ TEST_F(Integration{{ op.name }}DescriptorLifting, {{ op.name }}LiftWithoutFinali
 
     // Verify tensor dims and strides
     auto tensorMap = liftedGraph->getTensorsByUid();
-    ASSERT_GE(tensorMap.size(), {{ op.required_tensor_fields | length }}u);
+    ASSERT_EQ(tensorMap.size(), {{ op.required_tensor_fields | length }}u);
 
 {% for tf in op.required_tensor_fields %}
 {% set tf_upper = tf.name | upper %}
-    ASSERT_NE(tensorMap.count(K_TEST_{{ tf_upper }}_UID), 0u);
-{% if first_tc %}
-    EXPECT_EQ(tensorMap[K_TEST_{{ tf_upper }}_UID]->get_dim(), toVec(K_TEST_DIMS));
-    EXPECT_EQ(tensorMap[K_TEST_{{ tf_upper }}_UID]->get_stride(), toVec(K_TEST_STRIDES));
+{% set tc = op.test_data.tensor_configs.get(tf.name) %}
+    ASSERT_NE(tensorMap.count(K_TENSOR_{{ tf_upper }}_UID), 0u);
+{% if tc %}
+    EXPECT_EQ(tensorMap[K_TENSOR_{{ tf_upper }}_UID]->get_dim(), toVec(K_TENSOR_{{ tf_upper }}_DIMS));
+    EXPECT_EQ(tensorMap[K_TENSOR_{{ tf_upper }}_UID]->get_stride(), toVec(K_TENSOR_{{ tf_upper }}_STRIDES));
 {% endif %}
 {% endfor %}
 }
@@ -343,12 +346,13 @@ TEST_F(Integration{{ op.name }}DescriptorLifting, {{ df.pascal_name }}PreservedI
 {% set rmap = op.frontend_to_tensor_field_map %}
 {% for param in op.frontend.graph_method_params %}
 {% set tf_name = rmap.get(param.tensor_name, param.tensor_name) %}
+{% set tc = op.test_data.tensor_configs.get(tf_name) %}
     auto {{ param.name }} = std::make_shared<TensorAttributes>();
-    {{ param.name }}->set_uid(K_TEST_{{ tf_name | upper }}_UID)
+    {{ param.name }}->set_uid(K_TENSOR_{{ tf_name | upper }}_UID)
         .set_name("{{ param.tensor_name }}")
         .set_data_type(DataType::FLOAT);
-{% if first_tc %}
-    {{ param.name }}->set_dim(toVec(K_TEST_DIMS)).set_stride(toVec(K_TEST_STRIDES));
+{% if tc %}
+    {{ param.name }}->set_dim(toVec(K_TENSOR_{{ tf_name | upper }}_DIMS)).set_stride(toVec(K_TENSOR_{{ tf_name | upper }}_STRIDES));
 {% endif %}
 
 {% endfor %}
@@ -362,7 +366,8 @@ TEST_F(Integration{{ op.name }}DescriptorLifting, {{ df.pascal_name }}PreservedI
 {% endif %}
 {% for vf in op.data_fields if vf.is_vector and vf.required %}
 {% if vf.name in op.test_data.field_values %}
-    attrs.{{ vf.frontend_setter_name }}({{ '{' }}{{ op.test_data.field_values[vf.name] | join(', ') }}{{ '}' }});
+{% set const_name = vector_const_name(vf, op) %}
+    attrs.{{ vf.frontend_setter_name }}(toVec({{ const_name }}));
 {% endif %}
 {% endfor %}
     attrs.{{ df.frontend_setter_name }}({{ test_val }});
@@ -370,23 +375,25 @@ TEST_F(Integration{{ op.name }}DescriptorLifting, {{ df.pascal_name }}PreservedI
 {% if op.frontend.graph_return_type == 'single' %}
 {% set out_name = op.frontend.graph_return_outputs[0] %}
 {% set out_tf_name = rmap.get(out_name, out_name) %}
+{% set out_tc = op.test_data.tensor_configs.get(out_tf_name) %}
     auto {{ out_name }} = graph->{{ op.frontend.graph_method_name }}(
 {% for param in op.frontend.graph_method_params %}
         {{ param.name }},
 {% endfor %}
         attrs);
-    {{ out_name }}->set_uid(K_TEST_{{ out_tf_name | upper }}_UID)
+    {{ out_name }}->set_uid(K_TENSOR_{{ out_tf_name | upper }}_UID)
         .set_output(true)
         .set_name("{{ out_name }}");
 {% elif op.frontend.graph_return_type == 'array' %}
 {% set out_name = op.frontend.graph_return_outputs[0] %}
 {% set out_tf_name = rmap.get(out_name, out_name) %}
+{% set out_tc = op.test_data.tensor_configs.get(out_tf_name) %}
     auto results = graph->{{ op.frontend.graph_method_name }}(
 {% for param in op.frontend.graph_method_params %}
         {{ param.name }},
 {% endfor %}
         attrs);
-    results[0]->set_uid(K_TEST_{{ out_tf_name | upper }}_UID)
+    results[0]->set_uid(K_TENSOR_{{ out_tf_name | upper }}_UID)
         .set_output(true)
         .set_name("{{ out_name }}");
 {% endif %}
@@ -419,4 +426,121 @@ TEST_F(Integration{{ op.name }}DescriptorLifting, {{ df.pascal_name }}PreservedI
 }
 
 {% endfor %}
+// Builds a {{ op.name }} graph without calling set_uid() on any tensor,
+// lowers to backend, lifts, and verifies all auto-assigned UIDs are
+// distinct and survive the round-trip.
+TEST_F(Integration{{ op.name }}DescriptorLifting, AutoAssignedUidsPreservedInLiftingRoundTrip)
+{
+    auto graph = std::make_shared<TestableGraph>();
+    graph->set_name("{{ op.name }}AutoUidLiftTest")
+        .set_compute_data_type(DataType::FLOAT)
+        .set_intermediate_data_type(DataType::FLOAT)
+        .set_io_data_type(DataType::FLOAT);
+
+{% set rmap = op.frontend_to_tensor_field_map %}
+{% for param in op.frontend.graph_method_params %}
+{% set tf_name = rmap.get(param.tensor_name, param.tensor_name) %}
+{% set tc = op.test_data.tensor_configs.get(tf_name) %}
+    auto {{ param.name }} = std::make_shared<TensorAttributes>();
+    {{ param.name }}->set_name("{{ param.tensor_name }}")
+        .set_data_type(DataType::FLOAT);
+{% if tc %}
+    {{ param.name }}->set_dim(toVec(K_TENSOR_{{ tf_name | upper }}_DIMS)).set_stride(toVec(K_TENSOR_{{ tf_name | upper }}_STRIDES));
+{% endif %}
+
+{% endfor %}
+    {{ op.frontend.attributes_class }} attrs;
+    attrs.set_name("test_auto_uid");
+{% if op.mode_fields %}
+{% set mf = op.mode_fields[0] %}
+{% if non_sentinel %}
+    attrs.{{ mf.frontend_setter_name }}({{ mf.effective_frontend_type }}::{{ non_sentinel[0].effective_frontend_name }});
+{% endif %}
+{% endif %}
+{% for vf in op.data_fields if vf.is_vector and vf.required %}
+{% if vf.name in op.test_data.field_values %}
+{% set const_name = vector_const_name(vf, op) %}
+    attrs.{{ vf.frontend_setter_name }}(toVec({{ const_name }}));
+{% endif %}
+{% endfor %}
+
+{% if op.frontend.graph_return_type == 'single' %}
+{% set out_name = op.frontend.graph_return_outputs[0] %}
+    auto {{ out_name }} = graph->{{ op.frontend.graph_method_name }}(
+{% for param in op.frontend.graph_method_params %}
+        {{ param.name }},
+{% endfor %}
+        attrs);
+    {{ out_name }}->set_output(true)
+        .set_name("{{ out_name }}");
+{% elif op.frontend.graph_return_type == 'array' %}
+{% set out_name = op.frontend.graph_return_outputs[0] %}
+    auto results = graph->{{ op.frontend.graph_method_name }}(
+{% for param in op.frontend.graph_method_params %}
+        {{ param.name }},
+{% endfor %}
+        attrs);
+    results[0]->set_output(true)
+        .set_name("{{ out_name }}");
+{% endif %}
+
+    auto result = graph->validate();
+    ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
+
+    result = graph->build_operation_graph(_handle);
+    ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
+
+    auto rawDesc = graph->get_raw_graph_descriptor();
+    ASSERT_NE(rawDesc, nullptr);
+
+    auto liftedGraph = std::make_shared<TestableGraph>();
+    result = liftedGraph->fromBackendDescriptor(rawDesc);
+    ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
+
+    // Verify the tensor map has the expected number of tensors
+    auto tensorMap = liftedGraph->getTensorsByUid();
+    ASSERT_EQ(tensorMap.size(), {{ op.required_tensor_fields | length }}u);
+
+    // Verify all UIDs are positive and distinct
+    std::vector<int64_t> uids;
+    uids.reserve(tensorMap.size());
+    for(const auto& [uid, tensor] : tensorMap)
+    {
+        EXPECT_GT(uid, 0) << "Auto-assigned UID should be positive";
+        uids.push_back(uid);
+    }
+    std::sort(uids.begin(), uids.end());
+    ASSERT_EQ(std::adjacent_find(uids.begin(), uids.end()), uids.end())
+        << "Found duplicate auto-assigned UIDs";
+
+    // Verify sub-node tensor UIDs are distinct via the node attributes
+    auto& subNodes = liftedGraph->getSubNodes();
+    ASSERT_EQ(subNodes.size(), 1u);
+
+    auto* opNode = dynamic_cast<{{ op.frontend.node_class }}*>(subNodes[0].get());
+    ASSERT_NE(opNode, nullptr);
+
+    std::set<int64_t> nodeUids;
+{% set tf_map = op.tensor_field_frontend_map %}
+{% for tf in op.required_tensor_fields %}
+{% set ft = tf_map.get(tf.name) %}
+{% if ft %}
+    ASSERT_NE(opNode->attributes.{{ ft.effective_getter_name }}(), nullptr);
+    nodeUids.insert(opNode->attributes.{{ ft.effective_getter_name }}()->get_uid());
+{% endif %}
+{% endfor %}
+    ASSERT_EQ(nodeUids.size(), {{ op.required_tensor_fields | length }}u)
+        << "Node tensor UIDs are not all distinct";
+
+    // Verify tensor dims survived the round trip
+{% for tf in op.required_tensor_fields %}
+{% set ft = tf_map.get(tf.name) %}
+{% set tc = op.test_data.tensor_configs.get(tf.name) %}
+{% if ft and tc %}
+    EXPECT_EQ(opNode->attributes.{{ ft.effective_getter_name }}()->get_dim(), toVec(K_TENSOR_{{ tf.name | upper }}_DIMS));
+    EXPECT_EQ(opNode->attributes.{{ ft.effective_getter_name }}()->get_stride(), toVec(K_TENSOR_{{ tf.name | upper }}_STRIDES));
+{% endif %}
+{% endfor %}
+}
+
 } // namespace

--- a/projects/hipdnn/tools/DescriptorGenerator/tests/test_generate.py
+++ b/projects/hipdnn/tools/DescriptorGenerator/tests/test_generate.py
@@ -209,8 +209,8 @@ class TestPreviewFilesLiftOnly:
 
     def test_lift_only_file_count(self, convolution_fwd_config):
         files = _preview_files(convolution_fwd_config, MODE_LIFT_ONLY)
-        # 3 files + 7 fragments = 10
-        assert len(files) == 10
+        # 3 files + 8 fragments = 11
+        assert len(files) == 11
 
     def test_lift_only_contains_unpacker(self, convolution_fwd_config):
         files = _preview_files(convolution_fwd_config, MODE_LIFT_ONLY)
@@ -234,6 +234,7 @@ class TestPreviewFilesLiftOnly:
             "fragments/node_unpack_override.txt",
             "fragments/descriptor_lifting_additions.txt",
             "fragments/packer_name_addition.txt",
+            "fragments/packer_name_test.txt",
         ]
         for fragment in expected_fragments:
             assert fragment in files, f"Missing fragment: {fragment}"

--- a/projects/hipdnn/tools/DescriptorGenerator/tests/test_generate.py
+++ b/projects/hipdnn/tools/DescriptorGenerator/tests/test_generate.py
@@ -330,9 +330,44 @@ class TestPreviewFilesWithRealConfigs:
         assert not any("mode_frontend_plumbing" in f for f in files)
 
     def test_matmul_backend_exact_count(self, matmul_config):
-        """Matmul backend: 9 files + 10 fragments = 19, no mode enums."""
+        """Matmul backend: 9 files + 10 fragments = 19, no mode enums.
+
+        matmul_config has constants_include set, so no constants file is generated.
+        """
         files = _preview_files(matmul_config, MODE_BACKEND)
         assert len(files) == 19
+
+
+class TestPreviewFilesConstants:
+    """Verify constants file presence in preview based on constants_include."""
+
+    def test_no_constants_when_constants_include_set(self, convolution_fwd_config):
+        """ConvFwd has constants_include set, no constants file in preview."""
+        files = _preview_files(convolution_fwd_config, MODE_BACKEND)
+        constants_files = [f for f in files if "constants/" in f]
+        assert len(constants_files) == 0
+
+    def test_constants_in_backend_when_not_set(self, load_test_config):
+        """Config without constants_include gets a constants file in backend preview."""
+        config = load_test_config("batchnorm_backward.yaml")
+        files = _preview_files(config, MODE_BACKEND)
+        constants_files = [f for f in files if "constants/" in f]
+        assert len(constants_files) == 1
+        assert "BatchnormBackwardConstants.hpp" in constants_files[0]
+
+    def test_constants_in_lift_only_when_not_set(self, load_test_config):
+        """Config without constants_include gets a constants file in lift-only preview."""
+        config = load_test_config("convolution_bwd.yaml")
+        files = _preview_files(config, MODE_LIFT_ONLY)
+        constants_files = [f for f in files if "constants/" in f]
+        assert len(constants_files) == 1
+        assert "ConvolutionBwdConstants.hpp" in constants_files[0]
+
+    def test_no_constants_in_frontend_mode(self, convolution_fwd_config):
+        """Frontend mode never generates constants file."""
+        files = _preview_files(convolution_fwd_config, MODE_FRONTEND)
+        constants_files = [f for f in files if "constants/" in f]
+        assert len(constants_files) == 0
 
 
 # ---------------------------------------------------------------------------

--- a/projects/hipdnn/tools/DescriptorGenerator/tests/test_integration.py
+++ b/projects/hipdnn/tools/DescriptorGenerator/tests/test_integration.py
@@ -1297,3 +1297,258 @@ class TestOptionalTensorTemplateOutput:
         # Optional tensor UIDs must be dereferenced with * in findTensorInMap calls
         assert "*attrs->in_1_tensor_uid" in content
         assert "*attrs->in_2_tensor_uid" in content
+
+
+# ---------------------------------------------------------------------------
+# Constants file generation
+# ---------------------------------------------------------------------------
+
+
+class TestConstantsGeneration:
+    """Test that the constants header file is generated correctly."""
+
+    def test_constants_generated_when_not_set(
+        self, load_test_config, generator, tmp_path
+    ):
+        """Constants file IS generated for configs without constants_include."""
+        config = load_test_config("batchnorm_backward.yaml")
+        assert not config.test_data.constants_include
+
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        written = generator.render(config, output_dir, "backend")
+
+        constants_path = (
+            f"test_sdk/include/hipdnn_test_sdk/constants/"
+            f"{config.effective_constants_include}.hpp"
+        )
+        assert constants_path in written
+
+        # Verify the file exists and has correct content
+        full_path = output_dir / constants_path
+        assert full_path.exists()
+        content = full_path.read_text()
+        assert "#pragma once" in content
+        assert "namespace hipdnn_tests::constants" in content
+        assert "K_TENSOR_DY_UID" in content
+        assert "K_TENSOR_X_UID" in content
+
+    def test_constants_not_generated_when_set(
+        self, convolution_fwd_config, generator, tmp_path
+    ):
+        """Constants file is NOT generated for configs with constants_include."""
+        assert (
+            convolution_fwd_config.test_data.constants_include == "ConvFpropConstants"
+        )
+
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        written = generator.render(convolution_fwd_config, output_dir, "backend")
+
+        constants_files = [f for f in written if "constants/" in f]
+        assert len(constants_files) == 0
+
+    def test_constants_generated_in_lift_only_mode(
+        self, load_test_config, generator, tmp_path
+    ):
+        """Constants file IS generated in lift-only mode when not set."""
+        config = load_test_config("convolution_bwd.yaml")
+        assert not config.test_data.constants_include
+
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        written = generator.render(config, output_dir, "lift-only")
+
+        constants_path = (
+            f"test_sdk/include/hipdnn_test_sdk/constants/"
+            f"{config.effective_constants_include}.hpp"
+        )
+        assert constants_path in written
+
+    def test_constants_not_generated_in_lift_only_when_set(
+        self, convolution_fwd_config, generator, tmp_path
+    ):
+        """Constants file is NOT generated in lift-only mode when set."""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        written = generator.render(convolution_fwd_config, output_dir, "lift-only")
+
+        constants_files = [f for f in written if "constants/" in f]
+        assert len(constants_files) == 0
+
+    def test_constants_has_tensor_uids(self, load_test_config, generator, tmp_path):
+        """Generated constants include UID constants for all tensors."""
+        config = load_test_config("batchnorm_inference.yaml")
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        generator.render(config, output_dir, "backend")
+
+        constants_path = (
+            output_dir
+            / "test_sdk/include/hipdnn_test_sdk/constants"
+            / f"{config.effective_constants_include}.hpp"
+        )
+        content = constants_path.read_text()
+
+        for tf in config.tensor_fields:
+            uid = config.test_data.tensor_uids.get(tf.name, 0)
+            assert f"K_TENSOR_{tf.name.upper()}_UID = {uid}" in content
+
+    def test_constants_has_dims_and_strides(
+        self, load_test_config, generator, tmp_path
+    ):
+        """Generated constants include dims/strides for tensors with configs."""
+        config = load_test_config("batchnorm_inference.yaml")
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        generator.render(config, output_dir, "backend")
+
+        constants_path = (
+            output_dir
+            / "test_sdk/include/hipdnn_test_sdk/constants"
+            / f"{config.effective_constants_include}.hpp"
+        )
+        content = constants_path.read_text()
+
+        assert "K_TENSOR_X_DIMS" in content
+        assert "K_TENSOR_X_STRIDES" in content
+
+    def test_all_test_files_reference_constants_header(
+        self, load_test_config, generator, tmp_path
+    ):
+        """All generated test files include the constants header."""
+        config = load_test_config("batchnorm_inference.yaml")
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        generator.render(config, output_dir, "backend")
+
+        expected_include = config.effective_constants_include
+
+        test_files = [
+            output_dir / "backend/tests/descriptors" / config.test_descriptor_filename,
+            output_dir / "backend/tests/descriptors" / config.test_graph_filename,
+            output_dir / "backend/tests/descriptors" / config.test_from_node_filename,
+            output_dir / "tests/frontend" / config.test_integration_filename,
+            output_dir / "tests/frontend" / config.test_integration_lifting_filename,
+        ]
+
+        for test_file in test_files:
+            content = test_file.read_text()
+            assert (
+                expected_include in content
+            ), f"{test_file.name} does not reference {expected_include}"
+
+
+class TestLiftingTemplateImprovements:
+    """Test ASSERT_EQ and auto-UIDs in lifting template."""
+
+    def test_lifting_uses_assert_eq_not_ge(
+        self, convolution_fwd_config, generator, tmp_path
+    ):
+        """Lifting test uses ASSERT_EQ for tensorMap.size(), not ASSERT_GE."""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        generator.render(convolution_fwd_config, output_dir, "backend")
+
+        lifting_path = (
+            output_dir
+            / "tests/frontend"
+            / convolution_fwd_config.test_integration_lifting_filename
+        )
+        content = lifting_path.read_text()
+
+        assert "ASSERT_GE(tensorMap.size()" not in content
+        assert "ASSERT_EQ(tensorMap.size()" in content
+
+    def test_lifting_has_auto_uid_test(
+        self, convolution_fwd_config, generator, tmp_path
+    ):
+        """Lifting test includes AutoAssignedUidsPreservedInLiftingRoundTrip."""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        generator.render(convolution_fwd_config, output_dir, "backend")
+
+        lifting_path = (
+            output_dir
+            / "tests/frontend"
+            / convolution_fwd_config.test_integration_lifting_filename
+        )
+        content = lifting_path.read_text()
+
+        assert "AutoAssignedUidsPreservedInLiftingRoundTrip" in content
+        assert "std::adjacent_find" in content
+        assert "std::set<int64_t>" in content
+
+    def test_lifting_includes_algorithm_and_set(
+        self, convolution_fwd_config, generator, tmp_path
+    ):
+        """Lifting test includes <algorithm> and <set> headers."""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        generator.render(convolution_fwd_config, output_dir, "backend")
+
+        lifting_path = (
+            output_dir
+            / "tests/frontend"
+            / convolution_fwd_config.test_integration_lifting_filename
+        )
+        content = lifting_path.read_text()
+
+        assert "#include <algorithm>" in content
+        assert "#include <set>" in content
+
+    def test_lifting_uses_constants_not_inline(
+        self, convolution_fwd_config, generator, tmp_path
+    ):
+        """Lifting test uses K_TENSOR_ constants, not K_TEST_ inline constants."""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        generator.render(convolution_fwd_config, output_dir, "backend")
+
+        lifting_path = (
+            output_dir
+            / "tests/frontend"
+            / convolution_fwd_config.test_integration_lifting_filename
+        )
+        content = lifting_path.read_text()
+
+        assert "K_TEST_" not in content
+        assert "K_TENSOR_X_UID" in content
+        assert "using namespace hipdnn_tests::constants;" in content
+
+    def test_lowering_uses_constants_not_inline(
+        self, convolution_fwd_config, generator, tmp_path
+    ):
+        """Lowering test uses K_TENSOR_ constants, not K_TEST_ inline constants."""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        generator.render(convolution_fwd_config, output_dir, "backend")
+
+        lowering_path = (
+            output_dir
+            / "tests/frontend"
+            / convolution_fwd_config.test_integration_filename
+        )
+        content = lowering_path.read_text()
+
+        assert "K_TEST_" not in content
+        assert "K_TENSOR_X_UID" in content
+        assert "using namespace hipdnn_tests::constants;" in content
+
+    def test_lowering_uses_assert_eq_not_ge(
+        self, convolution_fwd_config, generator, tmp_path
+    ):
+        """Lowering test uses ASSERT_EQ for tensor count, not ASSERT_GE."""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        generator.render(convolution_fwd_config, output_dir, "backend")
+
+        lowering_path = (
+            output_dir
+            / "tests/frontend"
+            / convolution_fwd_config.test_integration_filename
+        )
+        content = lowering_path.read_text()
+
+        assert "ASSERT_GE(graphT.tensors.size()" not in content
+        assert "ASSERT_EQ(graphT.tensors.size()" in content

--- a/projects/hipdnn/tools/DescriptorGenerator/tests/test_integration.py
+++ b/projects/hipdnn/tools/DescriptorGenerator/tests/test_integration.py
@@ -283,9 +283,9 @@ class TestDescriptorLiftingAdditions:
         assert "finalizeDescriptor()" in output
 
     def test_graph_descriptor_test_reminder(self, convolution_fwd_config, generator):
-        """Output contains graph descriptor test update reminder."""
+        """Output contains graph descriptor name tests note."""
         output = generator._render_descriptor_lifting_additions(convolution_fwd_config)
-        assert "Graph Descriptor Test Update Required" in output
+        assert "Graph Descriptor Name Tests" in output
         assert "OperationNamePreservedInSerialization" in output
         assert "OperationNameRoundTripThroughLifting" in output
 
@@ -910,12 +910,12 @@ class TestDirectRenderMethods:
         assert len(result) == 19
 
     def test_render_lift_only_file_count(self, matmul_config, generator, tmp_path):
-        """render_lift_only produces exactly 10 outputs (3 files + 6 fragments + 1 additions)."""
+        """render_lift_only produces exactly 11 outputs (3 files + 7 fragments + 1 additions)."""
         output_dir = tmp_path / "output"
         output_dir.mkdir()
         result = generator.render_lift_only(matmul_config, output_dir)
-        # 3 lift templates + 6 lift fragments + 1 descriptor_lifting_additions = 10
-        assert len(result) == 10
+        # 3 lift templates + 7 lift fragments + 1 descriptor_lifting_additions = 11
+        assert len(result) == 11
 
     def test_render_frontend_file_count(
         self, convolution_fwd_config, generator, tmp_path

--- a/projects/hipdnn/tools/DescriptorGenerator/tests/test_models.py
+++ b/projects/hipdnn/tools/DescriptorGenerator/tests/test_models.py
@@ -23,6 +23,7 @@ from tests.helpers import (
     make_frontend_tensor_config,
     make_minimal_config,
     make_tensor_field,
+    make_test_data,
 )
 
 
@@ -1433,3 +1434,21 @@ class TestOperationConfigEdgeCases:
             cfg.test_integration_lifting_filename
             == "IntegrationBatchNormFwdDescriptorLifting.cpp"
         )
+
+
+class TestEffectiveConstantsInclude:
+    """Tests for effective_constants_include and constants_namespace properties."""
+
+    def test_returns_constants_include_when_set(self):
+        td = make_test_data(constants_include="ConvFpropConstants")
+        cfg = make_minimal_config(test_data=td)
+        assert cfg.effective_constants_include == "ConvFpropConstants"
+
+    def test_derives_from_name_when_not_set(self):
+        td = make_test_data(constants_include="")
+        cfg = make_minimal_config(name="BatchnormInference", test_data=td)
+        assert cfg.effective_constants_include == "BatchnormInferenceConstants"
+
+    def test_derives_from_name_when_default(self):
+        cfg = make_minimal_config(name="ConvolutionBwd")
+        assert cfg.effective_constants_include == "ConvolutionBwdConstants"


### PR DESCRIPTION
## Summary

- The DescriptorGenerator now **auto-generates a shared constants header** (`<Op>Constants.hpp`) from the YAML `test_data` section, eliminating the manual Step 10 post-generation task of extracting inline literals into constants
- All test templates unconditionally use the constants header — **no more `{% if constants_include %}` branching** or inline literal fallbacks
- **`ASSERT_GE` → `ASSERT_EQ`** for `tensorMap.size()` checks in both lifting and lowering integration tests
- **`AutoAssignedUidsPreservedInLiftingRoundTrip`** test is now auto-generated in every lifting integration test
- Shared **Jinja2 macro** (`vector_const_name`) deduplicates the constant name derivation pattern across 5 templates
- Lowering integration test updated to use **per-tensor dims/strides** from constants (was using single shared dims for all tensors)
- 6 YAML configs updated with `constants_include` pointing to their pre-existing headers
- 23 new Python tests, 561 total passing

## Test plan

- [x] Run `pytest tests/` — 561 passed
- [x] Verify dry-run parity (preview vs actual) for all 10 configs × all applicable modes
- [x] Verify constants file generated for configs without `constants_include` (e.g., `batchnorm_inference`)
- [x] Verify constants file NOT generated for configs with `constants_include` (e.g., `convolution_fwd`)
- [x] Verify no `ASSERT_GE(tensorMap.size()` or `K_TEST_` references remain in generated output
- [x] Verify `AutoAssignedUidsPreservedInLiftingRoundTrip` appears in generated lifting tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)