### PR TITLE
[hipDNN] Add batchnorm backward lifting path

### DIFF
--- a/projects/hipdnn/backend/src/descriptors/BatchnormBackwardOperationDescriptor.cpp
+++ b/projects/hipdnn/backend/src/descriptors/BatchnormBackwardOperationDescriptor.cpp
@@ -5,6 +5,7 @@
 #include "DescriptorAttributeUtils.hpp"
 #include "HipdnnBackendDescriptorType.h"
 #include "HipdnnException.hpp"
+#include "HipdnnOperationType.h"
 #include <hipdnn_data_sdk/utilities/StringUtil.hpp>
 
 namespace hipdnn_backend
@@ -149,6 +150,13 @@ void BatchnormBackwardOperationDescriptor::setAttribute(hipdnnBackendAttributeNa
                                  arrayOfElements,
                                  "BatchnormBackwardOperationDescriptor::setAttribute()");
         break;
+    case HIPDNN_ATTR_OPERATION_NAME_EXT:
+        setString(_name,
+                  attributeType,
+                  elementCount,
+                  arrayOfElements,
+                  "BatchnormBackwardOperationDescriptor::setAttribute()");
+        break;
     default:
         throw HipdnnException(
             HIPDNN_STATUS_NOT_SUPPORTED,
@@ -253,6 +261,22 @@ void BatchnormBackwardOperationDescriptor::getAttribute(hipdnnBackendAttributeNa
                                  arrayOfElements,
                                  "BatchnormBackwardOperationDescriptor::getAttribute()");
         break;
+    case HIPDNN_ATTR_OPERATION_NAME_EXT:
+        getString(_name,
+                  attributeType,
+                  requestedElementCount,
+                  elementCount,
+                  arrayOfElements,
+                  "BatchnormBackwardOperationDescriptor::getAttribute()");
+        break;
+    case HIPDNN_ATTR_OPERATION_TYPE_EXT:
+        getOperationType(HIPDNN_OPERATION_TYPE_BATCHNORM_BACKWARD,
+                         attributeType,
+                         requestedElementCount,
+                         elementCount,
+                         arrayOfElements,
+                         "BatchnormBackwardOperationDescriptor::getAttribute()");
+        break;
     default:
         throw HipdnnException(
             HIPDNN_STATUS_NOT_SUPPORTED,
@@ -285,6 +309,7 @@ std::unique_ptr<hipdnn_data_sdk::data_objects::NodeT>
     BatchnormBackwardOperationDescriptor::buildNode() const
 {
     auto node = std::make_unique<hipdnn_data_sdk::data_objects::NodeT>();
+    node->name = _name;
     node->compute_data_type = _computeDataType;
     node->attributes.Set(hipdnn_data_sdk::data_objects::BatchnormBackwardAttributesT(_data));
     return node;
@@ -299,6 +324,7 @@ std::string BatchnormBackwardOperationDescriptor::toString() const
 {
     using hipdnn_data_sdk::utilities::vecToString;
     std::string str = "BatchnormBackwardOperationDescriptor: {";
+    str += "name=" + _name + ", ";
     str += "dy_uid=" + std::to_string(_data.dy_tensor_uid);
     str += ", x_uid=" + std::to_string(_data.x_tensor_uid);
     str += ", scale_uid=" + std::to_string(_data.scale_tensor_uid);
@@ -317,6 +343,58 @@ std::string BatchnormBackwardOperationDescriptor::toString() const
     str += hipdnn_data_sdk::data_objects::EnumNameDataType(_computeDataType);
     str += "}";
     return str;
+}
+
+std::shared_ptr<BatchnormBackwardOperationDescriptor>
+    BatchnormBackwardOperationDescriptor::fromNode(
+        const hipdnn_data_sdk::data_objects::NodeT& nodeT,
+        const std::unordered_map<int64_t, std::shared_ptr<TensorDescriptor>>& tensorMap)
+{
+    const auto* attrs = nodeT.attributes.AsBatchnormBackwardAttributes();
+    THROW_IF_NULL(
+        attrs,
+        HIPDNN_STATUS_INTERNAL_ERROR,
+        "BatchnormBackwardOperationDescriptor::fromNode: BatchnormBackwardAttributes is null");
+
+    auto desc = std::make_shared<BatchnormBackwardOperationDescriptor>();
+    desc->_data = *attrs;
+    desc->_computeDataType = nodeT.compute_data_type;
+    desc->_name = nodeT.name;
+    desc->_dyDesc = findTensorInMap(
+        tensorMap, attrs->dy_tensor_uid, "BatchnormBackwardOperationDescriptor::fromNode: DY");
+    desc->_xDesc = findTensorInMap(
+        tensorMap, attrs->x_tensor_uid, "BatchnormBackwardOperationDescriptor::fromNode: X");
+    desc->_scaleDesc = findTensorInMap(tensorMap,
+                                       attrs->scale_tensor_uid,
+                                       "BatchnormBackwardOperationDescriptor::fromNode: Scale");
+    desc->_dxDesc = findTensorInMap(
+        tensorMap, attrs->dx_tensor_uid, "BatchnormBackwardOperationDescriptor::fromNode: DX");
+    desc->_dscaleDesc = findTensorInMap(tensorMap,
+                                        attrs->dscale_tensor_uid,
+                                        "BatchnormBackwardOperationDescriptor::fromNode: DScale");
+    desc->_dbiasDesc = findTensorInMap(tensorMap,
+                                       attrs->dbias_tensor_uid,
+                                       "BatchnormBackwardOperationDescriptor::fromNode: DBias");
+    if(attrs->mean_tensor_uid)
+    {
+        desc->_meanDesc = findTensorInMap(tensorMap,
+                                          *attrs->mean_tensor_uid,
+                                          "BatchnormBackwardOperationDescriptor::fromNode: Mean");
+    }
+    if(attrs->inv_variance_tensor_uid)
+    {
+        desc->_invVarianceDesc
+            = findTensorInMap(tensorMap,
+                              *attrs->inv_variance_tensor_uid,
+                              "BatchnormBackwardOperationDescriptor::fromNode: InvVariance");
+    }
+    for(auto uid : attrs->peer_stats_tensor_uid)
+    {
+        desc->_peerStatsDescs.push_back(findTensorInMap(
+            tensorMap, uid, "BatchnormBackwardOperationDescriptor::fromNode: peer_stats"));
+    }
+    desc->finalize();
+    return desc;
 }
 
 } // namespace hipdnn_backend

--- a/projects/hipdnn/backend/src/descriptors/BatchnormBackwardOperationDescriptor.cpp
+++ b/projects/hipdnn/backend/src/descriptors/BatchnormBackwardOperationDescriptor.cpp
@@ -230,20 +230,20 @@ void BatchnormBackwardOperationDescriptor::getAttribute(hipdnnBackendAttributeNa
                             "BatchnormBackwardOperationDescriptor::getAttribute()");
         break;
     case HIPDNN_ATTR_OPERATION_BATCHNORM_BACKWARD_MEAN_EXT:
-        getTensorDescriptor(_meanDesc,
-                            attributeType,
-                            requestedElementCount,
-                            elementCount,
-                            arrayOfElements,
-                            "BatchnormBackwardOperationDescriptor::getAttribute()");
+        getOptionalTensorDescriptor(_meanDesc,
+                                    attributeType,
+                                    requestedElementCount,
+                                    elementCount,
+                                    arrayOfElements,
+                                    "BatchnormBackwardOperationDescriptor::getAttribute()");
         break;
     case HIPDNN_ATTR_OPERATION_BATCHNORM_BACKWARD_INV_VARIANCE_EXT:
-        getTensorDescriptor(_invVarianceDesc,
-                            attributeType,
-                            requestedElementCount,
-                            elementCount,
-                            arrayOfElements,
-                            "BatchnormBackwardOperationDescriptor::getAttribute()");
+        getOptionalTensorDescriptor(_invVarianceDesc,
+                                    attributeType,
+                                    requestedElementCount,
+                                    elementCount,
+                                    arrayOfElements,
+                                    "BatchnormBackwardOperationDescriptor::getAttribute()");
         break;
     case HIPDNN_ATTR_BATCHNORM_BACKWARD_COMP_TYPE_EXT:
         getDataType(_computeDataType,

--- a/projects/hipdnn/backend/src/descriptors/BatchnormBackwardOperationDescriptor.hpp
+++ b/projects/hipdnn/backend/src/descriptors/BatchnormBackwardOperationDescriptor.hpp
@@ -7,6 +7,7 @@
 #include "IGraphOperation.hpp"
 #include "TensorDescriptor.hpp"
 #include <hipdnn_data_sdk/data_objects/batchnorm_backward_attributes_generated.h>
+#include <unordered_map>
 
 namespace hipdnn_backend
 {
@@ -79,6 +80,13 @@ public:
     std::vector<std::shared_ptr<TensorDescriptor>> getTensorDescriptors() const override;
     std::unique_ptr<hipdnn_data_sdk::data_objects::NodeT> buildNode() const override;
 
+    // Creates a finalized BatchnormBackwardOperationDescriptor directly from a FlatBuffer NodeT.
+    // Casts nodeT.attributes to BatchnormBackwardAttributesT internally, then directly assigns
+    // the data struct, looks up tensor descriptors from the tensor map, and calls finalize().
+    static std::shared_ptr<BatchnormBackwardOperationDescriptor>
+        fromNode(const hipdnn_data_sdk::data_objects::NodeT& nodeT,
+                 const std::unordered_map<int64_t, std::shared_ptr<TensorDescriptor>>& tensorMap);
+
     static hipdnnBackendDescriptorType_t getStaticType();
 
     std::string toString() const override;
@@ -102,6 +110,8 @@ private:
     // Compute data type for this operation (stored at node level in graph)
     hipdnn_data_sdk::data_objects::DataType _computeDataType
         = hipdnn_data_sdk::data_objects::DataType::UNSET;
+
+    std::string _name;
 };
 
 } // namespace hipdnn_backend

--- a/projects/hipdnn/backend/src/descriptors/NodeFactory.cpp
+++ b/projects/hipdnn/backend/src/descriptors/NodeFactory.cpp
@@ -19,8 +19,8 @@ std::shared_ptr<IBackendDescriptor> NodeFactory::createOperationFromNode(
     // Uncomment when fromNode() is implemented in the lifting PR:
     case NodeAttributes::BatchnormAttributes:
         return BatchnormOperationDescriptor::fromNode(nodeT, tensorMap);
-    // case NodeAttributes::BatchnormBackwardAttributes:
-    //     return BatchnormBackwardOperationDescriptor::fromNode(nodeT, tensorMap);
+    case NodeAttributes::BatchnormBackwardAttributes:
+        return BatchnormBackwardOperationDescriptor::fromNode(nodeT, tensorMap);
     // case NodeAttributes::BatchnormInferenceAttributes:
     //     return BatchnormInferenceOperationDescriptor::fromNode(nodeT, tensorMap);
     // case NodeAttributes::BatchnormInferenceAttributesVarianceExt:

--- a/projects/hipdnn/backend/src/descriptors/NodeFactory.cpp
+++ b/projects/hipdnn/backend/src/descriptors/NodeFactory.cpp
@@ -16,7 +16,6 @@ std::shared_ptr<IBackendDescriptor> NodeFactory::createOperationFromNode(
 
     switch(nodeT.attributes.type)
     {
-    // Uncomment when fromNode() is implemented in the lifting PR:
     case NodeAttributes::BatchnormAttributes:
         return BatchnormOperationDescriptor::fromNode(nodeT, tensorMap);
     case NodeAttributes::BatchnormBackwardAttributes:

--- a/projects/hipdnn/backend/src/descriptors/NodeFactory.hpp
+++ b/projects/hipdnn/backend/src/descriptors/NodeFactory.hpp
@@ -3,8 +3,7 @@
 
 #pragma once
 
-// Uncomment when fromNode() is implemented in the lifting PR:
-// #include "BatchnormBackwardOperationDescriptor.hpp"
+#include "BatchnormBackwardOperationDescriptor.hpp"
 // #include "BatchnormInferenceOperationDescriptor.hpp"
 // #include "BatchnormInferenceVarianceExtOperationDescriptor.hpp"
 #include "BatchnormOperationDescriptor.hpp"

--- a/projects/hipdnn/backend/tests/CMakeLists.txt
+++ b/projects/hipdnn/backend/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ add_executable(
     descriptors/TestKnobDescriptor.cpp
     descriptors/TestKnobSettingDescriptor.cpp
     descriptors/TestBatchnormBackwardOperationDescriptor.cpp
+    descriptors/TestBatchnormBackwardOperationFromNode.cpp
     descriptors/TestConvolutionBwdOperationDescriptor.cpp
     descriptors/TestGraphDescriptorBlockScaleQuantize.cpp
     descriptors/TestMatmulOperationDescriptor.cpp

--- a/projects/hipdnn/backend/tests/descriptors/TestBatchnormBackwardOperationFromNode.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestBatchnormBackwardOperationFromNode.cpp
@@ -12,6 +12,7 @@
 
 #include <gtest/gtest.h>
 #include <hipdnn_data_sdk/data_objects/batchnorm_backward_attributes_generated.h>
+#include <hipdnn_data_sdk/data_objects/convolution_fwd_attributes_generated.h>
 #include <hipdnn_data_sdk/data_objects/graph_generated.h>
 #include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
 #include <hipdnn_test_sdk/constants/BatchnormBackwardConstants.hpp>
@@ -577,6 +578,47 @@ TEST_F(TestBatchnormBackwardOperationFromNode, GetAttributeWorksAfterFromNode)
                                            HIPDNN_DATA_FLOAT,
                                            toVec(K_BN_BWD_TENSOR_INV_VARIANCE_DIMS),
                                            toVec(K_BN_BWD_TENSOR_INV_VARIANCE_STRIDES));
+
+    // --- Peer stats tensor array ---
+
+    // Query count first
+    int64_t peerStatsCount = 0;
+    desc->getAttribute(HIPDNN_ATTR_OPERATION_BATCHNORM_BACKWARD_PEER_STATS_EXT,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       0,
+                       &peerStatsCount,
+                       nullptr);
+    ASSERT_EQ(peerStatsCount, 2);
+
+    // Retrieve both peer_stats descriptors
+    hipdnn_backend::ScopedDescriptor peerStats0Scoped;
+    hipdnn_backend::ScopedDescriptor peerStats1Scoped;
+    std::array<hipdnnBackendDescriptor_t, 2> peerStatsArray = {};
+    int64_t peerStatsRetrievedCount = 0;
+    desc->getAttribute(HIPDNN_ATTR_OPERATION_BATCHNORM_BACKWARD_PEER_STATS_EXT,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       2,
+                       &peerStatsRetrievedCount,
+                       static_cast<void*>(peerStatsArray.data()));
+    ASSERT_EQ(peerStatsRetrievedCount, 2);
+    // Transfer ownership to ScopedDescriptors
+    peerStats0Scoped = hipdnn_backend::ScopedDescriptor(peerStatsArray[0]);
+    peerStats1Scoped = hipdnn_backend::ScopedDescriptor(peerStatsArray[1]);
+    ASSERT_NE(peerStats0Scoped.get(), nullptr);
+    ASSERT_NE(peerStats1Scoped.get(), nullptr);
+
+    test_utilities::verifyTensorDescriptor(
+        peerStats0Scoped.get(),
+        K_BN_BWD_TENSOR_PEER_STAT_0_UID,
+        HIPDNN_DATA_FLOAT,
+        {K_BN_BWD_TENSOR_PEER_STAT_DIMS.begin(), K_BN_BWD_TENSOR_PEER_STAT_DIMS.end()},
+        {K_BN_BWD_TENSOR_PEER_STAT_STRIDES.begin(), K_BN_BWD_TENSOR_PEER_STAT_STRIDES.end()});
+    test_utilities::verifyTensorDescriptor(
+        peerStats1Scoped.get(),
+        K_BN_BWD_TENSOR_PEER_STAT_1_UID,
+        HIPDNN_DATA_FLOAT,
+        {K_BN_BWD_TENSOR_PEER_STAT_DIMS.begin(), K_BN_BWD_TENSOR_PEER_STAT_DIMS.end()},
+        {K_BN_BWD_TENSOR_PEER_STAT_STRIDES.begin(), K_BN_BWD_TENSOR_PEER_STAT_STRIDES.end()});
 }
 
 TEST_F(TestBatchnormBackwardOperationFromNode, GetTensorDescriptorsReturnsAllTensors)
@@ -597,4 +639,23 @@ TEST_F(TestBatchnormBackwardOperationFromNode, GetTensorDescriptorsReturnsAllTen
     EXPECT_EQ(tensors[7]->getData().uid, K_BN_BWD_TENSOR_INV_VARIANCE_UID);
     EXPECT_EQ(tensors[8]->getData().uid, K_BN_BWD_TENSOR_PEER_STAT_0_UID);
     EXPECT_EQ(tensors[9]->getData().uid, K_BN_BWD_TENSOR_PEER_STAT_1_UID);
+}
+
+TEST_F(TestBatchnormBackwardOperationFromNode, FailsWithWrongAttributesType)
+{
+    NodeT node;
+    node.compute_data_type = DataType::FLOAT;
+    node.attributes.Set(ConvolutionFwdAttributesT{});
+
+    ASSERT_THROW_HIPDNN_STATUS(BatchnormBackwardOperationDescriptor::fromNode(node, _tensorMap),
+                               HIPDNN_STATUS_INTERNAL_ERROR);
+}
+
+TEST_F(TestBatchnormBackwardOperationFromNode, FailsWithMissingPeerStatsTensor)
+{
+    _tensorMap.erase(K_BN_BWD_TENSOR_PEER_STAT_0_UID);
+    auto node = createStandardNode();
+
+    ASSERT_THROW_HIPDNN_STATUS(BatchnormBackwardOperationDescriptor::fromNode(node, _tensorMap),
+                               HIPDNN_STATUS_INTERNAL_ERROR);
 }

--- a/projects/hipdnn/backend/tests/descriptors/TestBatchnormBackwardOperationFromNode.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestBatchnormBackwardOperationFromNode.cpp
@@ -593,4 +593,8 @@ TEST_F(TestBatchnormBackwardOperationFromNode, GetTensorDescriptorsReturnsAllTen
     EXPECT_EQ(tensors[3]->getData().uid, K_BN_BWD_TENSOR_DX_UID);
     EXPECT_EQ(tensors[4]->getData().uid, K_BN_BWD_TENSOR_DSCALE_UID);
     EXPECT_EQ(tensors[5]->getData().uid, K_BN_BWD_TENSOR_DBIAS_UID);
+    EXPECT_EQ(tensors[6]->getData().uid, K_BN_BWD_TENSOR_MEAN_UID);
+    EXPECT_EQ(tensors[7]->getData().uid, K_BN_BWD_TENSOR_INV_VARIANCE_UID);
+    EXPECT_EQ(tensors[8]->getData().uid, K_BN_BWD_TENSOR_PEER_STAT_0_UID);
+    EXPECT_EQ(tensors[9]->getData().uid, K_BN_BWD_TENSOR_PEER_STAT_1_UID);
 }

--- a/projects/hipdnn/backend/tests/descriptors/TestBatchnormBackwardOperationFromNode.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestBatchnormBackwardOperationFromNode.cpp
@@ -1,0 +1,596 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include "HipdnnOperationType.h"
+#include "TensorDescriptorTestUtils.hpp"
+#include "TestMacros.hpp"
+#include "descriptors/BatchnormBackwardOperationDescriptor.hpp"
+#include "descriptors/NodeFactory.hpp"
+#include "descriptors/ScopedDescriptor.hpp"
+#include "descriptors/TensorDescriptor.hpp"
+#include "hipdnn_backend.h"
+
+#include <gtest/gtest.h>
+#include <hipdnn_data_sdk/data_objects/batchnorm_backward_attributes_generated.h>
+#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_test_sdk/constants/BatchnormBackwardConstants.hpp>
+#include <hipdnn_test_sdk/utilities/ToVec.hpp>
+
+#include <array>
+#include <memory>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+using namespace hipdnn_backend;
+using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_tests::constants;
+using hipdnn_tests::toVec;
+
+// =============================================================================
+// BatchnormBackwardOperationDescriptor::fromNode() Tests
+// =============================================================================
+
+class TestBatchnormBackwardOperationFromNode : public ::testing::Test
+{
+protected:
+    std::unordered_map<int64_t, std::shared_ptr<TensorDescriptor>> _tensorMap;
+
+    void SetUp() override
+    {
+        auto addTensor =
+            [&](int64_t uid, const auto& dims, const auto& strides, DataType dt = DataType::FLOAT) {
+                TensorAttributesT attrs;
+                attrs.uid = uid;
+                attrs.data_type = dt;
+                attrs.dims = {dims.begin(), dims.end()};
+                attrs.strides = {strides.begin(), strides.end()};
+                _tensorMap[uid] = TensorDescriptor::fromFlatBuffer(attrs);
+            };
+
+        addTensor(K_BN_BWD_TENSOR_DY_UID, K_BN_BWD_TENSOR_DY_DIMS, K_BN_BWD_TENSOR_DY_STRIDES);
+        addTensor(K_BN_BWD_TENSOR_X_UID, K_BN_BWD_TENSOR_X_DIMS, K_BN_BWD_TENSOR_X_STRIDES);
+        addTensor(
+            K_BN_BWD_TENSOR_SCALE_UID, K_BN_BWD_TENSOR_SCALE_DIMS, K_BN_BWD_TENSOR_SCALE_STRIDES);
+        addTensor(K_BN_BWD_TENSOR_DX_UID, K_BN_BWD_TENSOR_DX_DIMS, K_BN_BWD_TENSOR_DX_STRIDES);
+        addTensor(K_BN_BWD_TENSOR_DSCALE_UID,
+                  K_BN_BWD_TENSOR_DSCALE_DIMS,
+                  K_BN_BWD_TENSOR_DSCALE_STRIDES);
+        addTensor(
+            K_BN_BWD_TENSOR_DBIAS_UID, K_BN_BWD_TENSOR_DBIAS_DIMS, K_BN_BWD_TENSOR_DBIAS_STRIDES);
+        addTensor(
+            K_BN_BWD_TENSOR_MEAN_UID, K_BN_BWD_TENSOR_MEAN_DIMS, K_BN_BWD_TENSOR_MEAN_STRIDES);
+        addTensor(K_BN_BWD_TENSOR_INV_VARIANCE_UID,
+                  K_BN_BWD_TENSOR_INV_VARIANCE_DIMS,
+                  K_BN_BWD_TENSOR_INV_VARIANCE_STRIDES);
+        addTensor(K_BN_BWD_TENSOR_PEER_STAT_0_UID,
+                  K_BN_BWD_TENSOR_PEER_STAT_DIMS,
+                  K_BN_BWD_TENSOR_PEER_STAT_STRIDES);
+        addTensor(K_BN_BWD_TENSOR_PEER_STAT_1_UID,
+                  K_BN_BWD_TENSOR_PEER_STAT_DIMS,
+                  K_BN_BWD_TENSOR_PEER_STAT_STRIDES);
+    }
+
+    static BatchnormBackwardAttributesT createStandardAttrs()
+    {
+        BatchnormBackwardAttributesT attrs;
+        attrs.dy_tensor_uid = K_BN_BWD_TENSOR_DY_UID;
+        attrs.x_tensor_uid = K_BN_BWD_TENSOR_X_UID;
+        attrs.scale_tensor_uid = K_BN_BWD_TENSOR_SCALE_UID;
+        attrs.dx_tensor_uid = K_BN_BWD_TENSOR_DX_UID;
+        attrs.dscale_tensor_uid = K_BN_BWD_TENSOR_DSCALE_UID;
+        attrs.dbias_tensor_uid = K_BN_BWD_TENSOR_DBIAS_UID;
+        attrs.mean_tensor_uid = K_BN_BWD_TENSOR_MEAN_UID;
+        attrs.inv_variance_tensor_uid = K_BN_BWD_TENSOR_INV_VARIANCE_UID;
+        attrs.peer_stats_tensor_uid
+            = {K_BN_BWD_TENSOR_PEER_STAT_0_UID, K_BN_BWD_TENSOR_PEER_STAT_1_UID};
+        return attrs;
+    }
+
+    static NodeT createStandardNode(DataType computeType = DataType::FLOAT)
+    {
+        NodeT node;
+        node.compute_data_type = computeType;
+        node.attributes.Set(createStandardAttrs());
+        return node;
+    }
+};
+
+TEST_F(TestBatchnormBackwardOperationFromNode, CreatesValidFinalizedDescriptor)
+{
+    auto node = createStandardNode();
+    auto desc = BatchnormBackwardOperationDescriptor::fromNode(node, _tensorMap);
+
+    ASSERT_NE(desc, nullptr);
+    ASSERT_TRUE(desc->isFinalized());
+    ASSERT_EQ(desc->getType(), HIPDNN_BACKEND_OPERATION_BATCHNORM_BACKWARD_DESCRIPTOR_EXT);
+    EXPECT_EQ(desc->getData().dy_tensor_uid, K_BN_BWD_TENSOR_DY_UID);
+}
+
+TEST_F(TestBatchnormBackwardOperationFromNode, NodeFactoryDelegatesCorrectly)
+{
+    auto node = createStandardNode();
+
+    auto graphOp = NodeFactory::createOperationFromNode(node, _tensorMap);
+    ASSERT_NE(graphOp, nullptr);
+
+    auto* op = graphOp->asGraphOperation();
+    ASSERT_NE(op, nullptr);
+    auto rebuiltNode = op->buildNode();
+    ASSERT_EQ(rebuiltNode->attributes.type, NodeAttributes::BatchnormBackwardAttributes);
+    auto desc = std::static_pointer_cast<BatchnormBackwardOperationDescriptor>(graphOp);
+    ASSERT_TRUE(desc->isFinalized());
+
+    EXPECT_EQ(desc->getData().dy_tensor_uid, K_BN_BWD_TENSOR_DY_UID);
+    EXPECT_EQ(desc->getData().x_tensor_uid, K_BN_BWD_TENSOR_X_UID);
+    EXPECT_EQ(desc->getData().scale_tensor_uid, K_BN_BWD_TENSOR_SCALE_UID);
+    EXPECT_EQ(desc->getData().dx_tensor_uid, K_BN_BWD_TENSOR_DX_UID);
+    EXPECT_EQ(desc->getData().dscale_tensor_uid, K_BN_BWD_TENSOR_DSCALE_UID);
+    EXPECT_EQ(desc->getData().dbias_tensor_uid, K_BN_BWD_TENSOR_DBIAS_UID);
+    EXPECT_EQ(desc->getComputeDataType(), DataType::FLOAT);
+}
+
+TEST_F(TestBatchnormBackwardOperationFromNode, PreservesComputeDataType)
+{
+    auto node = createStandardNode(DataType::HALF);
+    auto desc = BatchnormBackwardOperationDescriptor::fromNode(node, _tensorMap);
+
+    ASSERT_EQ(desc->getComputeDataType(), DataType::HALF);
+}
+
+TEST_F(TestBatchnormBackwardOperationFromNode, SetsTensorReferencesWithFullValues)
+{
+    auto node = createStandardNode();
+    auto desc = BatchnormBackwardOperationDescriptor::fromNode(node, _tensorMap);
+
+    // DY tensor
+    ASSERT_NE(desc->getDyDesc(), nullptr);
+    EXPECT_EQ(desc->getDyDesc()->getData().uid, K_BN_BWD_TENSOR_DY_UID);
+    EXPECT_EQ(desc->getDyDesc()->getData().data_type, DataType::FLOAT);
+    EXPECT_EQ(desc->getDyDesc()->getData().dims, toVec(K_BN_BWD_TENSOR_DY_DIMS));
+    EXPECT_EQ(desc->getDyDesc()->getData().strides, toVec(K_BN_BWD_TENSOR_DY_STRIDES));
+
+    // X tensor
+    ASSERT_NE(desc->getXDesc(), nullptr);
+    EXPECT_EQ(desc->getXDesc()->getData().uid, K_BN_BWD_TENSOR_X_UID);
+    EXPECT_EQ(desc->getXDesc()->getData().data_type, DataType::FLOAT);
+    EXPECT_EQ(desc->getXDesc()->getData().dims, toVec(K_BN_BWD_TENSOR_X_DIMS));
+    EXPECT_EQ(desc->getXDesc()->getData().strides, toVec(K_BN_BWD_TENSOR_X_STRIDES));
+
+    // Scale tensor
+    ASSERT_NE(desc->getScaleDesc(), nullptr);
+    EXPECT_EQ(desc->getScaleDesc()->getData().uid, K_BN_BWD_TENSOR_SCALE_UID);
+    EXPECT_EQ(desc->getScaleDesc()->getData().data_type, DataType::FLOAT);
+    EXPECT_EQ(desc->getScaleDesc()->getData().dims, toVec(K_BN_BWD_TENSOR_SCALE_DIMS));
+    EXPECT_EQ(desc->getScaleDesc()->getData().strides, toVec(K_BN_BWD_TENSOR_SCALE_STRIDES));
+
+    // DX tensor
+    ASSERT_NE(desc->getDxDesc(), nullptr);
+    EXPECT_EQ(desc->getDxDesc()->getData().uid, K_BN_BWD_TENSOR_DX_UID);
+    EXPECT_EQ(desc->getDxDesc()->getData().data_type, DataType::FLOAT);
+    EXPECT_EQ(desc->getDxDesc()->getData().dims, toVec(K_BN_BWD_TENSOR_DX_DIMS));
+    EXPECT_EQ(desc->getDxDesc()->getData().strides, toVec(K_BN_BWD_TENSOR_DX_STRIDES));
+
+    // DScale tensor
+    ASSERT_NE(desc->getDscaleDesc(), nullptr);
+    EXPECT_EQ(desc->getDscaleDesc()->getData().uid, K_BN_BWD_TENSOR_DSCALE_UID);
+    EXPECT_EQ(desc->getDscaleDesc()->getData().data_type, DataType::FLOAT);
+    EXPECT_EQ(desc->getDscaleDesc()->getData().dims, toVec(K_BN_BWD_TENSOR_DSCALE_DIMS));
+    EXPECT_EQ(desc->getDscaleDesc()->getData().strides, toVec(K_BN_BWD_TENSOR_DSCALE_STRIDES));
+
+    // DBias tensor
+    ASSERT_NE(desc->getDbiasDesc(), nullptr);
+    EXPECT_EQ(desc->getDbiasDesc()->getData().uid, K_BN_BWD_TENSOR_DBIAS_UID);
+    EXPECT_EQ(desc->getDbiasDesc()->getData().data_type, DataType::FLOAT);
+    EXPECT_EQ(desc->getDbiasDesc()->getData().dims, toVec(K_BN_BWD_TENSOR_DBIAS_DIMS));
+    EXPECT_EQ(desc->getDbiasDesc()->getData().strides, toVec(K_BN_BWD_TENSOR_DBIAS_STRIDES));
+
+    // Mean tensor (optional)
+    ASSERT_NE(desc->getMeanDesc(), nullptr);
+    EXPECT_EQ(desc->getMeanDesc()->getData().uid, K_BN_BWD_TENSOR_MEAN_UID);
+    EXPECT_EQ(desc->getMeanDesc()->getData().data_type, DataType::FLOAT);
+    EXPECT_EQ(desc->getMeanDesc()->getData().dims, toVec(K_BN_BWD_TENSOR_MEAN_DIMS));
+    EXPECT_EQ(desc->getMeanDesc()->getData().strides, toVec(K_BN_BWD_TENSOR_MEAN_STRIDES));
+
+    // InvVariance tensor (optional)
+    ASSERT_NE(desc->getInvVarianceDesc(), nullptr);
+    EXPECT_EQ(desc->getInvVarianceDesc()->getData().uid, K_BN_BWD_TENSOR_INV_VARIANCE_UID);
+    EXPECT_EQ(desc->getInvVarianceDesc()->getData().data_type, DataType::FLOAT);
+    EXPECT_EQ(desc->getInvVarianceDesc()->getData().dims, toVec(K_BN_BWD_TENSOR_INV_VARIANCE_DIMS));
+    EXPECT_EQ(desc->getInvVarianceDesc()->getData().strides,
+              toVec(K_BN_BWD_TENSOR_INV_VARIANCE_STRIDES));
+}
+
+TEST_F(TestBatchnormBackwardOperationFromNode, TensorReferencesMatchTensorMap)
+{
+    auto node = createStandardNode();
+    auto desc = BatchnormBackwardOperationDescriptor::fromNode(node, _tensorMap);
+
+    EXPECT_EQ(desc->getDyDesc(), _tensorMap[K_BN_BWD_TENSOR_DY_UID]);
+    EXPECT_EQ(desc->getXDesc(), _tensorMap[K_BN_BWD_TENSOR_X_UID]);
+    EXPECT_EQ(desc->getScaleDesc(), _tensorMap[K_BN_BWD_TENSOR_SCALE_UID]);
+    EXPECT_EQ(desc->getDxDesc(), _tensorMap[K_BN_BWD_TENSOR_DX_UID]);
+    EXPECT_EQ(desc->getDscaleDesc(), _tensorMap[K_BN_BWD_TENSOR_DSCALE_UID]);
+    EXPECT_EQ(desc->getDbiasDesc(), _tensorMap[K_BN_BWD_TENSOR_DBIAS_UID]);
+    EXPECT_EQ(desc->getMeanDesc(), _tensorMap[K_BN_BWD_TENSOR_MEAN_UID]);
+    EXPECT_EQ(desc->getInvVarianceDesc(), _tensorMap[K_BN_BWD_TENSOR_INV_VARIANCE_UID]);
+}
+
+TEST_F(TestBatchnormBackwardOperationFromNode, FailsWithMissingDyTensor)
+{
+    _tensorMap.erase(K_BN_BWD_TENSOR_DY_UID);
+    auto node = createStandardNode();
+
+    ASSERT_THROW_HIPDNN_STATUS(BatchnormBackwardOperationDescriptor::fromNode(node, _tensorMap),
+                               HIPDNN_STATUS_INTERNAL_ERROR);
+}
+
+TEST_F(TestBatchnormBackwardOperationFromNode, FailsWithMissingXTensor)
+{
+    _tensorMap.erase(K_BN_BWD_TENSOR_X_UID);
+    auto node = createStandardNode();
+
+    ASSERT_THROW_HIPDNN_STATUS(BatchnormBackwardOperationDescriptor::fromNode(node, _tensorMap),
+                               HIPDNN_STATUS_INTERNAL_ERROR);
+}
+
+TEST_F(TestBatchnormBackwardOperationFromNode, FailsWithMissingScaleTensor)
+{
+    _tensorMap.erase(K_BN_BWD_TENSOR_SCALE_UID);
+    auto node = createStandardNode();
+
+    ASSERT_THROW_HIPDNN_STATUS(BatchnormBackwardOperationDescriptor::fromNode(node, _tensorMap),
+                               HIPDNN_STATUS_INTERNAL_ERROR);
+}
+
+TEST_F(TestBatchnormBackwardOperationFromNode, FailsWithMissingDxTensor)
+{
+    _tensorMap.erase(K_BN_BWD_TENSOR_DX_UID);
+    auto node = createStandardNode();
+
+    ASSERT_THROW_HIPDNN_STATUS(BatchnormBackwardOperationDescriptor::fromNode(node, _tensorMap),
+                               HIPDNN_STATUS_INTERNAL_ERROR);
+}
+
+TEST_F(TestBatchnormBackwardOperationFromNode, FailsWithMissingDscaleTensor)
+{
+    _tensorMap.erase(K_BN_BWD_TENSOR_DSCALE_UID);
+    auto node = createStandardNode();
+
+    ASSERT_THROW_HIPDNN_STATUS(BatchnormBackwardOperationDescriptor::fromNode(node, _tensorMap),
+                               HIPDNN_STATUS_INTERNAL_ERROR);
+}
+
+TEST_F(TestBatchnormBackwardOperationFromNode, FailsWithMissingDbiasTensor)
+{
+    _tensorMap.erase(K_BN_BWD_TENSOR_DBIAS_UID);
+    auto node = createStandardNode();
+
+    ASSERT_THROW_HIPDNN_STATUS(BatchnormBackwardOperationDescriptor::fromNode(node, _tensorMap),
+                               HIPDNN_STATUS_INTERNAL_ERROR);
+}
+
+TEST_F(TestBatchnormBackwardOperationFromNode, SucceedsWithOnlyRequiredTensors)
+{
+    auto attrs = createStandardAttrs();
+    attrs.mean_tensor_uid = flatbuffers::nullopt;
+    attrs.inv_variance_tensor_uid = flatbuffers::nullopt;
+    attrs.peer_stats_tensor_uid.clear();
+
+    NodeT node;
+    node.compute_data_type = DataType::FLOAT;
+    node.attributes.Set(attrs);
+
+    auto desc = BatchnormBackwardOperationDescriptor::fromNode(node, _tensorMap);
+    ASSERT_NE(desc, nullptr);
+    ASSERT_TRUE(desc->isFinalized());
+
+    EXPECT_NE(desc->getDyDesc(), nullptr);
+    EXPECT_NE(desc->getXDesc(), nullptr);
+    EXPECT_NE(desc->getScaleDesc(), nullptr);
+    EXPECT_NE(desc->getDxDesc(), nullptr);
+    EXPECT_NE(desc->getDscaleDesc(), nullptr);
+    EXPECT_NE(desc->getDbiasDesc(), nullptr);
+    EXPECT_EQ(desc->getMeanDesc(), nullptr);
+    EXPECT_EQ(desc->getInvVarianceDesc(), nullptr);
+}
+
+TEST_F(TestBatchnormBackwardOperationFromNode, FailsWhenOptionalMeanUidSetButTensorMissing)
+{
+    _tensorMap.erase(K_BN_BWD_TENSOR_MEAN_UID);
+    auto node = createStandardNode();
+
+    ASSERT_THROW_HIPDNN_STATUS(BatchnormBackwardOperationDescriptor::fromNode(node, _tensorMap),
+                               HIPDNN_STATUS_INTERNAL_ERROR);
+}
+
+TEST_F(TestBatchnormBackwardOperationFromNode, FailsWhenOptionalInvVarianceUidSetButTensorMissing)
+{
+    _tensorMap.erase(K_BN_BWD_TENSOR_INV_VARIANCE_UID);
+    auto node = createStandardNode();
+
+    ASSERT_THROW_HIPDNN_STATUS(BatchnormBackwardOperationDescriptor::fromNode(node, _tensorMap),
+                               HIPDNN_STATUS_INTERNAL_ERROR);
+}
+
+TEST_F(TestBatchnormBackwardOperationFromNode, BuildNodeRoundTrip)
+{
+    auto node = createStandardNode();
+    node.name = "bn_bwd_round_trip";
+    auto desc = BatchnormBackwardOperationDescriptor::fromNode(node, _tensorMap);
+
+    auto rebuiltNode = desc->buildNode();
+    ASSERT_NE(rebuiltNode, nullptr);
+    ASSERT_EQ(rebuiltNode->compute_data_type, DataType::FLOAT);
+    ASSERT_EQ(rebuiltNode->attributes.type, NodeAttributes::BatchnormBackwardAttributes);
+
+    const auto* rebuiltAttrs = rebuiltNode->attributes.AsBatchnormBackwardAttributes();
+    ASSERT_NE(rebuiltAttrs, nullptr);
+    EXPECT_EQ(rebuiltAttrs->dy_tensor_uid, K_BN_BWD_TENSOR_DY_UID);
+    EXPECT_EQ(rebuiltAttrs->x_tensor_uid, K_BN_BWD_TENSOR_X_UID);
+    EXPECT_EQ(rebuiltAttrs->scale_tensor_uid, K_BN_BWD_TENSOR_SCALE_UID);
+    EXPECT_EQ(rebuiltAttrs->dx_tensor_uid, K_BN_BWD_TENSOR_DX_UID);
+    EXPECT_EQ(rebuiltAttrs->dscale_tensor_uid, K_BN_BWD_TENSOR_DSCALE_UID);
+    EXPECT_EQ(rebuiltAttrs->dbias_tensor_uid, K_BN_BWD_TENSOR_DBIAS_UID);
+    EXPECT_EQ(rebuiltAttrs->mean_tensor_uid, K_BN_BWD_TENSOR_MEAN_UID);
+    EXPECT_EQ(rebuiltAttrs->inv_variance_tensor_uid, K_BN_BWD_TENSOR_INV_VARIANCE_UID);
+
+    ASSERT_EQ(rebuiltAttrs->peer_stats_tensor_uid.size(), 2);
+    EXPECT_EQ(rebuiltAttrs->peer_stats_tensor_uid[0], K_BN_BWD_TENSOR_PEER_STAT_0_UID);
+    EXPECT_EQ(rebuiltAttrs->peer_stats_tensor_uid[1], K_BN_BWD_TENSOR_PEER_STAT_1_UID);
+
+    EXPECT_EQ(rebuiltNode->name, "bn_bwd_round_trip");
+}
+
+TEST_F(TestBatchnormBackwardOperationFromNode, BuildNodeRoundTripWithOnlyRequiredTensors)
+{
+    auto attrs = createStandardAttrs();
+    attrs.mean_tensor_uid = flatbuffers::nullopt;
+    attrs.inv_variance_tensor_uid = flatbuffers::nullopt;
+    attrs.peer_stats_tensor_uid.clear();
+
+    NodeT node;
+    node.compute_data_type = DataType::FLOAT;
+    node.attributes.Set(attrs);
+
+    auto desc = BatchnormBackwardOperationDescriptor::fromNode(node, _tensorMap);
+    auto rebuiltNode = desc->buildNode();
+
+    const auto* rebuiltAttrs = rebuiltNode->attributes.AsBatchnormBackwardAttributes();
+    ASSERT_NE(rebuiltAttrs, nullptr);
+
+    EXPECT_EQ(rebuiltAttrs->dy_tensor_uid, K_BN_BWD_TENSOR_DY_UID);
+    EXPECT_EQ(rebuiltAttrs->x_tensor_uid, K_BN_BWD_TENSOR_X_UID);
+    EXPECT_EQ(rebuiltAttrs->scale_tensor_uid, K_BN_BWD_TENSOR_SCALE_UID);
+    EXPECT_EQ(rebuiltAttrs->dx_tensor_uid, K_BN_BWD_TENSOR_DX_UID);
+    EXPECT_EQ(rebuiltAttrs->dscale_tensor_uid, K_BN_BWD_TENSOR_DSCALE_UID);
+    EXPECT_EQ(rebuiltAttrs->dbias_tensor_uid, K_BN_BWD_TENSOR_DBIAS_UID);
+
+    EXPECT_FALSE(rebuiltAttrs->mean_tensor_uid.has_value());
+    EXPECT_FALSE(rebuiltAttrs->inv_variance_tensor_uid.has_value());
+    EXPECT_TRUE(rebuiltAttrs->peer_stats_tensor_uid.empty());
+}
+
+TEST_F(TestBatchnormBackwardOperationFromNode, NamePreservedFromNode)
+{
+    auto node = createStandardNode();
+    node.name = "test_bn_bwd_1";
+
+    auto desc = BatchnormBackwardOperationDescriptor::fromNode(node, _tensorMap);
+
+    int64_t count = 0;
+    desc->getAttribute(HIPDNN_ATTR_OPERATION_NAME_EXT, HIPDNN_TYPE_CHAR, 0, &count, nullptr);
+    ASSERT_EQ(count, static_cast<int64_t>(std::string("test_bn_bwd_1").size() + 1));
+
+    std::vector<char> buffer(static_cast<size_t>(count));
+    int64_t actualCount = 0;
+    desc->getAttribute(
+        HIPDNN_ATTR_OPERATION_NAME_EXT, HIPDNN_TYPE_CHAR, count, &actualCount, buffer.data());
+    EXPECT_STREQ(buffer.data(), "test_bn_bwd_1");
+}
+
+TEST_F(TestBatchnormBackwardOperationFromNode, EmptyNamePreservedFromNode)
+{
+    auto node = createStandardNode();
+    auto desc = BatchnormBackwardOperationDescriptor::fromNode(node, _tensorMap);
+
+    int64_t count = 0;
+    desc->getAttribute(HIPDNN_ATTR_OPERATION_NAME_EXT, HIPDNN_TYPE_CHAR, 0, &count, nullptr);
+    EXPECT_EQ(count, 1);
+}
+
+TEST_F(TestBatchnormBackwardOperationFromNode, BuildNodePreservesName)
+{
+    auto node = createStandardNode();
+    node.name = "test_build_name";
+
+    auto desc = BatchnormBackwardOperationDescriptor::fromNode(node, _tensorMap);
+    auto rebuiltNode = desc->buildNode();
+
+    ASSERT_NE(rebuiltNode, nullptr);
+    EXPECT_EQ(rebuiltNode->name, "test_build_name");
+}
+
+TEST_F(TestBatchnormBackwardOperationFromNode, GetAttributeWorksAfterFromNode)
+{
+    auto node = createStandardNode();
+    node.name = "bn_bwd_getattr";
+    auto desc = BatchnormBackwardOperationDescriptor::fromNode(node, _tensorMap);
+
+    // Verify compute type via getAttribute
+    hipdnnDataType_t computeType = {};
+    int64_t dtCount = 0;
+    desc->getAttribute(HIPDNN_ATTR_BATCHNORM_BACKWARD_COMP_TYPE_EXT,
+                       HIPDNN_TYPE_DATA_TYPE,
+                       1,
+                       &dtCount,
+                       &computeType);
+    ASSERT_EQ(dtCount, 1);
+    EXPECT_EQ(computeType, HIPDNN_DATA_FLOAT);
+
+    // Verify operation type
+    hipdnnOperationType_t opType = HIPDNN_OPERATION_TYPE_NOT_SET;
+    int64_t opTypeCount = 0;
+    desc->getAttribute(
+        HIPDNN_ATTR_OPERATION_TYPE_EXT, HIPDNN_TYPE_OPERATION_TYPE_EXT, 1, &opTypeCount, &opType);
+    ASSERT_EQ(opTypeCount, 1);
+    EXPECT_EQ(opType, HIPDNN_OPERATION_TYPE_BATCHNORM_BACKWARD);
+
+    // Verify name
+    int64_t nameCount = 0;
+    desc->getAttribute(HIPDNN_ATTR_OPERATION_NAME_EXT, HIPDNN_TYPE_CHAR, 0, &nameCount, nullptr);
+    ASSERT_EQ(nameCount, static_cast<int64_t>(std::string("bn_bwd_getattr").size() + 1));
+    std::vector<char> nameBuffer(static_cast<size_t>(nameCount));
+    int64_t actualNameCount = 0;
+    desc->getAttribute(HIPDNN_ATTR_OPERATION_NAME_EXT,
+                       HIPDNN_TYPE_CHAR,
+                       nameCount,
+                       &actualNameCount,
+                       nameBuffer.data());
+    EXPECT_STREQ(nameBuffer.data(), "bn_bwd_getattr");
+
+    // DY tensor - full verification
+    hipdnn_backend::ScopedDescriptor dyScoped;
+    int64_t dyCount = 0;
+    desc->getAttribute(HIPDNN_ATTR_OPERATION_BATCHNORM_BACKWARD_DY_EXT,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       &dyCount,
+                       static_cast<void*>(dyScoped.getPtr()));
+    ASSERT_EQ(dyCount, 1);
+    ASSERT_NE(dyScoped.get(), nullptr);
+    test_utilities::verifyTensorDescriptor(dyScoped.get(),
+                                           K_BN_BWD_TENSOR_DY_UID,
+                                           HIPDNN_DATA_FLOAT,
+                                           toVec(K_BN_BWD_TENSOR_DY_DIMS),
+                                           toVec(K_BN_BWD_TENSOR_DY_STRIDES));
+
+    // X tensor - full verification
+    hipdnn_backend::ScopedDescriptor xScoped;
+    int64_t xCount = 0;
+    desc->getAttribute(HIPDNN_ATTR_OPERATION_BATCHNORM_BACKWARD_X_EXT,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       &xCount,
+                       static_cast<void*>(xScoped.getPtr()));
+    ASSERT_EQ(xCount, 1);
+    ASSERT_NE(xScoped.get(), nullptr);
+    test_utilities::verifyTensorDescriptor(xScoped.get(),
+                                           K_BN_BWD_TENSOR_X_UID,
+                                           HIPDNN_DATA_FLOAT,
+                                           toVec(K_BN_BWD_TENSOR_X_DIMS),
+                                           toVec(K_BN_BWD_TENSOR_X_STRIDES));
+
+    // Scale tensor - full verification
+    hipdnn_backend::ScopedDescriptor scaleScoped;
+    int64_t scaleCount = 0;
+    desc->getAttribute(HIPDNN_ATTR_OPERATION_BATCHNORM_BACKWARD_SCALE_EXT,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       &scaleCount,
+                       static_cast<void*>(scaleScoped.getPtr()));
+    ASSERT_EQ(scaleCount, 1);
+    ASSERT_NE(scaleScoped.get(), nullptr);
+    test_utilities::verifyTensorDescriptor(scaleScoped.get(),
+                                           K_BN_BWD_TENSOR_SCALE_UID,
+                                           HIPDNN_DATA_FLOAT,
+                                           toVec(K_BN_BWD_TENSOR_SCALE_DIMS),
+                                           toVec(K_BN_BWD_TENSOR_SCALE_STRIDES));
+
+    // DX tensor - full verification
+    hipdnn_backend::ScopedDescriptor dxScoped;
+    int64_t dxCount = 0;
+    desc->getAttribute(HIPDNN_ATTR_OPERATION_BATCHNORM_BACKWARD_DX_EXT,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       &dxCount,
+                       static_cast<void*>(dxScoped.getPtr()));
+    ASSERT_EQ(dxCount, 1);
+    ASSERT_NE(dxScoped.get(), nullptr);
+    test_utilities::verifyTensorDescriptor(dxScoped.get(),
+                                           K_BN_BWD_TENSOR_DX_UID,
+                                           HIPDNN_DATA_FLOAT,
+                                           toVec(K_BN_BWD_TENSOR_DX_DIMS),
+                                           toVec(K_BN_BWD_TENSOR_DX_STRIDES));
+
+    // DScale tensor - full verification
+    hipdnn_backend::ScopedDescriptor dscaleScoped;
+    int64_t dscaleCount = 0;
+    desc->getAttribute(HIPDNN_ATTR_OPERATION_BATCHNORM_BACKWARD_DSCALE_EXT,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       &dscaleCount,
+                       static_cast<void*>(dscaleScoped.getPtr()));
+    ASSERT_EQ(dscaleCount, 1);
+    ASSERT_NE(dscaleScoped.get(), nullptr);
+    test_utilities::verifyTensorDescriptor(dscaleScoped.get(),
+                                           K_BN_BWD_TENSOR_DSCALE_UID,
+                                           HIPDNN_DATA_FLOAT,
+                                           toVec(K_BN_BWD_TENSOR_DSCALE_DIMS),
+                                           toVec(K_BN_BWD_TENSOR_DSCALE_STRIDES));
+
+    // DBias tensor - full verification
+    hipdnn_backend::ScopedDescriptor dbiasScoped;
+    int64_t dbiasCount = 0;
+    desc->getAttribute(HIPDNN_ATTR_OPERATION_BATCHNORM_BACKWARD_DBIAS_EXT,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       &dbiasCount,
+                       static_cast<void*>(dbiasScoped.getPtr()));
+    ASSERT_EQ(dbiasCount, 1);
+    ASSERT_NE(dbiasScoped.get(), nullptr);
+    test_utilities::verifyTensorDescriptor(dbiasScoped.get(),
+                                           K_BN_BWD_TENSOR_DBIAS_UID,
+                                           HIPDNN_DATA_FLOAT,
+                                           toVec(K_BN_BWD_TENSOR_DBIAS_DIMS),
+                                           toVec(K_BN_BWD_TENSOR_DBIAS_STRIDES));
+
+    // Mean tensor - full verification (optional, set in standard node)
+    hipdnn_backend::ScopedDescriptor meanScoped;
+    int64_t meanCount = 0;
+    desc->getAttribute(HIPDNN_ATTR_OPERATION_BATCHNORM_BACKWARD_MEAN_EXT,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       &meanCount,
+                       static_cast<void*>(meanScoped.getPtr()));
+    ASSERT_EQ(meanCount, 1);
+    ASSERT_NE(meanScoped.get(), nullptr);
+    test_utilities::verifyTensorDescriptor(meanScoped.get(),
+                                           K_BN_BWD_TENSOR_MEAN_UID,
+                                           HIPDNN_DATA_FLOAT,
+                                           toVec(K_BN_BWD_TENSOR_MEAN_DIMS),
+                                           toVec(K_BN_BWD_TENSOR_MEAN_STRIDES));
+
+    // InvVariance tensor - full verification (optional, set in standard node)
+    hipdnn_backend::ScopedDescriptor invVarScoped;
+    int64_t invVarCount = 0;
+    desc->getAttribute(HIPDNN_ATTR_OPERATION_BATCHNORM_BACKWARD_INV_VARIANCE_EXT,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       &invVarCount,
+                       static_cast<void*>(invVarScoped.getPtr()));
+    ASSERT_EQ(invVarCount, 1);
+    ASSERT_NE(invVarScoped.get(), nullptr);
+    test_utilities::verifyTensorDescriptor(invVarScoped.get(),
+                                           K_BN_BWD_TENSOR_INV_VARIANCE_UID,
+                                           HIPDNN_DATA_FLOAT,
+                                           toVec(K_BN_BWD_TENSOR_INV_VARIANCE_DIMS),
+                                           toVec(K_BN_BWD_TENSOR_INV_VARIANCE_STRIDES));
+}
+
+TEST_F(TestBatchnormBackwardOperationFromNode, GetTensorDescriptorsReturnsAllTensors)
+{
+    auto node = createStandardNode();
+    auto desc = BatchnormBackwardOperationDescriptor::fromNode(node, _tensorMap);
+
+    auto tensors = desc->getTensorDescriptors();
+    // 6 required + 2 optional (mean, inv_variance) + 2 peer_stats = 10
+    ASSERT_EQ(tensors.size(), 10);
+    EXPECT_EQ(tensors[0]->getData().uid, K_BN_BWD_TENSOR_DY_UID);
+    EXPECT_EQ(tensors[1]->getData().uid, K_BN_BWD_TENSOR_X_UID);
+    EXPECT_EQ(tensors[2]->getData().uid, K_BN_BWD_TENSOR_SCALE_UID);
+    EXPECT_EQ(tensors[3]->getData().uid, K_BN_BWD_TENSOR_DX_UID);
+    EXPECT_EQ(tensors[4]->getData().uid, K_BN_BWD_TENSOR_DSCALE_UID);
+    EXPECT_EQ(tensors[5]->getData().uid, K_BN_BWD_TENSOR_DBIAS_UID);
+}

--- a/projects/hipdnn/backend/tests/descriptors/TestGraphDescriptorBatchnormBackward.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestGraphDescriptorBatchnormBackward.cpp
@@ -389,6 +389,12 @@ TEST_F(TestGraphDescriptorBatchnormBackward, OperationNameRoundTripThroughLiftin
     EXPECT_EQ(attrs->dx_tensor_uid, 63);
     EXPECT_EQ(attrs->dscale_tensor_uid, 64);
     EXPECT_EQ(attrs->dbias_tensor_uid, 65);
+
+    // Verify optional tensor UIDs survived
+    ASSERT_TRUE(attrs->mean_tensor_uid.has_value());
+    EXPECT_EQ(attrs->mean_tensor_uid.value(), 7);
+    ASSERT_TRUE(attrs->inv_variance_tensor_uid.has_value());
+    EXPECT_EQ(attrs->inv_variance_tensor_uid.value(), 8);
 }
 
 } // namespace

--- a/projects/hipdnn/backend/tests/descriptors/TestGraphDescriptorBatchnormBackward.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestGraphDescriptorBatchnormBackward.cpp
@@ -19,8 +19,10 @@
 #include <hipdnn_test_sdk/utilities/ToVec.hpp>
 
 #include <array>
+#include <cstdint>
 #include <memory>
 #include <set>
+#include <string>
 #include <vector>
 
 using namespace hipdnn_backend;
@@ -40,7 +42,8 @@ inline std::unique_ptr<HipdnnBackendDescriptor>
                                        HipdnnBackendDescriptor* meanDesc,
                                        HipdnnBackendDescriptor* invVarianceDesc,
                                        hipdnnDataType_t computeType = HIPDNN_DATA_FLOAT,
-                                       std::vector<HipdnnBackendDescriptor*> peerStatsDescs = {})
+                                       std::vector<HipdnnBackendDescriptor*> peerStatsDescs = {},
+                                       const std::string& name = "")
 {
     auto wrapper = createDescriptor<BatchnormBackwardOperationDescriptor>();
     auto desc = wrapper->asDescriptor<BatchnormBackwardOperationDescriptor>();
@@ -86,6 +89,14 @@ inline std::unique_ptr<HipdnnBackendDescriptor>
                            HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                            static_cast<int64_t>(peerStatsDescs.size()),
                            static_cast<const void*>(peerStatsDescs.data()));
+    }
+
+    if(!name.empty())
+    {
+        desc->setAttribute(HIPDNN_ATTR_OPERATION_NAME_EXT,
+                           HIPDNN_TYPE_CHAR,
+                           static_cast<int64_t>(name.size()),
+                           name.c_str());
     }
 
     desc->finalize();
@@ -272,6 +283,112 @@ TEST_F(TestGraphDescriptorBatchnormBackward, BuildWithPeerStatsTensorArray)
     ASSERT_EQ(attrs->peer_stats_tensor_uid.size(), 2u);
     EXPECT_EQ(attrs->peer_stats_tensor_uid[0], 110);
     EXPECT_EQ(attrs->peer_stats_tensor_uid[1], 111);
+}
+
+TEST_F(TestGraphDescriptorBatchnormBackward, OperationNamePreservedInSerialization)
+{
+    auto dyDesc = createFinalizedTensor(60, {1, 64, 32, 32}, {65536, 1024, 32, 1});
+    auto xDesc = createFinalizedTensor(61, {1, 64, 32, 32}, {65536, 1024, 32, 1});
+    auto scaleDesc = createFinalizedTensor(62, {1, 64, 1, 1}, {64, 1, 1, 1});
+    auto dxDesc = createFinalizedTensor(63, {1, 64, 32, 32}, {65536, 1024, 32, 1});
+    auto dscaleDesc = createFinalizedTensor(64, {1, 64, 1, 1}, {64, 1, 1, 1});
+    auto dbiasDesc = createFinalizedTensor(65, {1, 64, 1, 1}, {64, 1, 1, 1});
+    auto meanDesc = createFinalizedTensor(7);
+    auto invVarianceDesc = createFinalizedTensor(8);
+    auto opDesc = createFinalizedBatchnormBackwardOp(dyDesc.get(),
+                                                     xDesc.get(),
+                                                     scaleDesc.get(),
+                                                     dxDesc.get(),
+                                                     dscaleDesc.get(),
+                                                     dbiasDesc.get(),
+                                                     meanDesc.get(),
+                                                     invVarianceDesc.get(),
+                                                     HIPDNN_DATA_FLOAT,
+                                                     {},
+                                                     "bn_bwd_train");
+
+    auto desc = getDescriptor();
+    setHandle();
+
+    std::array<HipdnnBackendDescriptor*, 1> ops = {opDesc.get()};
+    desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       static_cast<const void*>(ops.data()));
+    desc->finalize();
+
+    auto serialized = desc->getSerializedGraph();
+    auto graphT = UnPackGraph(serialized.ptr);
+
+    ASSERT_EQ(graphT->nodes.size(), 1u);
+    EXPECT_EQ(graphT->nodes[0]->name, "bn_bwd_train");
+}
+
+TEST_F(TestGraphDescriptorBatchnormBackward, OperationNameRoundTripThroughLifting)
+{
+    auto dyDesc = createFinalizedTensor(60, {1, 64, 32, 32}, {65536, 1024, 32, 1});
+    auto xDesc = createFinalizedTensor(61, {1, 64, 32, 32}, {65536, 1024, 32, 1});
+    auto scaleDesc = createFinalizedTensor(62, {1, 64, 1, 1}, {64, 1, 1, 1});
+    auto dxDesc = createFinalizedTensor(63, {1, 64, 32, 32}, {65536, 1024, 32, 1});
+    auto dscaleDesc = createFinalizedTensor(64, {1, 64, 1, 1}, {64, 1, 1, 1});
+    auto dbiasDesc = createFinalizedTensor(65, {1, 64, 1, 1}, {64, 1, 1, 1});
+    auto meanDesc = createFinalizedTensor(7);
+    auto invVarianceDesc = createFinalizedTensor(8);
+    auto opDesc = createFinalizedBatchnormBackwardOp(dyDesc.get(),
+                                                     xDesc.get(),
+                                                     scaleDesc.get(),
+                                                     dxDesc.get(),
+                                                     dscaleDesc.get(),
+                                                     dbiasDesc.get(),
+                                                     meanDesc.get(),
+                                                     invVarianceDesc.get(),
+                                                     HIPDNN_DATA_FLOAT,
+                                                     {},
+                                                     "bn_bwd_train");
+
+    auto desc = getDescriptor();
+    setHandle();
+
+    std::array<HipdnnBackendDescriptor*, 1> ops = {opDesc.get()};
+    desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       static_cast<const void*>(ops.data()));
+    desc->finalize();
+
+    // Serialize the graph
+    auto serialized = desc->getSerializedGraph();
+    std::vector<uint8_t> bytes(static_cast<const uint8_t*>(serialized.ptr),
+                               static_cast<const uint8_t*>(serialized.ptr) + serialized.size);
+
+    // Deserialize into a new GraphDescriptor (lifting path)
+    auto liftedWrapper = createDescriptor<GraphDescriptor>();
+    auto liftedDesc = liftedWrapper->asDescriptor<GraphDescriptor>();
+    liftedDesc->deserializeGraph(bytes.data(), bytes.size());
+
+    hipdnnHandle_t handle = &_mockHandle;
+    liftedDesc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE,
+                             HIPDNN_TYPE_HANDLE,
+                             1,
+                             static_cast<const void*>(&handle));
+    liftedDesc->finalize();
+
+    // Re-serialize and verify name survived the round-trip
+    auto reSerialized = liftedDesc->getSerializedGraph();
+    auto graphT = UnPackGraph(reSerialized.ptr);
+
+    ASSERT_EQ(graphT->nodes.size(), 1u);
+    EXPECT_EQ(graphT->nodes[0]->name, "bn_bwd_train");
+
+    // Verify all tensor UIDs survived
+    auto* attrs = graphT->nodes[0]->attributes.AsBatchnormBackwardAttributes();
+    ASSERT_NE(attrs, nullptr);
+    EXPECT_EQ(attrs->dy_tensor_uid, 60);
+    EXPECT_EQ(attrs->x_tensor_uid, 61);
+    EXPECT_EQ(attrs->scale_tensor_uid, 62);
+    EXPECT_EQ(attrs->dx_tensor_uid, 63);
+    EXPECT_EQ(attrs->dscale_tensor_uid, 64);
+    EXPECT_EQ(attrs->dbias_tensor_uid, 65);
 }
 
 } // namespace

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/detail/BatchnormBackwardPacker.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/detail/BatchnormBackwardPacker.hpp
@@ -96,6 +96,14 @@ inline Error createBatchnormBackwardOperation(
         }
     }
 
+    // Set operation name if provided
+    auto& opName = attributes.get_name();
+    if(!opName.empty())
+    {
+        HIPDNN_CHECK_ERROR(setDescriptorAttrString(
+            opDesc.get(), HIPDNN_ATTR_OPERATION_NAME_EXT, opName, "operation name"));
+    }
+
     // Finalize operation descriptor
     HIPDNN_CHECK_ERROR(finalizeDescriptor(opDesc.get(), "batchnorm backward operation descriptor"));
 

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/detail/BatchnormBackwardUnpacker.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/detail/BatchnormBackwardUnpacker.hpp
@@ -1,0 +1,160 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <hipdnn_frontend/Types.hpp>
+#include <hipdnn_frontend/attributes/BatchnormBackwardAttributes.hpp>
+#include <hipdnn_frontend/detail/DescriptorUnpackHelpers.hpp>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+namespace hipdnn_frontend::detail
+{
+
+/// Unpacks a batchnorm backward operation from a backend operation descriptor.
+/// Populates the BatchnormBackwardAttributes with tensors (using tensorMap for sharing)
+/// and compute data type.
+[[nodiscard]] inline Error unpackBatchnormBackwardOperation(
+    hipdnnBackendDescriptor_t opDesc,
+    std::unordered_map<int64_t, std::shared_ptr<graph::TensorAttributes>>& tensorMap,
+    graph::BatchnormBackwardAttributes& attributes)
+{
+    // Unpack required tensors
+    std::shared_ptr<graph::TensorAttributes> dyTensor;
+    HIPDNN_CHECK_ERROR(unpackAndRegisterTensor(opDesc,
+                                               HIPDNN_ATTR_OPERATION_BATCHNORM_BACKWARD_DY_EXT,
+                                               tensorMap,
+                                               dyTensor,
+                                               "batchnorm backward DY tensor"));
+    attributes.set_dy(dyTensor);
+
+    std::shared_ptr<graph::TensorAttributes> xTensor;
+    HIPDNN_CHECK_ERROR(unpackAndRegisterTensor(opDesc,
+                                               HIPDNN_ATTR_OPERATION_BATCHNORM_BACKWARD_X_EXT,
+                                               tensorMap,
+                                               xTensor,
+                                               "batchnorm backward X tensor"));
+    attributes.set_x(xTensor);
+
+    std::shared_ptr<graph::TensorAttributes> scaleTensor;
+    HIPDNN_CHECK_ERROR(unpackAndRegisterTensor(opDesc,
+                                               HIPDNN_ATTR_OPERATION_BATCHNORM_BACKWARD_SCALE_EXT,
+                                               tensorMap,
+                                               scaleTensor,
+                                               "batchnorm backward Scale tensor"));
+    attributes.set_scale(scaleTensor);
+
+    std::shared_ptr<graph::TensorAttributes> dxTensor;
+    HIPDNN_CHECK_ERROR(unpackAndRegisterTensor(opDesc,
+                                               HIPDNN_ATTR_OPERATION_BATCHNORM_BACKWARD_DX_EXT,
+                                               tensorMap,
+                                               dxTensor,
+                                               "batchnorm backward DX tensor"));
+    attributes.set_dx(dxTensor);
+
+    std::shared_ptr<graph::TensorAttributes> dscaleTensor;
+    HIPDNN_CHECK_ERROR(unpackAndRegisterTensor(opDesc,
+                                               HIPDNN_ATTR_OPERATION_BATCHNORM_BACKWARD_DSCALE_EXT,
+                                               tensorMap,
+                                               dscaleTensor,
+                                               "batchnorm backward DScale tensor"));
+    attributes.set_dscale(dscaleTensor);
+
+    std::shared_ptr<graph::TensorAttributes> dbiasTensor;
+    HIPDNN_CHECK_ERROR(unpackAndRegisterTensor(opDesc,
+                                               HIPDNN_ATTR_OPERATION_BATCHNORM_BACKWARD_DBIAS_EXT,
+                                               tensorMap,
+                                               dbiasTensor,
+                                               "batchnorm backward DBias tensor"));
+    attributes.set_dbias(dbiasTensor);
+
+    // Unpack optional tensors
+    std::shared_ptr<graph::TensorAttributes> meanTensor;
+    HIPDNN_CHECK_ERROR(unpackOptionalTensor(opDesc,
+                                            HIPDNN_ATTR_OPERATION_BATCHNORM_BACKWARD_MEAN_EXT,
+                                            tensorMap,
+                                            meanTensor,
+                                            "batchnorm backward Mean tensor"));
+    if(meanTensor)
+    {
+        attributes.set_mean(meanTensor);
+    }
+
+    std::shared_ptr<graph::TensorAttributes> invVarianceTensor;
+    HIPDNN_CHECK_ERROR(
+        unpackOptionalTensor(opDesc,
+                             HIPDNN_ATTR_OPERATION_BATCHNORM_BACKWARD_INV_VARIANCE_EXT,
+                             tensorMap,
+                             invVarianceTensor,
+                             "batchnorm backward InvVariance tensor"));
+    if(invVarianceTensor)
+    {
+        attributes.set_inv_variance(invVarianceTensor);
+    }
+
+    // Unpack peer_stats tensor array
+    auto [peerStatsDescs, peerStatsErr]
+        = getDescriptorAttrDescArray(opDesc,
+                                     HIPDNN_ATTR_OPERATION_BATCHNORM_BACKWARD_PEER_STATS_EXT,
+                                     "batchnorm backward peer_stats tensors");
+    if(peerStatsErr.is_bad())
+    {
+        return peerStatsErr;
+    }
+    if(!peerStatsDescs.empty())
+    {
+        std::vector<std::shared_ptr<graph::TensorAttributes>> peerStatsTensors;
+        peerStatsTensors.reserve(peerStatsDescs.size());
+        for(auto& scopedDesc : peerStatsDescs)
+        {
+            if(scopedDesc.get() == nullptr)
+            {
+                continue;
+            }
+
+            // Read UID to check if tensor already exists in map
+            int64_t uid = 0;
+            HIPDNN_CHECK_ERROR(getDescriptorAttrScalar(scopedDesc.get(),
+                                                       HIPDNN_ATTR_TENSOR_UNIQUE_ID,
+                                                       HIPDNN_TYPE_INT64,
+                                                       uid,
+                                                       "peer_stats tensor UID"));
+
+            auto it = tensorMap.find(uid);
+            if(it != tensorMap.end())
+            {
+                peerStatsTensors.push_back(it->second);
+            }
+            else
+            {
+                std::shared_ptr<graph::TensorAttributes> tensor;
+                HIPDNN_CHECK_ERROR(unpackTensorAttributes(scopedDesc.get(), tensor));
+                tensorMap[uid] = tensor;
+                peerStatsTensors.push_back(std::move(tensor));
+            }
+        }
+        attributes.set_peer_stats(std::move(peerStatsTensors));
+    }
+
+    // Unpack compute data type
+    auto [dt, dtErr] = unpackGraphDataType(opDesc,
+                                           HIPDNN_ATTR_BATCHNORM_BACKWARD_COMP_TYPE_EXT,
+                                           "batchnorm backward compute data type");
+    if(dtErr.is_bad())
+    {
+        return dtErr;
+    }
+    attributes.set_compute_data_type(dt);
+
+    // Unpack operation name
+    std::string opName;
+    HIPDNN_CHECK_ERROR(
+        getDescriptorAttrString(opDesc, HIPDNN_ATTR_OPERATION_NAME_EXT, opName, "operation name"));
+    attributes.set_name(opName);
+
+    return {};
+}
+
+} // namespace hipdnn_frontend::detail

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/detail/BatchnormBackwardUnpacker.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/detail/BatchnormBackwardUnpacker.hpp
@@ -95,46 +95,15 @@ namespace hipdnn_frontend::detail
     }
 
     // Unpack peer_stats tensor array
-    auto [peerStatsDescs, peerStatsErr]
-        = getDescriptorAttrDescArray(opDesc,
+    std::vector<std::shared_ptr<graph::TensorAttributes>> peerStatsTensors;
+    HIPDNN_CHECK_ERROR(
+        unpackAndRegisterTensorArray(opDesc,
                                      HIPDNN_ATTR_OPERATION_BATCHNORM_BACKWARD_PEER_STATS_EXT,
-                                     "batchnorm backward peer_stats tensors");
-    if(peerStatsErr.is_bad())
+                                     tensorMap,
+                                     peerStatsTensors,
+                                     "batchnorm backward peer_stats tensors"));
+    if(!peerStatsTensors.empty())
     {
-        return peerStatsErr;
-    }
-    if(!peerStatsDescs.empty())
-    {
-        std::vector<std::shared_ptr<graph::TensorAttributes>> peerStatsTensors;
-        peerStatsTensors.reserve(peerStatsDescs.size());
-        for(auto& scopedDesc : peerStatsDescs)
-        {
-            if(scopedDesc.get() == nullptr)
-            {
-                continue;
-            }
-
-            // Read UID to check if tensor already exists in map
-            int64_t uid = 0;
-            HIPDNN_CHECK_ERROR(getDescriptorAttrScalar(scopedDesc.get(),
-                                                       HIPDNN_ATTR_TENSOR_UNIQUE_ID,
-                                                       HIPDNN_TYPE_INT64,
-                                                       uid,
-                                                       "peer_stats tensor UID"));
-
-            auto it = tensorMap.find(uid);
-            if(it != tensorMap.end())
-            {
-                peerStatsTensors.push_back(it->second);
-            }
-            else
-            {
-                std::shared_ptr<graph::TensorAttributes> tensor;
-                HIPDNN_CHECK_ERROR(unpackTensorAttributes(scopedDesc.get(), tensor));
-                tensorMap[uid] = tensor;
-                peerStatsTensors.push_back(std::move(tensor));
-            }
-        }
         attributes.set_peer_stats(std::move(peerStatsTensors));
     }
 

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/detail/BatchnormUnpacker.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/detail/BatchnormUnpacker.hpp
@@ -137,44 +137,14 @@ namespace hipdnn_frontend::detail
     }
 
     // Unpack peer_stats tensor array
-    auto [peerStatsDescs, peerStatsErr] = getDescriptorAttrDescArray(
-        opDesc, HIPDNN_ATTR_OPERATION_BATCHNORM_PEER_STATS_EXT, "batchnorm peer_stats tensors");
-    if(peerStatsErr.is_bad())
+    std::vector<std::shared_ptr<graph::TensorAttributes>> peerStatsTensors;
+    HIPDNN_CHECK_ERROR(unpackAndRegisterTensorArray(opDesc,
+                                                    HIPDNN_ATTR_OPERATION_BATCHNORM_PEER_STATS_EXT,
+                                                    tensorMap,
+                                                    peerStatsTensors,
+                                                    "batchnorm peer_stats tensors"));
+    if(!peerStatsTensors.empty())
     {
-        return peerStatsErr;
-    }
-    if(!peerStatsDescs.empty())
-    {
-        std::vector<std::shared_ptr<graph::TensorAttributes>> peerStatsTensors;
-        peerStatsTensors.reserve(peerStatsDescs.size());
-        for(auto& scopedDesc : peerStatsDescs)
-        {
-            if(scopedDesc.get() == nullptr)
-            {
-                continue;
-            }
-
-            // Read UID to check if tensor already exists in map
-            int64_t uid = 0;
-            HIPDNN_CHECK_ERROR(getDescriptorAttrScalar(scopedDesc.get(),
-                                                       HIPDNN_ATTR_TENSOR_UNIQUE_ID,
-                                                       HIPDNN_TYPE_INT64,
-                                                       uid,
-                                                       "peer_stats tensor UID"));
-
-            auto it = tensorMap.find(uid);
-            if(it != tensorMap.end())
-            {
-                peerStatsTensors.push_back(it->second);
-            }
-            else
-            {
-                std::shared_ptr<graph::TensorAttributes> tensor;
-                HIPDNN_CHECK_ERROR(unpackTensorAttributes(scopedDesc.get(), tensor));
-                tensorMap[uid] = tensor;
-                peerStatsTensors.push_back(std::move(tensor));
-            }
-        }
         attributes.set_peer_stats(std::move(peerStatsTensors));
     }
 

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/detail/DescriptorUnpackHelpers.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/detail/DescriptorUnpackHelpers.hpp
@@ -525,10 +525,10 @@ template <typename T>
     std::vector<std::shared_ptr<graph::TensorAttributes>>& outTensors,
     const std::string& errorContext)
 {
-    auto [descs, err] = getDescriptorAttrDescArray(opDesc, tensorAttrName, errorContext);
-    if(err.is_bad())
+    auto [descs, descErr] = getDescriptorAttrDescArray(opDesc, tensorAttrName, errorContext);
+    if(descErr.is_bad())
     {
-        return err;
+        return descErr;
     }
 
     outTensors.clear();

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/detail/DescriptorUnpackHelpers.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/detail/DescriptorUnpackHelpers.hpp
@@ -515,4 +515,53 @@ template <typename T>
     return {};
 }
 
+/// Unpacks a tensor array attribute from an operation descriptor, deduplicating
+/// against the tensor map. Each tensor is either found in the map (shared) or
+/// unpacked fresh and registered.
+[[nodiscard]] inline Error unpackAndRegisterTensorArray(
+    hipdnnBackendDescriptor_t opDesc,
+    hipdnnBackendAttributeName_t tensorAttrName,
+    std::unordered_map<int64_t, std::shared_ptr<graph::TensorAttributes>>& tensorMap,
+    std::vector<std::shared_ptr<graph::TensorAttributes>>& outTensors,
+    const std::string& errorContext)
+{
+    auto [descs, err] = getDescriptorAttrDescArray(opDesc, tensorAttrName, errorContext);
+    if(err.is_bad())
+    {
+        return err;
+    }
+
+    outTensors.clear();
+    outTensors.reserve(descs.size());
+    for(auto& scopedDesc : descs)
+    {
+        if(scopedDesc.get() == nullptr)
+        {
+            continue;
+        }
+
+        int64_t uid = 0;
+        HIPDNN_CHECK_ERROR(getDescriptorAttrScalar(scopedDesc.get(),
+                                                   HIPDNN_ATTR_TENSOR_UNIQUE_ID,
+                                                   HIPDNN_TYPE_INT64,
+                                                   uid,
+                                                   errorContext + " tensor UID"));
+
+        auto it = tensorMap.find(uid);
+        if(it != tensorMap.end())
+        {
+            outTensors.push_back(it->second);
+        }
+        else
+        {
+            std::shared_ptr<graph::TensorAttributes> tensor;
+            HIPDNN_CHECK_ERROR(unpackTensorAttributes(scopedDesc.get(), tensor));
+            tensorMap[uid] = tensor;
+            outTensors.push_back(std::move(tensor));
+        }
+    }
+
+    return {};
+}
+
 } // namespace hipdnn_frontend::detail

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/detail/OperationUnpacker.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/detail/OperationUnpacker.hpp
@@ -9,8 +9,7 @@
 #include <hipdnn_frontend/attributes/GraphAttributes.hpp>
 #include <hipdnn_frontend/attributes/TensorAttributes.hpp>
 #include <hipdnn_frontend/detail/BackendWrapper.hpp>
-// Uncomment when unpack_from_descriptor() is implemented in the lifting PR:
-// #include <hipdnn_frontend/node/BatchnormBackwardNode.hpp>
+#include <hipdnn_frontend/node/BatchnormBackwardNode.hpp>
 // #include <hipdnn_frontend/node/BatchnormInferenceNode.hpp>
 // #include <hipdnn_frontend/node/BatchnormInferenceNodeVarianceExt.hpp>
 #include <hipdnn_frontend/node/BatchnormNode.hpp>
@@ -72,11 +71,10 @@ namespace hipdnn_frontend::detail
     case HIPDNN_OPERATION_TYPE_BATCHNORM:
         return {std::make_shared<graph::BatchnormNode>(graph::BatchnormAttributes{}, graphAttrs),
                 {}};
-    // Uncomment when unpack_from_descriptor() is implemented in the lifting PR:
-    // case HIPDNN_OPERATION_TYPE_BATCHNORM_BACKWARD:
-    //     return {std::make_shared<graph::BatchnormBackwardNode>(
-    //                 graph::BatchnormBackwardAttributes{}, graphAttrs),
-    //             {}};
+    case HIPDNN_OPERATION_TYPE_BATCHNORM_BACKWARD:
+        return {std::make_shared<graph::BatchnormBackwardNode>(graph::BatchnormBackwardAttributes{},
+                                                               graphAttrs),
+                {}};
     // case HIPDNN_OPERATION_TYPE_BATCHNORM_INFERENCE:
     //     return {std::make_shared<graph::BatchnormInferenceNode>(
     //                 graph::BatchnormInferenceAttributes{}, graphAttrs),

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/node/BatchnormBackwardNode.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/node/BatchnormBackwardNode.hpp
@@ -9,6 +9,7 @@
 #include <hipdnn_frontend/attributes/BatchnormBackwardAttributes.hpp>
 #include <hipdnn_frontend/attributes/GraphAttributes.hpp>
 #include <hipdnn_frontend/detail/BatchnormBackwardPacker.hpp>
+#include <hipdnn_frontend/detail/BatchnormBackwardUnpacker.hpp>
 #include <hipdnn_frontend/node/detail/Utilities.hpp>
 
 namespace hipdnn_frontend::graph
@@ -24,6 +25,16 @@ public:
         : BaseNode(graphAttrs)
         , attributes(std::move(batchnormAttrs))
     {
+    }
+
+    Error unpack_from_descriptor(
+        hipdnnBackendDescriptor_t opDesc,
+        std::unordered_map<int64_t, std::shared_ptr<TensorAttributes>>& tensorMap) override
+    {
+        BatchnormBackwardAttributes attrs;
+        HIPDNN_CHECK_ERROR(detail::unpackBatchnormBackwardOperation(opDesc, tensorMap, attrs));
+        attributes = std::move(attrs);
+        return {};
     }
 
     Error pre_validate_node() const override

--- a/projects/hipdnn/frontend/tests/TestBatchnormBackwardNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestBatchnormBackwardNode.cpp
@@ -821,6 +821,75 @@ TEST(TestBatchnormBackwardNode, PreValidateRejectsInvalid5DSpatialDimensions)
                 != std::string::npos);
 }
 
+TEST(TestBatchnormBackwardNode, PackNodePreservesName)
+{
+    BatchnormBackwardAttributes batchnormAttributes;
+    batchnormAttributes.set_name("bn_bwd_custom_name");
+
+    auto dyTensor = std::make_shared<TensorAttributes>();
+    dyTensor->set_uid(1)
+        .set_name("DyTensor")
+        .set_data_type(DataType::FLOAT)
+        .set_dim({1, 2, 3, 4})
+        .set_stride({4, 3, 2, 1});
+    batchnormAttributes.set_dy(dyTensor);
+
+    auto xTensor = std::make_shared<TensorAttributes>();
+    xTensor->set_uid(2)
+        .set_name("XTensor")
+        .set_data_type(DataType::FLOAT)
+        .set_dim({1, 2, 3, 4})
+        .set_stride({4, 3, 2, 1});
+    batchnormAttributes.set_x(xTensor);
+
+    auto scaleTensor = std::make_shared<TensorAttributes>();
+    scaleTensor->set_uid(3)
+        .set_name("ScaleTensor")
+        .set_data_type(DataType::FLOAT)
+        .set_dim({1, 2, 1, 1})
+        .set_stride({2, 1, 1, 1});
+    batchnormAttributes.set_scale(scaleTensor);
+
+    auto dxTensor = std::make_shared<TensorAttributes>();
+    dxTensor->set_uid(4)
+        .set_name("DxTensor")
+        .set_data_type(DataType::FLOAT)
+        .set_dim({1, 2, 3, 4})
+        .set_stride({4, 3, 2, 1});
+    batchnormAttributes.set_dx(dxTensor);
+
+    auto dscaleTensor = std::make_shared<TensorAttributes>();
+    dscaleTensor->set_uid(5)
+        .set_name("DscaleTensor")
+        .set_data_type(DataType::FLOAT)
+        .set_dim({1, 2, 1, 1})
+        .set_stride({2, 1, 1, 1});
+    batchnormAttributes.set_dscale(dscaleTensor);
+
+    auto dbiasTensor = std::make_shared<TensorAttributes>();
+    dbiasTensor->set_uid(6)
+        .set_name("DbiasTensor")
+        .set_data_type(DataType::FLOAT)
+        .set_dim({1, 2, 1, 1})
+        .set_stride({2, 1, 1, 1});
+    batchnormAttributes.set_dbias(dbiasTensor);
+
+    const GraphAttributes graphAttributes;
+    const BatchnormBackwardNode node(std::move(batchnormAttributes), graphAttributes);
+
+    flatbuffers::FlatBufferBuilder builder;
+    auto offset = node.pack_node(builder);
+    EXPECT_NE(offset.o, 0);
+
+    builder.Finish(offset);
+    auto bufferPointer = builder.GetBufferPointer();
+    auto nodeFlatbuffer = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Node>(bufferPointer);
+
+    EXPECT_STREQ(nodeFlatbuffer->name()->c_str(), "bn_bwd_custom_name");
+    EXPECT_EQ(nodeFlatbuffer->attributes_type(),
+              hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes);
+}
+
 TEST(TestBatchnormBackwardNode, GetNodeTypeReturnsBatchnormBackward)
 {
     const GraphAttributes graphAttrs;

--- a/projects/hipdnn/frontend/tests/TestOperationUnpacker.cpp
+++ b/projects/hipdnn/frontend/tests/TestOperationUnpacker.cpp
@@ -9,8 +9,7 @@
 #include <string>
 
 #include <hipdnn_frontend/detail/OperationUnpacker.hpp>
-// Uncomment when unpack_from_descriptor() is implemented in the lifting PR:
-// #include <hipdnn_frontend/node/BatchnormBackwardNode.hpp>
+#include <hipdnn_frontend/node/BatchnormBackwardNode.hpp>
 // #include <hipdnn_frontend/node/BatchnormInferenceNode.hpp>
 // #include <hipdnn_frontend/node/BatchnormInferenceNodeVarianceExt.hpp>
 #include <hipdnn_frontend/node/BatchnormNode.hpp>
@@ -262,7 +261,6 @@ TEST_F(TestUnpackOperation, FailsImmediatelyOnUnpackError)
 // createNodeForType tests
 // ---------------------------------------------------------------------------
 
-// Uncomment when unpack_from_descriptor() is implemented in the lifting PR:
 TEST(TestCreateNodeForType, CreatesBatchnormNode)
 {
     const GraphAttributes graphAttrs;
@@ -273,15 +271,15 @@ TEST(TestCreateNodeForType, CreatesBatchnormNode)
     EXPECT_NE(typedNode, nullptr);
 }
 
-// TEST(TestCreateNodeForType, CreatesBatchnormBackwardNode)
-// {
-//     const GraphAttributes graphAttrs;
-//     auto [node, err] = createNodeForType(HIPDNN_OPERATION_TYPE_BATCHNORM_BACKWARD, graphAttrs);
-//     EXPECT_EQ(err.code, ErrorCode::OK);
-//     ASSERT_NE(node, nullptr);
-//     auto typedNode = std::dynamic_pointer_cast<BatchnormBackwardNode>(node);
-//     EXPECT_NE(typedNode, nullptr);
-// }
+TEST(TestCreateNodeForType, CreatesBatchnormBackwardNode)
+{
+    const GraphAttributes graphAttrs;
+    auto [node, err] = createNodeForType(HIPDNN_OPERATION_TYPE_BATCHNORM_BACKWARD, graphAttrs);
+    EXPECT_EQ(err.code, ErrorCode::OK);
+    ASSERT_NE(node, nullptr);
+    auto typedNode = std::dynamic_pointer_cast<BatchnormBackwardNode>(node);
+    EXPECT_NE(typedNode, nullptr);
+}
 
 // TEST(TestCreateNodeForType, CreatesBatchnormInferenceNode)
 // {

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/constants/BatchnormBackwardConstants.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/constants/BatchnormBackwardConstants.hpp
@@ -1,0 +1,95 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+namespace hipdnn_tests::constants
+{
+
+// Standard batchnorm backward constants for testing.
+// Represents: BatchNormBackward(DY[1, 64, 32, 32], X[1, 64, 32, 32], Scale[1, 64, 1, 1])
+// Output: DX[1, 64, 32, 32], DScale[1, 64, 1, 1], DBias[1, 64, 1, 1]
+// Optional: Mean[1, 64, 1, 1], InvVariance[1, 64, 1, 1]
+
+// -- Required tensors --
+
+constexpr int64_t K_BN_BWD_TENSOR_DY_UID = 60;
+constexpr std::array<int64_t, 4> K_BN_BWD_TENSOR_DY_DIMS = {1, 64, 32, 32};
+constexpr std::array<int64_t, 4> K_BN_BWD_TENSOR_DY_STRIDES = {65536, 1024, 32, 1};
+
+constexpr int64_t K_BN_BWD_TENSOR_X_UID = 61;
+constexpr std::array<int64_t, 4> K_BN_BWD_TENSOR_X_DIMS = {1, 64, 32, 32};
+constexpr std::array<int64_t, 4> K_BN_BWD_TENSOR_X_STRIDES = {65536, 1024, 32, 1};
+
+constexpr int64_t K_BN_BWD_TENSOR_SCALE_UID = 62;
+constexpr std::array<int64_t, 4> K_BN_BWD_TENSOR_SCALE_DIMS = {1, 64, 1, 1};
+constexpr std::array<int64_t, 4> K_BN_BWD_TENSOR_SCALE_STRIDES = {64, 1, 1, 1};
+
+constexpr int64_t K_BN_BWD_TENSOR_DX_UID = 63;
+constexpr std::array<int64_t, 4> K_BN_BWD_TENSOR_DX_DIMS = {1, 64, 32, 32};
+constexpr std::array<int64_t, 4> K_BN_BWD_TENSOR_DX_STRIDES = {65536, 1024, 32, 1};
+
+constexpr int64_t K_BN_BWD_TENSOR_DSCALE_UID = 64;
+constexpr std::array<int64_t, 4> K_BN_BWD_TENSOR_DSCALE_DIMS = {1, 64, 1, 1};
+constexpr std::array<int64_t, 4> K_BN_BWD_TENSOR_DSCALE_STRIDES = {64, 1, 1, 1};
+
+constexpr int64_t K_BN_BWD_TENSOR_DBIAS_UID = 65;
+constexpr std::array<int64_t, 4> K_BN_BWD_TENSOR_DBIAS_DIMS = {1, 64, 1, 1};
+constexpr std::array<int64_t, 4> K_BN_BWD_TENSOR_DBIAS_STRIDES = {64, 1, 1, 1};
+
+// -- Optional tensors --
+
+constexpr int64_t K_BN_BWD_TENSOR_MEAN_UID = 66;
+constexpr std::array<int64_t, 4> K_BN_BWD_TENSOR_MEAN_DIMS = {1, 64, 1, 1};
+constexpr std::array<int64_t, 4> K_BN_BWD_TENSOR_MEAN_STRIDES = {64, 1, 1, 1};
+
+constexpr int64_t K_BN_BWD_TENSOR_INV_VARIANCE_UID = 67;
+constexpr std::array<int64_t, 4> K_BN_BWD_TENSOR_INV_VARIANCE_DIMS = {1, 64, 1, 1};
+constexpr std::array<int64_t, 4> K_BN_BWD_TENSOR_INV_VARIANCE_STRIDES = {64, 1, 1, 1};
+
+// -- Peer stats test UIDs --
+
+constexpr int64_t K_BN_BWD_TENSOR_PEER_STAT_0_UID = 110;
+constexpr int64_t K_BN_BWD_TENSOR_PEER_STAT_1_UID = 111;
+constexpr std::array<int64_t, 4> K_BN_BWD_TENSOR_PEER_STAT_DIMS = {1, 64, 1, 1};
+constexpr std::array<int64_t, 4> K_BN_BWD_TENSOR_PEER_STAT_STRIDES = {64, 1, 1, 1};
+
+// -- Integration test constants (full round-trip with all optional tensors) --
+
+constexpr int64_t K_BN_BWD_INTEG_TENSOR_DY_UID = 600;
+constexpr int64_t K_BN_BWD_INTEG_TENSOR_X_UID = 601;
+constexpr int64_t K_BN_BWD_INTEG_TENSOR_SCALE_UID = 602;
+constexpr int64_t K_BN_BWD_INTEG_TENSOR_DX_UID = 603;
+constexpr int64_t K_BN_BWD_INTEG_TENSOR_DSCALE_UID = 604;
+constexpr int64_t K_BN_BWD_INTEG_TENSOR_DBIAS_UID = 605;
+constexpr int64_t K_BN_BWD_INTEG_TENSOR_MEAN_UID = 606;
+constexpr int64_t K_BN_BWD_INTEG_TENSOR_INV_VARIANCE_UID = 607;
+
+// Shared dims for integration tests
+constexpr std::array<int64_t, 4> K_BN_BWD_INTEG_DATA_DIMS = {2, 64, 16, 16};
+constexpr std::array<int64_t, 4> K_BN_BWD_INTEG_DATA_STRIDES = {16384, 256, 16, 1};
+constexpr std::array<int64_t, 4> K_BN_BWD_INTEG_PARAM_DIMS = {1, 64, 1, 1};
+constexpr std::array<int64_t, 4> K_BN_BWD_INTEG_PARAM_STRIDES = {64, 1, 1, 1};
+
+// For MinimalRequired integration test (no optional tensors)
+constexpr int64_t K_BN_BWD_MINIMAL_TENSOR_DY_UID = 620;
+constexpr int64_t K_BN_BWD_MINIMAL_TENSOR_X_UID = 621;
+constexpr int64_t K_BN_BWD_MINIMAL_TENSOR_SCALE_UID = 622;
+constexpr int64_t K_BN_BWD_MINIMAL_TENSOR_DX_UID = 623;
+constexpr int64_t K_BN_BWD_MINIMAL_TENSOR_DSCALE_UID = 624;
+constexpr int64_t K_BN_BWD_MINIMAL_TENSOR_DBIAS_UID = 625;
+
+// For PeerStats integration test
+constexpr int64_t K_BN_BWD_INTEG_TENSOR_PEER_STAT_0_UID = 650;
+constexpr int64_t K_BN_BWD_INTEG_TENSOR_PEER_STAT_1_UID = 651;
+
+// Distinct dims for AutoAssignedUids integration test
+constexpr std::array<int64_t, 4> K_BN_BWD_AUTO_DATA_DIMS = {4, 32, 8, 8};
+constexpr std::array<int64_t, 4> K_BN_BWD_AUTO_DATA_STRIDES = {2048, 64, 8, 1};
+constexpr std::array<int64_t, 4> K_BN_BWD_AUTO_PARAM_DIMS = {1, 32, 1, 1};
+constexpr std::array<int64_t, 4> K_BN_BWD_AUTO_PARAM_STRIDES = {32, 1, 1, 1};
+
+} // namespace hipdnn_tests::constants

--- a/projects/hipdnn/tests/frontend/CMakeLists.txt
+++ b/projects/hipdnn/tests/frontend/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(Threads REQUIRED)
 add_executable(
     hipdnn_public_frontend_tests
     main.cpp
+    IntegrationBatchnormBackwardDescriptorLifting.cpp
     IntegrationBatchnormBackwardDescriptorLowering.cpp
     IntegrationBatchnormDescriptorLifting.cpp
     IntegrationBatchnormDescriptorLowering.cpp

--- a/projects/hipdnn/tests/frontend/IntegrationBatchnormBackwardDescriptorLifting.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationBatchnormBackwardDescriptorLifting.cpp
@@ -1,0 +1,419 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <algorithm>
+#include <gtest/gtest.h>
+#include <hip/hip_runtime.h>
+#include <memory>
+#include <vector>
+
+#include <hipdnn_frontend.hpp>
+#include <hipdnn_frontend/detail/ScopedHipdnnBackendDescriptor.hpp>
+#include <hipdnn_frontend/node/BatchnormBackwardNode.hpp>
+#include <hipdnn_test_sdk/constants/BatchnormBackwardConstants.hpp>
+#include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
+#include <hipdnn_test_sdk/utilities/ToVec.hpp>
+
+#include "test_plugins/TestPluginConstants.hpp"
+
+using namespace hipdnn_frontend;
+using namespace hipdnn_frontend::graph;
+using hipdnn_tests::toVec;
+using namespace hipdnn_tests::constants;
+
+namespace
+{
+
+// Exposes protected Graph methods for testing
+class TestableGraph : public Graph
+{
+public:
+    using Graph::build_operation_graph;
+    using Graph::deserialize_via_backend;
+    using Graph::get_raw_graph_descriptor;
+
+    const std::vector<std::shared_ptr<INode>>& getSubNodes() const
+    {
+        return _sub_nodes;
+    }
+};
+
+class IntegrationBatchnormBackwardDescriptorLifting : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        SKIP_IF_NO_DEVICES();
+
+        ASSERT_EQ(hipInit(0), hipSuccess);
+
+        const std::array<const char*, 1> paths
+            = {hipdnn_tests::plugin_constants::testGoodPluginPath().c_str()};
+        ASSERT_EQ(hipdnnSetEnginePluginPaths_ext(
+                      paths.size(), paths.data(), HIPDNN_PLUGIN_LOADING_ABSOLUTE),
+                  HIPDNN_STATUS_SUCCESS);
+
+        ASSERT_EQ(hipdnnCreate(&_handle), HIPDNN_STATUS_SUCCESS);
+    }
+
+    void TearDown() override
+    {
+        if(_handle != nullptr)
+        {
+            hipdnnDestroy(_handle);
+        }
+    }
+
+    // Builds a batchnorm backward graph with optional mean/invVariance for round-trip testing
+    static std::shared_ptr<TestableGraph> buildBatchnormBackwardGraph()
+    {
+        auto graph = std::make_shared<TestableGraph>();
+        graph->set_name("BnBwdLiftingTestGraph")
+            .set_compute_data_type(DataType::FLOAT)
+            .set_intermediate_data_type(DataType::FLOAT)
+            .set_io_data_type(DataType::FLOAT);
+
+        auto dy = std::make_shared<TensorAttributes>();
+        dy->set_uid(K_BN_BWD_INTEG_TENSOR_DY_UID).set_name("DY").set_data_type(DataType::FLOAT);
+        dy->set_dim(toVec(K_BN_BWD_INTEG_DATA_DIMS)).set_stride(toVec(K_BN_BWD_INTEG_DATA_STRIDES));
+
+        auto x = std::make_shared<TensorAttributes>();
+        x->set_uid(K_BN_BWD_INTEG_TENSOR_X_UID).set_name("X").set_data_type(DataType::FLOAT);
+        x->set_dim(toVec(K_BN_BWD_INTEG_DATA_DIMS)).set_stride(toVec(K_BN_BWD_INTEG_DATA_STRIDES));
+
+        auto scale = std::make_shared<TensorAttributes>();
+        scale->set_uid(K_BN_BWD_INTEG_TENSOR_SCALE_UID)
+            .set_name("Scale")
+            .set_data_type(DataType::FLOAT);
+        scale->set_dim(toVec(K_BN_BWD_INTEG_PARAM_DIMS))
+            .set_stride(toVec(K_BN_BWD_INTEG_PARAM_STRIDES));
+
+        auto mean = std::make_shared<TensorAttributes>();
+        mean->set_uid(K_BN_BWD_INTEG_TENSOR_MEAN_UID)
+            .set_name("Mean")
+            .set_data_type(DataType::FLOAT);
+        mean->set_dim(toVec(K_BN_BWD_INTEG_PARAM_DIMS))
+            .set_stride(toVec(K_BN_BWD_INTEG_PARAM_STRIDES));
+
+        auto invVar = std::make_shared<TensorAttributes>();
+        invVar->set_uid(K_BN_BWD_INTEG_TENSOR_INV_VARIANCE_UID)
+            .set_name("InvVariance")
+            .set_data_type(DataType::FLOAT);
+        invVar->set_dim(toVec(K_BN_BWD_INTEG_PARAM_DIMS))
+            .set_stride(toVec(K_BN_BWD_INTEG_PARAM_STRIDES));
+
+        BatchnormBackwardAttributes bnBwdAttrs;
+        bnBwdAttrs.set_name("bn_bwd_op");
+        bnBwdAttrs.set_saved_mean_and_inv_variance(mean, invVar);
+
+        auto [dxOut, dscaleOut, dbiasOut] = graph->batchnorm_backward(dy, x, scale, bnBwdAttrs);
+        dxOut->set_uid(K_BN_BWD_INTEG_TENSOR_DX_UID).set_output(true).set_name("DX");
+        dscaleOut->set_uid(K_BN_BWD_INTEG_TENSOR_DSCALE_UID).set_output(true).set_name("DScale");
+        dbiasOut->set_uid(K_BN_BWD_INTEG_TENSOR_DBIAS_UID).set_output(true).set_name("DBias");
+
+        return graph;
+    }
+
+    // Builds a minimal batchnorm backward graph (no optional mean/invVariance)
+    static std::shared_ptr<TestableGraph> buildMinimalBatchnormBackwardGraph()
+    {
+        auto graph = std::make_shared<TestableGraph>();
+        graph->set_name("MinimalBnBwdLiftingTestGraph")
+            .set_compute_data_type(DataType::FLOAT)
+            .set_intermediate_data_type(DataType::FLOAT)
+            .set_io_data_type(DataType::FLOAT);
+
+        auto dy = std::make_shared<TensorAttributes>();
+        dy->set_uid(K_BN_BWD_MINIMAL_TENSOR_DY_UID).set_name("DY").set_data_type(DataType::FLOAT);
+        dy->set_dim(toVec(K_BN_BWD_INTEG_DATA_DIMS)).set_stride(toVec(K_BN_BWD_INTEG_DATA_STRIDES));
+
+        auto x = std::make_shared<TensorAttributes>();
+        x->set_uid(K_BN_BWD_MINIMAL_TENSOR_X_UID).set_name("X").set_data_type(DataType::FLOAT);
+        x->set_dim(toVec(K_BN_BWD_INTEG_DATA_DIMS)).set_stride(toVec(K_BN_BWD_INTEG_DATA_STRIDES));
+
+        auto scale = std::make_shared<TensorAttributes>();
+        scale->set_uid(K_BN_BWD_MINIMAL_TENSOR_SCALE_UID)
+            .set_name("Scale")
+            .set_data_type(DataType::FLOAT);
+        scale->set_dim(toVec(K_BN_BWD_INTEG_PARAM_DIMS))
+            .set_stride(toVec(K_BN_BWD_INTEG_PARAM_STRIDES));
+
+        BatchnormBackwardAttributes bnBwdAttrs;
+        bnBwdAttrs.set_name("minimal_bn_bwd_op");
+
+        auto [dxOut, dscaleOut, dbiasOut] = graph->batchnorm_backward(dy, x, scale, bnBwdAttrs);
+        dxOut->set_uid(K_BN_BWD_MINIMAL_TENSOR_DX_UID).set_output(true).set_name("DX");
+        dscaleOut->set_uid(K_BN_BWD_MINIMAL_TENSOR_DSCALE_UID).set_output(true).set_name("DScale");
+        dbiasOut->set_uid(K_BN_BWD_MINIMAL_TENSOR_DBIAS_UID).set_output(true).set_name("DBias");
+
+        return graph;
+    }
+
+    hipdnnHandle_t _handle = nullptr;
+};
+
+// Builds a batchnorm backward graph with mean/invVariance, lowers via
+// build_operation_graph(handle), lifts back with fromBackendDescriptor(),
+// and validates all tensors and operation attributes.
+TEST_F(IntegrationBatchnormBackwardDescriptorLifting, BasicBatchnormBackwardRoundTrip)
+{
+    auto originalGraph = buildBatchnormBackwardGraph();
+
+    auto result = originalGraph->validate();
+    ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
+
+    result = originalGraph->build_operation_graph(_handle);
+    ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
+
+    auto rawDesc = originalGraph->get_raw_graph_descriptor();
+    ASSERT_NE(rawDesc, nullptr);
+
+    auto liftedGraph = std::make_shared<TestableGraph>();
+    result = liftedGraph->fromBackendDescriptor(rawDesc);
+    ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
+
+    // Verify graph-level data types
+    EXPECT_EQ(liftedGraph->get_compute_data_type(), DataType::FLOAT);
+    EXPECT_EQ(liftedGraph->get_intermediate_data_type(), DataType::FLOAT);
+    EXPECT_EQ(liftedGraph->get_io_data_type(), DataType::FLOAT);
+
+    // Verify tensors by UID
+    auto tensorMap = liftedGraph->getTensorsByUid();
+    // dy, x, scale, mean, invVar, dx, dscale, dbias = 8
+    ASSERT_EQ(tensorMap.size(), 8u) << "Expected 8 tensors in lifted graph";
+
+    // DY tensor
+    ASSERT_NE(tensorMap.count(K_BN_BWD_INTEG_TENSOR_DY_UID), 0u);
+    auto liftedDy = tensorMap[K_BN_BWD_INTEG_TENSOR_DY_UID];
+    EXPECT_EQ(liftedDy->get_uid(), K_BN_BWD_INTEG_TENSOR_DY_UID);
+    EXPECT_EQ(liftedDy->get_name(), "DY");
+    EXPECT_EQ(liftedDy->get_dim(), toVec(K_BN_BWD_INTEG_DATA_DIMS));
+    EXPECT_EQ(liftedDy->get_stride(), toVec(K_BN_BWD_INTEG_DATA_STRIDES));
+    EXPECT_EQ(liftedDy->get_data_type(), DataType::FLOAT);
+
+    // X tensor
+    ASSERT_NE(tensorMap.count(K_BN_BWD_INTEG_TENSOR_X_UID), 0u);
+    auto liftedX = tensorMap[K_BN_BWD_INTEG_TENSOR_X_UID];
+    EXPECT_EQ(liftedX->get_uid(), K_BN_BWD_INTEG_TENSOR_X_UID);
+    EXPECT_EQ(liftedX->get_name(), "X");
+    EXPECT_EQ(liftedX->get_dim(), toVec(K_BN_BWD_INTEG_DATA_DIMS));
+    EXPECT_EQ(liftedX->get_stride(), toVec(K_BN_BWD_INTEG_DATA_STRIDES));
+    EXPECT_EQ(liftedX->get_data_type(), DataType::FLOAT);
+
+    // Scale tensor
+    ASSERT_NE(tensorMap.count(K_BN_BWD_INTEG_TENSOR_SCALE_UID), 0u);
+    auto liftedScale = tensorMap[K_BN_BWD_INTEG_TENSOR_SCALE_UID];
+    EXPECT_EQ(liftedScale->get_uid(), K_BN_BWD_INTEG_TENSOR_SCALE_UID);
+    EXPECT_EQ(liftedScale->get_name(), "Scale");
+    EXPECT_EQ(liftedScale->get_dim(), toVec(K_BN_BWD_INTEG_PARAM_DIMS));
+    EXPECT_EQ(liftedScale->get_stride(), toVec(K_BN_BWD_INTEG_PARAM_STRIDES));
+    EXPECT_EQ(liftedScale->get_data_type(), DataType::FLOAT);
+
+    // Mean tensor (optional, set in this graph)
+    ASSERT_NE(tensorMap.count(K_BN_BWD_INTEG_TENSOR_MEAN_UID), 0u);
+    auto liftedMean = tensorMap[K_BN_BWD_INTEG_TENSOR_MEAN_UID];
+    EXPECT_EQ(liftedMean->get_uid(), K_BN_BWD_INTEG_TENSOR_MEAN_UID);
+    EXPECT_EQ(liftedMean->get_name(), "Mean");
+    EXPECT_EQ(liftedMean->get_dim(), toVec(K_BN_BWD_INTEG_PARAM_DIMS));
+    EXPECT_EQ(liftedMean->get_stride(), toVec(K_BN_BWD_INTEG_PARAM_STRIDES));
+    EXPECT_EQ(liftedMean->get_data_type(), DataType::FLOAT);
+
+    // InvVariance tensor (optional, set in this graph)
+    ASSERT_NE(tensorMap.count(K_BN_BWD_INTEG_TENSOR_INV_VARIANCE_UID), 0u);
+    auto liftedInvVar = tensorMap[K_BN_BWD_INTEG_TENSOR_INV_VARIANCE_UID];
+    EXPECT_EQ(liftedInvVar->get_uid(), K_BN_BWD_INTEG_TENSOR_INV_VARIANCE_UID);
+    EXPECT_EQ(liftedInvVar->get_name(), "InvVariance");
+    EXPECT_EQ(liftedInvVar->get_dim(), toVec(K_BN_BWD_INTEG_PARAM_DIMS));
+    EXPECT_EQ(liftedInvVar->get_stride(), toVec(K_BN_BWD_INTEG_PARAM_STRIDES));
+    EXPECT_EQ(liftedInvVar->get_data_type(), DataType::FLOAT);
+
+    // DX tensor (output)
+    ASSERT_NE(tensorMap.count(K_BN_BWD_INTEG_TENSOR_DX_UID), 0u);
+    auto liftedDx = tensorMap[K_BN_BWD_INTEG_TENSOR_DX_UID];
+    EXPECT_EQ(liftedDx->get_uid(), K_BN_BWD_INTEG_TENSOR_DX_UID);
+    EXPECT_EQ(liftedDx->get_name(), "DX");
+    EXPECT_FALSE(liftedDx->get_dim().empty());
+    EXPECT_FALSE(liftedDx->get_stride().empty());
+
+    // DScale tensor (output)
+    ASSERT_NE(tensorMap.count(K_BN_BWD_INTEG_TENSOR_DSCALE_UID), 0u);
+    auto liftedDscale = tensorMap[K_BN_BWD_INTEG_TENSOR_DSCALE_UID];
+    EXPECT_EQ(liftedDscale->get_uid(), K_BN_BWD_INTEG_TENSOR_DSCALE_UID);
+    EXPECT_EQ(liftedDscale->get_name(), "DScale");
+    EXPECT_FALSE(liftedDscale->get_dim().empty());
+    EXPECT_FALSE(liftedDscale->get_stride().empty());
+
+    // DBias tensor (output)
+    ASSERT_NE(tensorMap.count(K_BN_BWD_INTEG_TENSOR_DBIAS_UID), 0u);
+    auto liftedDbias = tensorMap[K_BN_BWD_INTEG_TENSOR_DBIAS_UID];
+    EXPECT_EQ(liftedDbias->get_uid(), K_BN_BWD_INTEG_TENSOR_DBIAS_UID);
+    EXPECT_EQ(liftedDbias->get_name(), "DBias");
+    EXPECT_FALSE(liftedDbias->get_dim().empty());
+    EXPECT_FALSE(liftedDbias->get_stride().empty());
+
+    // Verify 1 sub-node of the correct type
+    auto& subNodes = liftedGraph->getSubNodes();
+    ASSERT_EQ(subNodes.size(), 1u) << "Expected 1 operation node in lifted graph";
+
+    auto* bnBwdNode = dynamic_cast<BatchnormBackwardNode*>(subNodes[0].get());
+    ASSERT_NE(bnBwdNode, nullptr) << "Expected a BatchnormBackwardNode";
+
+    // Verify operation name and compute data type
+    EXPECT_EQ(bnBwdNode->attributes.get_name(), "bn_bwd_op");
+    EXPECT_EQ(bnBwdNode->attributes.compute_data_type, DataType::FLOAT);
+}
+
+// Verifies tensor pointer sharing is preserved after lifting.
+TEST_F(IntegrationBatchnormBackwardDescriptorLifting, BatchnormBackwardTensorSharingPreserved)
+{
+    auto originalGraph = buildBatchnormBackwardGraph();
+
+    auto result = originalGraph->validate();
+    ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
+
+    result = originalGraph->build_operation_graph(_handle);
+    ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
+
+    auto rawDesc = originalGraph->get_raw_graph_descriptor();
+    ASSERT_NE(rawDesc, nullptr);
+
+    auto liftedGraph = std::make_shared<TestableGraph>();
+    result = liftedGraph->fromBackendDescriptor(rawDesc);
+    ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
+
+    auto tensorMap = liftedGraph->getTensorsByUid();
+    auto& subNodes = liftedGraph->getSubNodes();
+    ASSERT_EQ(subNodes.size(), 1u);
+
+    auto* bnBwdNode = dynamic_cast<BatchnormBackwardNode*>(subNodes[0].get());
+    ASSERT_NE(bnBwdNode, nullptr);
+
+    // Verify pointer equality between tensor map and node attributes
+    EXPECT_EQ(tensorMap[K_BN_BWD_INTEG_TENSOR_DY_UID].get(), bnBwdNode->attributes.get_dy().get());
+    EXPECT_EQ(tensorMap[K_BN_BWD_INTEG_TENSOR_X_UID].get(), bnBwdNode->attributes.get_x().get());
+    EXPECT_EQ(tensorMap[K_BN_BWD_INTEG_TENSOR_SCALE_UID].get(),
+              bnBwdNode->attributes.get_scale().get());
+    EXPECT_EQ(tensorMap[K_BN_BWD_INTEG_TENSOR_MEAN_UID].get(),
+              bnBwdNode->attributes.get_mean().get());
+    EXPECT_EQ(tensorMap[K_BN_BWD_INTEG_TENSOR_INV_VARIANCE_UID].get(),
+              bnBwdNode->attributes.get_inv_variance().get());
+    EXPECT_EQ(tensorMap[K_BN_BWD_INTEG_TENSOR_DX_UID].get(), bnBwdNode->attributes.get_dx().get());
+    EXPECT_EQ(tensorMap[K_BN_BWD_INTEG_TENSOR_DSCALE_UID].get(),
+              bnBwdNode->attributes.get_dscale().get());
+    EXPECT_EQ(tensorMap[K_BN_BWD_INTEG_TENSOR_DBIAS_UID].get(),
+              bnBwdNode->attributes.get_dbias().get());
+}
+
+// Serializes to binary (FlatBuffer path), lifts without finalization, and verifies all fields.
+TEST_F(IntegrationBatchnormBackwardDescriptorLifting, BatchnormBackwardLiftWithoutFinalization)
+{
+    auto originalGraph = buildBatchnormBackwardGraph();
+
+    auto result = originalGraph->validate();
+    ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
+
+    auto data = originalGraph->toBinary();
+    ASSERT_FALSE(data.empty());
+
+    const detail::ScopedHipdnnBackendDescriptor graphDesc(data.data(), data.size());
+    ASSERT_TRUE(graphDesc.valid()) << "Failed to create backend graph descriptor";
+
+    auto liftedGraph = std::make_shared<TestableGraph>();
+    result = liftedGraph->fromBackendDescriptor(graphDesc.get());
+    ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
+
+    EXPECT_EQ(liftedGraph->get_compute_data_type(), DataType::FLOAT);
+    EXPECT_EQ(liftedGraph->get_intermediate_data_type(), DataType::FLOAT);
+    EXPECT_EQ(liftedGraph->get_io_data_type(), DataType::FLOAT);
+
+    auto tensorMap = liftedGraph->getTensorsByUid();
+    ASSERT_EQ(tensorMap.size(), 8u) << "Expected 8 tensors in lifted graph";
+
+    auto& subNodes = liftedGraph->getSubNodes();
+    ASSERT_EQ(subNodes.size(), 1u);
+
+    auto* bnBwdNode = dynamic_cast<BatchnormBackwardNode*>(subNodes[0].get());
+    ASSERT_NE(bnBwdNode, nullptr);
+
+    EXPECT_EQ(bnBwdNode->attributes.get_name(), "bn_bwd_op");
+    EXPECT_EQ(bnBwdNode->attributes.compute_data_type, DataType::FLOAT);
+
+    // Verify key tensor dims and names
+    ASSERT_NE(tensorMap.count(K_BN_BWD_INTEG_TENSOR_DY_UID), 0u);
+    EXPECT_EQ(tensorMap[K_BN_BWD_INTEG_TENSOR_DY_UID]->get_dim(), toVec(K_BN_BWD_INTEG_DATA_DIMS));
+    EXPECT_EQ(tensorMap[K_BN_BWD_INTEG_TENSOR_DY_UID]->get_stride(),
+              toVec(K_BN_BWD_INTEG_DATA_STRIDES));
+    EXPECT_EQ(tensorMap[K_BN_BWD_INTEG_TENSOR_DY_UID]->get_name(), "DY");
+
+    ASSERT_NE(tensorMap.count(K_BN_BWD_INTEG_TENSOR_X_UID), 0u);
+    EXPECT_EQ(tensorMap[K_BN_BWD_INTEG_TENSOR_X_UID]->get_dim(), toVec(K_BN_BWD_INTEG_DATA_DIMS));
+    EXPECT_EQ(tensorMap[K_BN_BWD_INTEG_TENSOR_X_UID]->get_stride(),
+              toVec(K_BN_BWD_INTEG_DATA_STRIDES));
+    EXPECT_EQ(tensorMap[K_BN_BWD_INTEG_TENSOR_X_UID]->get_name(), "X");
+
+    ASSERT_NE(tensorMap.count(K_BN_BWD_INTEG_TENSOR_SCALE_UID), 0u);
+    EXPECT_EQ(tensorMap[K_BN_BWD_INTEG_TENSOR_SCALE_UID]->get_dim(),
+              toVec(K_BN_BWD_INTEG_PARAM_DIMS));
+    EXPECT_EQ(tensorMap[K_BN_BWD_INTEG_TENSOR_SCALE_UID]->get_stride(),
+              toVec(K_BN_BWD_INTEG_PARAM_STRIDES));
+    EXPECT_EQ(tensorMap[K_BN_BWD_INTEG_TENSOR_SCALE_UID]->get_name(), "Scale");
+
+    ASSERT_NE(tensorMap.count(K_BN_BWD_INTEG_TENSOR_MEAN_UID), 0u);
+    EXPECT_EQ(tensorMap[K_BN_BWD_INTEG_TENSOR_MEAN_UID]->get_name(), "Mean");
+
+    ASSERT_NE(tensorMap.count(K_BN_BWD_INTEG_TENSOR_INV_VARIANCE_UID), 0u);
+    EXPECT_EQ(tensorMap[K_BN_BWD_INTEG_TENSOR_INV_VARIANCE_UID]->get_name(), "InvVariance");
+
+    ASSERT_NE(tensorMap.count(K_BN_BWD_INTEG_TENSOR_DX_UID), 0u);
+    EXPECT_EQ(tensorMap[K_BN_BWD_INTEG_TENSOR_DX_UID]->get_name(), "DX");
+
+    ASSERT_NE(tensorMap.count(K_BN_BWD_INTEG_TENSOR_DSCALE_UID), 0u);
+    EXPECT_EQ(tensorMap[K_BN_BWD_INTEG_TENSOR_DSCALE_UID]->get_name(), "DScale");
+
+    ASSERT_NE(tensorMap.count(K_BN_BWD_INTEG_TENSOR_DBIAS_UID), 0u);
+    EXPECT_EQ(tensorMap[K_BN_BWD_INTEG_TENSOR_DBIAS_UID]->get_name(), "DBias");
+}
+
+// Builds a minimal graph (no optional mean/invVariance), verifies optional tensors
+// are absent after lifting.
+TEST_F(IntegrationBatchnormBackwardDescriptorLifting,
+       BatchnormBackwardMinimalRequiredTensorsRoundTrip)
+{
+    auto originalGraph = buildMinimalBatchnormBackwardGraph();
+
+    auto result = originalGraph->validate();
+    ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
+
+    result = originalGraph->build_operation_graph(_handle);
+    ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
+
+    auto rawDesc = originalGraph->get_raw_graph_descriptor();
+    ASSERT_NE(rawDesc, nullptr);
+
+    auto liftedGraph = std::make_shared<TestableGraph>();
+    result = liftedGraph->fromBackendDescriptor(rawDesc);
+    ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
+
+    auto tensorMap = liftedGraph->getTensorsByUid();
+    // dy, x, scale, dx, dscale, dbias = 6 (no mean/invVariance)
+    ASSERT_EQ(tensorMap.size(), 6u)
+        << "Expected 6 tensors in minimal lifted graph (no mean/invVariance)";
+
+    auto& subNodes = liftedGraph->getSubNodes();
+    ASSERT_EQ(subNodes.size(), 1u);
+
+    auto* bnBwdNode = dynamic_cast<BatchnormBackwardNode*>(subNodes[0].get());
+    ASSERT_NE(bnBwdNode, nullptr);
+
+    EXPECT_EQ(bnBwdNode->attributes.get_name(), "minimal_bn_bwd_op");
+    EXPECT_NE(bnBwdNode->attributes.get_dy(), nullptr);
+    EXPECT_NE(bnBwdNode->attributes.get_x(), nullptr);
+    EXPECT_NE(bnBwdNode->attributes.get_scale(), nullptr);
+    EXPECT_NE(bnBwdNode->attributes.get_dx(), nullptr);
+    EXPECT_NE(bnBwdNode->attributes.get_dscale(), nullptr);
+    EXPECT_NE(bnBwdNode->attributes.get_dbias(), nullptr);
+    EXPECT_EQ(bnBwdNode->attributes.get_mean(), nullptr);
+    EXPECT_EQ(bnBwdNode->attributes.get_inv_variance(), nullptr);
+}
+
+} // namespace

--- a/projects/hipdnn/tests/frontend/IntegrationBatchnormBackwardDescriptorLifting.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationBatchnormBackwardDescriptorLifting.cpp
@@ -114,6 +114,71 @@ protected:
         return graph;
     }
 
+    // Builds a batchnorm backward graph with peer_stats tensors for distributed testing
+    static std::shared_ptr<TestableGraph> buildBatchnormBackwardGraphWithPeerStats()
+    {
+        auto graph = std::make_shared<TestableGraph>();
+        graph->set_name("BnBwdPeerStatsLiftingTestGraph")
+            .set_compute_data_type(DataType::FLOAT)
+            .set_intermediate_data_type(DataType::FLOAT)
+            .set_io_data_type(DataType::FLOAT);
+
+        auto dy = std::make_shared<TensorAttributes>();
+        dy->set_uid(K_BN_BWD_INTEG_TENSOR_DY_UID).set_name("DY").set_data_type(DataType::FLOAT);
+        dy->set_dim(toVec(K_BN_BWD_INTEG_DATA_DIMS)).set_stride(toVec(K_BN_BWD_INTEG_DATA_STRIDES));
+
+        auto x = std::make_shared<TensorAttributes>();
+        x->set_uid(K_BN_BWD_INTEG_TENSOR_X_UID).set_name("X").set_data_type(DataType::FLOAT);
+        x->set_dim(toVec(K_BN_BWD_INTEG_DATA_DIMS)).set_stride(toVec(K_BN_BWD_INTEG_DATA_STRIDES));
+
+        auto scale = std::make_shared<TensorAttributes>();
+        scale->set_uid(K_BN_BWD_INTEG_TENSOR_SCALE_UID)
+            .set_name("Scale")
+            .set_data_type(DataType::FLOAT);
+        scale->set_dim(toVec(K_BN_BWD_INTEG_PARAM_DIMS))
+            .set_stride(toVec(K_BN_BWD_INTEG_PARAM_STRIDES));
+
+        auto mean = std::make_shared<TensorAttributes>();
+        mean->set_uid(K_BN_BWD_INTEG_TENSOR_MEAN_UID)
+            .set_name("Mean")
+            .set_data_type(DataType::FLOAT);
+        mean->set_dim(toVec(K_BN_BWD_INTEG_PARAM_DIMS))
+            .set_stride(toVec(K_BN_BWD_INTEG_PARAM_STRIDES));
+
+        auto invVar = std::make_shared<TensorAttributes>();
+        invVar->set_uid(K_BN_BWD_INTEG_TENSOR_INV_VARIANCE_UID)
+            .set_name("InvVariance")
+            .set_data_type(DataType::FLOAT);
+        invVar->set_dim(toVec(K_BN_BWD_INTEG_PARAM_DIMS))
+            .set_stride(toVec(K_BN_BWD_INTEG_PARAM_STRIDES));
+
+        auto peerStat0 = std::make_shared<TensorAttributes>();
+        peerStat0->set_uid(K_BN_BWD_INTEG_TENSOR_PEER_STAT_0_UID)
+            .set_name("PeerStat0")
+            .set_data_type(DataType::FLOAT);
+        peerStat0->set_dim(toVec(K_BN_BWD_INTEG_PARAM_DIMS))
+            .set_stride(toVec(K_BN_BWD_INTEG_PARAM_STRIDES));
+
+        auto peerStat1 = std::make_shared<TensorAttributes>();
+        peerStat1->set_uid(K_BN_BWD_INTEG_TENSOR_PEER_STAT_1_UID)
+            .set_name("PeerStat1")
+            .set_data_type(DataType::FLOAT);
+        peerStat1->set_dim(toVec(K_BN_BWD_INTEG_PARAM_DIMS))
+            .set_stride(toVec(K_BN_BWD_INTEG_PARAM_STRIDES));
+
+        BatchnormBackwardAttributes bnBwdAttrs;
+        bnBwdAttrs.set_name("bn_bwd_peer_stats_op");
+        bnBwdAttrs.set_saved_mean_and_inv_variance(mean, invVar);
+        bnBwdAttrs.set_peer_stats({peerStat0, peerStat1});
+
+        auto [dxOut, dscaleOut, dbiasOut] = graph->batchnorm_backward(dy, x, scale, bnBwdAttrs);
+        dxOut->set_uid(K_BN_BWD_INTEG_TENSOR_DX_UID).set_output(true).set_name("DX");
+        dscaleOut->set_uid(K_BN_BWD_INTEG_TENSOR_DSCALE_UID).set_output(true).set_name("DScale");
+        dbiasOut->set_uid(K_BN_BWD_INTEG_TENSOR_DBIAS_UID).set_output(true).set_name("DBias");
+
+        return graph;
+    }
+
     // Builds a minimal batchnorm backward graph (no optional mean/invVariance)
     static std::shared_ptr<TestableGraph> buildMinimalBatchnormBackwardGraph()
     {
@@ -414,6 +479,66 @@ TEST_F(IntegrationBatchnormBackwardDescriptorLifting,
     EXPECT_NE(bnBwdNode->attributes.get_dbias(), nullptr);
     EXPECT_EQ(bnBwdNode->attributes.get_mean(), nullptr);
     EXPECT_EQ(bnBwdNode->attributes.get_inv_variance(), nullptr);
+}
+
+// Builds a batchnorm backward graph with peer_stats tensors, performs a full round-trip,
+// and verifies peer_stats appear in the lifted tensor map and node attributes.
+TEST_F(IntegrationBatchnormBackwardDescriptorLifting, BatchnormBackwardPeerStatsPreserved)
+{
+    auto originalGraph = buildBatchnormBackwardGraphWithPeerStats();
+
+    auto result = originalGraph->validate();
+    ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
+
+    result = originalGraph->build_operation_graph(_handle);
+    ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
+
+    auto rawDesc = originalGraph->get_raw_graph_descriptor();
+    ASSERT_NE(rawDesc, nullptr);
+
+    auto liftedGraph = std::make_shared<TestableGraph>();
+    result = liftedGraph->fromBackendDescriptor(rawDesc);
+    ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
+
+    // Verify tensor map includes the 2 peer_stats tensors (8 base + 2 peer = 10)
+    auto tensorMap = liftedGraph->getTensorsByUid();
+    ASSERT_EQ(tensorMap.size(), 10u) << "Expected 10 tensors (8 base + 2 peer_stats)";
+
+    // Verify peer_stats tensors appear in the tensor map with correct UIDs, names, dims, strides
+    ASSERT_NE(tensorMap.count(K_BN_BWD_INTEG_TENSOR_PEER_STAT_0_UID), 0u);
+    auto liftedPeerStat0 = tensorMap[K_BN_BWD_INTEG_TENSOR_PEER_STAT_0_UID];
+    EXPECT_EQ(liftedPeerStat0->get_uid(), K_BN_BWD_INTEG_TENSOR_PEER_STAT_0_UID);
+    EXPECT_EQ(liftedPeerStat0->get_name(), "PeerStat0");
+    EXPECT_EQ(liftedPeerStat0->get_dim(), toVec(K_BN_BWD_INTEG_PARAM_DIMS));
+    EXPECT_EQ(liftedPeerStat0->get_stride(), toVec(K_BN_BWD_INTEG_PARAM_STRIDES));
+    EXPECT_EQ(liftedPeerStat0->get_data_type(), DataType::FLOAT);
+
+    ASSERT_NE(tensorMap.count(K_BN_BWD_INTEG_TENSOR_PEER_STAT_1_UID), 0u);
+    auto liftedPeerStat1 = tensorMap[K_BN_BWD_INTEG_TENSOR_PEER_STAT_1_UID];
+    EXPECT_EQ(liftedPeerStat1->get_uid(), K_BN_BWD_INTEG_TENSOR_PEER_STAT_1_UID);
+    EXPECT_EQ(liftedPeerStat1->get_name(), "PeerStat1");
+    EXPECT_EQ(liftedPeerStat1->get_dim(), toVec(K_BN_BWD_INTEG_PARAM_DIMS));
+    EXPECT_EQ(liftedPeerStat1->get_stride(), toVec(K_BN_BWD_INTEG_PARAM_STRIDES));
+    EXPECT_EQ(liftedPeerStat1->get_data_type(), DataType::FLOAT);
+
+    // Verify the lifted node's attributes reference peer_stats correctly
+    auto& subNodes = liftedGraph->getSubNodes();
+    ASSERT_EQ(subNodes.size(), 1u);
+
+    auto* bnBwdNode = dynamic_cast<BatchnormBackwardNode*>(subNodes[0].get());
+    ASSERT_NE(bnBwdNode, nullptr);
+
+    const auto& liftedPeerStats = bnBwdNode->attributes.get_peer_stats();
+    ASSERT_EQ(liftedPeerStats.size(), 2u) << "Expected 2 peer_stats tensors in lifted node";
+
+    EXPECT_EQ(liftedPeerStats[0]->get_uid(), K_BN_BWD_INTEG_TENSOR_PEER_STAT_0_UID);
+    EXPECT_EQ(liftedPeerStats[0]->get_name(), "PeerStat0");
+    EXPECT_EQ(liftedPeerStats[1]->get_uid(), K_BN_BWD_INTEG_TENSOR_PEER_STAT_1_UID);
+    EXPECT_EQ(liftedPeerStats[1]->get_name(), "PeerStat1");
+
+    // Verify pointer equality: peer_stats in node attributes share objects with tensor map
+    EXPECT_EQ(liftedPeerStats[0].get(), liftedPeerStat0.get());
+    EXPECT_EQ(liftedPeerStats[1].get(), liftedPeerStat1.get());
 }
 
 } // namespace

--- a/projects/hipdnn/tests/frontend/IntegrationBatchnormBackwardDescriptorLifting.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationBatchnormBackwardDescriptorLifting.cpp
@@ -541,4 +541,86 @@ TEST_F(IntegrationBatchnormBackwardDescriptorLifting, BatchnormBackwardPeerStats
     EXPECT_EQ(liftedPeerStats[1].get(), liftedPeerStat1.get());
 }
 
+// Builds a batchnorm backward graph without explicit set_uid() calls, performs a round-trip,
+// and verifies all auto-assigned UIDs are distinct and tensor dims survive.
+TEST_F(IntegrationBatchnormBackwardDescriptorLifting, BatchnormBackwardAutoAssignedUidsPreserved)
+{
+    auto graph = std::make_shared<TestableGraph>();
+    graph->set_name("AutoUidBnBwdLiftTest")
+        .set_compute_data_type(DataType::FLOAT)
+        .set_intermediate_data_type(DataType::FLOAT)
+        .set_io_data_type(DataType::FLOAT);
+
+    // Build tensors with distinct dims but NO set_uid() calls
+    auto dy = std::make_shared<TensorAttributes>();
+    dy->set_name("DY").set_data_type(DataType::FLOAT);
+    dy->set_dim(toVec(K_BN_BWD_AUTO_DATA_DIMS)).set_stride(toVec(K_BN_BWD_AUTO_DATA_STRIDES));
+
+    auto x = std::make_shared<TensorAttributes>();
+    x->set_name("X").set_data_type(DataType::FLOAT);
+    x->set_dim(toVec(K_BN_BWD_AUTO_DATA_DIMS)).set_stride(toVec(K_BN_BWD_AUTO_DATA_STRIDES));
+
+    auto scale = std::make_shared<TensorAttributes>();
+    scale->set_name("Scale").set_data_type(DataType::FLOAT);
+    scale->set_dim(toVec(K_BN_BWD_AUTO_PARAM_DIMS)).set_stride(toVec(K_BN_BWD_AUTO_PARAM_STRIDES));
+
+    BatchnormBackwardAttributes bnBwdAttrs;
+    bnBwdAttrs.set_name("auto_uid_bn_bwd_op");
+
+    auto [dxOut, dscaleOut, dbiasOut] = graph->batchnorm_backward(dy, x, scale, bnBwdAttrs);
+    dxOut->set_output(true).set_name("DX");
+    dscaleOut->set_output(true).set_name("DScale");
+    dbiasOut->set_output(true).set_name("DBias");
+
+    auto result = graph->validate();
+    ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
+
+    result = graph->build_operation_graph(_handle);
+    ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
+
+    auto rawDesc = graph->get_raw_graph_descriptor();
+    ASSERT_NE(rawDesc, nullptr);
+
+    auto liftedGraph = std::make_shared<TestableGraph>();
+    result = liftedGraph->fromBackendDescriptor(rawDesc);
+    ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
+
+    auto tensorMap = liftedGraph->getTensorsByUid();
+    // dy, x, scale, dx, dscale, dbias = 6 tensors (no optional mean/invVariance)
+    ASSERT_EQ(tensorMap.size(), 6u) << "Expected 6 tensors (dy, x, scale, dx, dscale, dbias)";
+
+    // Collect all UIDs and verify they are distinct
+    std::vector<int64_t> uids;
+    uids.reserve(tensorMap.size());
+    for(const auto& [uid, tensor] : tensorMap)
+    {
+        uids.push_back(uid);
+    }
+    std::sort(uids.begin(), uids.end());
+    EXPECT_EQ(std::adjacent_find(uids.begin(), uids.end()), uids.end())
+        << "All auto-assigned UIDs must be distinct";
+
+    // Verify the node references tensors with auto-assigned UIDs
+    auto& subNodes = liftedGraph->getSubNodes();
+    ASSERT_EQ(subNodes.size(), 1u);
+
+    auto* bnBwdNode = dynamic_cast<BatchnormBackwardNode*>(subNodes[0].get());
+    ASSERT_NE(bnBwdNode, nullptr);
+
+    // Verify tensor dims survived the round trip by identifying tensors via dims
+    auto dyUid = bnBwdNode->attributes.get_dy()->get_uid();
+    auto scaleUid = bnBwdNode->attributes.get_scale()->get_uid();
+    auto dxUid = bnBwdNode->attributes.get_dx()->get_uid();
+
+    EXPECT_NE(dyUid, scaleUid);
+    EXPECT_NE(dyUid, dxUid);
+
+    EXPECT_EQ(tensorMap[dyUid]->get_dim(), toVec(K_BN_BWD_AUTO_DATA_DIMS));
+    EXPECT_EQ(tensorMap[dyUid]->get_stride(), toVec(K_BN_BWD_AUTO_DATA_STRIDES));
+    EXPECT_EQ(tensorMap[scaleUid]->get_dim(), toVec(K_BN_BWD_AUTO_PARAM_DIMS));
+    EXPECT_EQ(tensorMap[scaleUid]->get_stride(), toVec(K_BN_BWD_AUTO_PARAM_STRIDES));
+    EXPECT_EQ(tensorMap[dxUid]->get_dim(), toVec(K_BN_BWD_AUTO_DATA_DIMS));
+    EXPECT_EQ(tensorMap[dxUid]->get_stride(), toVec(K_BN_BWD_AUTO_DATA_STRIDES));
+}
+
 } // namespace


### PR DESCRIPTION
## Summary

- Add the lifting path (backend → frontend reconstruction) for BatchnormBackward operations, enabling graph serialization round-trips
- Add `fromNode()` to `BatchnormBackwardOperationDescriptor` for reconstructing finalized descriptors from FlatBuffer `NodeT` objects
- Add `BatchnormBackwardUnpacker` for reconstructing frontend `BatchnormBackwardAttributes` from backend descriptors
- Wire `NodeFactory` and `OperationUnpacker` for BnBwd dispatch
- Add name packing to `BatchnormBackwardPacker` and `unpack_from_descriptor` to `BatchnormBackwardNode`
- Fix optional tensor `getAttribute` to use `getOptionalTensorDescriptor` for mean/inv_variance (pre-existing bug exposed by integration tests)

## Test plan

- [x] `TestBatchnormBackwardOperationFromNode` — 19 backend unit tests covering:
  - Deep tensor validation (UID + data_type + dims + strides) for all 8 tensors
  - Pointer identity between descriptor tensors and tensor map
  - Name and operation type round-trip via getAttribute
  - Error paths for missing required/optional tensors
  - BuildNode round-trip with and without optional tensors
- [x] `IntegrationBatchnormBackwardDescriptorLifting` — 5 integration tests covering:
  - Full lower-lift round-trip with tensor name/dim/stride/data_type validation
  - Tensor sharing (pointer identity) preservation
  - FlatBuffer-direct path (without finalization)
  - Minimal required tensors (no mean/inv_variance)
  - Peer stats tensor array round-trip with deep validation
- [x] Superbuild compilation passes
- [x] `hipdnn-unit-check` passes (6185 cases)
- [x] `hipdnn-check` passes (unit + integration, 8/8 suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)