### PR TITLE
[rocThrust] Fix benchmark build on Windows

### DIFF
--- a/projects/rocthrust/cmake/Dependencies.cmake
+++ b/projects/rocthrust/cmake/Dependencies.cmake
@@ -399,6 +399,18 @@ if(BUILD_BENCHMARK)
       GIT_TAG        v${BENCHMARK_VERSION}
     )
     FetchContent_MakeAvailable(googlebench)
+	# Clang on Windows with -pedantic-errors treats __COUNTER__ in Google  
+	# Benchmark as a C2y extension and fails. Also --offload-compress is unused  
+	# for host-only code. Suppress for the benchmark targets.  
+    # https://github.com/google/benchmark/issues/2057
+	if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND WIN32)  
+	  if(TARGET benchmark)  
+	    target_compile_options(benchmark PRIVATE -Wno-c2y-extensions -Wno-unused-command-line-argument)  
+	  endif()  
+	  if(TARGET benchmark_main)  
+	    target_compile_options(benchmark_main PRIVATE -Wno-c2y-extensions -Wno-unused-command-line-argument)	
+	  endif()
+	endif()    
     if(NOT TARGET benchmark::benchmark)
       add_library(benchmark::benchmark ALIAS benchmark)
     endif()

--- a/projects/rocthrust/cmake/Dependencies.cmake
+++ b/projects/rocthrust/cmake/Dependencies.cmake
@@ -367,7 +367,7 @@ endif()
 
 # Benchmark dependencies
 if(BUILD_BENCHMARK)
-  set(BENCHMARK_VERSION 1.9.4)
+  set(BENCHMARK_VERSION 1.9.5)
   if(NOT EXTERNAL_DEPS_FORCE_DOWNLOAD)
     # Google Benchmark (https://github.com/google/benchmark.git)
     find_package(benchmark ${BENCHMARK_VERSION} QUIET)
@@ -402,18 +402,17 @@ if(BUILD_BENCHMARK)
 	# Clang on Windows with -pedantic-errors treats __COUNTER__ in Google  
 	# Benchmark as a C2y extension and fails. Also --offload-compress is unused  
 	# for host-only code. Suppress for the benchmark targets.  
-    # https://github.com/google/benchmark/issues/2057
 	if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND WIN32)  
 	  if(TARGET benchmark)  
-	    target_compile_options(benchmark PRIVATE -Wno-c2y-extensions -Wno-unused-command-line-argument)  
+	    target_compile_options(benchmark PRIVATE -Wno-format-nonliteral -Wno-missing-format-attribute -Wno-unused-command-line-argument)  
 	  endif()  
 	  if(TARGET benchmark_main)  
-	    target_compile_options(benchmark_main PRIVATE -Wno-c2y-extensions -Wno-unused-command-line-argument)	
+	    target_compile_options(benchmark_main PRIVATE -Wno-format-nonliteral -Wno-missing-format-attribute -Wno-unused-command-line-argument)	
 	  endif()
-	endif()    
-    if(NOT TARGET benchmark::benchmark)
-      add_library(benchmark::benchmark ALIAS benchmark)
-    endif()
+      if(NOT TARGET benchmark::benchmark)
+        add_library(benchmark::benchmark ALIAS benchmark)
+      endif()
+	endif()
   endif()
 
   # rocRAND (https://github.com/ROCm/rocm-libraries)

--- a/projects/rocthrust/cmake/Dependencies.cmake
+++ b/projects/rocthrust/cmake/Dependencies.cmake
@@ -399,9 +399,8 @@ if(BUILD_BENCHMARK)
       GIT_TAG        v${BENCHMARK_VERSION}
     )
     FetchContent_MakeAvailable(googlebench)
-	# Clang on Windows with -pedantic-errors treats __COUNTER__ in Google  
-	# Benchmark as a C2y extension and fails. Also --offload-compress is unused  
-	# for host-only code. Suppress for the benchmark targets.  
+	# Clang on Windows throws the following warnings with Googlebenchmark v1.9.5 (along with Werror):
+    # googlebench-src/src/string_util.cc:158:34: error: format string is not a string literal [-Werror,-Wformat-nonliteral]
 	if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND WIN32)  
 	  if(TARGET benchmark)  
 	    target_compile_options(benchmark PRIVATE -Wno-format-nonliteral -Wno-missing-format-attribute -Wno-unused-command-line-argument)  


### PR DESCRIPTION
## Motivation

Currently the rocThrust benchmark fails to build on Windows because googlebench enables `-Werror` and also throws the following warning with clang on Windows:

`In file included from build-wasm/_deps/benchmark-src/src/benchmark_register.cc:39:
build-wasm/_deps/benchmark-src/include/benchmark/benchmark.h:1461:30: error: '__COUNTER__' is a C2y extension [-Werror,-Wc2y-extensions]
 1461 | #if defined(__COUNTER__) && (__COUNTER__ + 1 == __COUNTER__ + 0)`

The warning has been suppressed in [googlebench](https://github.com/google/benchmark/issues/2057) and is available in v1.9.5.  I have bumped to 1.9.5, however it seems to cause several more, different warnings as error problem.  For the time being I will suppress those warnings on Windows only until they are addressed in googlebench in a future relase.

## Technical Details

Update googlebench from 1.9.4 to 1.9.5, and suppress two warnings for googlebench.

## Test Plan

Rebuilt benchmarks.

## Test Result

Build passes.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
