### PR TITLE
Move graph deserialization methods to protected

### DIFF
--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Graph.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Graph.hpp
@@ -886,6 +886,77 @@ protected:
         return {ErrorCode::OK, ""};
     }
 
+    /// Reconstruct the Graph from a finalized backend OperationGraph descriptor.
+    ///
+    /// Extracts operations and graph-level data types from a backend descriptor
+    /// and rebuilds the frontend Graph representation. Tensors are shared across
+    /// operations via UID-based lookup.
+    ///
+    /// NOTE: Will be renamed to `deserialize` and made public once the API
+    /// stabilizes.
+    ///
+    /// @param graphDesc A finalized backend OperationGraph descriptor
+    /// @return ErrorCode::OK on success, or ErrorCode::INVALID_VALUE /
+    ///         ErrorCode::HIPDNN_BACKEND_ERROR on failure. Call get_message()
+    ///         for the specific failure reason.
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    Error fromBackendDescriptor(hipdnnBackendDescriptor_t graphDesc)
+    {
+        std::vector<std::shared_ptr<graph::INode>> tempNodes;
+        graph::GraphAttributes tempAttrs;
+        std::optional<int64_t> tempEngineId;
+
+        HIPDNN_CHECK_ERROR(
+            detail::unpackGraphDescriptor(graphDesc, tempNodes, tempAttrs, tempEngineId));
+
+        _sub_nodes = std::move(tempNodes);
+        graph_attributes = std::move(tempAttrs);
+        _preferredEngineId = tempEngineId;
+        _graphDesc.reset();
+        _engineConfigDesc.reset();
+        _executionPlanDesc.reset();
+        return {};
+    }
+
+    /// Deserialize the graph from binary via the backend descriptor path.
+    ///
+    /// Creates a backend graph descriptor from serialized bytes and rebuilds
+    /// the frontend Graph. If a handle is provided, the descriptor is
+    /// finalized for full backend support. Graphs containing unsupported
+    /// operation types will fail.
+    ///
+    /// NOTE: This method will eventually replace the public
+    /// deserialize(hipdnnHandle_t, const std::vector<uint8_t>&) once the
+    /// FlatBuffer path is removed.
+    ///
+    /// @param handle The hipDNN handle (can be nullptr)
+    /// @param data The serialized graph bytes
+    /// @return ErrorCode::OK on success, or ErrorCode::INVALID_VALUE /
+    ///         ErrorCode::HIPDNN_BACKEND_ERROR on failure. Call get_message()
+    ///         for the specific failure reason.
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    Error deserialize_via_backend(hipdnnHandle_t handle, const std::vector<uint8_t>& data)
+    {
+        std::vector<std::shared_ptr<graph::INode>> tempNodes;
+        graph::GraphAttributes tempAttrs;
+        std::optional<int64_t> tempEngineId;
+
+        auto [graphDesc, err]
+            = detail::deserializeAndUnpackGraph(handle, data, tempNodes, tempAttrs, tempEngineId);
+        if(err.is_bad())
+        {
+            return err;
+        }
+
+        _sub_nodes = std::move(tempNodes);
+        graph_attributes = std::move(tempAttrs);
+        _preferredEngineId = tempEngineId;
+        _graphDesc = std::move(graphDesc);
+        _engineConfigDesc.reset();
+        _executionPlanDesc.reset();
+        return {};
+    }
+
 public:
     /**
      * @brief Get available configuration knobs for a specific engine
@@ -1300,80 +1371,6 @@ public:
     }
 #endif
     /// @endcond
-
-    /**
-     * @brief Reconstruct the Graph from a finalized backend OperationGraph descriptor
-     *
-     * Extracts operations and graph-level data types from a backend descriptor
-     * and rebuilds the frontend Graph representation. Tensors are shared across
-     * operations via UID-based lookup.
-     *
-     * Currently supports: ConvolutionFprop operations (phased rollout —
-     * additional operation types will be added incrementally).
-     *
-     * @param graphDesc A finalized backend OperationGraph descriptor
-     * @return ErrorCode::OK on success, or ErrorCode::INVALID_VALUE /
-     *         ErrorCode::HIPDNN_BACKEND_ERROR on failure. Call get_message()
-     *         for the specific failure reason.
-     */
-    // NOLINTNEXTLINE(readability-identifier-naming)
-    Error fromBackendDescriptor(hipdnnBackendDescriptor_t graphDesc)
-    {
-        std::vector<std::shared_ptr<graph::INode>> tempNodes;
-        graph::GraphAttributes tempAttrs;
-        std::optional<int64_t> tempEngineId;
-
-        HIPDNN_CHECK_ERROR(
-            detail::unpackGraphDescriptor(graphDesc, tempNodes, tempAttrs, tempEngineId));
-
-        _sub_nodes = std::move(tempNodes);
-        graph_attributes = std::move(tempAttrs);
-        _preferredEngineId = tempEngineId;
-        _graphDesc.reset();
-        _engineConfigDesc.reset();
-        _executionPlanDesc.reset();
-        return {};
-    }
-
-    /**
-     * @brief Deserialize the graph from binary via the backend descriptor path
-     *
-     * Creates a backend graph descriptor from serialized bytes and rebuilds
-     * the frontend Graph. If a handle is provided, the descriptor is
-     * finalized for full backend support.
-     *
-     * Currently supports ConvolutionFprop operations (phased rollout —
-     * additional operation types will be added incrementally). Graphs
-     * containing unsupported operation types will fail.
-     *
-     * @param handle The hipDNN handle (can be nullptr)
-     * @param data The serialized graph bytes
-     * @return ErrorCode::OK on success, or ErrorCode::INVALID_VALUE /
-     *         ErrorCode::HIPDNN_BACKEND_ERROR on failure. Call get_message()
-     *         for the specific failure reason.
-     */
-    // NOLINTNEXTLINE(readability-identifier-naming)
-    Error deserialize_via_backend(hipdnnHandle_t handle, const std::vector<uint8_t>& data)
-    {
-        std::vector<std::shared_ptr<graph::INode>> tempNodes;
-        graph::GraphAttributes tempAttrs;
-        std::optional<int64_t> tempEngineId;
-
-        auto [graphDesc, err]
-            = detail::deserializeAndUnpackGraph(handle, data, tempNodes, tempAttrs, tempEngineId);
-        if(err.is_bad())
-        {
-            return err;
-        }
-
-        _sub_nodes = std::move(tempNodes);
-        graph_attributes = std::move(tempAttrs);
-        _preferredEngineId = tempEngineId;
-        _graphDesc = std::move(graphDesc);
-        _engineConfigDesc.reset();
-        _executionPlanDesc.reset();
-        return {};
-    }
 
     /**
      * @brief Finalize the execution plan

--- a/projects/hipdnn/tests/frontend/IntegrationBatchnormDescriptorLifting.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationBatchnormDescriptorLifting.cpp
@@ -30,6 +30,7 @@ class TestableGraph : public Graph
 public:
     using Graph::build_operation_graph;
     using Graph::deserialize_via_backend;
+    using Graph::fromBackendDescriptor;
     using Graph::get_raw_graph_descriptor;
 
     const std::vector<std::shared_ptr<INode>>& getSubNodes() const

--- a/projects/hipdnn/tests/frontend/IntegrationBatchnormInferenceDescriptorLifting.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationBatchnormInferenceDescriptorLifting.cpp
@@ -33,6 +33,7 @@ class TestableGraph : public Graph
 public:
     using Graph::build_operation_graph;
     using Graph::deserialize_via_backend;
+    using Graph::fromBackendDescriptor;
     using Graph::get_raw_graph_descriptor;
 
     const std::vector<std::shared_ptr<INode>>& getSubNodes() const

--- a/projects/hipdnn/tests/frontend/IntegrationBlockScaleDequantizeDescriptorLifting.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationBlockScaleDequantizeDescriptorLifting.cpp
@@ -30,6 +30,7 @@ class TestableGraph : public Graph
 public:
     using Graph::build_operation_graph;
     using Graph::deserialize_via_backend;
+    using Graph::fromBackendDescriptor;
     using Graph::get_raw_graph_descriptor;
 
     const std::vector<std::shared_ptr<INode>>& getSubNodes() const

--- a/projects/hipdnn/tests/frontend/IntegrationBlockScaleQuantizeDescriptorLifting.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationBlockScaleQuantizeDescriptorLifting.cpp
@@ -30,6 +30,7 @@ class TestableGraph : public Graph
 public:
     using Graph::build_operation_graph;
     using Graph::deserialize_via_backend;
+    using Graph::fromBackendDescriptor;
     using Graph::get_raw_graph_descriptor;
 
     const std::vector<std::shared_ptr<INode>>& getSubNodes() const

--- a/projects/hipdnn/tests/frontend/IntegrationConvFpropDescriptorLifting.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationConvFpropDescriptorLifting.cpp
@@ -29,6 +29,7 @@ class TestableGraph : public Graph
 public:
     using Graph::build_operation_graph;
     using Graph::deserialize_via_backend;
+    using Graph::fromBackendDescriptor;
     using Graph::get_raw_graph_descriptor;
 
     const std::vector<std::shared_ptr<INode>>& getSubNodes() const

--- a/projects/hipdnn/tests/frontend/IntegrationConvolutionWgradDescriptorLifting.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationConvolutionWgradDescriptorLifting.cpp
@@ -30,6 +30,7 @@ class TestableGraph : public Graph
 public:
     using Graph::build_operation_graph;
     using Graph::deserialize_via_backend;
+    using Graph::fromBackendDescriptor;
     using Graph::get_raw_graph_descriptor;
 
     const std::vector<std::shared_ptr<INode>>& getSubNodes() const

--- a/projects/hipdnn/tests/frontend/IntegrationGraphLifting.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationGraphLifting.cpp
@@ -28,6 +28,7 @@ class TestableGraph : public Graph
 public:
     using Graph::build_operation_graph;
     using Graph::deserialize_via_backend;
+    using Graph::fromBackendDescriptor;
     using Graph::get_raw_graph_descriptor;
 
     const std::vector<std::shared_ptr<INode>>& getSubNodes() const
@@ -240,7 +241,7 @@ TEST_F(IntegrationGraphLifting, PreferredEngineIdPreservedThroughCApi)
 // Verifies that fromBackendDescriptor(nullptr) returns an error.
 TEST_F(IntegrationGraphLifting, NullDescriptorReturnsError)
 {
-    auto graph = std::make_shared<Graph>();
+    auto graph = std::make_shared<TestableGraph>();
     auto result = graph->fromBackendDescriptor(nullptr);
     EXPECT_EQ(result.code, ErrorCode::INVALID_VALUE)
         << "fromBackendDescriptor(nullptr) should return INVALID_VALUE";

--- a/projects/hipdnn/tests/frontend/IntegrationLayerNormDescriptorLifting.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationLayerNormDescriptorLifting.cpp
@@ -29,6 +29,7 @@ class TestableGraph : public Graph
 public:
     using Graph::build_operation_graph;
     using Graph::deserialize_via_backend;
+    using Graph::fromBackendDescriptor;
     using Graph::get_raw_graph_descriptor;
 
     const std::vector<std::shared_ptr<INode>>& getSubNodes() const

--- a/projects/hipdnn/tests/frontend/IntegrationMatmulDescriptorLifting.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationMatmulDescriptorLifting.cpp
@@ -30,6 +30,7 @@ class TestableGraph : public Graph
 public:
     using Graph::build_operation_graph;
     using Graph::deserialize_via_backend;
+    using Graph::fromBackendDescriptor;
     using Graph::get_raw_graph_descriptor;
 
     const std::vector<std::shared_ptr<INode>>& getSubNodes() const

--- a/projects/hipdnn/tests/frontend/IntegrationPointwiseDescriptorLifting.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationPointwiseDescriptorLifting.cpp
@@ -30,6 +30,7 @@ class TestableGraph : public Graph
 public:
     using Graph::build_operation_graph;
     using Graph::deserialize_via_backend;
+    using Graph::fromBackendDescriptor;
     using Graph::get_raw_graph_descriptor;
 
     const std::vector<std::shared_ptr<INode>>& getSubNodes() const

--- a/projects/hipdnn/tests/frontend/IntegrationRMSNormDescriptorLifting.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationRMSNormDescriptorLifting.cpp
@@ -30,6 +30,7 @@ class TestableGraph : public Graph
 public:
     using Graph::build_operation_graph;
     using Graph::deserialize_via_backend;
+    using Graph::fromBackendDescriptor;
     using Graph::get_raw_graph_descriptor;
 
     const std::vector<std::shared_ptr<INode>>& getSubNodes() const

--- a/projects/hipdnn/tests/frontend/IntegrationSdpaBpropLifting.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationSdpaBpropLifting.cpp
@@ -29,6 +29,8 @@ class TestableGraph : public Graph
 {
 public:
     using Graph::build_operation_graph;
+    using Graph::deserialize_via_backend;
+    using Graph::fromBackendDescriptor;
     using Graph::get_raw_graph_descriptor;
 
     const std::vector<std::shared_ptr<INode>>& getSubNodes() const

--- a/projects/hipdnn/tests/frontend/IntegrationSdpaFpropDescriptorLifting.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationSdpaFpropDescriptorLifting.cpp
@@ -30,6 +30,7 @@ class TestableGraph : public Graph
 public:
     using Graph::build_operation_graph;
     using Graph::deserialize_via_backend;
+    using Graph::fromBackendDescriptor;
     using Graph::get_raw_graph_descriptor;
 
     const std::vector<std::shared_ptr<INode>>& getSubNodes() const

--- a/projects/hipdnn/tools/DescriptorGenerator/templates/test_integration_lifting.cpp.j2
+++ b/projects/hipdnn/tools/DescriptorGenerator/templates/test_integration_lifting.cpp.j2
@@ -31,6 +31,7 @@ class TestableGraph : public Graph
 {
 public:
     using Graph::build_operation_graph;
+    using Graph::fromBackendDescriptor;
     using Graph::deserialize_via_backend;
     using Graph::get_raw_graph_descriptor;
 


### PR DESCRIPTION
## Summary
- Move `fromBackendDescriptor` and `deserialize_via_backend` from `public` to `protected` in `Graph.hpp`
- These methods are not intended to be part of the public API yet 
- Remove outdated "currently supports ConvolutionFprop only" doc comments
- Add future-plans notes: `fromBackendDescriptor` will be renamed to `deserialize` and made public once the API stabilizes, and `deserialize_via_backend` will replace the FlatBuffer-based `deserialize` overload

Fixes accessibility issue identified in #5910

## Test plan
- [x] Verify hipDNN builds cleanly (`ninja`)
- [x] Run lifting integration tests (`--gtest_filter="*Lifting*"`)
- [x] Run serialization tests (`--gtest_filter="*Serialization*"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
