### PR TITLE
[hipSOLVER] Remove double underscores in gtest names

### DIFF
--- a/projects/hipsolver/CHANGELOG.md
+++ b/projects/hipsolver/CHANGELOG.md
@@ -8,7 +8,7 @@ Full documentation for hipSOLVER is available at the [hipSOLVER Documentation](h
 ### Added
 ### Changed
 
-* Replaced occurrences of double underscores in test suite names within the benchmarking client, for example, `checkin_lapack/GETRS.__float/0` was changed to `checkin_lapack/GETRS._float/0`.
+* Replaced occurrences of double underscores in test suite names within the benchmarking client, for example, `checkin_lapack/GETRS.__float/0` was changed to `checkin_lapack/GETRS.Float/0`.
 
 ### Removed
 ### Optimized

--- a/projects/hipsolver/CHANGELOG.md
+++ b/projects/hipsolver/CHANGELOG.md
@@ -8,8 +8,7 @@ Full documentation for hipSOLVER is available at the [hipSOLVER Documentation](h
 ### Added
 ### Changed
 
-* Replaced occurrences of double underscores in test suite names within benchmarking client
-    * e.g., `checkin_lapack/GETRS.__float/0` was changed to `checkin_lapack/GETRS._float/0`
+* Replaced occurrences of double underscores in test suite names within the benchmarking client, for example, `checkin_lapack/GETRS.__float/0` was changed to `checkin_lapack/GETRS._float/0`.
 
 ### Removed
 ### Optimized

--- a/projects/hipsolver/CHANGELOG.md
+++ b/projects/hipsolver/CHANGELOG.md
@@ -7,6 +7,10 @@ Full documentation for hipSOLVER is available at the [hipSOLVER Documentation](h
 
 ### Added
 ### Changed
+
+* Replaced occurrences of double underscores in test suite names within benchmarking client
+    * e.g., `checkin_lapack/GETRS.__float/0` was changed to `checkin_lapack/GETRS._float/0`
+
 ### Removed
 ### Optimized
 ### Resolved issues

--- a/projects/hipsolver/clients/gtest/csrlsvchol_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/csrlsvchol_gtest.cpp
@@ -99,42 +99,42 @@ class CSRLSVCHOLHOST : public CSRLSVCHOL_BASE<true>
 
 // non-batch tests
 
-TEST_P(CSRLSVCHOL, _float)
+TEST_P(CSRLSVCHOL, Float)
 {
     run_tests<float>();
 }
 
-TEST_P(CSRLSVCHOL, _double)
+TEST_P(CSRLSVCHOL, Double)
 {
     run_tests<double>();
 }
 
-// TEST_P(CSRLSVCHOL, _float_complex)
+// TEST_P(CSRLSVCHOL, FloatComplex)
 // {
 //     run_tests<rocblas_float_complex>();
 // }
 
-// TEST_P(CSRLSVCHOL, _double_complex)
+// TEST_P(CSRLSVCHOL, DoubleComplex)
 // {
 //     run_tests<rocblas_double_complex>();
 // }
 
-TEST_P(CSRLSVCHOLHOST, _float)
+TEST_P(CSRLSVCHOLHOST, Float)
 {
     run_tests<float>();
 }
 
-TEST_P(CSRLSVCHOLHOST, _double)
+TEST_P(CSRLSVCHOLHOST, Double)
 {
     run_tests<double>();
 }
 
-// TEST_P(CSRLSVCHOLHOST, _float_complex)
+// TEST_P(CSRLSVCHOLHOST, FloatComplex)
 // {
 //     run_tests<rocblas_float_complex>();
 // }
 
-// TEST_P(CSRLSVCHOLHOST, _double_complex)
+// TEST_P(CSRLSVCHOLHOST, DoubleComplex)
 // {
 //     run_tests<rocblas_double_complex>();
 // }

--- a/projects/hipsolver/clients/gtest/csrlsvchol_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/csrlsvchol_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #include "testing_csrlsvchol.hpp"
@@ -99,42 +99,42 @@ class CSRLSVCHOLHOST : public CSRLSVCHOL_BASE<true>
 
 // non-batch tests
 
-TEST_P(CSRLSVCHOL, __float)
+TEST_P(CSRLSVCHOL, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(CSRLSVCHOL, __double)
+TEST_P(CSRLSVCHOL, _double)
 {
     run_tests<double>();
 }
 
-// TEST_P(CSRLSVCHOL, __float_complex)
+// TEST_P(CSRLSVCHOL, _float_complex)
 // {
 //     run_tests<rocblas_float_complex>();
 // }
 
-// TEST_P(CSRLSVCHOL, __double_complex)
+// TEST_P(CSRLSVCHOL, _double_complex)
 // {
 //     run_tests<rocblas_double_complex>();
 // }
 
-TEST_P(CSRLSVCHOLHOST, __float)
+TEST_P(CSRLSVCHOLHOST, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(CSRLSVCHOLHOST, __double)
+TEST_P(CSRLSVCHOLHOST, _double)
 {
     run_tests<double>();
 }
 
-// TEST_P(CSRLSVCHOLHOST, __float_complex)
+// TEST_P(CSRLSVCHOLHOST, _float_complex)
 // {
 //     run_tests<rocblas_float_complex>();
 // }
 
-// TEST_P(CSRLSVCHOLHOST, __double_complex)
+// TEST_P(CSRLSVCHOLHOST, _double_complex)
 // {
 //     run_tests<rocblas_double_complex>();
 // }

--- a/projects/hipsolver/clients/gtest/csrlsvqr_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/csrlsvqr_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2024-2025 Advanced Micro Devices, Inc.
+ * Copyright (C) 2024-2026 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #include "testing_csrlsvqr.hpp"
@@ -99,42 +99,42 @@ class CSRLSVQRHOST : public CSRLSVQR_BASE<true>
 
 // non-batch tests
 
-TEST_P(CSRLSVQR, __float)
+TEST_P(CSRLSVQR, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(CSRLSVQR, __double)
+TEST_P(CSRLSVQR, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(CSRLSVQR, __float_complex)
+TEST_P(CSRLSVQR, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(CSRLSVQR, __double_complex)
+TEST_P(CSRLSVQR, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-// TEST_P(CSRLSVQRHOST, __float)
+// TEST_P(CSRLSVQRHOST, _float)
 // {
 //     run_tests<float>();
 // }
 
-// TEST_P(CSRLSVQRHOST, __double)
+// TEST_P(CSRLSVQRHOST, _double)
 // {
 //     run_tests<double>();
 // }
 
-// TEST_P(CSRLSVQRHOST, __float_complex)
+// TEST_P(CSRLSVQRHOST, _float_complex)
 // {
 //     run_tests<rocblas_float_complex>();
 // }
 
-// TEST_P(CSRLSVQRHOST, __double_complex)
+// TEST_P(CSRLSVQRHOST, _double_complex)
 // {
 //     run_tests<rocblas_double_complex>();
 // }

--- a/projects/hipsolver/clients/gtest/csrlsvqr_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/csrlsvqr_gtest.cpp
@@ -99,42 +99,42 @@ class CSRLSVQRHOST : public CSRLSVQR_BASE<true>
 
 // non-batch tests
 
-TEST_P(CSRLSVQR, _float)
+TEST_P(CSRLSVQR, Float)
 {
     run_tests<float>();
 }
 
-TEST_P(CSRLSVQR, _double)
+TEST_P(CSRLSVQR, Double)
 {
     run_tests<double>();
 }
 
-TEST_P(CSRLSVQR, _float_complex)
+TEST_P(CSRLSVQR, FloatComplex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(CSRLSVQR, _double_complex)
+TEST_P(CSRLSVQR, DoubleComplex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-// TEST_P(CSRLSVQRHOST, _float)
+// TEST_P(CSRLSVQRHOST, Float)
 // {
 //     run_tests<float>();
 // }
 
-// TEST_P(CSRLSVQRHOST, _double)
+// TEST_P(CSRLSVQRHOST, Double)
 // {
 //     run_tests<double>();
 // }
 
-// TEST_P(CSRLSVQRHOST, _float_complex)
+// TEST_P(CSRLSVQRHOST, FloatComplex)
 // {
 //     run_tests<rocblas_float_complex>();
 // }
 
-// TEST_P(CSRLSVQRHOST, _double_complex)
+// TEST_P(CSRLSVQRHOST, DoubleComplex)
 // {
 //     run_tests<rocblas_double_complex>();
 // }

--- a/projects/hipsolver/clients/gtest/csrrf_refactlu_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/csrrf_refactlu_gtest.cpp
@@ -79,22 +79,22 @@ protected:
 
 // non-batch tests
 
-/*TEST_P(CSRRF_REFACTLU, _float)
+/*TEST_P(CSRRF_REFACTLU, Float)
 {
     run_tests<float>();
 }*/
 
-TEST_P(CSRRF_REFACTLU, _double)
+TEST_P(CSRRF_REFACTLU, Double)
 {
     run_tests<double>();
 }
 
-/*TEST_P(CSRRF_REFACTLU, _float_complex)
+/*TEST_P(CSRRF_REFACTLU, FloatComplex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(CSRRF_REFACTLU, _double_complex)
+TEST_P(CSRRF_REFACTLU, DoubleComplex)
 {
     run_tests<rocblas_double_complex>();
 }*/

--- a/projects/hipsolver/clients/gtest/csrrf_refactlu_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/csrrf_refactlu_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #include "testing_csrrf_refactlu.hpp"
@@ -79,22 +79,22 @@ protected:
 
 // non-batch tests
 
-/*TEST_P(CSRRF_REFACTLU, __float)
+/*TEST_P(CSRRF_REFACTLU, _float)
 {
     run_tests<float>();
 }*/
 
-TEST_P(CSRRF_REFACTLU, __double)
+TEST_P(CSRRF_REFACTLU, _double)
 {
     run_tests<double>();
 }
 
-/*TEST_P(CSRRF_REFACTLU, __float_complex)
+/*TEST_P(CSRRF_REFACTLU, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(CSRRF_REFACTLU, __double_complex)
+TEST_P(CSRRF_REFACTLU, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }*/

--- a/projects/hipsolver/clients/gtest/csrrf_solve_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/csrrf_solve_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #include "testing_csrrf_solve.hpp"
@@ -83,22 +83,22 @@ protected:
 
 // non-batch tests
 
-/*TEST_P(CSRRF_SOLVE, __float)
+/*TEST_P(CSRRF_SOLVE, _float)
 {
     run_tests<float>();
 }*/
 
-TEST_P(CSRRF_SOLVE, __double)
+TEST_P(CSRRF_SOLVE, _double)
 {
     run_tests<double>();
 }
 
-/*TEST_P(CSRRF_SOLVE, __float_complex)
+/*TEST_P(CSRRF_SOLVE, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(CSRRF_SOLVE, __double_complex)
+TEST_P(CSRRF_SOLVE, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }*/

--- a/projects/hipsolver/clients/gtest/csrrf_solve_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/csrrf_solve_gtest.cpp
@@ -83,22 +83,22 @@ protected:
 
 // non-batch tests
 
-/*TEST_P(CSRRF_SOLVE, _float)
+/*TEST_P(CSRRF_SOLVE, Float)
 {
     run_tests<float>();
 }*/
 
-TEST_P(CSRRF_SOLVE, _double)
+TEST_P(CSRRF_SOLVE, Double)
 {
     run_tests<double>();
 }
 
-/*TEST_P(CSRRF_SOLVE, _float_complex)
+/*TEST_P(CSRRF_SOLVE, FloatComplex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(CSRRF_SOLVE, _double_complex)
+TEST_P(CSRRF_SOLVE, DoubleComplex)
 {
     run_tests<rocblas_double_complex>();
 }*/

--- a/projects/hipsolver/clients/gtest/gebrd_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/gebrd_gtest.cpp
@@ -119,62 +119,62 @@ class GEBRD_COMPAT : public GEBRD_BASE<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(GEBRD, _float)
+TEST_P(GEBRD, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEBRD, _double)
+TEST_P(GEBRD, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEBRD, _float_complex)
+TEST_P(GEBRD, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEBRD, _double_complex)
+TEST_P(GEBRD, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GEBRD_FORTRAN, _float)
+TEST_P(GEBRD_FORTRAN, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEBRD_FORTRAN, _double)
+TEST_P(GEBRD_FORTRAN, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEBRD_FORTRAN, _float_complex)
+TEST_P(GEBRD_FORTRAN, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEBRD_FORTRAN, _double_complex)
+TEST_P(GEBRD_FORTRAN, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GEBRD_COMPAT, _float)
+TEST_P(GEBRD_COMPAT, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEBRD_COMPAT, _double)
+TEST_P(GEBRD_COMPAT, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEBRD_COMPAT, _float_complex)
+TEST_P(GEBRD_COMPAT, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEBRD_COMPAT, _double_complex)
+TEST_P(GEBRD_COMPAT, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/gebrd_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/gebrd_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -119,62 +119,62 @@ class GEBRD_COMPAT : public GEBRD_BASE<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(GEBRD, __float)
+TEST_P(GEBRD, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEBRD, __double)
+TEST_P(GEBRD, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEBRD, __float_complex)
+TEST_P(GEBRD, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEBRD, __double_complex)
+TEST_P(GEBRD, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GEBRD_FORTRAN, __float)
+TEST_P(GEBRD_FORTRAN, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEBRD_FORTRAN, __double)
+TEST_P(GEBRD_FORTRAN, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEBRD_FORTRAN, __float_complex)
+TEST_P(GEBRD_FORTRAN, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEBRD_FORTRAN, __double_complex)
+TEST_P(GEBRD_FORTRAN, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GEBRD_COMPAT, __float)
+TEST_P(GEBRD_COMPAT, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEBRD_COMPAT, __double)
+TEST_P(GEBRD_COMPAT, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEBRD_COMPAT, __float_complex)
+TEST_P(GEBRD_COMPAT, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEBRD_COMPAT, __double_complex)
+TEST_P(GEBRD_COMPAT, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/gels_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/gels_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -134,82 +134,82 @@ class GELS_INPLACE : public GELS_BASE<API_NORMAL, true>
 
 // non-batch tests
 
-TEST_P(GELS, __float)
+TEST_P(GELS, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GELS, __double)
+TEST_P(GELS, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GELS, __float_complex)
+TEST_P(GELS, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GELS, __double_complex)
+TEST_P(GELS, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GELS_FORTRAN, __float)
+TEST_P(GELS_FORTRAN, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GELS_FORTRAN, __double)
+TEST_P(GELS_FORTRAN, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GELS_FORTRAN, __float_complex)
+TEST_P(GELS_FORTRAN, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GELS_FORTRAN, __double_complex)
+TEST_P(GELS_FORTRAN, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GELS_COMPAT, __float)
+TEST_P(GELS_COMPAT, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GELS_COMPAT, __double)
+TEST_P(GELS_COMPAT, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GELS_COMPAT, __float_complex)
+TEST_P(GELS_COMPAT, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GELS_COMPAT, __double_complex)
+TEST_P(GELS_COMPAT, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GELS_INPLACE, __float)
+TEST_P(GELS_INPLACE, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GELS_INPLACE, __double)
+TEST_P(GELS_INPLACE, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GELS_INPLACE, __float_complex)
+TEST_P(GELS_INPLACE, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GELS_INPLACE, __double_complex)
+TEST_P(GELS_INPLACE, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/gels_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/gels_gtest.cpp
@@ -134,82 +134,82 @@ class GELS_INPLACE : public GELS_BASE<API_NORMAL, true>
 
 // non-batch tests
 
-TEST_P(GELS, _float)
+TEST_P(GELS, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GELS, _double)
+TEST_P(GELS, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GELS, _float_complex)
+TEST_P(GELS, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GELS, _double_complex)
+TEST_P(GELS, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GELS_FORTRAN, _float)
+TEST_P(GELS_FORTRAN, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GELS_FORTRAN, _double)
+TEST_P(GELS_FORTRAN, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GELS_FORTRAN, _float_complex)
+TEST_P(GELS_FORTRAN, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GELS_FORTRAN, _double_complex)
+TEST_P(GELS_FORTRAN, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GELS_COMPAT, _float)
+TEST_P(GELS_COMPAT, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GELS_COMPAT, _double)
+TEST_P(GELS_COMPAT, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GELS_COMPAT, _float_complex)
+TEST_P(GELS_COMPAT, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GELS_COMPAT, _double_complex)
+TEST_P(GELS_COMPAT, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GELS_INPLACE, _float)
+TEST_P(GELS_INPLACE, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GELS_INPLACE, _double)
+TEST_P(GELS_INPLACE, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GELS_INPLACE, _float_complex)
+TEST_P(GELS_INPLACE, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GELS_INPLACE, _double_complex)
+TEST_P(GELS_INPLACE, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/geqrf_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/geqrf_gtest.cpp
@@ -123,82 +123,82 @@ class GEQRF_COMPAT_64 : public GEQRF_BASE<API_COMPAT, int64_t, size_t>
 
 // non-batch tests
 
-TEST_P(GEQRF, _float)
+TEST_P(GEQRF, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEQRF, _double)
+TEST_P(GEQRF, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEQRF, _float_complex)
+TEST_P(GEQRF, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEQRF, _double_complex)
+TEST_P(GEQRF, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GEQRF_FORTRAN, _float)
+TEST_P(GEQRF_FORTRAN, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEQRF_FORTRAN, _double)
+TEST_P(GEQRF_FORTRAN, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEQRF_FORTRAN, _float_complex)
+TEST_P(GEQRF_FORTRAN, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEQRF_FORTRAN, _double_complex)
+TEST_P(GEQRF_FORTRAN, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GEQRF_COMPAT, _float)
+TEST_P(GEQRF_COMPAT, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEQRF_COMPAT, _double)
+TEST_P(GEQRF_COMPAT, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEQRF_COMPAT, _float_complex)
+TEST_P(GEQRF_COMPAT, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEQRF_COMPAT, _double_complex)
+TEST_P(GEQRF_COMPAT, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GEQRF_COMPAT_64, _float)
+TEST_P(GEQRF_COMPAT_64, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEQRF_COMPAT_64, _double)
+TEST_P(GEQRF_COMPAT_64, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEQRF_COMPAT_64, _float_complex)
+TEST_P(GEQRF_COMPAT_64, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEQRF_COMPAT_64, _double_complex)
+TEST_P(GEQRF_COMPAT_64, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/geqrf_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/geqrf_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -123,82 +123,82 @@ class GEQRF_COMPAT_64 : public GEQRF_BASE<API_COMPAT, int64_t, size_t>
 
 // non-batch tests
 
-TEST_P(GEQRF, __float)
+TEST_P(GEQRF, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEQRF, __double)
+TEST_P(GEQRF, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEQRF, __float_complex)
+TEST_P(GEQRF, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEQRF, __double_complex)
+TEST_P(GEQRF, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GEQRF_FORTRAN, __float)
+TEST_P(GEQRF_FORTRAN, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEQRF_FORTRAN, __double)
+TEST_P(GEQRF_FORTRAN, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEQRF_FORTRAN, __float_complex)
+TEST_P(GEQRF_FORTRAN, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEQRF_FORTRAN, __double_complex)
+TEST_P(GEQRF_FORTRAN, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GEQRF_COMPAT, __float)
+TEST_P(GEQRF_COMPAT, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEQRF_COMPAT, __double)
+TEST_P(GEQRF_COMPAT, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEQRF_COMPAT, __float_complex)
+TEST_P(GEQRF_COMPAT, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEQRF_COMPAT, __double_complex)
+TEST_P(GEQRF_COMPAT, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GEQRF_COMPAT_64, __float)
+TEST_P(GEQRF_COMPAT_64, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEQRF_COMPAT_64, __double)
+TEST_P(GEQRF_COMPAT_64, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEQRF_COMPAT_64, __float_complex)
+TEST_P(GEQRF_COMPAT_64, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEQRF_COMPAT_64, __double_complex)
+TEST_P(GEQRF_COMPAT_64, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/gesv_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/gesv_gtest.cpp
@@ -129,83 +129,83 @@ class GESV_INPLACE : public GESV_BASE<API_NORMAL, true>
 
 // non-batch tests
 
-TEST_P(GESV, _float)
+TEST_P(GESV, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESV, _double)
+TEST_P(GESV, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESV, _float_complex)
+TEST_P(GESV, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESV, _double_complex)
+TEST_P(GESV, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GESV_FORTRAN, _float)
+TEST_P(GESV_FORTRAN, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESV_FORTRAN, _double)
+TEST_P(GESV_FORTRAN, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESV_FORTRAN, _float_complex)
+TEST_P(GESV_FORTRAN, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESV_FORTRAN, _double_complex)
+TEST_P(GESV_FORTRAN, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GESV_COMPAT, _float)
+TEST_P(GESV_COMPAT, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESV_COMPAT, _double)
+TEST_P(GESV_COMPAT, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESV_COMPAT, _float_complex)
+TEST_P(GESV_COMPAT, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESV_COMPAT, _double_complex)
+TEST_P(GESV_COMPAT, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 #if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
-TEST_P(GESV_INPLACE, _float)
+TEST_P(GESV_INPLACE, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESV_INPLACE, _double)
+TEST_P(GESV_INPLACE, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESV_INPLACE, _float_complex)
+TEST_P(GESV_INPLACE, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESV_INPLACE, _double_complex)
+TEST_P(GESV_INPLACE, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/gesv_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/gesv_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -129,83 +129,83 @@ class GESV_INPLACE : public GESV_BASE<API_NORMAL, true>
 
 // non-batch tests
 
-TEST_P(GESV, __float)
+TEST_P(GESV, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESV, __double)
+TEST_P(GESV, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESV, __float_complex)
+TEST_P(GESV, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESV, __double_complex)
+TEST_P(GESV, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GESV_FORTRAN, __float)
+TEST_P(GESV_FORTRAN, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESV_FORTRAN, __double)
+TEST_P(GESV_FORTRAN, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESV_FORTRAN, __float_complex)
+TEST_P(GESV_FORTRAN, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESV_FORTRAN, __double_complex)
+TEST_P(GESV_FORTRAN, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GESV_COMPAT, __float)
+TEST_P(GESV_COMPAT, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESV_COMPAT, __double)
+TEST_P(GESV_COMPAT, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESV_COMPAT, __float_complex)
+TEST_P(GESV_COMPAT, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESV_COMPAT, __double_complex)
+TEST_P(GESV_COMPAT, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 #if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
-TEST_P(GESV_INPLACE, __float)
+TEST_P(GESV_INPLACE, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESV_INPLACE, __double)
+TEST_P(GESV_INPLACE, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESV_INPLACE, __float_complex)
+TEST_P(GESV_INPLACE, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESV_INPLACE, __double_complex)
+TEST_P(GESV_INPLACE, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/gesvd_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/gesvd_gtest.cpp
@@ -186,82 +186,82 @@ class GESVD_NRWK : public GESVD_BASE<API_NORMAL, true>
 
 // non-batch tests
 
-TEST_P(GESVD, _float)
+TEST_P(GESVD, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESVD, _double)
+TEST_P(GESVD, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESVD, _float_complex)
+TEST_P(GESVD, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESVD, _double_complex)
+TEST_P(GESVD, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GESVD_FORTRAN, _float)
+TEST_P(GESVD_FORTRAN, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESVD_FORTRAN, _double)
+TEST_P(GESVD_FORTRAN, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESVD_FORTRAN, _float_complex)
+TEST_P(GESVD_FORTRAN, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESVD_FORTRAN, _double_complex)
+TEST_P(GESVD_FORTRAN, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GESVD_COMPAT, _float)
+TEST_P(GESVD_COMPAT, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESVD_COMPAT, _double)
+TEST_P(GESVD_COMPAT, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESVD_COMPAT, _float_complex)
+TEST_P(GESVD_COMPAT, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESVD_COMPAT, _double_complex)
+TEST_P(GESVD_COMPAT, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GESVD_NRWK, _float)
+TEST_P(GESVD_NRWK, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESVD_NRWK, _double)
+TEST_P(GESVD_NRWK, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESVD_NRWK, _float_complex)
+TEST_P(GESVD_NRWK, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESVD_NRWK, _double_complex)
+TEST_P(GESVD_NRWK, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/gesvd_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/gesvd_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -186,82 +186,82 @@ class GESVD_NRWK : public GESVD_BASE<API_NORMAL, true>
 
 // non-batch tests
 
-TEST_P(GESVD, __float)
+TEST_P(GESVD, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESVD, __double)
+TEST_P(GESVD, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESVD, __float_complex)
+TEST_P(GESVD, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESVD, __double_complex)
+TEST_P(GESVD, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GESVD_FORTRAN, __float)
+TEST_P(GESVD_FORTRAN, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESVD_FORTRAN, __double)
+TEST_P(GESVD_FORTRAN, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESVD_FORTRAN, __float_complex)
+TEST_P(GESVD_FORTRAN, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESVD_FORTRAN, __double_complex)
+TEST_P(GESVD_FORTRAN, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GESVD_COMPAT, __float)
+TEST_P(GESVD_COMPAT, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESVD_COMPAT, __double)
+TEST_P(GESVD_COMPAT, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESVD_COMPAT, __float_complex)
+TEST_P(GESVD_COMPAT, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESVD_COMPAT, __double_complex)
+TEST_P(GESVD_COMPAT, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GESVD_NRWK, __float)
+TEST_P(GESVD_NRWK, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESVD_NRWK, __double)
+TEST_P(GESVD_NRWK, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESVD_NRWK, __float_complex)
+TEST_P(GESVD_NRWK, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESVD_NRWK, __double_complex)
+TEST_P(GESVD_NRWK, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/gesvda_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/gesvda_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc.
+ * Copyright (C) 2022-2026 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -105,22 +105,22 @@ class GESVDA_COMPAT : public GESVDA_BASE<API_COMPAT>
 
 // strided_batched tests
 
-TEST_P(GESVDA_COMPAT, strided_batched__float)
+TEST_P(GESVDA_COMPAT, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GESVDA_COMPAT, strided_batched__double)
+TEST_P(GESVDA_COMPAT, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GESVDA_COMPAT, strided_batched__float_complex)
+TEST_P(GESVDA_COMPAT, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GESVDA_COMPAT, strided_batched__double_complex)
+TEST_P(GESVDA_COMPAT, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/gesvdj_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/gesvdj_gtest.cpp
@@ -151,62 +151,62 @@ class GESVDJ_COMPAT : public GESVDJ_BASE<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(GESVDJ, _float)
+TEST_P(GESVDJ, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESVDJ, _double)
+TEST_P(GESVDJ, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESVDJ, _float_complex)
+TEST_P(GESVDJ, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESVDJ, _double_complex)
+TEST_P(GESVDJ, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GESVDJ_FORTRAN, _float)
+TEST_P(GESVDJ_FORTRAN, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESVDJ_FORTRAN, _double)
+TEST_P(GESVDJ_FORTRAN, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESVDJ_FORTRAN, _float_complex)
+TEST_P(GESVDJ_FORTRAN, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESVDJ_FORTRAN, _double_complex)
+TEST_P(GESVDJ_FORTRAN, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GESVDJ_COMPAT, _float)
+TEST_P(GESVDJ_COMPAT, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESVDJ_COMPAT, _double)
+TEST_P(GESVDJ_COMPAT, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESVDJ_COMPAT, _float_complex)
+TEST_P(GESVDJ_COMPAT, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESVDJ_COMPAT, _double_complex)
+TEST_P(GESVDJ_COMPAT, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/gesvdj_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/gesvdj_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -151,124 +151,124 @@ class GESVDJ_COMPAT : public GESVDJ_BASE<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(GESVDJ, __float)
+TEST_P(GESVDJ, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESVDJ, __double)
+TEST_P(GESVDJ, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESVDJ, __float_complex)
+TEST_P(GESVDJ, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESVDJ, __double_complex)
+TEST_P(GESVDJ, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GESVDJ_FORTRAN, __float)
+TEST_P(GESVDJ_FORTRAN, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESVDJ_FORTRAN, __double)
+TEST_P(GESVDJ_FORTRAN, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESVDJ_FORTRAN, __float_complex)
+TEST_P(GESVDJ_FORTRAN, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESVDJ_FORTRAN, __double_complex)
+TEST_P(GESVDJ_FORTRAN, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GESVDJ_COMPAT, __float)
+TEST_P(GESVDJ_COMPAT, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESVDJ_COMPAT, __double)
+TEST_P(GESVDJ_COMPAT, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESVDJ_COMPAT, __float_complex)
+TEST_P(GESVDJ_COMPAT, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESVDJ_COMPAT, __double_complex)
+TEST_P(GESVDJ_COMPAT, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(GESVDJ, strided_batched__float)
+TEST_P(GESVDJ, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GESVDJ, strided_batched__double)
+TEST_P(GESVDJ, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GESVDJ, strided_batched__float_complex)
+TEST_P(GESVDJ, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GESVDJ, strided_batched__double_complex)
+TEST_P(GESVDJ, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GESVDJ_FORTRAN, strided_batched__float)
+TEST_P(GESVDJ_FORTRAN, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GESVDJ_FORTRAN, strided_batched__double)
+TEST_P(GESVDJ_FORTRAN, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GESVDJ_FORTRAN, strided_batched__float_complex)
+TEST_P(GESVDJ_FORTRAN, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GESVDJ_FORTRAN, strided_batched__double_complex)
+TEST_P(GESVDJ_FORTRAN, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GESVDJ_COMPAT, strided_batched__float)
+TEST_P(GESVDJ_COMPAT, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GESVDJ_COMPAT, strided_batched__double)
+TEST_P(GESVDJ_COMPAT, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GESVDJ_COMPAT, strided_batched__float_complex)
+TEST_P(GESVDJ_COMPAT, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GESVDJ_COMPAT, strided_batched__double_complex)
+TEST_P(GESVDJ_COMPAT, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/getrf_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/getrf_gtest.cpp
@@ -139,122 +139,122 @@ class GETRF_COMPAT_NPVT_64 : public GETRF_BASE<API_COMPAT, true, int64_t, size_t
 
 // non-batch tests
 
-TEST_P(GETRF, _float)
+TEST_P(GETRF, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRF, _double)
+TEST_P(GETRF, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRF, _float_complex)
+TEST_P(GETRF, FloatComplex)
 {
     run_tests<false, false, hipsolverComplex>();
 }
 
-TEST_P(GETRF, _double_complex)
+TEST_P(GETRF, DoubleComplex)
 {
     run_tests<false, false, hipsolverDoubleComplex>();
 }
 
-TEST_P(GETRF_NPVT, _float)
+TEST_P(GETRF_NPVT, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRF_NPVT, _double)
+TEST_P(GETRF_NPVT, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRF_NPVT, _float_complex)
+TEST_P(GETRF_NPVT, FloatComplex)
 {
     run_tests<false, false, hipsolverComplex>();
 }
 
-TEST_P(GETRF_NPVT, _double_complex)
+TEST_P(GETRF_NPVT, DoubleComplex)
 {
     run_tests<false, false, hipsolverDoubleComplex>();
 }
 
-TEST_P(GETRF_FORTRAN, _float)
+TEST_P(GETRF_FORTRAN, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRF_FORTRAN, _double)
+TEST_P(GETRF_FORTRAN, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRF_FORTRAN, _float_complex)
+TEST_P(GETRF_FORTRAN, FloatComplex)
 {
     run_tests<false, false, hipsolverComplex>();
 }
 
-TEST_P(GETRF_FORTRAN, _double_complex)
+TEST_P(GETRF_FORTRAN, DoubleComplex)
 {
     run_tests<false, false, hipsolverDoubleComplex>();
 }
 
-TEST_P(GETRF_COMPAT, _float)
+TEST_P(GETRF_COMPAT, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRF_COMPAT, _double)
+TEST_P(GETRF_COMPAT, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRF_COMPAT, _float_complex)
+TEST_P(GETRF_COMPAT, FloatComplex)
 {
     run_tests<false, false, hipsolverComplex>();
 }
 
-TEST_P(GETRF_COMPAT, _double_complex)
+TEST_P(GETRF_COMPAT, DoubleComplex)
 {
     run_tests<false, false, hipsolverDoubleComplex>();
 }
 
-TEST_P(GETRF_COMPAT_64, _float)
+TEST_P(GETRF_COMPAT_64, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRF_COMPAT_64, _double)
+TEST_P(GETRF_COMPAT_64, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRF_COMPAT_64, _float_complex)
+TEST_P(GETRF_COMPAT_64, FloatComplex)
 {
     run_tests<false, false, hipsolverComplex>();
 }
 
-TEST_P(GETRF_COMPAT_64, _double_complex)
+TEST_P(GETRF_COMPAT_64, DoubleComplex)
 {
     run_tests<false, false, hipsolverDoubleComplex>();
 }
 
-TEST_P(GETRF_COMPAT_NPVT_64, _float)
+TEST_P(GETRF_COMPAT_NPVT_64, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRF_COMPAT_NPVT_64, _double)
+TEST_P(GETRF_COMPAT_NPVT_64, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRF_COMPAT_NPVT_64, _float_complex)
+TEST_P(GETRF_COMPAT_NPVT_64, FloatComplex)
 {
     run_tests<false, false, hipsolverComplex>();
 }
 
-TEST_P(GETRF_COMPAT_NPVT_64, _double_complex)
+TEST_P(GETRF_COMPAT_NPVT_64, DoubleComplex)
 {
     run_tests<false, false, hipsolverDoubleComplex>();
 }

--- a/projects/hipsolver/clients/gtest/getrf_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/getrf_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -139,122 +139,122 @@ class GETRF_COMPAT_NPVT_64 : public GETRF_BASE<API_COMPAT, true, int64_t, size_t
 
 // non-batch tests
 
-TEST_P(GETRF, __float)
+TEST_P(GETRF, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRF, __double)
+TEST_P(GETRF, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRF, __float_complex)
+TEST_P(GETRF, _float_complex)
 {
     run_tests<false, false, hipsolverComplex>();
 }
 
-TEST_P(GETRF, __double_complex)
+TEST_P(GETRF, _double_complex)
 {
     run_tests<false, false, hipsolverDoubleComplex>();
 }
 
-TEST_P(GETRF_NPVT, __float)
+TEST_P(GETRF_NPVT, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRF_NPVT, __double)
+TEST_P(GETRF_NPVT, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRF_NPVT, __float_complex)
+TEST_P(GETRF_NPVT, _float_complex)
 {
     run_tests<false, false, hipsolverComplex>();
 }
 
-TEST_P(GETRF_NPVT, __double_complex)
+TEST_P(GETRF_NPVT, _double_complex)
 {
     run_tests<false, false, hipsolverDoubleComplex>();
 }
 
-TEST_P(GETRF_FORTRAN, __float)
+TEST_P(GETRF_FORTRAN, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRF_FORTRAN, __double)
+TEST_P(GETRF_FORTRAN, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRF_FORTRAN, __float_complex)
+TEST_P(GETRF_FORTRAN, _float_complex)
 {
     run_tests<false, false, hipsolverComplex>();
 }
 
-TEST_P(GETRF_FORTRAN, __double_complex)
+TEST_P(GETRF_FORTRAN, _double_complex)
 {
     run_tests<false, false, hipsolverDoubleComplex>();
 }
 
-TEST_P(GETRF_COMPAT, __float)
+TEST_P(GETRF_COMPAT, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRF_COMPAT, __double)
+TEST_P(GETRF_COMPAT, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRF_COMPAT, __float_complex)
+TEST_P(GETRF_COMPAT, _float_complex)
 {
     run_tests<false, false, hipsolverComplex>();
 }
 
-TEST_P(GETRF_COMPAT, __double_complex)
+TEST_P(GETRF_COMPAT, _double_complex)
 {
     run_tests<false, false, hipsolverDoubleComplex>();
 }
 
-TEST_P(GETRF_COMPAT_64, __float)
+TEST_P(GETRF_COMPAT_64, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRF_COMPAT_64, __double)
+TEST_P(GETRF_COMPAT_64, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRF_COMPAT_64, __float_complex)
+TEST_P(GETRF_COMPAT_64, _float_complex)
 {
     run_tests<false, false, hipsolverComplex>();
 }
 
-TEST_P(GETRF_COMPAT_64, __double_complex)
+TEST_P(GETRF_COMPAT_64, _double_complex)
 {
     run_tests<false, false, hipsolverDoubleComplex>();
 }
 
-TEST_P(GETRF_COMPAT_NPVT_64, __float)
+TEST_P(GETRF_COMPAT_NPVT_64, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRF_COMPAT_NPVT_64, __double)
+TEST_P(GETRF_COMPAT_NPVT_64, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRF_COMPAT_NPVT_64, __float_complex)
+TEST_P(GETRF_COMPAT_NPVT_64, _float_complex)
 {
     run_tests<false, false, hipsolverComplex>();
 }
 
-TEST_P(GETRF_COMPAT_NPVT_64, __double_complex)
+TEST_P(GETRF_COMPAT_NPVT_64, _double_complex)
 {
     run_tests<false, false, hipsolverDoubleComplex>();
 }

--- a/projects/hipsolver/clients/gtest/getrs_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/getrs_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -140,82 +140,82 @@ class GETRS_COMPAT_64 : public GETRS_BASE<API_COMPAT, int64_t, size_t>
 
 // non-batch tests
 
-TEST_P(GETRS, __float)
+TEST_P(GETRS, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRS, __double)
+TEST_P(GETRS, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRS, __float_complex)
+TEST_P(GETRS, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRS, __double_complex)
+TEST_P(GETRS, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GETRS_FORTRAN, __float)
+TEST_P(GETRS_FORTRAN, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRS_FORTRAN, __double)
+TEST_P(GETRS_FORTRAN, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRS_FORTRAN, __float_complex)
+TEST_P(GETRS_FORTRAN, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRS_FORTRAN, __double_complex)
+TEST_P(GETRS_FORTRAN, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GETRS_COMPAT, __float)
+TEST_P(GETRS_COMPAT, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRS_COMPAT, __double)
+TEST_P(GETRS_COMPAT, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRS_COMPAT, __float_complex)
+TEST_P(GETRS_COMPAT, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRS_COMPAT, __double_complex)
+TEST_P(GETRS_COMPAT, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GETRS_COMPAT_64, __float)
+TEST_P(GETRS_COMPAT_64, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRS_COMPAT_64, __double)
+TEST_P(GETRS_COMPAT_64, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRS_COMPAT_64, __float_complex)
+TEST_P(GETRS_COMPAT_64, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRS_COMPAT_64, __double_complex)
+TEST_P(GETRS_COMPAT_64, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/getrs_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/getrs_gtest.cpp
@@ -140,82 +140,82 @@ class GETRS_COMPAT_64 : public GETRS_BASE<API_COMPAT, int64_t, size_t>
 
 // non-batch tests
 
-TEST_P(GETRS, _float)
+TEST_P(GETRS, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRS, _double)
+TEST_P(GETRS, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRS, _float_complex)
+TEST_P(GETRS, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRS, _double_complex)
+TEST_P(GETRS, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GETRS_FORTRAN, _float)
+TEST_P(GETRS_FORTRAN, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRS_FORTRAN, _double)
+TEST_P(GETRS_FORTRAN, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRS_FORTRAN, _float_complex)
+TEST_P(GETRS_FORTRAN, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRS_FORTRAN, _double_complex)
+TEST_P(GETRS_FORTRAN, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GETRS_COMPAT, _float)
+TEST_P(GETRS_COMPAT, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRS_COMPAT, _double)
+TEST_P(GETRS_COMPAT, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRS_COMPAT, _float_complex)
+TEST_P(GETRS_COMPAT, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRS_COMPAT, _double_complex)
+TEST_P(GETRS_COMPAT, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GETRS_COMPAT_64, _float)
+TEST_P(GETRS_COMPAT_64, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRS_COMPAT_64, _double)
+TEST_P(GETRS_COMPAT_64, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRS_COMPAT_64, _float_complex)
+TEST_P(GETRS_COMPAT_64, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRS_COMPAT_64, _double_complex)
+TEST_P(GETRS_COMPAT_64, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/hipblas_include1_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/hipblas_include1_gtest.cpp
@@ -140,22 +140,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(HIPBLAS_INCLUDE1, _float)
+TEST_P(HIPBLAS_INCLUDE1, Float)
 {
     run_tests<float>();
 }
 
-TEST_P(HIPBLAS_INCLUDE1, _double)
+TEST_P(HIPBLAS_INCLUDE1, Double)
 {
     run_tests<double>();
 }
 
-TEST_P(HIPBLAS_INCLUDE1, _float_complex)
+TEST_P(HIPBLAS_INCLUDE1, FloatComplex)
 {
     run_tests<hipsolverComplex>();
 }
 
-TEST_P(HIPBLAS_INCLUDE1, _double_complex)
+TEST_P(HIPBLAS_INCLUDE1, DoubleComplex)
 {
     run_tests<hipsolverDoubleComplex>();
 }

--- a/projects/hipsolver/clients/gtest/hipblas_include1_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/hipblas_include1_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -140,22 +140,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(HIPBLAS_INCLUDE1, __float)
+TEST_P(HIPBLAS_INCLUDE1, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(HIPBLAS_INCLUDE1, __double)
+TEST_P(HIPBLAS_INCLUDE1, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(HIPBLAS_INCLUDE1, __float_complex)
+TEST_P(HIPBLAS_INCLUDE1, _float_complex)
 {
     run_tests<hipsolverComplex>();
 }
 
-TEST_P(HIPBLAS_INCLUDE1, __double_complex)
+TEST_P(HIPBLAS_INCLUDE1, _double_complex)
 {
     run_tests<hipsolverDoubleComplex>();
 }

--- a/projects/hipsolver/clients/gtest/hipblas_include2_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/hipblas_include2_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -140,22 +140,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(HIPBLAS_INCLUDE2, __float)
+TEST_P(HIPBLAS_INCLUDE2, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(HIPBLAS_INCLUDE2, __double)
+TEST_P(HIPBLAS_INCLUDE2, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(HIPBLAS_INCLUDE2, __float_complex)
+TEST_P(HIPBLAS_INCLUDE2, _float_complex)
 {
     run_tests<hipsolverComplex>();
 }
 
-TEST_P(HIPBLAS_INCLUDE2, __double_complex)
+TEST_P(HIPBLAS_INCLUDE2, _double_complex)
 {
     run_tests<hipsolverDoubleComplex>();
 }

--- a/projects/hipsolver/clients/gtest/hipblas_include2_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/hipblas_include2_gtest.cpp
@@ -140,22 +140,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(HIPBLAS_INCLUDE2, _float)
+TEST_P(HIPBLAS_INCLUDE2, Float)
 {
     run_tests<float>();
 }
 
-TEST_P(HIPBLAS_INCLUDE2, _double)
+TEST_P(HIPBLAS_INCLUDE2, Double)
 {
     run_tests<double>();
 }
 
-TEST_P(HIPBLAS_INCLUDE2, _float_complex)
+TEST_P(HIPBLAS_INCLUDE2, FloatComplex)
 {
     run_tests<hipsolverComplex>();
 }
 
-TEST_P(HIPBLAS_INCLUDE2, _double_complex)
+TEST_P(HIPBLAS_INCLUDE2, DoubleComplex)
 {
     run_tests<hipsolverDoubleComplex>();
 }

--- a/projects/hipsolver/clients/gtest/orgbr_ungbr_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/orgbr_ungbr_gtest.cpp
@@ -147,62 +147,62 @@ class UNGBR_COMPAT : public ORGBR_UNGBR<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(ORGBR, _float)
+TEST_P(ORGBR, Float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORGBR, _double)
+TEST_P(ORGBR, Double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNGBR, _float_complex)
+TEST_P(UNGBR, FloatComplex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNGBR, _double_complex)
+TEST_P(UNGBR, DoubleComplex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORGBR_FORTRAN, _float)
+TEST_P(ORGBR_FORTRAN, Float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORGBR_FORTRAN, _double)
+TEST_P(ORGBR_FORTRAN, Double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNGBR_FORTRAN, _float_complex)
+TEST_P(UNGBR_FORTRAN, FloatComplex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNGBR_FORTRAN, _double_complex)
+TEST_P(UNGBR_FORTRAN, DoubleComplex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORGBR_COMPAT, _float)
+TEST_P(ORGBR_COMPAT, Float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORGBR_COMPAT, _double)
+TEST_P(ORGBR_COMPAT, Double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNGBR_COMPAT, _float_complex)
+TEST_P(UNGBR_COMPAT, FloatComplex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNGBR_COMPAT, _double_complex)
+TEST_P(UNGBR_COMPAT, DoubleComplex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/orgbr_ungbr_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/orgbr_ungbr_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -147,62 +147,62 @@ class UNGBR_COMPAT : public ORGBR_UNGBR<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(ORGBR, __float)
+TEST_P(ORGBR, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORGBR, __double)
+TEST_P(ORGBR, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNGBR, __float_complex)
+TEST_P(UNGBR, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNGBR, __double_complex)
+TEST_P(UNGBR, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORGBR_FORTRAN, __float)
+TEST_P(ORGBR_FORTRAN, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORGBR_FORTRAN, __double)
+TEST_P(ORGBR_FORTRAN, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNGBR_FORTRAN, __float_complex)
+TEST_P(UNGBR_FORTRAN, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNGBR_FORTRAN, __double_complex)
+TEST_P(UNGBR_FORTRAN, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORGBR_COMPAT, __float)
+TEST_P(ORGBR_COMPAT, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORGBR_COMPAT, __double)
+TEST_P(ORGBR_COMPAT, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNGBR_COMPAT, __float_complex)
+TEST_P(UNGBR_COMPAT, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNGBR_COMPAT, __double_complex)
+TEST_P(UNGBR_COMPAT, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/orgqr_ungqr_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/orgqr_ungqr_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -132,62 +132,62 @@ class UNGQR_COMPAT : public ORGQR_UNGQR<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(ORGQR, __float)
+TEST_P(ORGQR, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORGQR, __double)
+TEST_P(ORGQR, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNGQR, __float_complex)
+TEST_P(UNGQR, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNGQR, __double_complex)
+TEST_P(UNGQR, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORGQR_FORTRAN, __float)
+TEST_P(ORGQR_FORTRAN, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORGQR_FORTRAN, __double)
+TEST_P(ORGQR_FORTRAN, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNGQR_FORTRAN, __float_complex)
+TEST_P(UNGQR_FORTRAN, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNGQR_FORTRAN, __double_complex)
+TEST_P(UNGQR_FORTRAN, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORGQR_COMPAT, __float)
+TEST_P(ORGQR_COMPAT, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORGQR_COMPAT, __double)
+TEST_P(ORGQR_COMPAT, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNGQR_COMPAT, __float_complex)
+TEST_P(UNGQR_COMPAT, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNGQR_COMPAT, __double_complex)
+TEST_P(UNGQR_COMPAT, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/orgqr_ungqr_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/orgqr_ungqr_gtest.cpp
@@ -132,62 +132,62 @@ class UNGQR_COMPAT : public ORGQR_UNGQR<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(ORGQR, _float)
+TEST_P(ORGQR, Float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORGQR, _double)
+TEST_P(ORGQR, Double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNGQR, _float_complex)
+TEST_P(UNGQR, FloatComplex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNGQR, _double_complex)
+TEST_P(UNGQR, DoubleComplex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORGQR_FORTRAN, _float)
+TEST_P(ORGQR_FORTRAN, Float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORGQR_FORTRAN, _double)
+TEST_P(ORGQR_FORTRAN, Double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNGQR_FORTRAN, _float_complex)
+TEST_P(UNGQR_FORTRAN, FloatComplex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNGQR_FORTRAN, _double_complex)
+TEST_P(UNGQR_FORTRAN, DoubleComplex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORGQR_COMPAT, _float)
+TEST_P(ORGQR_COMPAT, Float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORGQR_COMPAT, _double)
+TEST_P(ORGQR_COMPAT, Double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNGQR_COMPAT, _float_complex)
+TEST_P(UNGQR_COMPAT, FloatComplex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNGQR_COMPAT, _double_complex)
+TEST_P(UNGQR_COMPAT, DoubleComplex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/orgtr_ungtr_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/orgtr_ungtr_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -116,62 +116,62 @@ class UNGTR_COMPAT : public ORGTR_UNGTR<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(ORGTR, __float)
+TEST_P(ORGTR, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORGTR, __double)
+TEST_P(ORGTR, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNGTR, __float_complex)
+TEST_P(UNGTR, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNGTR, __double_complex)
+TEST_P(UNGTR, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORGTR_FORTRAN, __float)
+TEST_P(ORGTR_FORTRAN, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORGTR_FORTRAN, __double)
+TEST_P(ORGTR_FORTRAN, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNGTR_FORTRAN, __float_complex)
+TEST_P(UNGTR_FORTRAN, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNGTR_FORTRAN, __double_complex)
+TEST_P(UNGTR_FORTRAN, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORGTR_COMPAT, __float)
+TEST_P(ORGTR_COMPAT, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORGTR_COMPAT, __double)
+TEST_P(ORGTR_COMPAT, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNGTR_COMPAT, __float_complex)
+TEST_P(UNGTR_COMPAT, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNGTR_COMPAT, __double_complex)
+TEST_P(UNGTR_COMPAT, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/orgtr_ungtr_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/orgtr_ungtr_gtest.cpp
@@ -116,62 +116,62 @@ class UNGTR_COMPAT : public ORGTR_UNGTR<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(ORGTR, _float)
+TEST_P(ORGTR, Float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORGTR, _double)
+TEST_P(ORGTR, Double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNGTR, _float_complex)
+TEST_P(UNGTR, FloatComplex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNGTR, _double_complex)
+TEST_P(UNGTR, DoubleComplex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORGTR_FORTRAN, _float)
+TEST_P(ORGTR_FORTRAN, Float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORGTR_FORTRAN, _double)
+TEST_P(ORGTR_FORTRAN, Double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNGTR_FORTRAN, _float_complex)
+TEST_P(UNGTR_FORTRAN, FloatComplex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNGTR_FORTRAN, _double_complex)
+TEST_P(UNGTR_FORTRAN, DoubleComplex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORGTR_COMPAT, _float)
+TEST_P(ORGTR_COMPAT, Float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORGTR_COMPAT, _double)
+TEST_P(ORGTR_COMPAT, Double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNGTR_COMPAT, _float_complex)
+TEST_P(UNGTR_COMPAT, FloatComplex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNGTR_COMPAT, _double_complex)
+TEST_P(UNGTR_COMPAT, DoubleComplex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/ormqr_unmqr_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/ormqr_unmqr_gtest.cpp
@@ -156,62 +156,62 @@ class UNMQR_COMPAT : public ORMQR_UNMQR<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(ORMQR, _float)
+TEST_P(ORMQR, Float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORMQR, _double)
+TEST_P(ORMQR, Double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNMQR, _float_complex)
+TEST_P(UNMQR, FloatComplex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNMQR, _double_complex)
+TEST_P(UNMQR, DoubleComplex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORMQR_FORTRAN, _float)
+TEST_P(ORMQR_FORTRAN, Float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORMQR_FORTRAN, _double)
+TEST_P(ORMQR_FORTRAN, Double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNMQR_FORTRAN, _float_complex)
+TEST_P(UNMQR_FORTRAN, FloatComplex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNMQR_FORTRAN, _double_complex)
+TEST_P(UNMQR_FORTRAN, DoubleComplex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORMQR_COMPAT, _float)
+TEST_P(ORMQR_COMPAT, Float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORMQR_COMPAT, _double)
+TEST_P(ORMQR_COMPAT, Double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNMQR_COMPAT, _float_complex)
+TEST_P(UNMQR_COMPAT, FloatComplex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNMQR_COMPAT, _double_complex)
+TEST_P(UNMQR_COMPAT, DoubleComplex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/ormqr_unmqr_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/ormqr_unmqr_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -156,62 +156,62 @@ class UNMQR_COMPAT : public ORMQR_UNMQR<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(ORMQR, __float)
+TEST_P(ORMQR, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORMQR, __double)
+TEST_P(ORMQR, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNMQR, __float_complex)
+TEST_P(UNMQR, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNMQR, __double_complex)
+TEST_P(UNMQR, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORMQR_FORTRAN, __float)
+TEST_P(ORMQR_FORTRAN, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORMQR_FORTRAN, __double)
+TEST_P(ORMQR_FORTRAN, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNMQR_FORTRAN, __float_complex)
+TEST_P(UNMQR_FORTRAN, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNMQR_FORTRAN, __double_complex)
+TEST_P(UNMQR_FORTRAN, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORMQR_COMPAT, __float)
+TEST_P(ORMQR_COMPAT, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORMQR_COMPAT, __double)
+TEST_P(ORMQR_COMPAT, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNMQR_COMPAT, __float_complex)
+TEST_P(UNMQR_COMPAT, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNMQR_COMPAT, __double_complex)
+TEST_P(UNMQR_COMPAT, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/ormtr_unmtr_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/ormtr_unmtr_gtest.cpp
@@ -169,62 +169,62 @@ class UNMTR_COMPAT : public ORMTR_UNMTR<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(ORMTR, _float)
+TEST_P(ORMTR, Float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORMTR, _double)
+TEST_P(ORMTR, Double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNMTR, _float_complex)
+TEST_P(UNMTR, FloatComplex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNMTR, _double_complex)
+TEST_P(UNMTR, DoubleComplex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORMTR_FORTRAN, _float)
+TEST_P(ORMTR_FORTRAN, Float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORMTR_FORTRAN, _double)
+TEST_P(ORMTR_FORTRAN, Double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNMTR_FORTRAN, _float_complex)
+TEST_P(UNMTR_FORTRAN, FloatComplex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNMTR_FORTRAN, _double_complex)
+TEST_P(UNMTR_FORTRAN, DoubleComplex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORMTR_COMPAT, _float)
+TEST_P(ORMTR_COMPAT, Float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORMTR_COMPAT, _double)
+TEST_P(ORMTR_COMPAT, Double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNMTR_COMPAT, _float_complex)
+TEST_P(UNMTR_COMPAT, FloatComplex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNMTR_COMPAT, _double_complex)
+TEST_P(UNMTR_COMPAT, DoubleComplex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/ormtr_unmtr_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/ormtr_unmtr_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -169,62 +169,62 @@ class UNMTR_COMPAT : public ORMTR_UNMTR<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(ORMTR, __float)
+TEST_P(ORMTR, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORMTR, __double)
+TEST_P(ORMTR, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNMTR, __float_complex)
+TEST_P(UNMTR, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNMTR, __double_complex)
+TEST_P(UNMTR, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORMTR_FORTRAN, __float)
+TEST_P(ORMTR_FORTRAN, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORMTR_FORTRAN, __double)
+TEST_P(ORMTR_FORTRAN, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNMTR_FORTRAN, __float_complex)
+TEST_P(UNMTR_FORTRAN, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNMTR_FORTRAN, __double_complex)
+TEST_P(UNMTR_FORTRAN, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORMTR_COMPAT, __float)
+TEST_P(ORMTR_COMPAT, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORMTR_COMPAT, __double)
+TEST_P(ORMTR_COMPAT, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNMTR_COMPAT, __float_complex)
+TEST_P(UNMTR_COMPAT, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNMTR_COMPAT, __double_complex)
+TEST_P(UNMTR_COMPAT, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/potrf_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/potrf_gtest.cpp
@@ -116,62 +116,62 @@ class POTRF_COMPAT : public POTRF_BASE<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(POTRF, _float)
+TEST_P(POTRF, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTRF, _double)
+TEST_P(POTRF, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTRF, _float_complex)
+TEST_P(POTRF, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRF, _double_complex)
+TEST_P(POTRF, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(POTRF_FORTRAN, _float)
+TEST_P(POTRF_FORTRAN, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTRF_FORTRAN, _double)
+TEST_P(POTRF_FORTRAN, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTRF_FORTRAN, _float_complex)
+TEST_P(POTRF_FORTRAN, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRF_FORTRAN, _double_complex)
+TEST_P(POTRF_FORTRAN, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(POTRF_COMPAT, _float)
+TEST_P(POTRF_COMPAT, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTRF_COMPAT, _double)
+TEST_P(POTRF_COMPAT, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTRF_COMPAT, _float_complex)
+TEST_P(POTRF_COMPAT, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRF_COMPAT, _double_complex)
+TEST_P(POTRF_COMPAT, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/potrf_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/potrf_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -116,124 +116,124 @@ class POTRF_COMPAT : public POTRF_BASE<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(POTRF, __float)
+TEST_P(POTRF, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTRF, __double)
+TEST_P(POTRF, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTRF, __float_complex)
+TEST_P(POTRF, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRF, __double_complex)
+TEST_P(POTRF, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(POTRF_FORTRAN, __float)
+TEST_P(POTRF_FORTRAN, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTRF_FORTRAN, __double)
+TEST_P(POTRF_FORTRAN, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTRF_FORTRAN, __float_complex)
+TEST_P(POTRF_FORTRAN, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRF_FORTRAN, __double_complex)
+TEST_P(POTRF_FORTRAN, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(POTRF_COMPAT, __float)
+TEST_P(POTRF_COMPAT, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTRF_COMPAT, __double)
+TEST_P(POTRF_COMPAT, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTRF_COMPAT, __float_complex)
+TEST_P(POTRF_COMPAT, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRF_COMPAT, __double_complex)
+TEST_P(POTRF_COMPAT, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(POTRF, batched__float)
+TEST_P(POTRF, batched_float)
 {
     run_tests<true, false, float>();
 }
 
-TEST_P(POTRF, batched__double)
+TEST_P(POTRF, batched_double)
 {
     run_tests<true, false, double>();
 }
 
-TEST_P(POTRF, batched__float_complex)
+TEST_P(POTRF, batched_float_complex)
 {
     run_tests<true, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRF, batched__double_complex)
+TEST_P(POTRF, batched_double_complex)
 {
     run_tests<true, false, rocblas_double_complex>();
 }
 
-TEST_P(POTRF_FORTRAN, batched__float)
+TEST_P(POTRF_FORTRAN, batched_float)
 {
     run_tests<true, false, float>();
 }
 
-TEST_P(POTRF_FORTRAN, batched__double)
+TEST_P(POTRF_FORTRAN, batched_double)
 {
     run_tests<true, false, double>();
 }
 
-TEST_P(POTRF_FORTRAN, batched__float_complex)
+TEST_P(POTRF_FORTRAN, batched_float_complex)
 {
     run_tests<true, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRF_FORTRAN, batched__double_complex)
+TEST_P(POTRF_FORTRAN, batched_double_complex)
 {
     run_tests<true, false, rocblas_double_complex>();
 }
 
-TEST_P(POTRF_COMPAT, batched__float)
+TEST_P(POTRF_COMPAT, batched_float)
 {
     run_tests<true, false, float>();
 }
 
-TEST_P(POTRF_COMPAT, batched__double)
+TEST_P(POTRF_COMPAT, batched_double)
 {
     run_tests<true, false, double>();
 }
 
-TEST_P(POTRF_COMPAT, batched__float_complex)
+TEST_P(POTRF_COMPAT, batched_float_complex)
 {
     run_tests<true, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRF_COMPAT, batched__double_complex)
+TEST_P(POTRF_COMPAT, batched_double_complex)
 {
     run_tests<true, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/potri_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/potri_gtest.cpp
@@ -110,62 +110,62 @@ class POTRI_COMPAT : public POTRI_BASE<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(POTRI, _float)
+TEST_P(POTRI, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTRI, _double)
+TEST_P(POTRI, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTRI, _float_complex)
+TEST_P(POTRI, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRI, _double_complex)
+TEST_P(POTRI, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(POTRI_FORTRAN, _float)
+TEST_P(POTRI_FORTRAN, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTRI_FORTRAN, _double)
+TEST_P(POTRI_FORTRAN, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTRI_FORTRAN, _float_complex)
+TEST_P(POTRI_FORTRAN, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRI_FORTRAN, _double_complex)
+TEST_P(POTRI_FORTRAN, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(POTRI_COMPAT, _float)
+TEST_P(POTRI_COMPAT, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTRI_COMPAT, _double)
+TEST_P(POTRI_COMPAT, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTRI_COMPAT, _float_complex)
+TEST_P(POTRI_COMPAT, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRI_COMPAT, _double_complex)
+TEST_P(POTRI_COMPAT, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/potri_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/potri_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -110,62 +110,62 @@ class POTRI_COMPAT : public POTRI_BASE<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(POTRI, __float)
+TEST_P(POTRI, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTRI, __double)
+TEST_P(POTRI, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTRI, __float_complex)
+TEST_P(POTRI, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRI, __double_complex)
+TEST_P(POTRI, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(POTRI_FORTRAN, __float)
+TEST_P(POTRI_FORTRAN, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTRI_FORTRAN, __double)
+TEST_P(POTRI_FORTRAN, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTRI_FORTRAN, __float_complex)
+TEST_P(POTRI_FORTRAN, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRI_FORTRAN, __double_complex)
+TEST_P(POTRI_FORTRAN, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(POTRI_COMPAT, __float)
+TEST_P(POTRI_COMPAT, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTRI_COMPAT, __double)
+TEST_P(POTRI_COMPAT, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTRI_COMPAT, __float_complex)
+TEST_P(POTRI_COMPAT, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRI_COMPAT, __double_complex)
+TEST_P(POTRI_COMPAT, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/potrs_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/potrs_gtest.cpp
@@ -127,62 +127,62 @@ class POTRS_COMPAT : public POTRS_BASE<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(POTRS, _float)
+TEST_P(POTRS, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTRS, _double)
+TEST_P(POTRS, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTRS, _float_complex)
+TEST_P(POTRS, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRS, _double_complex)
+TEST_P(POTRS, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(POTRS_FORTRAN, _float)
+TEST_P(POTRS_FORTRAN, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTRS_FORTRAN, _double)
+TEST_P(POTRS_FORTRAN, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTRS_FORTRAN, _float_complex)
+TEST_P(POTRS_FORTRAN, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRS_FORTRAN, _double_complex)
+TEST_P(POTRS_FORTRAN, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(POTRS_COMPAT, _float)
+TEST_P(POTRS_COMPAT, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTRS_COMPAT, _double)
+TEST_P(POTRS_COMPAT, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTRS_COMPAT, _float_complex)
+TEST_P(POTRS_COMPAT, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRS_COMPAT, _double_complex)
+TEST_P(POTRS_COMPAT, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/potrs_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/potrs_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -127,124 +127,124 @@ class POTRS_COMPAT : public POTRS_BASE<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(POTRS, __float)
+TEST_P(POTRS, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTRS, __double)
+TEST_P(POTRS, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTRS, __float_complex)
+TEST_P(POTRS, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRS, __double_complex)
+TEST_P(POTRS, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(POTRS_FORTRAN, __float)
+TEST_P(POTRS_FORTRAN, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTRS_FORTRAN, __double)
+TEST_P(POTRS_FORTRAN, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTRS_FORTRAN, __float_complex)
+TEST_P(POTRS_FORTRAN, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRS_FORTRAN, __double_complex)
+TEST_P(POTRS_FORTRAN, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(POTRS_COMPAT, __float)
+TEST_P(POTRS_COMPAT, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTRS_COMPAT, __double)
+TEST_P(POTRS_COMPAT, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTRS_COMPAT, __float_complex)
+TEST_P(POTRS_COMPAT, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRS_COMPAT, __double_complex)
+TEST_P(POTRS_COMPAT, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(POTRS, batched__float)
+TEST_P(POTRS, batched_float)
 {
     run_tests<true, false, float>();
 }
 
-TEST_P(POTRS, batched__double)
+TEST_P(POTRS, batched_double)
 {
     run_tests<true, false, double>();
 }
 
-TEST_P(POTRS, batched__float_complex)
+TEST_P(POTRS, batched_float_complex)
 {
     run_tests<true, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRS, batched__double_complex)
+TEST_P(POTRS, batched_double_complex)
 {
     run_tests<true, false, rocblas_double_complex>();
 }
 
-TEST_P(POTRS_FORTRAN, batched__float)
+TEST_P(POTRS_FORTRAN, batched_float)
 {
     run_tests<true, false, float>();
 }
 
-TEST_P(POTRS_FORTRAN, batched__double)
+TEST_P(POTRS_FORTRAN, batched_double)
 {
     run_tests<true, false, double>();
 }
 
-TEST_P(POTRS_FORTRAN, batched__float_complex)
+TEST_P(POTRS_FORTRAN, batched_float_complex)
 {
     run_tests<true, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRS_FORTRAN, batched__double_complex)
+TEST_P(POTRS_FORTRAN, batched_double_complex)
 {
     run_tests<true, false, rocblas_double_complex>();
 }
 
-TEST_P(POTRS_COMPAT, batched__float)
+TEST_P(POTRS_COMPAT, batched_float)
 {
     run_tests<true, false, float>();
 }
 
-TEST_P(POTRS_COMPAT, batched__double)
+TEST_P(POTRS_COMPAT, batched_double)
 {
     run_tests<true, false, double>();
 }
 
-TEST_P(POTRS_COMPAT, batched__float_complex)
+TEST_P(POTRS_COMPAT, batched_float_complex)
 {
     run_tests<true, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRS_COMPAT, batched__double_complex)
+TEST_P(POTRS_COMPAT, batched_double_complex)
 {
     run_tests<true, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/syevd_heevd_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/syevd_heevd_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -124,62 +124,62 @@ class HEEVD_COMPAT : public SYEVD_HEEVD<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(SYEVD, __float)
+TEST_P(SYEVD, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEVD, __double)
+TEST_P(SYEVD, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEVD, __float_complex)
+TEST_P(HEEVD, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEVD, __double_complex)
+TEST_P(HEEVD, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYEVD_FORTRAN, __float)
+TEST_P(SYEVD_FORTRAN, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEVD_FORTRAN, __double)
+TEST_P(SYEVD_FORTRAN, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEVD_FORTRAN, __float_complex)
+TEST_P(HEEVD_FORTRAN, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEVD_FORTRAN, __double_complex)
+TEST_P(HEEVD_FORTRAN, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYEVD_COMPAT, __float)
+TEST_P(SYEVD_COMPAT, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEVD_COMPAT, __double)
+TEST_P(SYEVD_COMPAT, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEVD_COMPAT, __float_complex)
+TEST_P(HEEVD_COMPAT, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEVD_COMPAT, __double_complex)
+TEST_P(HEEVD_COMPAT, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/syevd_heevd_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/syevd_heevd_gtest.cpp
@@ -124,62 +124,62 @@ class HEEVD_COMPAT : public SYEVD_HEEVD<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(SYEVD, _float)
+TEST_P(SYEVD, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEVD, _double)
+TEST_P(SYEVD, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEVD, _float_complex)
+TEST_P(HEEVD, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEVD, _double_complex)
+TEST_P(HEEVD, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYEVD_FORTRAN, _float)
+TEST_P(SYEVD_FORTRAN, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEVD_FORTRAN, _double)
+TEST_P(SYEVD_FORTRAN, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEVD_FORTRAN, _float_complex)
+TEST_P(HEEVD_FORTRAN, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEVD_FORTRAN, _double_complex)
+TEST_P(HEEVD_FORTRAN, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYEVD_COMPAT, _float)
+TEST_P(SYEVD_COMPAT, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEVD_COMPAT, _double)
+TEST_P(SYEVD_COMPAT, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEVD_COMPAT, _float_complex)
+TEST_P(HEEVD_COMPAT, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEVD_COMPAT, _double_complex)
+TEST_P(HEEVD_COMPAT, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/syevdx_heevdx_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/syevdx_heevdx_gtest.cpp
@@ -126,42 +126,42 @@ class HEEVDX_COMPAT : public SYEVDX_HEEVDX<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(SYEVDX, _float)
+TEST_P(SYEVDX, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEVDX, _double)
+TEST_P(SYEVDX, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEVDX, _float_complex)
+TEST_P(HEEVDX, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEVDX, _double_complex)
+TEST_P(HEEVDX, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYEVDX_COMPAT, _float)
+TEST_P(SYEVDX_COMPAT, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEVDX_COMPAT, _double)
+TEST_P(SYEVDX_COMPAT, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEVDX_COMPAT, _float_complex)
+TEST_P(HEEVDX_COMPAT, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEVDX_COMPAT, _double_complex)
+TEST_P(HEEVDX_COMPAT, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/syevdx_heevdx_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/syevdx_heevdx_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -126,42 +126,42 @@ class HEEVDX_COMPAT : public SYEVDX_HEEVDX<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(SYEVDX, __float)
+TEST_P(SYEVDX, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEVDX, __double)
+TEST_P(SYEVDX, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEVDX, __float_complex)
+TEST_P(HEEVDX, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEVDX, __double_complex)
+TEST_P(HEEVDX, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYEVDX_COMPAT, __float)
+TEST_P(SYEVDX_COMPAT, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEVDX_COMPAT, __double)
+TEST_P(SYEVDX_COMPAT, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEVDX_COMPAT, __float_complex)
+TEST_P(HEEVDX_COMPAT, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEVDX_COMPAT, __double_complex)
+TEST_P(HEEVDX_COMPAT, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/syevj_heevj_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/syevj_heevj_gtest.cpp
@@ -126,62 +126,62 @@ class HEEVJ_COMPAT : public SYEVJ_HEEVJ<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(SYEVJ, _float)
+TEST_P(SYEVJ, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEVJ, _double)
+TEST_P(SYEVJ, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEVJ, _float_complex)
+TEST_P(HEEVJ, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEVJ, _double_complex)
+TEST_P(HEEVJ, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYEVJ_FORTRAN, _float)
+TEST_P(SYEVJ_FORTRAN, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEVJ_FORTRAN, _double)
+TEST_P(SYEVJ_FORTRAN, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEVJ_FORTRAN, _float_complex)
+TEST_P(HEEVJ_FORTRAN, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEVJ_FORTRAN, _double_complex)
+TEST_P(HEEVJ_FORTRAN, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYEVJ_COMPAT, _float)
+TEST_P(SYEVJ_COMPAT, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEVJ_COMPAT, _double)
+TEST_P(SYEVJ_COMPAT, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEVJ_COMPAT, _float_complex)
+TEST_P(HEEVJ_COMPAT, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEVJ_COMPAT, _double_complex)
+TEST_P(HEEVJ_COMPAT, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/syevj_heevj_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/syevj_heevj_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -126,124 +126,124 @@ class HEEVJ_COMPAT : public SYEVJ_HEEVJ<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(SYEVJ, __float)
+TEST_P(SYEVJ, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEVJ, __double)
+TEST_P(SYEVJ, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEVJ, __float_complex)
+TEST_P(HEEVJ, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEVJ, __double_complex)
+TEST_P(HEEVJ, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYEVJ_FORTRAN, __float)
+TEST_P(SYEVJ_FORTRAN, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEVJ_FORTRAN, __double)
+TEST_P(SYEVJ_FORTRAN, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEVJ_FORTRAN, __float_complex)
+TEST_P(HEEVJ_FORTRAN, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEVJ_FORTRAN, __double_complex)
+TEST_P(HEEVJ_FORTRAN, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYEVJ_COMPAT, __float)
+TEST_P(SYEVJ_COMPAT, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEVJ_COMPAT, __double)
+TEST_P(SYEVJ_COMPAT, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEVJ_COMPAT, __float_complex)
+TEST_P(HEEVJ_COMPAT, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEVJ_COMPAT, __double_complex)
+TEST_P(HEEVJ_COMPAT, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(SYEVJ, strided_batched__float)
+TEST_P(SYEVJ, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYEVJ, strided_batched__double)
+TEST_P(SYEVJ, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEEVJ, strided_batched__float_complex)
+TEST_P(HEEVJ, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEVJ, strided_batched__double_complex)
+TEST_P(HEEVJ, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(SYEVJ_FORTRAN, strided_batched__float)
+TEST_P(SYEVJ_FORTRAN, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYEVJ_FORTRAN, strided_batched__double)
+TEST_P(SYEVJ_FORTRAN, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEEVJ_FORTRAN, strided_batched__float_complex)
+TEST_P(HEEVJ_FORTRAN, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEVJ_FORTRAN, strided_batched__double_complex)
+TEST_P(HEEVJ_FORTRAN, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(SYEVJ_COMPAT, strided_batched__float)
+TEST_P(SYEVJ_COMPAT, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYEVJ_COMPAT, strided_batched__double)
+TEST_P(SYEVJ_COMPAT, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEEVJ_COMPAT, strided_batched__float_complex)
+TEST_P(HEEVJ_COMPAT, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEVJ_COMPAT, strided_batched__double_complex)
+TEST_P(HEEVJ_COMPAT, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/sygvd_hegvd_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/sygvd_hegvd_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -133,62 +133,62 @@ class HEGVD_COMPAT : public SYGVD_HEGVD<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(SYGVD, __float)
+TEST_P(SYGVD, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGVD, __double)
+TEST_P(SYGVD, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGVD, __float_complex)
+TEST_P(HEGVD, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGVD, __double_complex)
+TEST_P(HEGVD, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYGVD_FORTRAN, __float)
+TEST_P(SYGVD_FORTRAN, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGVD_FORTRAN, __double)
+TEST_P(SYGVD_FORTRAN, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGVD_FORTRAN, __float_complex)
+TEST_P(HEGVD_FORTRAN, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGVD_FORTRAN, __double_complex)
+TEST_P(HEGVD_FORTRAN, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYGVD_COMPAT, __float)
+TEST_P(SYGVD_COMPAT, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGVD_COMPAT, __double)
+TEST_P(SYGVD_COMPAT, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGVD_COMPAT, __float_complex)
+TEST_P(HEGVD_COMPAT, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGVD_COMPAT, __double_complex)
+TEST_P(HEGVD_COMPAT, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/sygvd_hegvd_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/sygvd_hegvd_gtest.cpp
@@ -133,62 +133,62 @@ class HEGVD_COMPAT : public SYGVD_HEGVD<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(SYGVD, _float)
+TEST_P(SYGVD, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGVD, _double)
+TEST_P(SYGVD, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGVD, _float_complex)
+TEST_P(HEGVD, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGVD, _double_complex)
+TEST_P(HEGVD, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYGVD_FORTRAN, _float)
+TEST_P(SYGVD_FORTRAN, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGVD_FORTRAN, _double)
+TEST_P(SYGVD_FORTRAN, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGVD_FORTRAN, _float_complex)
+TEST_P(HEGVD_FORTRAN, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGVD_FORTRAN, _double_complex)
+TEST_P(HEGVD_FORTRAN, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYGVD_COMPAT, _float)
+TEST_P(SYGVD_COMPAT, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGVD_COMPAT, _double)
+TEST_P(SYGVD_COMPAT, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGVD_COMPAT, _float_complex)
+TEST_P(HEGVD_COMPAT, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGVD_COMPAT, _double_complex)
+TEST_P(HEGVD_COMPAT, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/sygvdx_hegvdx_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/sygvdx_hegvdx_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -137,42 +137,42 @@ class HEGVDX_COMPAT : public SYGVDX_HEGVDX<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(SYGVDX, DISABLED__float)
+TEST_P(SYGVDX, DISABLED_float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGVDX, DISABLED__double)
+TEST_P(SYGVDX, DISABLED_double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGVDX, DISABLED__float_complex)
+TEST_P(HEGVDX, DISABLED_float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGVDX, DISABLED__double_complex)
+TEST_P(HEGVDX, DISABLED_double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYGVDX_COMPAT, DISABLED__float)
+TEST_P(SYGVDX_COMPAT, DISABLED_float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGVDX_COMPAT, DISABLED__double)
+TEST_P(SYGVDX_COMPAT, DISABLED_double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGVDX_COMPAT, DISABLED__float_complex)
+TEST_P(HEGVDX_COMPAT, DISABLED_float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGVDX_COMPAT, DISABLED__double_complex)
+TEST_P(HEGVDX_COMPAT, DISABLED_double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/sygvj_hegvj_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/sygvj_hegvj_gtest.cpp
@@ -138,62 +138,62 @@ class HEGVJ_COMPAT : public SYGVJ_HEGVJ<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(SYGVJ, _float)
+TEST_P(SYGVJ, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGVJ, _double)
+TEST_P(SYGVJ, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGVJ, _float_complex)
+TEST_P(HEGVJ, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGVJ, _double_complex)
+TEST_P(HEGVJ, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYGVJ_FORTRAN, _float)
+TEST_P(SYGVJ_FORTRAN, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGVJ_FORTRAN, _double)
+TEST_P(SYGVJ_FORTRAN, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGVJ_FORTRAN, _float_complex)
+TEST_P(HEGVJ_FORTRAN, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGVJ_FORTRAN, _double_complex)
+TEST_P(HEGVJ_FORTRAN, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYGVJ_COMPAT, _float)
+TEST_P(SYGVJ_COMPAT, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGVJ_COMPAT, _double)
+TEST_P(SYGVJ_COMPAT, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGVJ_COMPAT, _float_complex)
+TEST_P(HEGVJ_COMPAT, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGVJ_COMPAT, _double_complex)
+TEST_P(HEGVJ_COMPAT, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/sygvj_hegvj_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/sygvj_hegvj_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -138,62 +138,62 @@ class HEGVJ_COMPAT : public SYGVJ_HEGVJ<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(SYGVJ, __float)
+TEST_P(SYGVJ, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGVJ, __double)
+TEST_P(SYGVJ, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGVJ, __float_complex)
+TEST_P(HEGVJ, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGVJ, __double_complex)
+TEST_P(HEGVJ, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYGVJ_FORTRAN, __float)
+TEST_P(SYGVJ_FORTRAN, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGVJ_FORTRAN, __double)
+TEST_P(SYGVJ_FORTRAN, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGVJ_FORTRAN, __float_complex)
+TEST_P(HEGVJ_FORTRAN, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGVJ_FORTRAN, __double_complex)
+TEST_P(HEGVJ_FORTRAN, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYGVJ_COMPAT, __float)
+TEST_P(SYGVJ_COMPAT, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGVJ_COMPAT, __double)
+TEST_P(SYGVJ_COMPAT, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGVJ_COMPAT, __float_complex)
+TEST_P(HEGVJ_COMPAT, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGVJ_COMPAT, __double_complex)
+TEST_P(HEGVJ_COMPAT, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/sytrd_hetrd_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/sytrd_hetrd_gtest.cpp
@@ -123,62 +123,62 @@ class HETRD_COMPAT : public SYTRD_HETRD<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(SYTRD, _float)
+TEST_P(SYTRD, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYTRD, _double)
+TEST_P(SYTRD, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HETRD, _float_complex)
+TEST_P(HETRD, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HETRD, _double_complex)
+TEST_P(HETRD, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYTRD_FORTRAN, _float)
+TEST_P(SYTRD_FORTRAN, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYTRD_FORTRAN, _double)
+TEST_P(SYTRD_FORTRAN, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HETRD_FORTRAN, _float_complex)
+TEST_P(HETRD_FORTRAN, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HETRD_FORTRAN, _double_complex)
+TEST_P(HETRD_FORTRAN, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYTRD_COMPAT, _float)
+TEST_P(SYTRD_COMPAT, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYTRD_COMPAT, _double)
+TEST_P(SYTRD_COMPAT, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HETRD_COMPAT, _float_complex)
+TEST_P(HETRD_COMPAT, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HETRD_COMPAT, _double_complex)
+TEST_P(HETRD_COMPAT, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/sytrd_hetrd_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/sytrd_hetrd_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -123,62 +123,62 @@ class HETRD_COMPAT : public SYTRD_HETRD<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(SYTRD, __float)
+TEST_P(SYTRD, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYTRD, __double)
+TEST_P(SYTRD, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HETRD, __float_complex)
+TEST_P(HETRD, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HETRD, __double_complex)
+TEST_P(HETRD, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYTRD_FORTRAN, __float)
+TEST_P(SYTRD_FORTRAN, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYTRD_FORTRAN, __double)
+TEST_P(SYTRD_FORTRAN, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HETRD_FORTRAN, __float_complex)
+TEST_P(HETRD_FORTRAN, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HETRD_FORTRAN, __double_complex)
+TEST_P(HETRD_FORTRAN, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYTRD_COMPAT, __float)
+TEST_P(SYTRD_COMPAT, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYTRD_COMPAT, __double)
+TEST_P(SYTRD_COMPAT, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HETRD_COMPAT, __float_complex)
+TEST_P(HETRD_COMPAT, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HETRD_COMPAT, __double_complex)
+TEST_P(HETRD_COMPAT, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/sytrf_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/sytrf_gtest.cpp
@@ -114,62 +114,62 @@ class SYTRF_COMPAT : public SYTRF_BASE<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(SYTRF, _float)
+TEST_P(SYTRF, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYTRF, _double)
+TEST_P(SYTRF, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(SYTRF, _float_complex)
+TEST_P(SYTRF, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(SYTRF, _double_complex)
+TEST_P(SYTRF, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYTRF_FORTRAN, _float)
+TEST_P(SYTRF_FORTRAN, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYTRF_FORTRAN, _double)
+TEST_P(SYTRF_FORTRAN, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(SYTRF_FORTRAN, _float_complex)
+TEST_P(SYTRF_FORTRAN, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(SYTRF_FORTRAN, _double_complex)
+TEST_P(SYTRF_FORTRAN, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYTRF_COMPAT, _float)
+TEST_P(SYTRF_COMPAT, Float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYTRF_COMPAT, _double)
+TEST_P(SYTRF_COMPAT, Double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(SYTRF_COMPAT, _float_complex)
+TEST_P(SYTRF_COMPAT, FloatComplex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(SYTRF_COMPAT, _double_complex)
+TEST_P(SYTRF_COMPAT, DoubleComplex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/projects/hipsolver/clients/gtest/sytrf_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/sytrf_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -114,62 +114,62 @@ class SYTRF_COMPAT : public SYTRF_BASE<API_COMPAT>
 
 // non-batch tests
 
-TEST_P(SYTRF, __float)
+TEST_P(SYTRF, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYTRF, __double)
+TEST_P(SYTRF, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(SYTRF, __float_complex)
+TEST_P(SYTRF, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(SYTRF, __double_complex)
+TEST_P(SYTRF, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYTRF_FORTRAN, __float)
+TEST_P(SYTRF_FORTRAN, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYTRF_FORTRAN, __double)
+TEST_P(SYTRF_FORTRAN, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(SYTRF_FORTRAN, __float_complex)
+TEST_P(SYTRF_FORTRAN, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(SYTRF_FORTRAN, __double_complex)
+TEST_P(SYTRF_FORTRAN, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYTRF_COMPAT, __float)
+TEST_P(SYTRF_COMPAT, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYTRF_COMPAT, __double)
+TEST_P(SYTRF_COMPAT, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(SYTRF_COMPAT, __float_complex)
+TEST_P(SYTRF_COMPAT, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(SYTRF_COMPAT, __double_complex)
+TEST_P(SYTRF_COMPAT, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }


### PR DESCRIPTION
## Motivation

Identifiers with double underscores are [reserved in C++](https://en.cppreference.com/w/c/language/identifier.html).
GTest mentions this in their [FAQ](https://google.github.io/googletest/faq.html).

## Technical Details

Technically GTest recommends no underscores whatsoever.

## Test Plan

Run all tests.

## Test Result

All tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
