### PR TITLE
enable code-coverage generation with tox command for tensilelite

### DIFF
--- a/projects/hipblaslt/tensilelite/README.md
+++ b/projects/hipblaslt/tensilelite/README.md
@@ -22,6 +22,26 @@ Subsequently, you can run just the Tensile unit tests via:
 tox -e unit -- Tensile/Tests/unit
 ```
 
+### Generate coverage report with Tox
+
+```
+cd rocm-libraries/projects/hipblaslt/tensilelite
+tox -e coverage
+```
+
+This will:
+- Run all unit tests with coverage
+- Run all common tests with coverage
+- Generate HTML, XML, and JSON reports
+- Display a summary in the terminal
+
+```
+cd rocm-libraries/projects/hipblaslt/tensilelite
+tox -e coverage-unit
+```
+
+Runs only Python unit tests.
+
 ### Build client with invoke and Run a Test (Default Path)
 
 This workflow uses `invoke` to build the client into the default `build_tmp` directory.

--- a/projects/hipblaslt/tensilelite/pyproject.toml
+++ b/projects/hipblaslt/tensilelite/pyproject.toml
@@ -1,0 +1,58 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
+
+[tool.coverage.run]
+branch = true
+concurrency = ["multiprocessing"]
+omit = [
+    "*/Tests/*",
+    "*/tests/*",
+    "*/test_*.py",
+    "*/__pycache__/*",
+    "*/build_tmp/*",
+    "*/build/*",
+    "*/.tox/*",
+    "*/site-packages/*",
+    "*/conftest.py",
+    "*/setup.py",
+    "*/.eggs/*",
+]
+
+[tool.coverage.report]
+precision = 2
+show_missing = true
+skip_covered = false
+skip_empty = true
+sort = "Cover"
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "def __str__",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+    "@abstract",
+    "@abstractmethod",
+    "pass",
+    "\\.\\.\\.",
+]
+
+[tool.coverage.html]
+directory = "htmlcov"
+title = "TensileLite Code Coverage Report"
+show_contexts = true
+
+[tool.coverage.xml]
+output = "coverage.xml"
+
+[tool.coverage.json]
+output = "coverage.json"
+show_contexts = true
+
+[tool.pytest.ini_options]
+# You can also move pytest config here if desired
+testpaths = ["Tensile/Tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]

--- a/projects/hipblaslt/tensilelite/tox.ini
+++ b/projects/hipblaslt/tensilelite/tox.ini
@@ -5,6 +5,7 @@
 envlist = py3,lint
 labels =
     static = format, isort
+    coverage = coverage
 
 [testenv]
 # Some versions of Pytest versions have a bug:
@@ -91,6 +92,141 @@ deps =
 commands =
     flake8 {toxinidir}/Tensile
     py.test -q --basetemp={envtmpdir} --color=yes {toxinidir}/Tensile -m unit {posargs}
+
+[testenv:coverage]
+description = "Generate comprehensive code coverage for unit and common tests"
+basepython = python3
+deps =
+    {[testenv]deps}
+    pytest-cov>=4.0.0
+    coverage[toml]>=7.0.0
+setenv =
+    TENSILE_CLIENT_STATIC = {env:TENSILE_CLIENT_STATIC:}
+    PYTHONPATH = {toxinidir}
+    TENSILELITE_CLIENT_ARGS = {env:TENSILELITE_CLIENT_ARGS:}
+    COVERAGE_FILE = {toxinidir}/.coverage
+commands =
+    # Install rocisa
+    pip install --upgrade pip
+    pip install --no-build-isolation {toxinidir}/rocisa/
+
+    # Build the client
+    sh -c "ARCH=$(invoke get-gpu-arch); \
+          export TENSILE_ARCHITECTURE=\$ARCH; \
+          export TENSILELITE_CLIENT_ARGS='{env:TENSILELITE_CLIENT_ARGS:} --gpu-targets '$ARCH; \
+          invoke build-client --build-dir {toxinidir}/build_tmp $TENSILELITE_CLIENT_ARGS"
+
+    # Run unit tests with coverage (no report yet)
+    pytest --cov=Tensile --cov=rocisa \
+           --cov-config={toxinidir}/pyproject.toml \
+           --cov-report= \
+           -v --basetemp={envtmpdir} \
+           --junit-xml={toxinidir}/unit_tests.xml \
+           --junit-prefix=unit \
+           --color=yes \
+           -n 4 \
+           -m unit \
+           {toxinidir}/Tensile/Tests/unit
+
+    # Run common tests with coverage (append to existing coverage data)
+    pytest --cov=Tensile --cov=rocisa \
+           --cov-config={toxinidir}/pyproject.toml \
+           --cov-append \
+           --cov-report=html:{toxinidir}/htmlcov \
+           --cov-report=xml:{toxinidir}/coverage.xml \
+           --cov-report=json:{toxinidir}/coverage.json \
+           --cov-report=term-missing:skip-covered \
+           -v --basetemp={envtmpdir} \
+           --junit-xml={toxinidir}/common_tests.xml \
+           --junit-prefix=common \
+           --color=yes \
+           -n 4 \
+           -m common \
+           --prebuilt-client={toxinidir}/build_tmp/tensilelite/client/tensilelite-client \
+           {toxinidir}/Tensile/Tests/common {posargs}
+
+    # Generate detailed coverage report summary
+    coverage report --show-missing --skip-covered
+
+    # Print report locations
+    python -c "print('\n' + '='*70); \
+               print('CODE COVERAGE REPORTS GENERATED:'); \
+               print('='*70); \
+               print('HTML Report : htmlcov/index.html'); \
+               print('XML Report  : coverage.xml'); \
+               print('JSON Report : coverage.json'); \
+               print('JUnit XML   : unit_tests.xml, common_tests.xml'); \
+               print('='*70 + '\n')"
+
+[testenv:coverage-unit]
+description = "Generate code coverage for unit tests only (fast)"
+basepython = python3
+deps =
+    {[testenv]deps}
+    pytest-cov>=4.0.0
+    coverage[toml]>=7.0.0
+setenv =
+    TENSILE_CLIENT_STATIC = {env:TENSILE_CLIENT_STATIC:}
+    PYTHONPATH = {toxinidir}
+    TENSILELITE_CLIENT_ARGS = {env:TENSILELITE_CLIENT_ARGS:}
+    COVERAGE_FILE = {toxinidir}/.coverage
+commands =
+    pip install --upgrade pip
+    pip install --no-build-isolation {toxinidir}/rocisa/
+
+    pytest --cov=Tensile --cov=rocisa \
+           --cov-config={toxinidir}/pyproject.toml \
+           --cov-report=html:{toxinidir}/htmlcov \
+           --cov-report=xml:{toxinidir}/coverage.xml \
+           --cov-report=term-missing \
+           -v --basetemp={envtmpdir} \
+           --junit-xml={toxinidir}/unit_tests.xml \
+           --color=yes \
+           -n 4 \
+           -m unit \
+           {toxinidir}/Tensile/Tests/unit {posargs}
+
+    coverage report --show-missing
+
+    python -c "print('\nHTML Report: htmlcov/index.html')"
+
+[testenv:coverage-common]
+description = "Generate code coverage for common tests only (requires prebuilt client)"
+basepython = python3
+deps =
+    {[testenv]deps}
+    pytest-cov>=4.0.0
+    coverage[toml]>=7.0.0
+setenv =
+    TENSILE_CLIENT_STATIC = {env:TENSILE_CLIENT_STATIC:}
+    PYTHONPATH = {toxinidir}
+    TENSILELITE_CLIENT_ARGS = {env:TENSILELITE_CLIENT_ARGS:}
+    COVERAGE_FILE = {toxinidir}/.coverage
+commands =
+    pip install --upgrade pip
+    pip install --no-build-isolation {toxinidir}/rocisa/
+
+    sh -c "ARCH=$(invoke get-gpu-arch); \
+          export TENSILE_ARCHITECTURE=\$ARCH; \
+          export TENSILELITE_CLIENT_ARGS='{env:TENSILELITE_CLIENT_ARGS:} --gpu-targets '$ARCH; \
+          invoke build-client --build-dir {toxinidir}/build_tmp $TENSILELITE_CLIENT_ARGS"
+
+    pytest --cov=Tensile --cov=rocisa \
+           --cov-config={toxinidir}/pyproject.toml \
+           --cov-report=html:{toxinidir}/htmlcov \
+           --cov-report=xml:{toxinidir}/coverage.xml \
+           --cov-report=term-missing \
+           -v --basetemp={envtmpdir} \
+           --junit-xml={toxinidir}/common_tests.xml \
+           --color=yes \
+           -n 4 \
+           -m common \
+           --prebuilt-client={toxinidir}/build_tmp/tensilelite/client/tensilelite-client \
+           {toxinidir}/Tensile/Tests/common {posargs}
+
+    coverage report --show-missing
+
+    python -c "print('\nHTML Report: htmlcov/index.html')"
 
 [flake8]
 exclude = .git,build*,dist,.cache,*~

--- a/projects/hipblaslt/tensilelite/tox.ini
+++ b/projects/hipblaslt/tensilelite/tox.ini
@@ -45,7 +45,7 @@ commands =
     sh -c "ARCH=$(invoke get-gpu-arch); \
           export TENSILE_ARCHITECTURE=\$ARCH; \
           export TENSILELITE_CLIENT_ARGS='{env:TENSILELITE_CLIENT_ARGS:} --gpu-targets '$ARCH; \
-          invoke build-client --build-dir {toxinidir}/build_tmp --gpu-targets $ARCH $TENSILELITE_CLIENT_ARGS || exit $?; \
+          invoke build-client --build-dir {toxinidir}/build_tmp $TENSILELITE_CLIENT_ARGS || exit $?; \
           pytest -v --basetemp={envtmpdir} --junit-xml={toxinidir}/python_tests.xml --junit-prefix={envname} --color=yes -n $TENSILE_NUM_PYTEST_WORKERS --prebuilt-client={toxinidir}/build_tmp/tensilelite/client/tensilelite-client {posargs}; \
           rc=$?; test $rc -eq 5 && exit 0; exit $rc"
 allowlist_externals =


### PR DESCRIPTION
## Motivation

Generating code-coverage for tensilelite by extending existing infra

## Technical Details

We don't have easy way to generate code coverage for tensilelite. Through this PR by extending `tox` framework, we are enabling code coverage.

We can use tox command to generate coverage report. 

```
tox -e coverage
```

This will:
- Run all unit tests with coverage
- Run all common tests with coverage
- Generate HTML, XML, and JSON reports
- Display a summary in the terminal

```
tox -e coverage-unit
```

Runs only Python unit tests.

## Test Plan

NA
## Test Result

At the end, it does generate `html` report along with displaying on the screen like

```
Tensile/Components/CMSValidator.py                          979     30    438     22  96.05%   184, 235, 272, 316, 335, 401, 413, 428, 574, 687, 690, 714, 857, 924, 976, 1130->1141, 1236->1235, 1550, 1558, 1693, 1708, 1710, 1712, 2009->2012, 2073-2074, 2180-2187
Tensile/KernelWriterReduction.py                             59      1     12      1  97.18%   49
Tensile/KernelWriterActivationEnumHeader.py                  40      1      4      0  97.73%   45
------------------------------------------------------------------------------------------------------
TOTAL                                                     41262  20604  16814   2792  46.67%
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
