### PR TITLE
[hipDNN] ROCM-20458 Fix ASAN memory leaks in CustomOp backend tests

### DIFF
--- a/projects/hipdnn/backend/tests/descriptors/TestCustomOpOperationDescriptor.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestCustomOpOperationDescriptor.cpp
@@ -329,14 +329,17 @@ TEST_F(TestCustomOpOperationDescriptor, GetAttributeInputTensorArray)
                                        nullptr));
     ASSERT_EQ(elementCount, 2);
 
-    std::array<HipdnnBackendDescriptor*, 2> retrieved = {nullptr, nullptr};
+    std::array<HipdnnBackendDescriptor*, 2> rawRetrieved = {nullptr, nullptr};
     ASSERT_NO_THROW(desc->getAttribute(HIPDNN_ATTR_OPERATION_CUSTOM_OP_INPUTS_EXT,
                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                        2,
                                        &elementCount,
-                                       static_cast<void*>(retrieved.data())));
-    ASSERT_NE(retrieved[0], nullptr);
-    ASSERT_NE(retrieved[1], nullptr);
+                                       static_cast<void*>(rawRetrieved.data())));
+
+    auto retrieved0 = std::unique_ptr<HipdnnBackendDescriptor>(rawRetrieved[0]);
+    auto retrieved1 = std::unique_ptr<HipdnnBackendDescriptor>(rawRetrieved[1]);
+    ASSERT_NE(retrieved0, nullptr);
+    ASSERT_NE(retrieved1, nullptr);
 }
 
 TEST_F(TestCustomOpOperationDescriptor, GetAttributeOutputTensorArray)
@@ -352,12 +355,14 @@ TEST_F(TestCustomOpOperationDescriptor, GetAttributeOutputTensorArray)
                                        nullptr));
     ASSERT_EQ(elementCount, 1);
 
-    HipdnnBackendDescriptor* retrieved = nullptr;
+    HipdnnBackendDescriptor* rawRetrieved = nullptr;
     ASSERT_NO_THROW(desc->getAttribute(HIPDNN_ATTR_OPERATION_CUSTOM_OP_OUTPUTS_EXT,
                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                        1,
                                        &elementCount,
-                                       static_cast<void*>(&retrieved)));
+                                       static_cast<void*>(&rawRetrieved)));
+
+    auto retrieved = std::unique_ptr<HipdnnBackendDescriptor>(rawRetrieved);
     ASSERT_NE(retrieved, nullptr);
 }
 

--- a/projects/hipdnn/backend/tests/descriptors/TestGraphDescriptorCustomOp.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestGraphDescriptorCustomOp.cpp
@@ -128,7 +128,7 @@ TEST_F(TestGraphDescriptorCustomOp, BuildFromSingleCustomOpOperation)
     ASSERT_TRUE(verifier.VerifyBuffer<Graph>());
 
     auto graph = GetGraph(serialized.ptr);
-    auto graphT = graph->UnPack();
+    auto graphT = std::unique_ptr<GraphT>(graph->UnPack());
 
     ASSERT_EQ(graphT->nodes.size(), 1);
     ASSERT_EQ(graphT->tensors.size(), 3);
@@ -172,7 +172,7 @@ TEST_F(TestGraphDescriptorCustomOp, ComputeDataTypePreserved)
 
     auto serialized = desc->getSerializedGraph();
     auto graph = GetGraph(serialized.ptr);
-    auto graphT = graph->UnPack();
+    auto graphT = std::unique_ptr<GraphT>(graph->UnPack());
 
     ASSERT_EQ(graphT->nodes.size(), 1);
 

--- a/projects/hipdnn/backend/tests/descriptors/TestGraphDescriptorCustomOp.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestGraphDescriptorCustomOp.cpp
@@ -127,8 +127,7 @@ TEST_F(TestGraphDescriptorCustomOp, BuildFromSingleCustomOpOperation)
     flatbuffers::Verifier verifier(static_cast<const uint8_t*>(serialized.ptr), serialized.size);
     ASSERT_TRUE(verifier.VerifyBuffer<Graph>());
 
-    auto graph = GetGraph(serialized.ptr);
-    auto graphT = std::unique_ptr<GraphT>(graph->UnPack());
+    auto graphT = UnPackGraph(serialized.ptr);
 
     ASSERT_EQ(graphT->nodes.size(), 1);
     ASSERT_EQ(graphT->tensors.size(), 3);
@@ -171,8 +170,7 @@ TEST_F(TestGraphDescriptorCustomOp, ComputeDataTypePreserved)
     ASSERT_NO_THROW(desc->finalize());
 
     auto serialized = desc->getSerializedGraph();
-    auto graph = GetGraph(serialized.ptr);
-    auto graphT = std::unique_ptr<GraphT>(graph->UnPack());
+    auto graphT = UnPackGraph(serialized.ptr);
 
     ASSERT_EQ(graphT->nodes.size(), 1);
 

--- a/projects/hipdnn/docs/ai-rules.md
+++ b/projects/hipdnn/docs/ai-rules.md
@@ -139,6 +139,23 @@ When requested to build/test:
 - Use CMake for managing C/C++ dependencies
 - Use Flatbuffers for serialization needs
 
+### RAII & Resource Management
+
+**All owning raw pointers must be wrapped in RAII (smart pointers) immediately after acquisition.** Never rely on manual `delete` — if an assertion, exception, or early return occurs between allocation and `delete`, the resource leaks. This project runs under AddressSanitizer (ASAN) in CI, and any leak fails the build.
+
+**Common patterns and pitfalls:**
+
+| Pattern | Wrong | Right |
+|---------|-------|-------|
+| FlatBuffers Graph unpacking | `auto obj = graph->UnPack();` (raw `GraphT*`) | `auto obj = UnPackGraph(serialized.ptr);` (returns `unique_ptr<GraphT>`) |
+| FlatBuffers `UnPack()` (other types) | `auto obj = table->UnPack();` (raw `T*`) | `auto obj = std::unique_ptr<T>(table->UnPack());` |
+| `getAttribute()` for tensor arrays | Use raw pointer, forget cleanup | Wrap immediately: `auto owned = std::unique_ptr<HipdnnBackendDescriptor>(rawPtr);` |
+| `createDescriptorPtr<T>()` | Store raw pointer | Use `createDescriptor<T>()` which returns `unique_ptr` |
+
+**FlatBuffers `UnPack()` returns owning raw pointers.** The generated `Graph::UnPack()`, `Node::UnPack()`, etc. all return `T*` allocated with `new`. Prefer the generated helpers like `UnPackGraph()` which return `std::unique_ptr<T>` directly. For types without helpers, wrap manually: `std::unique_ptr<T>(table->UnPack())`.
+
+**`getAttribute()` with `HIPDNN_TYPE_BACKEND_DESCRIPTOR` allocates new descriptors.** The C API packs shared descriptors into fresh `HipdnnBackendDescriptor*` via `packDescriptor()`. Ownership transfers to the caller — wrap in `std::unique_ptr<HipdnnBackendDescriptor>` immediately after retrieval.
+
 ### Testing
 - Use Google Test (gtest) framework for all C/C++ tests
 - Never generate a `main()` function in test files — gtest provides its own


### PR DESCRIPTION
## Summary
- Fix memory leaks detected by AddressSanitizer in CustomOp backend tests (2,180 bytes in 46 allocations)
- Wrap `Graph::UnPack()` raw pointer results in `std::unique_ptr<GraphT>` in `TestGraphDescriptorCustomOp`
- Wrap descriptors returned by `getAttribute()` tensor array queries in `std::unique_ptr<HipdnnBackendDescriptor>` in `TestCustomOpOperationDescriptor`

## Details
The leaks were found while investigating [TheRock ASAN CI failures](https://github.com/ROCm/TheRock/actions/runs/22626310222/job/65799110671). That CI run also had an ODR violation which is a compiler false positive fixed by [llvm-project#1572](https://github.com/ROCm/llvm-project/pull/1572).

The leak sources:
1. **`Graph::UnPack()`** returns an owning `GraphT*` via `new`. Tests stored this in a raw `auto` (deduced as `GraphT*`) and never freed it.
2. **`getAttribute()` for tensor arrays** calls `packDescriptor()` which allocates a `new HipdnnBackendDescriptor` per tensor. Ownership transfers to the caller, but tests never freed the returned descriptors.

Both are fixed using RAII (`std::unique_ptr`) so cleanup is guaranteed even if assertions fail mid-test.

## Test plan
- [x] ASAN superbuild: `hipdnn-unit-check` passes 6/6 suites (100%), zero ASAN errors
- [x] Backend tests: 2049/2049 passed, no leak summary reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)