### PR TITLE
[hipsparselt] Fix metadata vgpr idx calculation

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
@@ -1026,8 +1026,7 @@ class LocalReadMFMA(LocalRead):
                                             # convert from [tile][MiInputPerThread][vector] to [tile][vector][MiInputPerThread]
                                             vgprIdx = int((vIdx*numVgpr+i)*tP["bpeDS"]*kernel["MIInputPerThread%s"%tc]//writer.states.bpr*min(writer.states.bpr//tP["bpeDS"],vectorWidth))
                                             if numSplitMetadata:
-                                                #TODO:
-                                                #vgprIdx = (vIdx*numVgpr+i)*ceil(tP["bpeDS"]*kernel["MIInputPerThread%s"%tc] / writer.states.bpr)*min(writer.states.bpr//tP["bpeDS"],vectorWidth)
+                                                vgprIdx = (vIdx*numVgpr+i)*ceil(tP["bpeDS"]*kernel["MIInputPerThread%s"%tc] / writer.states.bpr)*min(writer.states.bpr//tP["bpeDS"],vectorWidth)
                                                 if kernel["MIInputPerThread%s"%tc] == 4:
                                                     vgprOffset = 0
                                                     for elementIdx in range(0, numSplitMetadata+1):

--- a/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
@@ -1026,9 +1026,6 @@ class LocalReadMFMA(LocalRead):
                                             # convert from [tile][MiInputPerThread][vector] to [tile][vector][MiInputPerThread]
                                             vgprIdx = int((vIdx*numVgpr+i)*tP["bpeDS"]*kernel["MIInputPerThread%s"%tc]//writer.states.bpr*min(writer.states.bpr//tP["bpeDS"],vectorWidth))
                                             if numSplitMetadata:
-                                                # Make this explict guard to prevent redundant metadata packing
-                                                if eIdx != numReadsPerVector - 1:
-                                                    continue
                                                 vgprIdx = (vIdx*numVgpr+i)*ceil(tP["bpeDS"]*kernel["MIInputPerThread%s"%tc] / writer.states.bpr)*min(writer.states.bpr//tP["bpeDS"],vectorWidth)
                                                 if kernel["MIInputPerThread%s"%tc] == 4:
                                                     vgprOffset = 0

--- a/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
@@ -1026,6 +1026,9 @@ class LocalReadMFMA(LocalRead):
                                             # convert from [tile][MiInputPerThread][vector] to [tile][vector][MiInputPerThread]
                                             vgprIdx = int((vIdx*numVgpr+i)*tP["bpeDS"]*kernel["MIInputPerThread%s"%tc]//writer.states.bpr*min(writer.states.bpr//tP["bpeDS"],vectorWidth))
                                             if numSplitMetadata:
+                                                # Make this explict guard to prevent redundant metadata packing
+                                                if eIdx != numReadsPerVector - 1:
+                                                    continue
                                                 vgprIdx = (vIdx*numVgpr+i)*ceil(tP["bpeDS"]*kernel["MIInputPerThread%s"%tc] / writer.states.bpr)*min(writer.states.bpr//tP["bpeDS"],vectorWidth)
                                                 if kernel["MIInputPerThread%s"%tc] == 4:
                                                     vgprOffset = 0


### PR DESCRIPTION
## Motivation
- hipsparselt-test failed in gfx942
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

- The metadata packing calculation for vgpr index is not correct
<img width="1864" height="255" alt="image" src="https://github.com/user-attachments/assets/73fe93bc-b69d-4496-b245-e4e64058f1de" />

- In the failed assembly, vIdx=1 writes to +0,+1 (should be +2,+3) and vIdx=3 writes to +2,+3 (should be +6,+7). The ceil() fix changes vgprIdx so that each vIdx correctly steps by 2 registers instead of collapsing to the same slot as the previous vIdx.

<!-- Explain the changes along with any relevant GitHub links. -->



## Test Plan

- Test script: `./build/release/hipsparselt-install/bin/hipsparselt-test --gtest_output=xml --gtest_color=yes '--gtest_filter=*quick*'`

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

- Passed in both 942 and 950

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
