### PR TITLE
[CI] Add push triggers and concurrency cancellation to clang-tidy and pre-commit

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,6 +1,19 @@
 name: clang-tidy
 
 on:
+  push:
+    branches:
+      - develop
+      - release/therock-*
+    paths:
+      - 'projects/hipdnn/**/*.[ch]p?p?'
+      - 'projects/hipdnn/cmake/ClangTidy.cmake'
+      - 'projects/hipdnn/.clang-tidy'
+      # Disabled: see https://github.com/ROCm/rocm-libraries/issues/5067
+      # - 'dnn-providers/miopen-provider/**/*.[ch]p?p?'
+      # - 'dnn-providers/miopen-provider/cmake/ClangTidy.cmake'
+      # - 'dnn-providers/miopen-provider/.clang-tidy'
+      - '.github/workflows/clang-tidy.yml'
   pull_request:
     paths:
       - 'projects/hipdnn/**/*.[ch]p?p?'
@@ -12,6 +25,14 @@ on:
       # - 'dnn-providers/miopen-provider/.clang-tidy'
       - '.github/workflows/clang-tidy.yml'
   workflow_dispatch:
+
+concurrency:
+  # A PR number if a pull request and otherwise the commit hash. This cancels
+  # queued and in-progress runs for the same PR (presubmit) or commit
+  # (postsubmit). The workflow name is prepended to avoid conflicts between
+  # different workflows.
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name != 'push' || github.ref != 'refs/heads/develop' }}
 
 jobs:
   clang-tidy:

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -27,12 +27,12 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # A PR number if a pull request and otherwise the commit hash. This cancels
-  # queued and in-progress runs for the same PR (presubmit) or commit
-  # (postsubmit). The workflow name is prepended to avoid conflicts between
-  # different workflows.
+  # For PRs, group by PR number so a new commit cancels any in-progress run
+  # for the same PR. For postsubmits, group by commit SHA (unique per commit)
+  # so runs never cancel each other. The workflow name is prepended to avoid
+  # conflicts between different workflows.
   group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name != 'push' || github.ref != 'refs/heads/develop' }}
+  cancel-in-progress: true
 
 jobs:
   clang-tidy:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,12 +12,12 @@ permissions:
   contents: read
 
 concurrency:
-  # A PR number if a pull request and otherwise the commit hash. This cancels
-  # queued and in-progress runs for the same PR (presubmit) or commit
-  # (postsubmit). The workflow name is prepended to avoid conflicts between
-  # different workflows.
+  # For PRs, group by PR number so a new commit cancels any in-progress run
+  # for the same PR. For postsubmits, group by commit SHA (unique per commit)
+  # so runs never cancel each other. The workflow name is prepended to avoid
+  # conflicts between different workflows.
   group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name != 'push' || github.ref != 'refs/heads/develop' }}
+  cancel-in-progress: true
 
 jobs:
   pre-commit:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,11 +1,23 @@
 name: pre-commit
 
 on:
+  push:
+    branches:
+      - develop
+      - release/therock-*
   pull_request:
     branches: [develop]
 
 permissions:
   contents: read
+
+concurrency:
+  # A PR number if a pull request and otherwise the commit hash. This cancels
+  # queued and in-progress runs for the same PR (presubmit) or commit
+  # (postsubmit). The workflow name is prepended to avoid conflicts between
+  # different workflows.
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name != 'push' || github.ref != 'refs/heads/develop' }}
 
 jobs:
   pre-commit:


### PR DESCRIPTION
## Summary

- Adds `push` triggers on `develop` and `release/therock-*` branches to `clang-tidy` and `pre-commit` workflows so they run as postsubmits (matching `therock-ci` behavior)
- Adds a `concurrency` group to both workflows keyed on PR number (for presubmits) or commit SHA (for postsubmits), with `cancel-in-progress` set conditionally so in-progress PR runs are cancelled when a new commit is pushed, while postsubmit runs on `develop`/`release` branches are left to complete

## Test plan

- [x] Verify that pushing a new commit to an open PR cancels any in-progress clang-tidy / pre-commit run for that PR
- [ ] Verify that merges to `develop` run both workflows as postsubmits (will find out the hard way)