### PR TITLE
[Origami] Correct GPU names in `shared/origami/README.md` for `gfx1201`

### DIFF
--- a/shared/origami/README.md
+++ b/shared/origami/README.md
@@ -149,7 +149,7 @@ int main() {
 | gfx1151 | Radeon RX 8000 series | ✔️ | |
 | gfx1152 | AMD Radeon 840M iGPU | ✔️ | |
 | gfx1153 | AMD Radeon 820M iGPU | ✔️ | |
-| gfx1201 | Radeon RX 8900 XTX, Radeon RX 8900 XT, Radeon RX 8800 XT, Radeon RX 8800, Radeon RX 8700 XT, Radeon RX 8700, Radeon RX 8600 XT, Radeon RX 8600 | ✔️ | |
+| gfx1201 | Radeon RX 9070 XT, Radeon RX 9070 GRE, Radeon RX 9070 | ✔️ | |
 
 For more information on GPU hardware specifications, check out [ROCm documentation](https://rocm.docs.amd.com/en/latest/reference/gpu-arch-specs.html).
 


### PR DESCRIPTION
## Motivation

Update GPU names in origami's documentation to the correct, current GPU names for `gfx1201`. This ensures `shared/origami/README.md` is accurate for developers referencing GPU naming.

## Technical Details

- Replaced GPU names with verified/official names for gfx1201 from [AMD ROCm GPU hardware specifications](https://rocm.docs.amd.com/en/latest/reference/gpu-arch-specs.html#gpu-hardware-specifications).
- Only documentation changes; no code logic was altered.

## Test Plan

- Replaced all placeholder names in `README.md`.
- Confirmed formatting and links are correct.

## Test Result

- `README.md` shows correct GPU names.
- No formatting or link issues.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
