### PR TITLE
[rocSOLVER] Removed double underscores from gtest names

### DIFF
--- a/projects/rocsolver/CHANGELOG.md
+++ b/projects/rocsolver/CHANGELOG.md
@@ -16,8 +16,8 @@ Full documentation for rocSOLVER is available at the [rocSOLVER documentation](h
 
 ### Changed
 
-* Replaced occurrences of double underscores in test suite names within benchmarking client
-    * e.g., `daily_lapack/GETRI.__float/0` was changed to `daily_lapack/GETRI._float/0`
+* Replaced occurrences of double underscores in test suite names within the benchmarking client, for example, `checkin_lapack/GETRS.__float/0` was changed to `checkin_lapack/GETRS._float/0`.
+
 ### Removed
 ### Optimized
 

--- a/projects/rocsolver/CHANGELOG.md
+++ b/projects/rocsolver/CHANGELOG.md
@@ -15,6 +15,9 @@ Full documentation for rocSOLVER is available at the [rocSOLVER documentation](h
     * GECON_64
 
 ### Changed
+
+* Replaced occurrences of double underscores in test suite names within benchmarking client
+    * e.g., `daily_lapack/GETRI.__float/0` was changed to `daily_lapack/GETRI._float/0`
 ### Removed
 ### Optimized
 

--- a/projects/rocsolver/CHANGELOG.md
+++ b/projects/rocsolver/CHANGELOG.md
@@ -16,7 +16,8 @@ Full documentation for rocSOLVER is available at the [rocSOLVER documentation](h
 
 ### Changed
 
-* Replaced occurrences of double underscores in test suite names within the benchmarking client, for example, `checkin_lapack/GETRS.__float/0` was changed to `checkin_lapack/GETRS._float/0`.
+* Renamed the LARFB parameterized GTest cases from `_float`/`_double`/`_float_complex`/`_double_complex` to `type_float`/`type_double`/`type_float_complex`/`type_double_complex` to avoid generating reserved C++ identifiers (double underscores) in the test class names.
+* Replaced opaque numeric parameter indices in LARFB test names with a descriptive encoding of the argument values, for example, `daily_lapack/LARFB._float/0` is now `daily_lapack/LARFB.type_float/direct_F_k_35_lda_192_ldt_35_ldv_192_m_192_n_192_side_L_storev_C_trans_T`.
 
 ### Removed
 ### Optimized

--- a/projects/rocsolver/CHANGELOG.md
+++ b/projects/rocsolver/CHANGELOG.md
@@ -16,7 +16,7 @@ Full documentation for rocSOLVER is available at the [rocSOLVER documentation](h
 
 ### Changed
 
-* Renamed the LARFB parameterized GTest cases from `_float`/`_double`/`_float_complex`/`_double_complex` to `type_float`/`type_double`/`type_float_complex`/`type_double_complex` to avoid generating reserved C++ identifiers (double underscores) in the test class names.
+* Renamed the parameterized GTest cases from `_float`/`_double`/`_float_complex`/`_double_complex` to `type_float`/`type_double`/`type_float_complex`/`type_double_complex`
 * Replaced opaque numeric parameter indices in LARFB test names with a descriptive encoding of the argument values, for example, `daily_lapack/LARFB._float/0` is now `daily_lapack/LARFB.type_float/direct_F_k_35_lda_192_ldt_35_ldv_192_m_192_n_192_side_L_storev_C_trans_T`.
 
 ### Removed

--- a/projects/rocsolver/clients/common/misc/program_options.hpp
+++ b/projects/rocsolver/clients/common/misc/program_options.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -173,6 +173,30 @@ public:
             return val->get_value();
         else
             throw std::logic_error("Internal error: Invalid cast");
+    }
+
+    std::string to_string() const
+    {
+        auto* base = m_val.get();
+        if(auto* p = dynamic_cast<value<int32_t>*>(base))
+            return std::to_string(p->get_value());
+        if(auto* p = dynamic_cast<value<uint32_t>*>(base))
+            return std::to_string(p->get_value());
+        if(auto* p = dynamic_cast<value<int64_t>*>(base))
+            return std::to_string(p->get_value());
+        if(auto* p = dynamic_cast<value<uint64_t>*>(base))
+            return std::to_string(p->get_value());
+        if(auto* p = dynamic_cast<value<char>*>(base))
+            return std::string(1, p->get_value());
+        if(auto* p = dynamic_cast<value<float>*>(base))
+            return std::to_string(p->get_value());
+        if(auto* p = dynamic_cast<value<double>*>(base))
+            return std::to_string(p->get_value());
+        if(auto* p = dynamic_cast<value<bool>*>(base))
+            return p->get_value() ? "true" : "false";
+        if(auto* p = dynamic_cast<value<std::string>*>(base))
+            return p->get_value();
+        return "unknown";
     }
 };
 

--- a/projects/rocsolver/clients/common/misc/rocsolver_arguments.hpp
+++ b/projects/rocsolver/clients/common/misc/rocsolver_arguments.hpp
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include <cctype>
 #include <set>
 
 #include <fmt/format.h>
@@ -335,5 +336,29 @@ public:
         if(!to_consume.empty())
             throw std::invalid_argument(
                 fmt::format("Not all arguments were consumed: {}", fmt::join(to_consume, " ")));
+    }
+
+    std::string to_test_name() const
+    {
+        std::string name;
+        for(const auto& key : to_consume)
+        {
+            if(!name.empty())
+                name += '_';
+            std::string val = at(key).to_string();
+            std::string sanitized;
+            for(size_t i = 0; i < val.size(); ++i)
+            {
+                char c = val[i];
+                if(c == '-')
+                    sanitized += "neg";
+                else if(c == '.')
+                    sanitized += "p";
+                else if(std::isalnum(static_cast<unsigned char>(c)))
+                    sanitized += c;
+            }
+            name += key + "_" + sanitized;
+        }
+        return name;
     }
 };

--- a/projects/rocsolver/clients/gtest/auxiliary/bdsqr_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/bdsqr_gtest.cpp
@@ -144,42 +144,42 @@ class BDSQR_HYBRID : public BDSQR_BASE<1>
 
 // non-batch tests
 
-TEST_P(BDSQR, _float)
+TEST_P(BDSQR, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(BDSQR, _double)
+TEST_P(BDSQR, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(BDSQR, _float_complex)
+TEST_P(BDSQR, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(BDSQR, _double_complex)
+TEST_P(BDSQR, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(BDSQR_HYBRID, _float)
+TEST_P(BDSQR_HYBRID, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(BDSQR_HYBRID, _double)
+TEST_P(BDSQR_HYBRID, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(BDSQR_HYBRID, _float_complex)
+TEST_P(BDSQR_HYBRID, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(BDSQR_HYBRID, _double_complex)
+TEST_P(BDSQR_HYBRID, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/bdsqr_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/bdsqr_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/auxiliary/bdsqr_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/bdsqr_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -144,42 +144,42 @@ class BDSQR_HYBRID : public BDSQR_BASE<1>
 
 // non-batch tests
 
-TEST_P(BDSQR, __float)
+TEST_P(BDSQR, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(BDSQR, __double)
+TEST_P(BDSQR, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(BDSQR, __float_complex)
+TEST_P(BDSQR, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(BDSQR, __double_complex)
+TEST_P(BDSQR, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(BDSQR_HYBRID, __float)
+TEST_P(BDSQR_HYBRID, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(BDSQR_HYBRID, __double)
+TEST_P(BDSQR_HYBRID, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(BDSQR_HYBRID, __float_complex)
+TEST_P(BDSQR_HYBRID, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(BDSQR_HYBRID, __double_complex)
+TEST_P(BDSQR_HYBRID, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/bdsvdx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/bdsvdx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/auxiliary/bdsvdx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/bdsvdx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -140,12 +140,12 @@ protected:
 
 // non-batch tests
 
-TEST_P(BDSVDX, __float)
+TEST_P(BDSVDX, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(BDSVDX, __double)
+TEST_P(BDSVDX, _double)
 {
     run_tests<double>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/bdsvdx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/bdsvdx_gtest.cpp
@@ -140,12 +140,12 @@ protected:
 
 // non-batch tests
 
-TEST_P(BDSVDX, _float)
+TEST_P(BDSVDX, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(BDSVDX, _double)
+TEST_P(BDSVDX, __double)
 {
     run_tests<double>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/gecon_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/gecon_gtest.cpp
@@ -118,42 +118,42 @@ class GECON_64 : public GECON_BASE<int64_t>
 {
 };
 
-TEST_P(GECON, __float)
+TEST_P(GECON, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(GECON, __double)
+TEST_P(GECON, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(GECON, __float_complex)
+TEST_P(GECON, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(GECON, __double_complex)
+TEST_P(GECON, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(GECON_64, __float)
+TEST_P(GECON_64, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(GECON_64, __double)
+TEST_P(GECON_64, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(GECON_64, __float_complex)
+TEST_P(GECON_64, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(GECON_64, __double_complex)
+TEST_P(GECON_64, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/gecon_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/gecon_gtest.cpp
@@ -118,42 +118,42 @@ class GECON_64 : public GECON_BASE<int64_t>
 {
 };
 
-TEST_P(GECON, _float)
+TEST_P(GECON, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(GECON, _double)
+TEST_P(GECON, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(GECON, _float_complex)
+TEST_P(GECON, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(GECON, _double_complex)
+TEST_P(GECON, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(GECON_64, _float)
+TEST_P(GECON_64, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(GECON_64, _double)
+TEST_P(GECON_64, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(GECON_64, _float_complex)
+TEST_P(GECON_64, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(GECON_64, _double_complex)
+TEST_P(GECON_64, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/labrd_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/labrd_gtest.cpp
@@ -125,22 +125,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(LABRD, _float)
+TEST_P(LABRD, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(LABRD, _double)
+TEST_P(LABRD, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(LABRD, _float_complex)
+TEST_P(LABRD, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LABRD, _double_complex)
+TEST_P(LABRD, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/labrd_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/labrd_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/auxiliary/labrd_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/labrd_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -125,22 +125,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(LABRD, __float)
+TEST_P(LABRD, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(LABRD, __double)
+TEST_P(LABRD, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(LABRD, __float_complex)
+TEST_P(LABRD, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LABRD, __double_complex)
+TEST_P(LABRD, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/lacgv_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/lacgv_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -116,22 +116,22 @@ class LACGV_64 : public LACGV_BASE<int64_t>
 
 // non-batch tests
 
-TEST_P(LACGV, __float_complex)
+TEST_P(LACGV, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LACGV, __double_complex)
+TEST_P(LACGV, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(LACGV_64, __float_complex)
+TEST_P(LACGV_64, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LACGV_64, __double_complex)
+TEST_P(LACGV_64, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/lacgv_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/lacgv_gtest.cpp
@@ -116,22 +116,22 @@ class LACGV_64 : public LACGV_BASE<int64_t>
 
 // non-batch tests
 
-TEST_P(LACGV, _float_complex)
+TEST_P(LACGV, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LACGV, _double_complex)
+TEST_P(LACGV, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(LACGV_64, _float_complex)
+TEST_P(LACGV_64, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LACGV_64, _double_complex)
+TEST_P(LACGV_64, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/lacgv_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/lacgv_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/auxiliary/lange_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/lange_gtest.cpp
@@ -129,42 +129,42 @@ class LANGE_64 : public LANGE_BASE<int64_t>
 
 // non-batch tests
 
-TEST_P(LANGE, __float)
+TEST_P(LANGE, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(LANGE, __double)
+TEST_P(LANGE, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(LANGE, __float_complex)
+TEST_P(LANGE, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LANGE, __double_complex)
+TEST_P(LANGE, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(LANGE_64, __float)
+TEST_P(LANGE_64, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(LANGE_64, __double)
+TEST_P(LANGE_64, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(LANGE_64, __float_complex)
+TEST_P(LANGE_64, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LANGE_64, __double_complex)
+TEST_P(LANGE_64, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/lange_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/lange_gtest.cpp
@@ -129,42 +129,42 @@ class LANGE_64 : public LANGE_BASE<int64_t>
 
 // non-batch tests
 
-TEST_P(LANGE, _float)
+TEST_P(LANGE, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(LANGE, _double)
+TEST_P(LANGE, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(LANGE, _float_complex)
+TEST_P(LANGE, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LANGE, _double_complex)
+TEST_P(LANGE, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(LANGE_64, _float)
+TEST_P(LANGE_64, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(LANGE_64, _double)
+TEST_P(LANGE_64, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(LANGE_64, _float_complex)
+TEST_P(LANGE_64, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LANGE_64, _double_complex)
+TEST_P(LANGE_64, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/larf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/larf_gtest.cpp
@@ -151,42 +151,42 @@ class LARF_64 : public LARF_BASE<int64_t>
 
 // non-batch tests
 
-TEST_P(LARF, _float)
+TEST_P(LARF, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(LARF, _double)
+TEST_P(LARF, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(LARF, _float_complex)
+TEST_P(LARF, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LARF, _double_complex)
+TEST_P(LARF, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(LARF_64, _float)
+TEST_P(LARF_64, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(LARF_64, _double)
+TEST_P(LARF_64, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(LARF_64, _float_complex)
+TEST_P(LARF_64, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LARF_64, _double_complex)
+TEST_P(LARF_64, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/larf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/larf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/auxiliary/larf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/larf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -151,42 +151,42 @@ class LARF_64 : public LARF_BASE<int64_t>
 
 // non-batch tests
 
-TEST_P(LARF, __float)
+TEST_P(LARF, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(LARF, __double)
+TEST_P(LARF, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(LARF, __float_complex)
+TEST_P(LARF, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LARF, __double_complex)
+TEST_P(LARF, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(LARF_64, __float)
+TEST_P(LARF_64, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(LARF_64, __double)
+TEST_P(LARF_64, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(LARF_64, __float_complex)
+TEST_P(LARF_64, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LARF_64, __double_complex)
+TEST_P(LARF_64, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/larfb_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/larfb_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -138,22 +138,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(LARFB, __float)
+TEST_P(LARFB, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(LARFB, __double)
+TEST_P(LARFB, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(LARFB, __float_complex)
+TEST_P(LARFB, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LARFB, __double_complex)
+TEST_P(LARFB, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/larfb_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/larfb_gtest.cpp
@@ -138,22 +138,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(LARFB, _float)
+TEST_P(LARFB, type_float)
 {
     run_tests<float>();
 }
 
-TEST_P(LARFB, _double)
+TEST_P(LARFB, type_double)
 {
     run_tests<double>();
 }
 
-TEST_P(LARFB, _float_complex)
+TEST_P(LARFB, type_float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LARFB, _double_complex)
+TEST_P(LARFB, type_double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
@@ -161,8 +161,14 @@ TEST_P(LARFB, _double_complex)
 INSTANTIATE_TEST_SUITE_P(daily_lapack,
                          LARFB,
                          Combine(ValuesIn(large_matrix_size_range),
-                                 ValuesIn(large_reflector_size_range)));
+                                 ValuesIn(large_reflector_size_range)),
+                         [](const testing::TestParamInfo<larfb_tuple>& info) {
+                             return larfb_setup_arguments(info.param).to_test_name();
+                         });
 
 INSTANTIATE_TEST_SUITE_P(checkin_lapack,
                          LARFB,
-                         Combine(ValuesIn(matrix_size_range), ValuesIn(reflector_size_range)));
+                         Combine(ValuesIn(matrix_size_range), ValuesIn(reflector_size_range)),
+                         [](const testing::TestParamInfo<larfb_tuple>& info) {
+                             return larfb_setup_arguments(info.param).to_test_name();
+                         });

--- a/projects/rocsolver/clients/gtest/auxiliary/larfg_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/larfg_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -147,42 +147,42 @@ class LARFG_64 : public LARFG_BASE<int64_t>
 
 // non-batch tests
 
-TEST_P(LARFG, __float)
+TEST_P(LARFG, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(LARFG, __double)
+TEST_P(LARFG, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(LARFG, __float_complex)
+TEST_P(LARFG, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LARFG, __double_complex)
+TEST_P(LARFG, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(LARFG_64, __float)
+TEST_P(LARFG_64, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(LARFG_64, __double)
+TEST_P(LARFG_64, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(LARFG_64, __float_complex)
+TEST_P(LARFG_64, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LARFG_64, __double_complex)
+TEST_P(LARFG_64, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/larfg_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/larfg_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/auxiliary/larfg_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/larfg_gtest.cpp
@@ -147,42 +147,42 @@ class LARFG_64 : public LARFG_BASE<int64_t>
 
 // non-batch tests
 
-TEST_P(LARFG, _float)
+TEST_P(LARFG, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(LARFG, _double)
+TEST_P(LARFG, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(LARFG, _float_complex)
+TEST_P(LARFG, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LARFG, _double_complex)
+TEST_P(LARFG, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(LARFG_64, _float)
+TEST_P(LARFG_64, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(LARFG_64, _double)
+TEST_P(LARFG_64, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(LARFG_64, _float_complex)
+TEST_P(LARFG_64, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LARFG_64, _double_complex)
+TEST_P(LARFG_64, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/larft_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/larft_gtest.cpp
@@ -119,22 +119,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(LARFT, _float)
+TEST_P(LARFT, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(LARFT, _double)
+TEST_P(LARFT, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(LARFT, _float_complex)
+TEST_P(LARFT, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LARFT, _double_complex)
+TEST_P(LARFT, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/larft_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/larft_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/auxiliary/larft_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/larft_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -119,22 +119,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(LARFT, __float)
+TEST_P(LARFT, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(LARFT, __double)
+TEST_P(LARFT, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(LARFT, __float_complex)
+TEST_P(LARFT, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LARFT, __double_complex)
+TEST_P(LARFT, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/lasr_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/lasr_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/auxiliary/lasr_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/lasr_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -112,22 +112,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(LASR, __float)
+TEST_P(LASR, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(LASR, __double)
+TEST_P(LASR, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(LASR, __float_complex)
+TEST_P(LASR, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LASR, __double_complex)
+TEST_P(LASR, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/lasr_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/lasr_gtest.cpp
@@ -112,22 +112,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(LASR, _float)
+TEST_P(LASR, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(LASR, _double)
+TEST_P(LASR, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(LASR, _float_complex)
+TEST_P(LASR, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LASR, _double_complex)
+TEST_P(LASR, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/laswp_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/laswp_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -111,22 +111,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(LASWP, __float)
+TEST_P(LASWP, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(LASWP, __double)
+TEST_P(LASWP, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(LASWP, __float_complex)
+TEST_P(LASWP, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LASWP, __double_complex)
+TEST_P(LASWP, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/laswp_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/laswp_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/auxiliary/laswp_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/laswp_gtest.cpp
@@ -111,22 +111,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(LASWP, _float)
+TEST_P(LASWP, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(LASWP, _double)
+TEST_P(LASWP, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(LASWP, _float_complex)
+TEST_P(LASWP, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LASWP, _double_complex)
+TEST_P(LASWP, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/lasyf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/lasyf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -121,22 +121,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(LASYF, __float)
+TEST_P(LASYF, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(LASYF, __double)
+TEST_P(LASYF, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(LASYF, __float_complex)
+TEST_P(LASYF, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LASYF, __double_complex)
+TEST_P(LASYF, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/lasyf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/lasyf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/auxiliary/lasyf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/lasyf_gtest.cpp
@@ -121,22 +121,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(LASYF, _float)
+TEST_P(LASYF, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(LASYF, _double)
+TEST_P(LASYF, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(LASYF, _float_complex)
+TEST_P(LASYF, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LASYF, _double_complex)
+TEST_P(LASYF, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/latrd_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/latrd_gtest.cpp
@@ -144,42 +144,42 @@ protected:
 
 // non-batch tests
 
-TEST_P(LATRD, _float)
+TEST_P(LATRD, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(LATRD, _double)
+TEST_P(LATRD, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(LATRD, _float_complex)
+TEST_P(LATRD, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LATRD, _double_complex)
+TEST_P(LATRD, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(LATRD_FORSYTRD, _float)
+TEST_P(LATRD_FORSYTRD, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(LATRD_FORSYTRD, _double)
+TEST_P(LATRD_FORSYTRD, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(LATRD_FORSYTRD, _float_complex)
+TEST_P(LATRD_FORSYTRD, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LATRD_FORSYTRD, _double_complex)
+TEST_P(LATRD_FORSYTRD, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/latrd_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/latrd_gtest.cpp
@@ -144,42 +144,42 @@ protected:
 
 // non-batch tests
 
-TEST_P(LATRD, __float)
+TEST_P(LATRD, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(LATRD, __double)
+TEST_P(LATRD, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(LATRD, __float_complex)
+TEST_P(LATRD, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LATRD, __double_complex)
+TEST_P(LATRD, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(LATRD_FORSYTRD, __float)
+TEST_P(LATRD_FORSYTRD, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(LATRD_FORSYTRD, __double)
+TEST_P(LATRD_FORSYTRD, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(LATRD_FORSYTRD, __float_complex)
+TEST_P(LATRD_FORSYTRD, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LATRD_FORSYTRD, __double_complex)
+TEST_P(LATRD_FORSYTRD, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/lauum_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/lauum_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/auxiliary/lauum_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/lauum_gtest.cpp
@@ -93,22 +93,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(LAUUM, _float)
+TEST_P(LAUUM, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(LAUUM, _double)
+TEST_P(LAUUM, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(LAUUM, _float_complex)
+TEST_P(LAUUM, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LAUUM, _double_complex)
+TEST_P(LAUUM, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/lauum_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/lauum_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -93,22 +93,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(LAUUM, __float)
+TEST_P(LAUUM, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(LAUUM, __double)
+TEST_P(LAUUM, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(LAUUM, __float_complex)
+TEST_P(LAUUM, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(LAUUM, __double_complex)
+TEST_P(LAUUM, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/orgbr_ungbr_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/orgbr_ungbr_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/auxiliary/orgbr_ungbr_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/orgbr_ungbr_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -137,22 +137,22 @@ class UNGBR : public ORGBR_UNGBR
 
 // non-batch tests
 
-TEST_P(ORGBR, __float)
+TEST_P(ORGBR, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORGBR, __double)
+TEST_P(ORGBR, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNGBR, __float_complex)
+TEST_P(UNGBR, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNGBR, __double_complex)
+TEST_P(UNGBR, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/orgbr_ungbr_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/orgbr_ungbr_gtest.cpp
@@ -137,22 +137,22 @@ class UNGBR : public ORGBR_UNGBR
 
 // non-batch tests
 
-TEST_P(ORGBR, _float)
+TEST_P(ORGBR, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORGBR, _double)
+TEST_P(ORGBR, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNGBR, _float_complex)
+TEST_P(UNGBR, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNGBR, _double_complex)
+TEST_P(UNGBR, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/orglx_unglx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/orglx_unglx_gtest.cpp
@@ -128,42 +128,42 @@ class UNGLQ : public ORGLX_UNGLX<true>
 
 // non-batch tests
 
-TEST_P(ORGL2, _float)
+TEST_P(ORGL2, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORGL2, _double)
+TEST_P(ORGL2, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNGL2, _float_complex)
+TEST_P(UNGL2, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNGL2, _double_complex)
+TEST_P(UNGL2, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORGLQ, _float)
+TEST_P(ORGLQ, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORGLQ, _double)
+TEST_P(ORGLQ, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNGLQ, _float_complex)
+TEST_P(UNGLQ, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNGLQ, _double_complex)
+TEST_P(UNGLQ, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/orglx_unglx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/orglx_unglx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/auxiliary/orglx_unglx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/orglx_unglx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -128,42 +128,42 @@ class UNGLQ : public ORGLX_UNGLX<true>
 
 // non-batch tests
 
-TEST_P(ORGL2, __float)
+TEST_P(ORGL2, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORGL2, __double)
+TEST_P(ORGL2, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNGL2, __float_complex)
+TEST_P(UNGL2, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNGL2, __double_complex)
+TEST_P(UNGL2, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORGLQ, __float)
+TEST_P(ORGLQ, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORGLQ, __double)
+TEST_P(ORGLQ, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNGLQ, __float_complex)
+TEST_P(UNGLQ, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNGLQ, __double_complex)
+TEST_P(UNGLQ, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/orgtr_ungtr_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/orgtr_ungtr_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/auxiliary/orgtr_ungtr_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/orgtr_ungtr_gtest.cpp
@@ -105,22 +105,22 @@ class UNGTR : public ORGTR_UNGTR
 
 // non-batch tests
 
-TEST_P(ORGTR, _float)
+TEST_P(ORGTR, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORGTR, _double)
+TEST_P(ORGTR, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNGTR, _float_complex)
+TEST_P(UNGTR, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNGTR, _double_complex)
+TEST_P(UNGTR, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/orgtr_ungtr_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/orgtr_ungtr_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -105,22 +105,22 @@ class UNGTR : public ORGTR_UNGTR
 
 // non-batch tests
 
-TEST_P(ORGTR, __float)
+TEST_P(ORGTR, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORGTR, __double)
+TEST_P(ORGTR, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNGTR, __float_complex)
+TEST_P(UNGTR, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNGTR, __double_complex)
+TEST_P(UNGTR, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/orgxl_ungxl_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/orgxl_ungxl_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -133,42 +133,42 @@ class UNGQL : public ORGXL_UNGXL<true>
 
 // non-batch tests
 
-TEST_P(ORG2L, __float)
+TEST_P(ORG2L, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORG2L, __double)
+TEST_P(ORG2L, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNG2L, __float_complex)
+TEST_P(UNG2L, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNG2L, __double_complex)
+TEST_P(UNG2L, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORGQL, __float)
+TEST_P(ORGQL, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORGQL, __double)
+TEST_P(ORGQL, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNGQL, __float_complex)
+TEST_P(UNGQL, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNGQL, __double_complex)
+TEST_P(UNGQL, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/orgxl_ungxl_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/orgxl_ungxl_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/auxiliary/orgxl_ungxl_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/orgxl_ungxl_gtest.cpp
@@ -133,42 +133,42 @@ class UNGQL : public ORGXL_UNGXL<true>
 
 // non-batch tests
 
-TEST_P(ORG2L, _float)
+TEST_P(ORG2L, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORG2L, _double)
+TEST_P(ORG2L, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNG2L, _float_complex)
+TEST_P(UNG2L, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNG2L, _double_complex)
+TEST_P(UNG2L, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORGQL, _float)
+TEST_P(ORGQL, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORGQL, _double)
+TEST_P(ORGQL, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNGQL, _float_complex)
+TEST_P(UNGQL, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNGQL, _double_complex)
+TEST_P(UNGQL, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/orgxr_ungxr_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/orgxr_ungxr_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/auxiliary/orgxr_ungxr_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/orgxr_ungxr_gtest.cpp
@@ -132,42 +132,42 @@ class UNGQR : public ORGXR_UNGXR<true>
 
 // non-batch tests
 
-TEST_P(ORG2R, _float)
+TEST_P(ORG2R, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORG2R, _double)
+TEST_P(ORG2R, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNG2R, _float_complex)
+TEST_P(UNG2R, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNG2R, _double_complex)
+TEST_P(UNG2R, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORGQR, _float)
+TEST_P(ORGQR, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORGQR, _double)
+TEST_P(ORGQR, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNGQR, _float_complex)
+TEST_P(UNGQR, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNGQR, _double_complex)
+TEST_P(UNGQR, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/orgxr_ungxr_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/orgxr_ungxr_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -132,42 +132,42 @@ class UNGQR : public ORGXR_UNGXR<true>
 
 // non-batch tests
 
-TEST_P(ORG2R, __float)
+TEST_P(ORG2R, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORG2R, __double)
+TEST_P(ORG2R, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNG2R, __float_complex)
+TEST_P(UNG2R, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNG2R, __double_complex)
+TEST_P(UNG2R, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORGQR, __float)
+TEST_P(ORGQR, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORGQR, __double)
+TEST_P(ORGQR, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNGQR, __float_complex)
+TEST_P(UNGQR, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNGQR, __double_complex)
+TEST_P(UNGQR, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/ormbr_unmbr_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/ormbr_unmbr_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/auxiliary/ormbr_unmbr_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/ormbr_unmbr_gtest.cpp
@@ -162,22 +162,22 @@ class UNMBR : public ORMBR_UNMBR
 
 // non-batch tests
 
-TEST_P(ORMBR, _float)
+TEST_P(ORMBR, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORMBR, _double)
+TEST_P(ORMBR, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNMBR, _float_complex)
+TEST_P(UNMBR, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNMBR, _double_complex)
+TEST_P(UNMBR, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/ormbr_unmbr_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/ormbr_unmbr_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -162,22 +162,22 @@ class UNMBR : public ORMBR_UNMBR
 
 // non-batch tests
 
-TEST_P(ORMBR, __float)
+TEST_P(ORMBR, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORMBR, __double)
+TEST_P(ORMBR, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNMBR, __float_complex)
+TEST_P(UNMBR, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNMBR, __double_complex)
+TEST_P(UNMBR, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/ormlx_unmlx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/ormlx_unmlx_gtest.cpp
@@ -153,42 +153,42 @@ class UNMLQ : public ORMLX_UNMLX<true>
 
 // non-batch tests
 
-TEST_P(ORML2, _float)
+TEST_P(ORML2, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORML2, _double)
+TEST_P(ORML2, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNML2, _float_complex)
+TEST_P(UNML2, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNML2, _double_complex)
+TEST_P(UNML2, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORMLQ, _float)
+TEST_P(ORMLQ, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORMLQ, _double)
+TEST_P(ORMLQ, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNMLQ, _float_complex)
+TEST_P(UNMLQ, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNMLQ, _double_complex)
+TEST_P(UNMLQ, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/ormlx_unmlx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/ormlx_unmlx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/auxiliary/ormlx_unmlx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/ormlx_unmlx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -153,42 +153,42 @@ class UNMLQ : public ORMLX_UNMLX<true>
 
 // non-batch tests
 
-TEST_P(ORML2, __float)
+TEST_P(ORML2, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORML2, __double)
+TEST_P(ORML2, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNML2, __float_complex)
+TEST_P(UNML2, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNML2, __double_complex)
+TEST_P(UNML2, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORMLQ, __float)
+TEST_P(ORMLQ, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORMLQ, __double)
+TEST_P(ORMLQ, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNMLQ, __float_complex)
+TEST_P(UNMLQ, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNMLQ, __double_complex)
+TEST_P(UNMLQ, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/ormtr_unmtr_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/ormtr_unmtr_gtest.cpp
@@ -155,22 +155,22 @@ class UNMTR : public ORMTR_UNMTR
 
 // non-batch tests
 
-TEST_P(ORMTR, _float)
+TEST_P(ORMTR, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORMTR, _double)
+TEST_P(ORMTR, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNMTR, _float_complex)
+TEST_P(UNMTR, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNMTR, _double_complex)
+TEST_P(UNMTR, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/ormtr_unmtr_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/ormtr_unmtr_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/auxiliary/ormtr_unmtr_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/ormtr_unmtr_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -155,22 +155,22 @@ class UNMTR : public ORMTR_UNMTR
 
 // non-batch tests
 
-TEST_P(ORMTR, __float)
+TEST_P(ORMTR, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORMTR, __double)
+TEST_P(ORMTR, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNMTR, __float_complex)
+TEST_P(UNMTR, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNMTR, __double_complex)
+TEST_P(UNMTR, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/ormxl_unmxl_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/ormxl_unmxl_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -156,42 +156,42 @@ class UNMQL : public ORMXL_UNMXL<true>
 
 // non-batch tests
 
-TEST_P(ORM2L, __float)
+TEST_P(ORM2L, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORM2L, __double)
+TEST_P(ORM2L, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNM2L, __float_complex)
+TEST_P(UNM2L, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNM2L, __double_complex)
+TEST_P(UNM2L, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORMQL, __float)
+TEST_P(ORMQL, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORMQL, __double)
+TEST_P(ORMQL, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNMQL, __float_complex)
+TEST_P(UNMQL, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNMQL, __double_complex)
+TEST_P(UNMQL, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/ormxl_unmxl_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/ormxl_unmxl_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/auxiliary/ormxl_unmxl_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/ormxl_unmxl_gtest.cpp
@@ -156,42 +156,42 @@ class UNMQL : public ORMXL_UNMXL<true>
 
 // non-batch tests
 
-TEST_P(ORM2L, _float)
+TEST_P(ORM2L, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORM2L, _double)
+TEST_P(ORM2L, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNM2L, _float_complex)
+TEST_P(UNM2L, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNM2L, _double_complex)
+TEST_P(UNM2L, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORMQL, _float)
+TEST_P(ORMQL, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORMQL, _double)
+TEST_P(ORMQL, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNMQL, _float_complex)
+TEST_P(UNMQL, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNMQL, _double_complex)
+TEST_P(UNMQL, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/ormxr_unmxr_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/ormxr_unmxr_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/auxiliary/ormxr_unmxr_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/ormxr_unmxr_gtest.cpp
@@ -156,42 +156,42 @@ class UNMQR : public ORMXR_UNMXR<true>
 
 // non-batch tests
 
-TEST_P(ORM2R, _float)
+TEST_P(ORM2R, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORM2R, _double)
+TEST_P(ORM2R, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNM2R, _float_complex)
+TEST_P(UNM2R, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNM2R, _double_complex)
+TEST_P(UNM2R, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORMQR, _float)
+TEST_P(ORMQR, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORMQR, _double)
+TEST_P(ORMQR, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNMQR, _float_complex)
+TEST_P(UNMQR, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNMQR, _double_complex)
+TEST_P(UNMQR, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/ormxr_unmxr_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/ormxr_unmxr_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -156,42 +156,42 @@ class UNMQR : public ORMXR_UNMXR<true>
 
 // non-batch tests
 
-TEST_P(ORM2R, __float)
+TEST_P(ORM2R, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORM2R, __double)
+TEST_P(ORM2R, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNM2R, __float_complex)
+TEST_P(UNM2R, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNM2R, __double_complex)
+TEST_P(UNM2R, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(ORMQR, __float)
+TEST_P(ORMQR, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(ORMQR, __double)
+TEST_P(ORMQR, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(UNMQR, __float_complex)
+TEST_P(UNMQR, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(UNMQR, __double_complex)
+TEST_P(UNMQR, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/stebz_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/stebz_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -132,12 +132,12 @@ protected:
 
 // non-batch tests
 
-TEST_P(STEBZ, __float)
+TEST_P(STEBZ, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(STEBZ, __double)
+TEST_P(STEBZ, _double)
 {
     run_tests<double>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/stebz_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/stebz_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/auxiliary/stebz_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/stebz_gtest.cpp
@@ -132,12 +132,12 @@ protected:
 
 // non-batch tests
 
-TEST_P(STEBZ, _float)
+TEST_P(STEBZ, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(STEBZ, _double)
+TEST_P(STEBZ, __double)
 {
     run_tests<double>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/stedc_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/stedc_gtest.cpp
@@ -99,22 +99,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(STEDC, _float)
+TEST_P(STEDC, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(STEDC, _double)
+TEST_P(STEDC, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(STEDC, _float_complex)
+TEST_P(STEDC, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(STEDC, _double_complex)
+TEST_P(STEDC, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/stedc_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/stedc_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/auxiliary/stedc_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/stedc_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -99,22 +99,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(STEDC, __float)
+TEST_P(STEDC, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(STEDC, __double)
+TEST_P(STEDC, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(STEDC, __float_complex)
+TEST_P(STEDC, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(STEDC, __double_complex)
+TEST_P(STEDC, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/stedcj_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/stedcj_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -94,22 +94,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(STEDCJ, __float)
+TEST_P(STEDCJ, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(STEDCJ, __double)
+TEST_P(STEDCJ, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(STEDCJ, __float_complex)
+TEST_P(STEDCJ, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(STEDCJ, __double_complex)
+TEST_P(STEDCJ, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/stedcj_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/stedcj_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/auxiliary/stedcj_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/stedcj_gtest.cpp
@@ -94,22 +94,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(STEDCJ, _float)
+TEST_P(STEDCJ, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(STEDCJ, _double)
+TEST_P(STEDCJ, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(STEDCJ, _float_complex)
+TEST_P(STEDCJ, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(STEDCJ, _double_complex)
+TEST_P(STEDCJ, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/stedcx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/stedcx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/auxiliary/stedcx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/stedcx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -135,22 +135,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(STEDCX, __float)
+TEST_P(STEDCX, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(STEDCX, __double)
+TEST_P(STEDCX, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(STEDCX, __float_complex)
+TEST_P(STEDCX, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(STEDCX, __double_complex)
+TEST_P(STEDCX, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/stedcx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/stedcx_gtest.cpp
@@ -135,22 +135,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(STEDCX, _float)
+TEST_P(STEDCX, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(STEDCX, _double)
+TEST_P(STEDCX, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(STEDCX, _float_complex)
+TEST_P(STEDCX, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(STEDCX, _double_complex)
+TEST_P(STEDCX, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/stein_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/stein_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/auxiliary/stein_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/stein_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -99,22 +99,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(STEIN, __float)
+TEST_P(STEIN, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(STEIN, __double)
+TEST_P(STEIN, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(STEIN, __float_complex)
+TEST_P(STEIN, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(STEIN, __double_complex)
+TEST_P(STEIN, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/stein_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/stein_gtest.cpp
@@ -99,22 +99,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(STEIN, _float)
+TEST_P(STEIN, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(STEIN, _double)
+TEST_P(STEIN, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(STEIN, _float_complex)
+TEST_P(STEIN, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(STEIN, _double_complex)
+TEST_P(STEIN, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/steqr_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/steqr_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -109,42 +109,42 @@ class STEQR_HYBRID : public STEQR_BASE<1>
 
 // non-batch tests
 
-TEST_P(STEQR, __float)
+TEST_P(STEQR, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(STEQR, __double)
+TEST_P(STEQR, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(STEQR, __float_complex)
+TEST_P(STEQR, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(STEQR, __double_complex)
+TEST_P(STEQR, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(STEQR_HYBRID, __float)
+TEST_P(STEQR_HYBRID, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(STEQR_HYBRID, __double)
+TEST_P(STEQR_HYBRID, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(STEQR_HYBRID, __float_complex)
+TEST_P(STEQR_HYBRID, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(STEQR_HYBRID, __double_complex)
+TEST_P(STEQR_HYBRID, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/steqr_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/steqr_gtest.cpp
@@ -109,42 +109,42 @@ class STEQR_HYBRID : public STEQR_BASE<1>
 
 // non-batch tests
 
-TEST_P(STEQR, _float)
+TEST_P(STEQR, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(STEQR, _double)
+TEST_P(STEQR, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(STEQR, _float_complex)
+TEST_P(STEQR, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(STEQR, _double_complex)
+TEST_P(STEQR, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }
 
-TEST_P(STEQR_HYBRID, _float)
+TEST_P(STEQR_HYBRID, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(STEQR_HYBRID, _double)
+TEST_P(STEQR_HYBRID, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(STEQR_HYBRID, _float_complex)
+TEST_P(STEQR_HYBRID, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(STEQR_HYBRID, _double_complex)
+TEST_P(STEQR_HYBRID, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/steqr_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/steqr_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/auxiliary/sterf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/sterf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -97,22 +97,22 @@ class STERF_HYBRID : public STERF_BASE<1>
 
 // non-batch tests
 
-TEST_P(STERF, __float)
+TEST_P(STERF, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(STERF, __double)
+TEST_P(STERF, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(STERF_HYBRID, __float)
+TEST_P(STERF_HYBRID, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(STERF_HYBRID, __double)
+TEST_P(STERF_HYBRID, _double)
 {
     run_tests<double>();
 }

--- a/projects/rocsolver/clients/gtest/auxiliary/sterf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/sterf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/auxiliary/sterf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/auxiliary/sterf_gtest.cpp
@@ -97,22 +97,22 @@ class STERF_HYBRID : public STERF_BASE<1>
 
 // non-batch tests
 
-TEST_P(STERF, _float)
+TEST_P(STERF, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(STERF, _double)
+TEST_P(STERF, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(STERF_HYBRID, _float)
+TEST_P(STERF_HYBRID, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(STERF_HYBRID, _double)
+TEST_P(STERF_HYBRID, __double)
 {
     run_tests<double>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/gebd2_gebrd_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/gebd2_gebrd_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/gebd2_gebrd_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/gebd2_gebrd_gtest.cpp
@@ -119,126 +119,126 @@ class GEBRD : public GEBD2_GEBRD<true>
 
 // non-batch tests
 
-TEST_P(GEBD2, _float)
+TEST_P(GEBD2, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEBD2, _double)
+TEST_P(GEBD2, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEBD2, _float_complex)
+TEST_P(GEBD2, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEBD2, _double_complex)
+TEST_P(GEBD2, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GEBRD, _float)
+TEST_P(GEBRD, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEBRD, _double)
+TEST_P(GEBRD, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEBRD, _float_complex)
+TEST_P(GEBRD, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEBRD, _double_complex)
+TEST_P(GEBRD, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GEBD2, batched_float)
+TEST_P(GEBD2, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GEBD2, batched_double)
+TEST_P(GEBD2, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GEBD2, batched_float_complex)
+TEST_P(GEBD2, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GEBD2, batched_double_complex)
+TEST_P(GEBD2, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GEBRD, batched_float)
+TEST_P(GEBRD, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GEBRD, batched_double)
+TEST_P(GEBRD, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GEBRD, batched_float_complex)
+TEST_P(GEBRD, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GEBRD, batched_double_complex)
+TEST_P(GEBRD, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(GEBD2, strided_batched_float)
+TEST_P(GEBD2, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GEBD2, strided_batched_double)
+TEST_P(GEBD2, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GEBD2, strided_batched_float_complex)
+TEST_P(GEBD2, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GEBD2, strided_batched_double_complex)
+TEST_P(GEBD2, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GEBRD, strided_batched_float)
+TEST_P(GEBRD, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GEBRD, strided_batched_double)
+TEST_P(GEBRD, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GEBRD, strided_batched_float_complex)
+TEST_P(GEBRD, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GEBRD, strided_batched_double_complex)
+TEST_P(GEBRD, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/gebd2_gebrd_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/gebd2_gebrd_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -119,126 +119,126 @@ class GEBRD : public GEBD2_GEBRD<true>
 
 // non-batch tests
 
-TEST_P(GEBD2, __float)
+TEST_P(GEBD2, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEBD2, __double)
+TEST_P(GEBD2, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEBD2, __float_complex)
+TEST_P(GEBD2, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEBD2, __double_complex)
+TEST_P(GEBD2, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GEBRD, __float)
+TEST_P(GEBRD, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEBRD, __double)
+TEST_P(GEBRD, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEBRD, __float_complex)
+TEST_P(GEBRD, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEBRD, __double_complex)
+TEST_P(GEBRD, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GEBD2, batched__float)
+TEST_P(GEBD2, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GEBD2, batched__double)
+TEST_P(GEBD2, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GEBD2, batched__float_complex)
+TEST_P(GEBD2, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GEBD2, batched__double_complex)
+TEST_P(GEBD2, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GEBRD, batched__float)
+TEST_P(GEBRD, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GEBRD, batched__double)
+TEST_P(GEBRD, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GEBRD, batched__float_complex)
+TEST_P(GEBRD, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GEBRD, batched__double_complex)
+TEST_P(GEBRD, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(GEBD2, strided_batched__float)
+TEST_P(GEBD2, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GEBD2, strided_batched__double)
+TEST_P(GEBD2, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GEBD2, strided_batched__float_complex)
+TEST_P(GEBD2, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GEBD2, strided_batched__double_complex)
+TEST_P(GEBD2, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GEBRD, strided_batched__float)
+TEST_P(GEBRD, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GEBRD, strided_batched__double)
+TEST_P(GEBRD, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GEBRD, strided_batched__float_complex)
+TEST_P(GEBRD, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GEBRD, strided_batched__double_complex)
+TEST_P(GEBRD, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/geblttrf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/geblttrf_gtest.cpp
@@ -155,88 +155,88 @@ protected:
 
 // non-batch tests
 
-TEST_P(GEBLTTRF_NPVT, _float)
+TEST_P(GEBLTTRF_NPVT, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEBLTTRF_NPVT, _double)
+TEST_P(GEBLTTRF_NPVT, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEBLTTRF_NPVT, _float_complex)
+TEST_P(GEBLTTRF_NPVT, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEBLTTRF_NPVT, _double_complex)
+TEST_P(GEBLTTRF_NPVT, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GEBLTTRF_NPVT, batched_float)
+TEST_P(GEBLTTRF_NPVT, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GEBLTTRF_NPVT, batched_double)
+TEST_P(GEBLTTRF_NPVT, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GEBLTTRF_NPVT, batched_float_complex)
+TEST_P(GEBLTTRF_NPVT, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GEBLTTRF_NPVT, batched_double_complex)
+TEST_P(GEBLTTRF_NPVT, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(GEBLTTRF_NPVT, strided_batched_float)
+TEST_P(GEBLTTRF_NPVT, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GEBLTTRF_NPVT, strided_batched_double)
+TEST_P(GEBLTTRF_NPVT, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GEBLTTRF_NPVT, strided_batched_float_complex)
+TEST_P(GEBLTTRF_NPVT, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GEBLTTRF_NPVT, strided_batched_double_complex)
+TEST_P(GEBLTTRF_NPVT, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
 // interleaved_batched tests
 
-TEST_P(GEBLTTRF_NPVT_INTERLEAVED, interleaved_batched_float)
+TEST_P(GEBLTTRF_NPVT_INTERLEAVED, interleaved_batched__float)
 {
     run_tests<float>();
 }
 
-TEST_P(GEBLTTRF_NPVT_INTERLEAVED, interleaved_batched_double)
+TEST_P(GEBLTTRF_NPVT_INTERLEAVED, interleaved_batched__double)
 {
     run_tests<double>();
 }
 
-TEST_P(GEBLTTRF_NPVT_INTERLEAVED, interleaved_batched_float_complex)
+TEST_P(GEBLTTRF_NPVT_INTERLEAVED, interleaved_batched__float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(GEBLTTRF_NPVT_INTERLEAVED, interleaved_batched_double_complex)
+TEST_P(GEBLTTRF_NPVT_INTERLEAVED, interleaved_batched__double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/geblttrf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/geblttrf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/geblttrf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/geblttrf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -155,88 +155,88 @@ protected:
 
 // non-batch tests
 
-TEST_P(GEBLTTRF_NPVT, __float)
+TEST_P(GEBLTTRF_NPVT, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEBLTTRF_NPVT, __double)
+TEST_P(GEBLTTRF_NPVT, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEBLTTRF_NPVT, __float_complex)
+TEST_P(GEBLTTRF_NPVT, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEBLTTRF_NPVT, __double_complex)
+TEST_P(GEBLTTRF_NPVT, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GEBLTTRF_NPVT, batched__float)
+TEST_P(GEBLTTRF_NPVT, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GEBLTTRF_NPVT, batched__double)
+TEST_P(GEBLTTRF_NPVT, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GEBLTTRF_NPVT, batched__float_complex)
+TEST_P(GEBLTTRF_NPVT, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GEBLTTRF_NPVT, batched__double_complex)
+TEST_P(GEBLTTRF_NPVT, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(GEBLTTRF_NPVT, strided_batched__float)
+TEST_P(GEBLTTRF_NPVT, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GEBLTTRF_NPVT, strided_batched__double)
+TEST_P(GEBLTTRF_NPVT, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GEBLTTRF_NPVT, strided_batched__float_complex)
+TEST_P(GEBLTTRF_NPVT, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GEBLTTRF_NPVT, strided_batched__double_complex)
+TEST_P(GEBLTTRF_NPVT, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
 // interleaved_batched tests
 
-TEST_P(GEBLTTRF_NPVT_INTERLEAVED, interleaved_batched__float)
+TEST_P(GEBLTTRF_NPVT_INTERLEAVED, interleaved_batched_float)
 {
     run_tests<float>();
 }
 
-TEST_P(GEBLTTRF_NPVT_INTERLEAVED, interleaved_batched__double)
+TEST_P(GEBLTTRF_NPVT_INTERLEAVED, interleaved_batched_double)
 {
     run_tests<double>();
 }
 
-TEST_P(GEBLTTRF_NPVT_INTERLEAVED, interleaved_batched__float_complex)
+TEST_P(GEBLTTRF_NPVT_INTERLEAVED, interleaved_batched_float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(GEBLTTRF_NPVT_INTERLEAVED, interleaved_batched__double_complex)
+TEST_P(GEBLTTRF_NPVT_INTERLEAVED, interleaved_batched_double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/geblttrs_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/geblttrs_gtest.cpp
@@ -154,88 +154,88 @@ protected:
 
 // non-batch tests
 
-TEST_P(GEBLTTRS_NPVT, _float)
+TEST_P(GEBLTTRS_NPVT, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEBLTTRS_NPVT, _double)
+TEST_P(GEBLTTRS_NPVT, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEBLTTRS_NPVT, _float_complex)
+TEST_P(GEBLTTRS_NPVT, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEBLTTRS_NPVT, _double_complex)
+TEST_P(GEBLTTRS_NPVT, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GEBLTTRS_NPVT, batched_float)
+TEST_P(GEBLTTRS_NPVT, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GEBLTTRS_NPVT, batched_double)
+TEST_P(GEBLTTRS_NPVT, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GEBLTTRS_NPVT, batched_float_complex)
+TEST_P(GEBLTTRS_NPVT, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GEBLTTRS_NPVT, batched_double_complex)
+TEST_P(GEBLTTRS_NPVT, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(GEBLTTRS_NPVT, strided_batched_float)
+TEST_P(GEBLTTRS_NPVT, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GEBLTTRS_NPVT, strided_batched_double)
+TEST_P(GEBLTTRS_NPVT, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GEBLTTRS_NPVT, strided_batched_float_complex)
+TEST_P(GEBLTTRS_NPVT, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GEBLTTRS_NPVT, strided_batched_double_complex)
+TEST_P(GEBLTTRS_NPVT, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(GEBLTTRS_NPVT_INTERLEAVED, interleaved_batched_float)
+TEST_P(GEBLTTRS_NPVT_INTERLEAVED, interleaved_batched__float)
 {
     run_tests<float>();
 }
 
-TEST_P(GEBLTTRS_NPVT_INTERLEAVED, interleaved_batched_double)
+TEST_P(GEBLTTRS_NPVT_INTERLEAVED, interleaved_batched__double)
 {
     run_tests<double>();
 }
 
-TEST_P(GEBLTTRS_NPVT_INTERLEAVED, interleaved_batched_float_complex)
+TEST_P(GEBLTTRS_NPVT_INTERLEAVED, interleaved_batched__float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(GEBLTTRS_NPVT_INTERLEAVED, interleaved_batched_double_complex)
+TEST_P(GEBLTTRS_NPVT_INTERLEAVED, interleaved_batched__double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/geblttrs_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/geblttrs_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/geblttrs_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/geblttrs_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -154,88 +154,88 @@ protected:
 
 // non-batch tests
 
-TEST_P(GEBLTTRS_NPVT, __float)
+TEST_P(GEBLTTRS_NPVT, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEBLTTRS_NPVT, __double)
+TEST_P(GEBLTTRS_NPVT, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEBLTTRS_NPVT, __float_complex)
+TEST_P(GEBLTTRS_NPVT, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEBLTTRS_NPVT, __double_complex)
+TEST_P(GEBLTTRS_NPVT, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GEBLTTRS_NPVT, batched__float)
+TEST_P(GEBLTTRS_NPVT, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GEBLTTRS_NPVT, batched__double)
+TEST_P(GEBLTTRS_NPVT, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GEBLTTRS_NPVT, batched__float_complex)
+TEST_P(GEBLTTRS_NPVT, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GEBLTTRS_NPVT, batched__double_complex)
+TEST_P(GEBLTTRS_NPVT, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(GEBLTTRS_NPVT, strided_batched__float)
+TEST_P(GEBLTTRS_NPVT, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GEBLTTRS_NPVT, strided_batched__double)
+TEST_P(GEBLTTRS_NPVT, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GEBLTTRS_NPVT, strided_batched__float_complex)
+TEST_P(GEBLTTRS_NPVT, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GEBLTTRS_NPVT, strided_batched__double_complex)
+TEST_P(GEBLTTRS_NPVT, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(GEBLTTRS_NPVT_INTERLEAVED, interleaved_batched__float)
+TEST_P(GEBLTTRS_NPVT_INTERLEAVED, interleaved_batched_float)
 {
     run_tests<float>();
 }
 
-TEST_P(GEBLTTRS_NPVT_INTERLEAVED, interleaved_batched__double)
+TEST_P(GEBLTTRS_NPVT_INTERLEAVED, interleaved_batched_double)
 {
     run_tests<double>();
 }
 
-TEST_P(GEBLTTRS_NPVT_INTERLEAVED, interleaved_batched__float_complex)
+TEST_P(GEBLTTRS_NPVT_INTERLEAVED, interleaved_batched_float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(GEBLTTRS_NPVT_INTERLEAVED, interleaved_batched__double_complex)
+TEST_P(GEBLTTRS_NPVT_INTERLEAVED, interleaved_batched_double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/gelq2_gelqf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/gelq2_gelqf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/gelq2_gelqf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/gelq2_gelqf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -120,126 +120,126 @@ class GELQF : public GELQ2_GELQF<true>
 
 // non-batch tests
 
-TEST_P(GELQ2, __float)
+TEST_P(GELQ2, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GELQ2, __double)
+TEST_P(GELQ2, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GELQ2, __float_complex)
+TEST_P(GELQ2, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GELQ2, __double_complex)
+TEST_P(GELQ2, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GELQF, __float)
+TEST_P(GELQF, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GELQF, __double)
+TEST_P(GELQF, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GELQF, __float_complex)
+TEST_P(GELQF, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GELQF, __double_complex)
+TEST_P(GELQF, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GELQ2, batched__float)
+TEST_P(GELQ2, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GELQ2, batched__double)
+TEST_P(GELQ2, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GELQ2, batched__float_complex)
+TEST_P(GELQ2, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GELQ2, batched__double_complex)
+TEST_P(GELQ2, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GELQF, batched__float)
+TEST_P(GELQF, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GELQF, batched__double)
+TEST_P(GELQF, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GELQF, batched__float_complex)
+TEST_P(GELQF, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GELQF, batched__double_complex)
+TEST_P(GELQF, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(GELQ2, strided_batched__float)
+TEST_P(GELQ2, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GELQ2, strided_batched__double)
+TEST_P(GELQ2, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GELQ2, strided_batched__float_complex)
+TEST_P(GELQ2, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GELQ2, strided_batched__double_complex)
+TEST_P(GELQ2, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GELQF, strided_batched__float)
+TEST_P(GELQF, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GELQF, strided_batched__double)
+TEST_P(GELQF, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GELQF, strided_batched__float_complex)
+TEST_P(GELQF, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GELQF, strided_batched__double_complex)
+TEST_P(GELQF, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/gelq2_gelqf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/gelq2_gelqf_gtest.cpp
@@ -120,126 +120,126 @@ class GELQF : public GELQ2_GELQF<true>
 
 // non-batch tests
 
-TEST_P(GELQ2, _float)
+TEST_P(GELQ2, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GELQ2, _double)
+TEST_P(GELQ2, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GELQ2, _float_complex)
+TEST_P(GELQ2, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GELQ2, _double_complex)
+TEST_P(GELQ2, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GELQF, _float)
+TEST_P(GELQF, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GELQF, _double)
+TEST_P(GELQF, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GELQF, _float_complex)
+TEST_P(GELQF, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GELQF, _double_complex)
+TEST_P(GELQF, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GELQ2, batched_float)
+TEST_P(GELQ2, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GELQ2, batched_double)
+TEST_P(GELQ2, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GELQ2, batched_float_complex)
+TEST_P(GELQ2, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GELQ2, batched_double_complex)
+TEST_P(GELQ2, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GELQF, batched_float)
+TEST_P(GELQF, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GELQF, batched_double)
+TEST_P(GELQF, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GELQF, batched_float_complex)
+TEST_P(GELQF, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GELQF, batched_double_complex)
+TEST_P(GELQF, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(GELQ2, strided_batched_float)
+TEST_P(GELQ2, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GELQ2, strided_batched_double)
+TEST_P(GELQ2, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GELQ2, strided_batched_float_complex)
+TEST_P(GELQ2, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GELQ2, strided_batched_double_complex)
+TEST_P(GELQ2, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GELQF, strided_batched_float)
+TEST_P(GELQF, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GELQF, strided_batched_double)
+TEST_P(GELQF, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GELQF, strided_batched_float_complex)
+TEST_P(GELQF, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GELQF, strided_batched_double_complex)
+TEST_P(GELQF, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/gels_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/gels_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/gels_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/gels_gtest.cpp
@@ -169,86 +169,86 @@ protected:
 
 // non-batch tests
 
-TEST_P(GELS, _float)
+TEST_P(GELS, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GELS, _double)
+TEST_P(GELS, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GELS, _float_complex)
+TEST_P(GELS, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GELS, _double_complex)
+TEST_P(GELS, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GELS_OUTOFPLACE, _float)
+TEST_P(GELS_OUTOFPLACE, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GELS_OUTOFPLACE, _double)
+TEST_P(GELS_OUTOFPLACE, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GELS_OUTOFPLACE, _float_complex)
+TEST_P(GELS_OUTOFPLACE, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GELS_OUTOFPLACE, _double_complex)
+TEST_P(GELS_OUTOFPLACE, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GELS, batched_float)
+TEST_P(GELS, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GELS, batched_double)
+TEST_P(GELS, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GELS, batched_float_complex)
+TEST_P(GELS, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GELS, batched_double_complex)
+TEST_P(GELS, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(GELS, strided_batched_float)
+TEST_P(GELS, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GELS, strided_batched_double)
+TEST_P(GELS, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GELS, strided_batched_float_complex)
+TEST_P(GELS, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GELS, strided_batched_double_complex)
+TEST_P(GELS, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/gels_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/gels_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -169,86 +169,86 @@ protected:
 
 // non-batch tests
 
-TEST_P(GELS, __float)
+TEST_P(GELS, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GELS, __double)
+TEST_P(GELS, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GELS, __float_complex)
+TEST_P(GELS, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GELS, __double_complex)
+TEST_P(GELS, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GELS_OUTOFPLACE, __float)
+TEST_P(GELS_OUTOFPLACE, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GELS_OUTOFPLACE, __double)
+TEST_P(GELS_OUTOFPLACE, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GELS_OUTOFPLACE, __float_complex)
+TEST_P(GELS_OUTOFPLACE, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GELS_OUTOFPLACE, __double_complex)
+TEST_P(GELS_OUTOFPLACE, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GELS, batched__float)
+TEST_P(GELS, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GELS, batched__double)
+TEST_P(GELS, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GELS, batched__float_complex)
+TEST_P(GELS, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GELS, batched__double_complex)
+TEST_P(GELS, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(GELS, strided_batched__float)
+TEST_P(GELS, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GELS, strided_batched__double)
+TEST_P(GELS, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GELS, strided_batched__float_complex)
+TEST_P(GELS, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GELS, strided_batched__double_complex)
+TEST_P(GELS, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/geql2_geqlf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/geql2_geqlf_gtest.cpp
@@ -120,126 +120,126 @@ class GEQLF : public GEQL2_GEQLF<true>
 
 // non-batch tests
 
-TEST_P(GEQL2, _float)
+TEST_P(GEQL2, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEQL2, _double)
+TEST_P(GEQL2, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEQL2, _float_complex)
+TEST_P(GEQL2, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEQL2, _double_complex)
+TEST_P(GEQL2, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GEQLF, _float)
+TEST_P(GEQLF, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEQLF, _double)
+TEST_P(GEQLF, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEQLF, _float_complex)
+TEST_P(GEQLF, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEQLF, _double_complex)
+TEST_P(GEQLF, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GEQL2, batched_float)
+TEST_P(GEQL2, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GEQL2, batched_double)
+TEST_P(GEQL2, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GEQL2, batched_float_complex)
+TEST_P(GEQL2, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GEQL2, batched_double_complex)
+TEST_P(GEQL2, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GEQLF, batched_float)
+TEST_P(GEQLF, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GEQLF, batched_double)
+TEST_P(GEQLF, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GEQLF, batched_float_complex)
+TEST_P(GEQLF, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GEQLF, batched_double_complex)
+TEST_P(GEQLF, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(GEQL2, strided_batched_float)
+TEST_P(GEQL2, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GEQL2, strided_batched_double)
+TEST_P(GEQL2, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GEQL2, strided_batched_float_complex)
+TEST_P(GEQL2, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GEQL2, strided_batched_double_complex)
+TEST_P(GEQL2, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GEQLF, strided_batched_float)
+TEST_P(GEQLF, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GEQLF, strided_batched_double)
+TEST_P(GEQLF, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GEQLF, strided_batched_float_complex)
+TEST_P(GEQLF, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GEQLF, strided_batched_double_complex)
+TEST_P(GEQLF, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/geql2_geqlf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/geql2_geqlf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/geql2_geqlf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/geql2_geqlf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -120,126 +120,126 @@ class GEQLF : public GEQL2_GEQLF<true>
 
 // non-batch tests
 
-TEST_P(GEQL2, __float)
+TEST_P(GEQL2, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEQL2, __double)
+TEST_P(GEQL2, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEQL2, __float_complex)
+TEST_P(GEQL2, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEQL2, __double_complex)
+TEST_P(GEQL2, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GEQLF, __float)
+TEST_P(GEQLF, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEQLF, __double)
+TEST_P(GEQLF, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEQLF, __float_complex)
+TEST_P(GEQLF, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEQLF, __double_complex)
+TEST_P(GEQLF, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GEQL2, batched__float)
+TEST_P(GEQL2, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GEQL2, batched__double)
+TEST_P(GEQL2, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GEQL2, batched__float_complex)
+TEST_P(GEQL2, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GEQL2, batched__double_complex)
+TEST_P(GEQL2, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GEQLF, batched__float)
+TEST_P(GEQLF, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GEQLF, batched__double)
+TEST_P(GEQLF, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GEQLF, batched__float_complex)
+TEST_P(GEQLF, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GEQLF, batched__double_complex)
+TEST_P(GEQLF, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(GEQL2, strided_batched__float)
+TEST_P(GEQL2, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GEQL2, strided_batched__double)
+TEST_P(GEQL2, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GEQL2, strided_batched__float_complex)
+TEST_P(GEQL2, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GEQL2, strided_batched__double_complex)
+TEST_P(GEQL2, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GEQLF, strided_batched__float)
+TEST_P(GEQLF, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GEQLF, strided_batched__double)
+TEST_P(GEQLF, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GEQLF, strided_batched__float_complex)
+TEST_P(GEQLF, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GEQLF, strided_batched__double_complex)
+TEST_P(GEQLF, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/geqr2_geqrf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/geqr2_geqrf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/geqr2_geqrf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/geqr2_geqrf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -158,148 +158,148 @@ class GEQRF_64 : public GEQR2_GEQRF<true, int64_t>
 
 // non-batch tests
 
-TEST_P(GEQR2, __float)
+TEST_P(GEQR2, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEQR2, __double)
+TEST_P(GEQR2, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEQR2, __float_complex)
+TEST_P(GEQR2, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEQR2, __double_complex)
+TEST_P(GEQR2, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GEQRF, __float)
+TEST_P(GEQRF, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEQRF, __double)
+TEST_P(GEQRF, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEQRF, __float_complex)
+TEST_P(GEQRF, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEQRF, __double_complex)
+TEST_P(GEQRF, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GEQR2, batched__float)
+TEST_P(GEQR2, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GEQR2, batched__double)
+TEST_P(GEQR2, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GEQR2, batched__float_complex)
+TEST_P(GEQR2, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GEQR2, batched__double_complex)
+TEST_P(GEQR2, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GEQRF, batched__float)
+TEST_P(GEQRF, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GEQRF, batched__double)
+TEST_P(GEQRF, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GEQRF, batched__float_complex)
+TEST_P(GEQRF, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GEQRF, batched__double_complex)
+TEST_P(GEQRF, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(GEQR2, strided_batched__float)
+TEST_P(GEQR2, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GEQR2, strided_batched__double)
+TEST_P(GEQR2, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GEQR2, strided_batched__float_complex)
+TEST_P(GEQR2, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GEQR2, strided_batched__double_complex)
+TEST_P(GEQR2, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GEQRF, strided_batched__float)
+TEST_P(GEQRF, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GEQRF, strided_batched__double)
+TEST_P(GEQRF, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GEQRF, strided_batched__float_complex)
+TEST_P(GEQRF, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GEQRF, strided_batched__double_complex)
+TEST_P(GEQRF, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
 // ptr_batched tests
 
-TEST_P(GEQRF, ptr_batched__float)
+TEST_P(GEQRF, ptr_batched_float)
 {
     run_tests<true, false, float>();
 }
 
-TEST_P(GEQRF, ptr_batched__double)
+TEST_P(GEQRF, ptr_batched_double)
 {
     run_tests<true, false, double>();
 }
 
-TEST_P(GEQRF, ptr_batched__float_complex)
+TEST_P(GEQRF, ptr_batched_float_complex)
 {
     run_tests<true, false, rocblas_float_complex>();
 }
 
-TEST_P(GEQRF, ptr_batched__double_complex)
+TEST_P(GEQRF, ptr_batched_double_complex)
 {
     run_tests<true, false, rocblas_double_complex>();
 }
@@ -308,148 +308,148 @@ TEST_P(GEQRF, ptr_batched__double_complex)
 
 // non-batch tests
 
-TEST_P(GEQR2_64, __float)
+TEST_P(GEQR2_64, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEQR2_64, __double)
+TEST_P(GEQR2_64, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEQR2_64, __float_complex)
+TEST_P(GEQR2_64, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEQR2_64, __double_complex)
+TEST_P(GEQR2_64, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GEQRF_64, __float)
+TEST_P(GEQRF_64, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEQRF_64, __double)
+TEST_P(GEQRF_64, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEQRF_64, __float_complex)
+TEST_P(GEQRF_64, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEQRF_64, __double_complex)
+TEST_P(GEQRF_64, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GEQR2_64, batched__float)
+TEST_P(GEQR2_64, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GEQR2_64, batched__double)
+TEST_P(GEQR2_64, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GEQR2_64, batched__float_complex)
+TEST_P(GEQR2_64, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GEQR2_64, batched__double_complex)
+TEST_P(GEQR2_64, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GEQRF_64, batched__float)
+TEST_P(GEQRF_64, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GEQRF_64, batched__double)
+TEST_P(GEQRF_64, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GEQRF_64, batched__float_complex)
+TEST_P(GEQRF_64, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GEQRF_64, batched__double_complex)
+TEST_P(GEQRF_64, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(GEQR2_64, strided_batched__float)
+TEST_P(GEQR2_64, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GEQR2_64, strided_batched__double)
+TEST_P(GEQR2_64, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GEQR2_64, strided_batched__float_complex)
+TEST_P(GEQR2_64, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GEQR2_64, strided_batched__double_complex)
+TEST_P(GEQR2_64, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GEQRF_64, strided_batched__float)
+TEST_P(GEQRF_64, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GEQRF_64, strided_batched__double)
+TEST_P(GEQRF_64, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GEQRF_64, strided_batched__float_complex)
+TEST_P(GEQRF_64, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GEQRF_64, strided_batched__double_complex)
+TEST_P(GEQRF_64, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
 // ptr_batched tests
 
-TEST_P(GEQRF_64, ptr_batched__float)
+TEST_P(GEQRF_64, ptr_batched_float)
 {
     run_tests<true, false, float>();
 }
 
-TEST_P(GEQRF_64, ptr_batched__double)
+TEST_P(GEQRF_64, ptr_batched_double)
 {
     run_tests<true, false, double>();
 }
 
-TEST_P(GEQRF_64, ptr_batched__float_complex)
+TEST_P(GEQRF_64, ptr_batched_float_complex)
 {
     run_tests<true, false, rocblas_float_complex>();
 }
 
-TEST_P(GEQRF_64, ptr_batched__double_complex)
+TEST_P(GEQRF_64, ptr_batched_double_complex)
 {
     run_tests<true, false, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/geqr2_geqrf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/geqr2_geqrf_gtest.cpp
@@ -158,148 +158,148 @@ class GEQRF_64 : public GEQR2_GEQRF<true, int64_t>
 
 // non-batch tests
 
-TEST_P(GEQR2, _float)
+TEST_P(GEQR2, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEQR2, _double)
+TEST_P(GEQR2, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEQR2, _float_complex)
+TEST_P(GEQR2, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEQR2, _double_complex)
+TEST_P(GEQR2, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GEQRF, _float)
+TEST_P(GEQRF, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEQRF, _double)
+TEST_P(GEQRF, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEQRF, _float_complex)
+TEST_P(GEQRF, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEQRF, _double_complex)
+TEST_P(GEQRF, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GEQR2, batched_float)
+TEST_P(GEQR2, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GEQR2, batched_double)
+TEST_P(GEQR2, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GEQR2, batched_float_complex)
+TEST_P(GEQR2, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GEQR2, batched_double_complex)
+TEST_P(GEQR2, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GEQRF, batched_float)
+TEST_P(GEQRF, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GEQRF, batched_double)
+TEST_P(GEQRF, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GEQRF, batched_float_complex)
+TEST_P(GEQRF, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GEQRF, batched_double_complex)
+TEST_P(GEQRF, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(GEQR2, strided_batched_float)
+TEST_P(GEQR2, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GEQR2, strided_batched_double)
+TEST_P(GEQR2, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GEQR2, strided_batched_float_complex)
+TEST_P(GEQR2, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GEQR2, strided_batched_double_complex)
+TEST_P(GEQR2, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GEQRF, strided_batched_float)
+TEST_P(GEQRF, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GEQRF, strided_batched_double)
+TEST_P(GEQRF, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GEQRF, strided_batched_float_complex)
+TEST_P(GEQRF, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GEQRF, strided_batched_double_complex)
+TEST_P(GEQRF, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
 // ptr_batched tests
 
-TEST_P(GEQRF, ptr_batched_float)
+TEST_P(GEQRF, ptr_batched__float)
 {
     run_tests<true, false, float>();
 }
 
-TEST_P(GEQRF, ptr_batched_double)
+TEST_P(GEQRF, ptr_batched__double)
 {
     run_tests<true, false, double>();
 }
 
-TEST_P(GEQRF, ptr_batched_float_complex)
+TEST_P(GEQRF, ptr_batched__float_complex)
 {
     run_tests<true, false, rocblas_float_complex>();
 }
 
-TEST_P(GEQRF, ptr_batched_double_complex)
+TEST_P(GEQRF, ptr_batched__double_complex)
 {
     run_tests<true, false, rocblas_double_complex>();
 }
@@ -308,148 +308,148 @@ TEST_P(GEQRF, ptr_batched_double_complex)
 
 // non-batch tests
 
-TEST_P(GEQR2_64, _float)
+TEST_P(GEQR2_64, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEQR2_64, _double)
+TEST_P(GEQR2_64, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEQR2_64, _float_complex)
+TEST_P(GEQR2_64, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEQR2_64, _double_complex)
+TEST_P(GEQR2_64, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GEQRF_64, _float)
+TEST_P(GEQRF_64, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEQRF_64, _double)
+TEST_P(GEQRF_64, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEQRF_64, _float_complex)
+TEST_P(GEQRF_64, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEQRF_64, _double_complex)
+TEST_P(GEQRF_64, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GEQR2_64, batched_float)
+TEST_P(GEQR2_64, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GEQR2_64, batched_double)
+TEST_P(GEQR2_64, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GEQR2_64, batched_float_complex)
+TEST_P(GEQR2_64, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GEQR2_64, batched_double_complex)
+TEST_P(GEQR2_64, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GEQRF_64, batched_float)
+TEST_P(GEQRF_64, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GEQRF_64, batched_double)
+TEST_P(GEQRF_64, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GEQRF_64, batched_float_complex)
+TEST_P(GEQRF_64, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GEQRF_64, batched_double_complex)
+TEST_P(GEQRF_64, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(GEQR2_64, strided_batched_float)
+TEST_P(GEQR2_64, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GEQR2_64, strided_batched_double)
+TEST_P(GEQR2_64, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GEQR2_64, strided_batched_float_complex)
+TEST_P(GEQR2_64, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GEQR2_64, strided_batched_double_complex)
+TEST_P(GEQR2_64, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GEQRF_64, strided_batched_float)
+TEST_P(GEQRF_64, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GEQRF_64, strided_batched_double)
+TEST_P(GEQRF_64, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GEQRF_64, strided_batched_float_complex)
+TEST_P(GEQRF_64, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GEQRF_64, strided_batched_double_complex)
+TEST_P(GEQRF_64, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
 // ptr_batched tests
 
-TEST_P(GEQRF_64, ptr_batched_float)
+TEST_P(GEQRF_64, ptr_batched__float)
 {
     run_tests<true, false, float>();
 }
 
-TEST_P(GEQRF_64, ptr_batched_double)
+TEST_P(GEQRF_64, ptr_batched__double)
 {
     run_tests<true, false, double>();
 }
 
-TEST_P(GEQRF_64, ptr_batched_float_complex)
+TEST_P(GEQRF_64, ptr_batched__float_complex)
 {
     run_tests<true, false, rocblas_float_complex>();
 }
 
-TEST_P(GEQRF_64, ptr_batched_double_complex)
+TEST_P(GEQRF_64, ptr_batched__double_complex)
 {
     run_tests<true, false, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/gerq2_gerqf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/gerq2_gerqf_gtest.cpp
@@ -120,126 +120,126 @@ class GERQF : public GERQ2_GERQF<true>
 
 // non-batch tests
 
-TEST_P(GERQ2, _float)
+TEST_P(GERQ2, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GERQ2, _double)
+TEST_P(GERQ2, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GERQ2, _float_complex)
+TEST_P(GERQ2, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GERQ2, _double_complex)
+TEST_P(GERQ2, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GERQF, _float)
+TEST_P(GERQF, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GERQF, _double)
+TEST_P(GERQF, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GERQF, _float_complex)
+TEST_P(GERQF, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GERQF, _double_complex)
+TEST_P(GERQF, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GERQ2, batched_float)
+TEST_P(GERQ2, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GERQ2, batched_double)
+TEST_P(GERQ2, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GERQ2, batched_float_complex)
+TEST_P(GERQ2, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GERQ2, batched_double_complex)
+TEST_P(GERQ2, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GERQF, batched_float)
+TEST_P(GERQF, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GERQF, batched_double)
+TEST_P(GERQF, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GERQF, batched_float_complex)
+TEST_P(GERQF, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GERQF, batched_double_complex)
+TEST_P(GERQF, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(GERQ2, strided_batched_float)
+TEST_P(GERQ2, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GERQ2, strided_batched_double)
+TEST_P(GERQ2, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GERQ2, strided_batched_float_complex)
+TEST_P(GERQ2, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GERQ2, strided_batched_double_complex)
+TEST_P(GERQ2, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GERQF, strided_batched_float)
+TEST_P(GERQF, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GERQF, strided_batched_double)
+TEST_P(GERQF, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GERQF, strided_batched_float_complex)
+TEST_P(GERQF, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GERQF, strided_batched_double_complex)
+TEST_P(GERQF, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/gerq2_gerqf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/gerq2_gerqf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/gerq2_gerqf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/gerq2_gerqf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -120,126 +120,126 @@ class GERQF : public GERQ2_GERQF<true>
 
 // non-batch tests
 
-TEST_P(GERQ2, __float)
+TEST_P(GERQ2, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GERQ2, __double)
+TEST_P(GERQ2, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GERQ2, __float_complex)
+TEST_P(GERQ2, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GERQ2, __double_complex)
+TEST_P(GERQ2, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GERQF, __float)
+TEST_P(GERQF, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GERQF, __double)
+TEST_P(GERQF, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GERQF, __float_complex)
+TEST_P(GERQF, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GERQF, __double_complex)
+TEST_P(GERQF, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GERQ2, batched__float)
+TEST_P(GERQ2, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GERQ2, batched__double)
+TEST_P(GERQ2, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GERQ2, batched__float_complex)
+TEST_P(GERQ2, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GERQ2, batched__double_complex)
+TEST_P(GERQ2, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GERQF, batched__float)
+TEST_P(GERQF, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GERQF, batched__double)
+TEST_P(GERQF, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GERQF, batched__float_complex)
+TEST_P(GERQF, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GERQF, batched__double_complex)
+TEST_P(GERQF, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(GERQ2, strided_batched__float)
+TEST_P(GERQ2, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GERQ2, strided_batched__double)
+TEST_P(GERQ2, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GERQ2, strided_batched__float_complex)
+TEST_P(GERQ2, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GERQ2, strided_batched__double_complex)
+TEST_P(GERQ2, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GERQF, strided_batched__float)
+TEST_P(GERQF, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GERQF, strided_batched__double)
+TEST_P(GERQF, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GERQF, strided_batched__float_complex)
+TEST_P(GERQF, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GERQF, strided_batched__double_complex)
+TEST_P(GERQF, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/gesdd_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/gesdd_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -179,106 +179,106 @@ protected:
 
 // non-batch tests
 
-TEST_P(GESDD, __float)
+TEST_P(GESDD, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESDD, __double)
+TEST_P(GESDD, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESDD, __float_complex)
+TEST_P(GESDD, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESDD, __double_complex)
+TEST_P(GESDD, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-/* TEST_P(GESDD_NOTRANSV, __float) */
+/* TEST_P(GESDD_NOTRANSV, _float) */
 /* { */
 /*     run_tests<false, false, float>(); */
 /* } */
 
-/* TEST_P(GESDD_NOTRANSV, __double) */
+/* TEST_P(GESDD_NOTRANSV, _double) */
 /* { */
 /*     run_tests<false, false, double>(); */
 /* } */
 
-/* TEST_P(GESDD_NOTRANSV, __float_complex) */
+/* TEST_P(GESDD_NOTRANSV, _float_complex) */
 /* { */
 /*     run_tests<false, false, rocblas_float_complex>(); */
 /* } */
 
-/* TEST_P(GESDD_NOTRANSV, __double_complex) */
+/* TEST_P(GESDD_NOTRANSV, _double_complex) */
 /* { */
 /*     run_tests<false, false, rocblas_double_complex>(); */
 /* } */
 
 // batched tests
 
-TEST_P(GESDD, batched__float)
+TEST_P(GESDD, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GESDD, batched__double)
+TEST_P(GESDD, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GESDD, batched__float_complex)
+TEST_P(GESDD, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GESDD, batched__double_complex)
+TEST_P(GESDD, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(GESDD, strided_batched__float)
+TEST_P(GESDD, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GESDD, strided_batched__double)
+TEST_P(GESDD, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GESDD, strided_batched__float_complex)
+TEST_P(GESDD, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GESDD, strided_batched__double_complex)
+TEST_P(GESDD, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-/* TEST_P(GESDD_NOTRANSV, strided_batched__float) */
+/* TEST_P(GESDD_NOTRANSV, strided_batched_float) */
 /* { */
 /*     run_tests<false, true, float>(); */
 /* } */
 
-/* TEST_P(GESDD_NOTRANSV, strided_batched__double) */
+/* TEST_P(GESDD_NOTRANSV, strided_batched_double) */
 /* { */
 /*     run_tests<false, true, double>(); */
 /* } */
 
-/* TEST_P(GESDD_NOTRANSV, strided_batched__float_complex) */
+/* TEST_P(GESDD_NOTRANSV, strided_batched_float_complex) */
 /* { */
 /*     run_tests<false, true, rocblas_float_complex>(); */
 /* } */
 
-/* TEST_P(GESDD_NOTRANSV, strided_batched__double_complex) */
+/* TEST_P(GESDD_NOTRANSV, strided_batched_double_complex) */
 /* { */
 /*     run_tests<false, true, rocblas_double_complex>(); */
 /* } */

--- a/projects/rocsolver/clients/gtest/lapack/gesdd_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/gesdd_gtest.cpp
@@ -179,106 +179,106 @@ protected:
 
 // non-batch tests
 
-TEST_P(GESDD, _float)
+TEST_P(GESDD, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESDD, _double)
+TEST_P(GESDD, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESDD, _float_complex)
+TEST_P(GESDD, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESDD, _double_complex)
+TEST_P(GESDD, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-/* TEST_P(GESDD_NOTRANSV, _float) */
+/* TEST_P(GESDD_NOTRANSV, __float) */
 /* { */
 /*     run_tests<false, false, float>(); */
 /* } */
 
-/* TEST_P(GESDD_NOTRANSV, _double) */
+/* TEST_P(GESDD_NOTRANSV, __double) */
 /* { */
 /*     run_tests<false, false, double>(); */
 /* } */
 
-/* TEST_P(GESDD_NOTRANSV, _float_complex) */
+/* TEST_P(GESDD_NOTRANSV, __float_complex) */
 /* { */
 /*     run_tests<false, false, rocblas_float_complex>(); */
 /* } */
 
-/* TEST_P(GESDD_NOTRANSV, _double_complex) */
+/* TEST_P(GESDD_NOTRANSV, __double_complex) */
 /* { */
 /*     run_tests<false, false, rocblas_double_complex>(); */
 /* } */
 
 // batched tests
 
-TEST_P(GESDD, batched_float)
+TEST_P(GESDD, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GESDD, batched_double)
+TEST_P(GESDD, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GESDD, batched_float_complex)
+TEST_P(GESDD, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GESDD, batched_double_complex)
+TEST_P(GESDD, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(GESDD, strided_batched_float)
+TEST_P(GESDD, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GESDD, strided_batched_double)
+TEST_P(GESDD, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GESDD, strided_batched_float_complex)
+TEST_P(GESDD, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GESDD, strided_batched_double_complex)
+TEST_P(GESDD, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-/* TEST_P(GESDD_NOTRANSV, strided_batched_float) */
+/* TEST_P(GESDD_NOTRANSV, strided_batched__float) */
 /* { */
 /*     run_tests<false, true, float>(); */
 /* } */
 
-/* TEST_P(GESDD_NOTRANSV, strided_batched_double) */
+/* TEST_P(GESDD_NOTRANSV, strided_batched__double) */
 /* { */
 /*     run_tests<false, true, double>(); */
 /* } */
 
-/* TEST_P(GESDD_NOTRANSV, strided_batched_float_complex) */
+/* TEST_P(GESDD_NOTRANSV, strided_batched__float_complex) */
 /* { */
 /*     run_tests<false, true, rocblas_float_complex>(); */
 /* } */
 
-/* TEST_P(GESDD_NOTRANSV, strided_batched_double_complex) */
+/* TEST_P(GESDD_NOTRANSV, strided_batched__double_complex) */
 /* { */
 /*     run_tests<false, true, rocblas_double_complex>(); */
 /* } */

--- a/projects/rocsolver/clients/gtest/lapack/gesdd_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/gesdd_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/gesv_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/gesv_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -153,86 +153,86 @@ protected:
 
 // non-batch tests
 
-TEST_P(GESV, __float)
+TEST_P(GESV, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESV, __double)
+TEST_P(GESV, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESV, __float_complex)
+TEST_P(GESV, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESV, __double_complex)
+TEST_P(GESV, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GESV_OUTOFPLACE, __float)
+TEST_P(GESV_OUTOFPLACE, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESV_OUTOFPLACE, __double)
+TEST_P(GESV_OUTOFPLACE, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESV_OUTOFPLACE, __float_complex)
+TEST_P(GESV_OUTOFPLACE, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESV_OUTOFPLACE, __double_complex)
+TEST_P(GESV_OUTOFPLACE, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GESV, batched__float)
+TEST_P(GESV, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GESV, batched__double)
+TEST_P(GESV, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GESV, batched__float_complex)
+TEST_P(GESV, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GESV, batched__double_complex)
+TEST_P(GESV, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(GESV, strided_batched__float)
+TEST_P(GESV, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GESV, strided_batched__double)
+TEST_P(GESV, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GESV, strided_batched__float_complex)
+TEST_P(GESV, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GESV, strided_batched__double_complex)
+TEST_P(GESV, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/gesv_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/gesv_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/gesv_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/gesv_gtest.cpp
@@ -153,86 +153,86 @@ protected:
 
 // non-batch tests
 
-TEST_P(GESV, _float)
+TEST_P(GESV, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESV, _double)
+TEST_P(GESV, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESV, _float_complex)
+TEST_P(GESV, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESV, _double_complex)
+TEST_P(GESV, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GESV_OUTOFPLACE, _float)
+TEST_P(GESV_OUTOFPLACE, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESV_OUTOFPLACE, _double)
+TEST_P(GESV_OUTOFPLACE, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESV_OUTOFPLACE, _float_complex)
+TEST_P(GESV_OUTOFPLACE, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESV_OUTOFPLACE, _double_complex)
+TEST_P(GESV_OUTOFPLACE, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GESV, batched_float)
+TEST_P(GESV, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GESV, batched_double)
+TEST_P(GESV, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GESV, batched_float_complex)
+TEST_P(GESV, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GESV, batched_double_complex)
+TEST_P(GESV, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(GESV, strided_batched_float)
+TEST_P(GESV, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GESV, strided_batched_double)
+TEST_P(GESV, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GESV, strided_batched_float_complex)
+TEST_P(GESV, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GESV, strided_batched_double_complex)
+TEST_P(GESV, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/gesvd_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/gesvd_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/gesvd_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/gesvd_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -192,126 +192,126 @@ class GESVD_HYBRID : public GESVD_BASE<1>
 
 // non-batch tests
 
-TEST_P(GESVD, __float)
+TEST_P(GESVD, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESVD, __double)
+TEST_P(GESVD, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESVD, __float_complex)
+TEST_P(GESVD, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESVD, __double_complex)
+TEST_P(GESVD, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GESVD_HYBRID, __float)
+TEST_P(GESVD_HYBRID, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESVD_HYBRID, __double)
+TEST_P(GESVD_HYBRID, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESVD_HYBRID, __float_complex)
+TEST_P(GESVD_HYBRID, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESVD_HYBRID, __double_complex)
+TEST_P(GESVD_HYBRID, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GESVD, batched__float)
+TEST_P(GESVD, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GESVD, batched__double)
+TEST_P(GESVD, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GESVD, batched__float_complex)
+TEST_P(GESVD, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GESVD, batched__double_complex)
+TEST_P(GESVD, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GESVD_HYBRID, batched__float)
+TEST_P(GESVD_HYBRID, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GESVD_HYBRID, batched__double)
+TEST_P(GESVD_HYBRID, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GESVD_HYBRID, batched__float_complex)
+TEST_P(GESVD_HYBRID, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GESVD_HYBRID, batched__double_complex)
+TEST_P(GESVD_HYBRID, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(GESVD, strided_batched__float)
+TEST_P(GESVD, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GESVD, strided_batched__double)
+TEST_P(GESVD, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GESVD, strided_batched__float_complex)
+TEST_P(GESVD, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GESVD, strided_batched__double_complex)
+TEST_P(GESVD, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GESVD_HYBRID, strided_batched__float)
+TEST_P(GESVD_HYBRID, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GESVD_HYBRID, strided_batched__double)
+TEST_P(GESVD_HYBRID, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GESVD_HYBRID, strided_batched__float_complex)
+TEST_P(GESVD_HYBRID, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GESVD_HYBRID, strided_batched__double_complex)
+TEST_P(GESVD_HYBRID, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/gesvd_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/gesvd_gtest.cpp
@@ -192,126 +192,126 @@ class GESVD_HYBRID : public GESVD_BASE<1>
 
 // non-batch tests
 
-TEST_P(GESVD, _float)
+TEST_P(GESVD, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESVD, _double)
+TEST_P(GESVD, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESVD, _float_complex)
+TEST_P(GESVD, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESVD, _double_complex)
+TEST_P(GESVD, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GESVD_HYBRID, _float)
+TEST_P(GESVD_HYBRID, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESVD_HYBRID, _double)
+TEST_P(GESVD_HYBRID, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESVD_HYBRID, _float_complex)
+TEST_P(GESVD_HYBRID, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESVD_HYBRID, _double_complex)
+TEST_P(GESVD_HYBRID, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GESVD, batched_float)
+TEST_P(GESVD, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GESVD, batched_double)
+TEST_P(GESVD, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GESVD, batched_float_complex)
+TEST_P(GESVD, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GESVD, batched_double_complex)
+TEST_P(GESVD, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GESVD_HYBRID, batched_float)
+TEST_P(GESVD_HYBRID, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GESVD_HYBRID, batched_double)
+TEST_P(GESVD_HYBRID, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GESVD_HYBRID, batched_float_complex)
+TEST_P(GESVD_HYBRID, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GESVD_HYBRID, batched_double_complex)
+TEST_P(GESVD_HYBRID, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(GESVD, strided_batched_float)
+TEST_P(GESVD, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GESVD, strided_batched_double)
+TEST_P(GESVD, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GESVD, strided_batched_float_complex)
+TEST_P(GESVD, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GESVD, strided_batched_double_complex)
+TEST_P(GESVD, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GESVD_HYBRID, strided_batched_float)
+TEST_P(GESVD_HYBRID, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GESVD_HYBRID, strided_batched_double)
+TEST_P(GESVD_HYBRID, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GESVD_HYBRID, strided_batched_float_complex)
+TEST_P(GESVD_HYBRID, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GESVD_HYBRID, strided_batched_double_complex)
+TEST_P(GESVD_HYBRID, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/gesvdj_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/gesvdj_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/gesvdj_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/gesvdj_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -182,106 +182,106 @@ protected:
 
 // non-batch tests
 
-TEST_P(GESVDJ, __float)
+TEST_P(GESVDJ, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESVDJ, __double)
+TEST_P(GESVDJ, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESVDJ, __float_complex)
+TEST_P(GESVDJ, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESVDJ, __double_complex)
+TEST_P(GESVDJ, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GESVDJ_NOTRANSV, __float)
+TEST_P(GESVDJ_NOTRANSV, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESVDJ_NOTRANSV, __double)
+TEST_P(GESVDJ_NOTRANSV, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESVDJ_NOTRANSV, __float_complex)
+TEST_P(GESVDJ_NOTRANSV, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESVDJ_NOTRANSV, __double_complex)
+TEST_P(GESVDJ_NOTRANSV, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GESVDJ, batched__float)
+TEST_P(GESVDJ, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GESVDJ, batched__double)
+TEST_P(GESVDJ, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GESVDJ, batched__float_complex)
+TEST_P(GESVDJ, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GESVDJ, batched__double_complex)
+TEST_P(GESVDJ, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(GESVDJ, strided_batched__float)
+TEST_P(GESVDJ, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GESVDJ, strided_batched__double)
+TEST_P(GESVDJ, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GESVDJ, strided_batched__float_complex)
+TEST_P(GESVDJ, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GESVDJ, strided_batched__double_complex)
+TEST_P(GESVDJ, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GESVDJ_NOTRANSV, strided_batched__float)
+TEST_P(GESVDJ_NOTRANSV, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GESVDJ_NOTRANSV, strided_batched__double)
+TEST_P(GESVDJ_NOTRANSV, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GESVDJ_NOTRANSV, strided_batched__float_complex)
+TEST_P(GESVDJ_NOTRANSV, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GESVDJ_NOTRANSV, strided_batched__double_complex)
+TEST_P(GESVDJ_NOTRANSV, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/gesvdj_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/gesvdj_gtest.cpp
@@ -182,106 +182,106 @@ protected:
 
 // non-batch tests
 
-TEST_P(GESVDJ, _float)
+TEST_P(GESVDJ, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESVDJ, _double)
+TEST_P(GESVDJ, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESVDJ, _float_complex)
+TEST_P(GESVDJ, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESVDJ, _double_complex)
+TEST_P(GESVDJ, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GESVDJ_NOTRANSV, _float)
+TEST_P(GESVDJ_NOTRANSV, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESVDJ_NOTRANSV, _double)
+TEST_P(GESVDJ_NOTRANSV, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESVDJ_NOTRANSV, _float_complex)
+TEST_P(GESVDJ_NOTRANSV, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESVDJ_NOTRANSV, _double_complex)
+TEST_P(GESVDJ_NOTRANSV, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GESVDJ, batched_float)
+TEST_P(GESVDJ, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GESVDJ, batched_double)
+TEST_P(GESVDJ, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GESVDJ, batched_float_complex)
+TEST_P(GESVDJ, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GESVDJ, batched_double_complex)
+TEST_P(GESVDJ, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(GESVDJ, strided_batched_float)
+TEST_P(GESVDJ, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GESVDJ, strided_batched_double)
+TEST_P(GESVDJ, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GESVDJ, strided_batched_float_complex)
+TEST_P(GESVDJ, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GESVDJ, strided_batched_double_complex)
+TEST_P(GESVDJ, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GESVDJ_NOTRANSV, strided_batched_float)
+TEST_P(GESVDJ_NOTRANSV, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GESVDJ_NOTRANSV, strided_batched_double)
+TEST_P(GESVDJ_NOTRANSV, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GESVDJ_NOTRANSV, strided_batched_float_complex)
+TEST_P(GESVDJ_NOTRANSV, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GESVDJ_NOTRANSV, strided_batched_double_complex)
+TEST_P(GESVDJ_NOTRANSV, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/gesvdx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/gesvdx_gtest.cpp
@@ -197,86 +197,86 @@ protected:
 
 // non-batch tests
 
-TEST_P(GESVDX, _float)
+TEST_P(GESVDX, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESVDX, _double)
+TEST_P(GESVDX, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESVDX, _float_complex)
+TEST_P(GESVDX, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESVDX, _double_complex)
+TEST_P(GESVDX, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GESVDX, batched_float)
+TEST_P(GESVDX, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GESVDX, batched_double)
+TEST_P(GESVDX, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GESVDX, batched_float_complex)
+TEST_P(GESVDX, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GESVDX, batched_double_complex)
+TEST_P(GESVDX, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(GESVDX, strided_batched_float)
+TEST_P(GESVDX, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GESVDX, strided_batched_double)
+TEST_P(GESVDX, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GESVDX, strided_batched_float_complex)
+TEST_P(GESVDX, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GESVDX, strided_batched_double_complex)
+TEST_P(GESVDX, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GESVDX_NOTRANSV, strided_batched_float)
+TEST_P(GESVDX_NOTRANSV, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GESVDX_NOTRANSV, strided_batched_double)
+TEST_P(GESVDX_NOTRANSV, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GESVDX_NOTRANSV, strided_batched_float_complex)
+TEST_P(GESVDX_NOTRANSV, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GESVDX_NOTRANSV, strided_batched_double_complex)
+TEST_P(GESVDX_NOTRANSV, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/gesvdx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/gesvdx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -197,86 +197,86 @@ protected:
 
 // non-batch tests
 
-TEST_P(GESVDX, __float)
+TEST_P(GESVDX, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GESVDX, __double)
+TEST_P(GESVDX, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GESVDX, __float_complex)
+TEST_P(GESVDX, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GESVDX, __double_complex)
+TEST_P(GESVDX, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GESVDX, batched__float)
+TEST_P(GESVDX, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GESVDX, batched__double)
+TEST_P(GESVDX, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GESVDX, batched__float_complex)
+TEST_P(GESVDX, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GESVDX, batched__double_complex)
+TEST_P(GESVDX, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(GESVDX, strided_batched__float)
+TEST_P(GESVDX, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GESVDX, strided_batched__double)
+TEST_P(GESVDX, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GESVDX, strided_batched__float_complex)
+TEST_P(GESVDX, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GESVDX, strided_batched__double_complex)
+TEST_P(GESVDX, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GESVDX_NOTRANSV, strided_batched__float)
+TEST_P(GESVDX_NOTRANSV, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GESVDX_NOTRANSV, strided_batched__double)
+TEST_P(GESVDX_NOTRANSV, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GESVDX_NOTRANSV, strided_batched__float_complex)
+TEST_P(GESVDX_NOTRANSV, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GESVDX_NOTRANSV, strided_batched__double_complex)
+TEST_P(GESVDX_NOTRANSV, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/gesvdx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/gesvdx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/getf2_getrf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/getf2_getrf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -181,484 +181,484 @@ class GETRF_NPVT_64 : public GETF2_GETRF_NPVT<true, int64_t>
 };
 
 // non-batch tests
-TEST_P(GETF2_NPVT, __float)
+TEST_P(GETF2_NPVT, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETF2_NPVT, __double)
+TEST_P(GETF2_NPVT, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETF2_NPVT, __float_complex)
+TEST_P(GETF2_NPVT, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETF2_NPVT, __double_complex)
+TEST_P(GETF2_NPVT, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GETRF_NPVT, __float)
+TEST_P(GETRF_NPVT, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRF_NPVT, __double)
+TEST_P(GETRF_NPVT, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRF_NPVT, __float_complex)
+TEST_P(GETRF_NPVT, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRF_NPVT, __double_complex)
+TEST_P(GETRF_NPVT, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GETF2, __float)
+TEST_P(GETF2, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETF2, __double)
+TEST_P(GETF2, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETF2, __float_complex)
+TEST_P(GETF2, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETF2, __double_complex)
+TEST_P(GETF2, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GETRF, __float)
+TEST_P(GETRF, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRF, __double)
+TEST_P(GETRF, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRF, __float_complex)
+TEST_P(GETRF, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRF, __double_complex)
+TEST_P(GETRF, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GETF2_NPVT_64, __float)
+TEST_P(GETF2_NPVT_64, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETF2_NPVT_64, __double)
+TEST_P(GETF2_NPVT_64, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETF2_NPVT_64, __float_complex)
+TEST_P(GETF2_NPVT_64, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETF2_NPVT_64, __double_complex)
+TEST_P(GETF2_NPVT_64, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GETRF_NPVT_64, __float)
+TEST_P(GETRF_NPVT_64, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRF_NPVT_64, __double)
+TEST_P(GETRF_NPVT_64, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRF_NPVT_64, __float_complex)
+TEST_P(GETRF_NPVT_64, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRF_NPVT_64, __double_complex)
+TEST_P(GETRF_NPVT_64, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GETF2_64, __float)
+TEST_P(GETF2_64, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETF2_64, __double)
+TEST_P(GETF2_64, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETF2_64, __float_complex)
+TEST_P(GETF2_64, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETF2_64, __double_complex)
+TEST_P(GETF2_64, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GETRF_64, __float)
+TEST_P(GETRF_64, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRF_64, __double)
+TEST_P(GETRF_64, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRF_64, __float_complex)
+TEST_P(GETRF_64, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRF_64, __double_complex)
+TEST_P(GETRF_64, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
-TEST_P(GETF2_NPVT, batched__float)
+TEST_P(GETF2_NPVT, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GETF2_NPVT, batched__double)
+TEST_P(GETF2_NPVT, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GETF2_NPVT, batched__float_complex)
+TEST_P(GETF2_NPVT, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GETF2_NPVT, batched__double_complex)
+TEST_P(GETF2_NPVT, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRF_NPVT, batched__float)
+TEST_P(GETRF_NPVT, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GETRF_NPVT, batched__double)
+TEST_P(GETRF_NPVT, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GETRF_NPVT, batched__float_complex)
+TEST_P(GETRF_NPVT, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRF_NPVT, batched__double_complex)
+TEST_P(GETRF_NPVT, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GETF2, batched__float)
+TEST_P(GETF2, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GETF2, batched__double)
+TEST_P(GETF2, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GETF2, batched__float_complex)
+TEST_P(GETF2, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GETF2, batched__double_complex)
+TEST_P(GETF2, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRF, batched__float)
+TEST_P(GETRF, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GETRF, batched__double)
+TEST_P(GETRF, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GETRF, batched__float_complex)
+TEST_P(GETRF, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRF, batched__double_complex)
+TEST_P(GETRF, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GETF2_NPVT_64, batched__float)
+TEST_P(GETF2_NPVT_64, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GETF2_NPVT_64, batched__double)
+TEST_P(GETF2_NPVT_64, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GETF2_NPVT_64, batched__float_complex)
+TEST_P(GETF2_NPVT_64, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GETF2_NPVT_64, batched__double_complex)
+TEST_P(GETF2_NPVT_64, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRF_NPVT_64, batched__float)
+TEST_P(GETRF_NPVT_64, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GETRF_NPVT_64, batched__double)
+TEST_P(GETRF_NPVT_64, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GETRF_NPVT_64, batched__float_complex)
+TEST_P(GETRF_NPVT_64, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRF_NPVT_64, batched__double_complex)
+TEST_P(GETRF_NPVT_64, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GETF2_64, batched__float)
+TEST_P(GETF2_64, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GETF2_64, batched__double)
+TEST_P(GETF2_64, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GETF2_64, batched__float_complex)
+TEST_P(GETF2_64, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GETF2_64, batched__double_complex)
+TEST_P(GETF2_64, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRF_64, batched__float)
+TEST_P(GETRF_64, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GETRF_64, batched__double)
+TEST_P(GETRF_64, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GETRF_64, batched__float_complex)
+TEST_P(GETRF_64, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRF_64, batched__double_complex)
+TEST_P(GETRF_64, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
-TEST_P(GETF2_NPVT, strided_batched__float)
+TEST_P(GETF2_NPVT, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GETF2_NPVT, strided_batched__double)
+TEST_P(GETF2_NPVT, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GETF2_NPVT, strided_batched__float_complex)
+TEST_P(GETF2_NPVT, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GETF2_NPVT, strided_batched__double_complex)
+TEST_P(GETF2_NPVT, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRF_NPVT, strided_batched__float)
+TEST_P(GETRF_NPVT, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GETRF_NPVT, strided_batched__double)
+TEST_P(GETRF_NPVT, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GETRF_NPVT, strided_batched__float_complex)
+TEST_P(GETRF_NPVT, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRF_NPVT, strided_batched__double_complex)
+TEST_P(GETRF_NPVT, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GETF2, strided_batched__float)
+TEST_P(GETF2, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GETF2, strided_batched__double)
+TEST_P(GETF2, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GETF2, strided_batched__float_complex)
+TEST_P(GETF2, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GETF2, strided_batched__double_complex)
+TEST_P(GETF2, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRF, strided_batched__float)
+TEST_P(GETRF, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GETRF, strided_batched__double)
+TEST_P(GETRF, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GETRF, strided_batched__float_complex)
+TEST_P(GETRF, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRF, strided_batched__double_complex)
+TEST_P(GETRF, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GETF2_NPVT_64, strided_batched__float)
+TEST_P(GETF2_NPVT_64, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GETF2_NPVT_64, strided_batched__double)
+TEST_P(GETF2_NPVT_64, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GETF2_NPVT_64, strided_batched__float_complex)
+TEST_P(GETF2_NPVT_64, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GETF2_NPVT_64, strided_batched__double_complex)
+TEST_P(GETF2_NPVT_64, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRF_NPVT_64, strided_batched__float)
+TEST_P(GETRF_NPVT_64, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GETRF_NPVT_64, strided_batched__double)
+TEST_P(GETRF_NPVT_64, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GETRF_NPVT_64, strided_batched__float_complex)
+TEST_P(GETRF_NPVT_64, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRF_NPVT_64, strided_batched__double_complex)
+TEST_P(GETRF_NPVT_64, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GETF2_64, strided_batched__float)
+TEST_P(GETF2_64, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GETF2_64, strided_batched__double)
+TEST_P(GETF2_64, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GETF2_64, strided_batched__float_complex)
+TEST_P(GETF2_64, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GETF2_64, strided_batched__double_complex)
+TEST_P(GETF2_64, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRF_64, strided_batched__float)
+TEST_P(GETRF_64, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GETRF_64, strided_batched__double)
+TEST_P(GETRF_64, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GETRF_64, strided_batched__float_complex)
+TEST_P(GETRF_64, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRF_64, strided_batched__double_complex)
+TEST_P(GETRF_64, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/getf2_getrf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/getf2_getrf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/getf2_getrf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/getf2_getrf_gtest.cpp
@@ -181,484 +181,484 @@ class GETRF_NPVT_64 : public GETF2_GETRF_NPVT<true, int64_t>
 };
 
 // non-batch tests
-TEST_P(GETF2_NPVT, _float)
+TEST_P(GETF2_NPVT, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETF2_NPVT, _double)
+TEST_P(GETF2_NPVT, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETF2_NPVT, _float_complex)
+TEST_P(GETF2_NPVT, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETF2_NPVT, _double_complex)
+TEST_P(GETF2_NPVT, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GETRF_NPVT, _float)
+TEST_P(GETRF_NPVT, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRF_NPVT, _double)
+TEST_P(GETRF_NPVT, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRF_NPVT, _float_complex)
+TEST_P(GETRF_NPVT, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRF_NPVT, _double_complex)
+TEST_P(GETRF_NPVT, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GETF2, _float)
+TEST_P(GETF2, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETF2, _double)
+TEST_P(GETF2, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETF2, _float_complex)
+TEST_P(GETF2, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETF2, _double_complex)
+TEST_P(GETF2, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GETRF, _float)
+TEST_P(GETRF, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRF, _double)
+TEST_P(GETRF, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRF, _float_complex)
+TEST_P(GETRF, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRF, _double_complex)
+TEST_P(GETRF, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GETF2_NPVT_64, _float)
+TEST_P(GETF2_NPVT_64, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETF2_NPVT_64, _double)
+TEST_P(GETF2_NPVT_64, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETF2_NPVT_64, _float_complex)
+TEST_P(GETF2_NPVT_64, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETF2_NPVT_64, _double_complex)
+TEST_P(GETF2_NPVT_64, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GETRF_NPVT_64, _float)
+TEST_P(GETRF_NPVT_64, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRF_NPVT_64, _double)
+TEST_P(GETRF_NPVT_64, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRF_NPVT_64, _float_complex)
+TEST_P(GETRF_NPVT_64, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRF_NPVT_64, _double_complex)
+TEST_P(GETRF_NPVT_64, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GETF2_64, _float)
+TEST_P(GETF2_64, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETF2_64, _double)
+TEST_P(GETF2_64, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETF2_64, _float_complex)
+TEST_P(GETF2_64, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETF2_64, _double_complex)
+TEST_P(GETF2_64, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GETRF_64, _float)
+TEST_P(GETRF_64, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRF_64, _double)
+TEST_P(GETRF_64, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRF_64, _float_complex)
+TEST_P(GETRF_64, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRF_64, _double_complex)
+TEST_P(GETRF_64, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
-TEST_P(GETF2_NPVT, batched_float)
+TEST_P(GETF2_NPVT, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GETF2_NPVT, batched_double)
+TEST_P(GETF2_NPVT, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GETF2_NPVT, batched_float_complex)
+TEST_P(GETF2_NPVT, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GETF2_NPVT, batched_double_complex)
+TEST_P(GETF2_NPVT, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRF_NPVT, batched_float)
+TEST_P(GETRF_NPVT, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GETRF_NPVT, batched_double)
+TEST_P(GETRF_NPVT, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GETRF_NPVT, batched_float_complex)
+TEST_P(GETRF_NPVT, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRF_NPVT, batched_double_complex)
+TEST_P(GETRF_NPVT, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GETF2, batched_float)
+TEST_P(GETF2, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GETF2, batched_double)
+TEST_P(GETF2, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GETF2, batched_float_complex)
+TEST_P(GETF2, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GETF2, batched_double_complex)
+TEST_P(GETF2, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRF, batched_float)
+TEST_P(GETRF, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GETRF, batched_double)
+TEST_P(GETRF, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GETRF, batched_float_complex)
+TEST_P(GETRF, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRF, batched_double_complex)
+TEST_P(GETRF, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GETF2_NPVT_64, batched_float)
+TEST_P(GETF2_NPVT_64, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GETF2_NPVT_64, batched_double)
+TEST_P(GETF2_NPVT_64, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GETF2_NPVT_64, batched_float_complex)
+TEST_P(GETF2_NPVT_64, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GETF2_NPVT_64, batched_double_complex)
+TEST_P(GETF2_NPVT_64, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRF_NPVT_64, batched_float)
+TEST_P(GETRF_NPVT_64, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GETRF_NPVT_64, batched_double)
+TEST_P(GETRF_NPVT_64, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GETRF_NPVT_64, batched_float_complex)
+TEST_P(GETRF_NPVT_64, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRF_NPVT_64, batched_double_complex)
+TEST_P(GETRF_NPVT_64, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GETF2_64, batched_float)
+TEST_P(GETF2_64, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GETF2_64, batched_double)
+TEST_P(GETF2_64, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GETF2_64, batched_float_complex)
+TEST_P(GETF2_64, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GETF2_64, batched_double_complex)
+TEST_P(GETF2_64, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRF_64, batched_float)
+TEST_P(GETRF_64, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GETRF_64, batched_double)
+TEST_P(GETRF_64, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GETRF_64, batched_float_complex)
+TEST_P(GETRF_64, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRF_64, batched_double_complex)
+TEST_P(GETRF_64, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
-TEST_P(GETF2_NPVT, strided_batched_float)
+TEST_P(GETF2_NPVT, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GETF2_NPVT, strided_batched_double)
+TEST_P(GETF2_NPVT, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GETF2_NPVT, strided_batched_float_complex)
+TEST_P(GETF2_NPVT, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GETF2_NPVT, strided_batched_double_complex)
+TEST_P(GETF2_NPVT, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRF_NPVT, strided_batched_float)
+TEST_P(GETRF_NPVT, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GETRF_NPVT, strided_batched_double)
+TEST_P(GETRF_NPVT, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GETRF_NPVT, strided_batched_float_complex)
+TEST_P(GETRF_NPVT, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRF_NPVT, strided_batched_double_complex)
+TEST_P(GETRF_NPVT, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GETF2, strided_batched_float)
+TEST_P(GETF2, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GETF2, strided_batched_double)
+TEST_P(GETF2, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GETF2, strided_batched_float_complex)
+TEST_P(GETF2, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GETF2, strided_batched_double_complex)
+TEST_P(GETF2, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRF, strided_batched_float)
+TEST_P(GETRF, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GETRF, strided_batched_double)
+TEST_P(GETRF, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GETRF, strided_batched_float_complex)
+TEST_P(GETRF, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRF, strided_batched_double_complex)
+TEST_P(GETRF, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GETF2_NPVT_64, strided_batched_float)
+TEST_P(GETF2_NPVT_64, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GETF2_NPVT_64, strided_batched_double)
+TEST_P(GETF2_NPVT_64, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GETF2_NPVT_64, strided_batched_float_complex)
+TEST_P(GETF2_NPVT_64, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GETF2_NPVT_64, strided_batched_double_complex)
+TEST_P(GETF2_NPVT_64, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRF_NPVT_64, strided_batched_float)
+TEST_P(GETRF_NPVT_64, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GETRF_NPVT_64, strided_batched_double)
+TEST_P(GETRF_NPVT_64, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GETRF_NPVT_64, strided_batched_float_complex)
+TEST_P(GETRF_NPVT_64, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRF_NPVT_64, strided_batched_double_complex)
+TEST_P(GETRF_NPVT_64, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GETF2_64, strided_batched_float)
+TEST_P(GETF2_64, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GETF2_64, strided_batched_double)
+TEST_P(GETF2_64, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GETF2_64, strided_batched_float_complex)
+TEST_P(GETF2_64, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GETF2_64, strided_batched_double_complex)
+TEST_P(GETF2_64, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRF_64, strided_batched_float)
+TEST_P(GETRF_64, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GETRF_64, strided_batched_double)
+TEST_P(GETRF_64, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GETRF_64, strided_batched_float_complex)
+TEST_P(GETRF_64, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRF_64, strided_batched_double_complex)
+TEST_P(GETRF_64, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/getrf_large_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/getrf_large_gtest.cpp
@@ -102,66 +102,66 @@ protected:
 
 // non-batch tests
 
-TEST_P(GETRF_LARGE, _float)
+TEST_P(GETRF_LARGE, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRF_LARGE, _double)
+TEST_P(GETRF_LARGE, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRF_LARGE, _float_complex)
+TEST_P(GETRF_LARGE, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRF_LARGE, _double_complex)
+TEST_P(GETRF_LARGE, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 /*
 // batched tests
 
-TEST_P(GETRF_LARGE, batched_float)
+TEST_P(GETRF_LARGE, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GETRF_LARGE, batched_double)
+TEST_P(GETRF_LARGE, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GETRF_LARGE, batched_float_complex)
+TEST_P(GETRF_LARGE, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRF_LARGE, batched_double_complex)
+TEST_P(GETRF_LARGE, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(GETRF_LARGE, strided_batched_float)
+TEST_P(GETRF_LARGE, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GETRF_LARGE, strided_batched_double)
+TEST_P(GETRF_LARGE, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GETRF_LARGE, strided_batched_float_complex)
+TEST_P(GETRF_LARGE, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRF_LARGE, strided_batched_double_complex)
+TEST_P(GETRF_LARGE, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/getrf_large_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/getrf_large_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/getrf_large_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/getrf_large_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -102,66 +102,66 @@ protected:
 
 // non-batch tests
 
-TEST_P(GETRF_LARGE, __float)
+TEST_P(GETRF_LARGE, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRF_LARGE, __double)
+TEST_P(GETRF_LARGE, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRF_LARGE, __float_complex)
+TEST_P(GETRF_LARGE, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRF_LARGE, __double_complex)
+TEST_P(GETRF_LARGE, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 /*
 // batched tests
 
-TEST_P(GETRF_LARGE, batched__float)
+TEST_P(GETRF_LARGE, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GETRF_LARGE, batched__double)
+TEST_P(GETRF_LARGE, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GETRF_LARGE, batched__float_complex)
+TEST_P(GETRF_LARGE, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRF_LARGE, batched__double_complex)
+TEST_P(GETRF_LARGE, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(GETRF_LARGE, strided_batched__float)
+TEST_P(GETRF_LARGE, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GETRF_LARGE, strided_batched__double)
+TEST_P(GETRF_LARGE, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GETRF_LARGE, strided_batched__float_complex)
+TEST_P(GETRF_LARGE, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRF_LARGE, strided_batched__double_complex)
+TEST_P(GETRF_LARGE, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/getri_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/getri_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -182,246 +182,246 @@ protected:
 
 // non-batch tests
 
-TEST_P(GETRI, __float)
+TEST_P(GETRI, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRI, __double)
+TEST_P(GETRI, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRI, __float_complex)
+TEST_P(GETRI, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRI, __double_complex)
+TEST_P(GETRI, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GETRI_NPVT, __float)
+TEST_P(GETRI_NPVT, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRI_NPVT, __double)
+TEST_P(GETRI_NPVT, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRI_NPVT, __float_complex)
+TEST_P(GETRI_NPVT, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRI_NPVT, __double_complex)
+TEST_P(GETRI_NPVT, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GETRI_OUTOFPLACE, __float)
+TEST_P(GETRI_OUTOFPLACE, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRI_OUTOFPLACE, __double)
+TEST_P(GETRI_OUTOFPLACE, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRI_OUTOFPLACE, __float_complex)
+TEST_P(GETRI_OUTOFPLACE, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRI_OUTOFPLACE, __double_complex)
+TEST_P(GETRI_OUTOFPLACE, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GETRI_NPVT_OUTOFPLACE, __float)
+TEST_P(GETRI_NPVT_OUTOFPLACE, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRI_NPVT_OUTOFPLACE, __double)
+TEST_P(GETRI_NPVT_OUTOFPLACE, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRI_NPVT_OUTOFPLACE, __float_complex)
+TEST_P(GETRI_NPVT_OUTOFPLACE, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRI_NPVT_OUTOFPLACE, __double_complex)
+TEST_P(GETRI_NPVT_OUTOFPLACE, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GETRI, batched__float)
+TEST_P(GETRI, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GETRI, batched__double)
+TEST_P(GETRI, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GETRI, batched__float_complex)
+TEST_P(GETRI, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRI, batched__double_complex)
+TEST_P(GETRI, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRI_NPVT, batched__float)
+TEST_P(GETRI_NPVT, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GETRI_NPVT, batched__double)
+TEST_P(GETRI_NPVT, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GETRI_NPVT, batched__float_complex)
+TEST_P(GETRI_NPVT, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRI_NPVT, batched__double_complex)
+TEST_P(GETRI_NPVT, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRI_OUTOFPLACE, batched__float)
+TEST_P(GETRI_OUTOFPLACE, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GETRI_OUTOFPLACE, batched__double)
+TEST_P(GETRI_OUTOFPLACE, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GETRI_OUTOFPLACE, batched__float_complex)
+TEST_P(GETRI_OUTOFPLACE, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRI_OUTOFPLACE, batched__double_complex)
+TEST_P(GETRI_OUTOFPLACE, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRI_NPVT_OUTOFPLACE, batched__float)
+TEST_P(GETRI_NPVT_OUTOFPLACE, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GETRI_NPVT_OUTOFPLACE, batched__double)
+TEST_P(GETRI_NPVT_OUTOFPLACE, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GETRI_NPVT_OUTOFPLACE, batched__float_complex)
+TEST_P(GETRI_NPVT_OUTOFPLACE, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRI_NPVT_OUTOFPLACE, batched__double_complex)
+TEST_P(GETRI_NPVT_OUTOFPLACE, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(GETRI, strided_batched__float)
+TEST_P(GETRI, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GETRI, strided_batched__double)
+TEST_P(GETRI, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GETRI, strided_batched__float_complex)
+TEST_P(GETRI, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRI, strided_batched__double_complex)
+TEST_P(GETRI, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRI_NPVT, strided_batched__float)
+TEST_P(GETRI_NPVT, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GETRI_NPVT, strided_batched__double)
+TEST_P(GETRI_NPVT, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GETRI_NPVT, strided_batched__float_complex)
+TEST_P(GETRI_NPVT, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRI_NPVT, strided_batched__double_complex)
+TEST_P(GETRI_NPVT, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRI_OUTOFPLACE, strided_batched__float)
+TEST_P(GETRI_OUTOFPLACE, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GETRI_OUTOFPLACE, strided_batched__double)
+TEST_P(GETRI_OUTOFPLACE, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GETRI_OUTOFPLACE, strided_batched__float_complex)
+TEST_P(GETRI_OUTOFPLACE, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRI_OUTOFPLACE, strided_batched__double_complex)
+TEST_P(GETRI_OUTOFPLACE, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRI_NPVT_OUTOFPLACE, strided_batched__float)
+TEST_P(GETRI_NPVT_OUTOFPLACE, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GETRI_NPVT_OUTOFPLACE, strided_batched__double)
+TEST_P(GETRI_NPVT_OUTOFPLACE, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GETRI_NPVT_OUTOFPLACE, strided_batched__float_complex)
+TEST_P(GETRI_NPVT_OUTOFPLACE, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRI_NPVT_OUTOFPLACE, strided_batched__double_complex)
+TEST_P(GETRI_NPVT_OUTOFPLACE, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/getri_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/getri_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/getri_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/getri_gtest.cpp
@@ -182,246 +182,246 @@ protected:
 
 // non-batch tests
 
-TEST_P(GETRI, _float)
+TEST_P(GETRI, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRI, _double)
+TEST_P(GETRI, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRI, _float_complex)
+TEST_P(GETRI, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRI, _double_complex)
+TEST_P(GETRI, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GETRI_NPVT, _float)
+TEST_P(GETRI_NPVT, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRI_NPVT, _double)
+TEST_P(GETRI_NPVT, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRI_NPVT, _float_complex)
+TEST_P(GETRI_NPVT, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRI_NPVT, _double_complex)
+TEST_P(GETRI_NPVT, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GETRI_OUTOFPLACE, _float)
+TEST_P(GETRI_OUTOFPLACE, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRI_OUTOFPLACE, _double)
+TEST_P(GETRI_OUTOFPLACE, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRI_OUTOFPLACE, _float_complex)
+TEST_P(GETRI_OUTOFPLACE, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRI_OUTOFPLACE, _double_complex)
+TEST_P(GETRI_OUTOFPLACE, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GETRI_NPVT_OUTOFPLACE, _float)
+TEST_P(GETRI_NPVT_OUTOFPLACE, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRI_NPVT_OUTOFPLACE, _double)
+TEST_P(GETRI_NPVT_OUTOFPLACE, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRI_NPVT_OUTOFPLACE, _float_complex)
+TEST_P(GETRI_NPVT_OUTOFPLACE, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRI_NPVT_OUTOFPLACE, _double_complex)
+TEST_P(GETRI_NPVT_OUTOFPLACE, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GETRI, batched_float)
+TEST_P(GETRI, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GETRI, batched_double)
+TEST_P(GETRI, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GETRI, batched_float_complex)
+TEST_P(GETRI, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRI, batched_double_complex)
+TEST_P(GETRI, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRI_NPVT, batched_float)
+TEST_P(GETRI_NPVT, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GETRI_NPVT, batched_double)
+TEST_P(GETRI_NPVT, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GETRI_NPVT, batched_float_complex)
+TEST_P(GETRI_NPVT, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRI_NPVT, batched_double_complex)
+TEST_P(GETRI_NPVT, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRI_OUTOFPLACE, batched_float)
+TEST_P(GETRI_OUTOFPLACE, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GETRI_OUTOFPLACE, batched_double)
+TEST_P(GETRI_OUTOFPLACE, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GETRI_OUTOFPLACE, batched_float_complex)
+TEST_P(GETRI_OUTOFPLACE, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRI_OUTOFPLACE, batched_double_complex)
+TEST_P(GETRI_OUTOFPLACE, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRI_NPVT_OUTOFPLACE, batched_float)
+TEST_P(GETRI_NPVT_OUTOFPLACE, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GETRI_NPVT_OUTOFPLACE, batched_double)
+TEST_P(GETRI_NPVT_OUTOFPLACE, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GETRI_NPVT_OUTOFPLACE, batched_float_complex)
+TEST_P(GETRI_NPVT_OUTOFPLACE, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRI_NPVT_OUTOFPLACE, batched_double_complex)
+TEST_P(GETRI_NPVT_OUTOFPLACE, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(GETRI, strided_batched_float)
+TEST_P(GETRI, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GETRI, strided_batched_double)
+TEST_P(GETRI, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GETRI, strided_batched_float_complex)
+TEST_P(GETRI, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRI, strided_batched_double_complex)
+TEST_P(GETRI, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRI_NPVT, strided_batched_float)
+TEST_P(GETRI_NPVT, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GETRI_NPVT, strided_batched_double)
+TEST_P(GETRI_NPVT, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GETRI_NPVT, strided_batched_float_complex)
+TEST_P(GETRI_NPVT, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRI_NPVT, strided_batched_double_complex)
+TEST_P(GETRI_NPVT, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRI_OUTOFPLACE, strided_batched_float)
+TEST_P(GETRI_OUTOFPLACE, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GETRI_OUTOFPLACE, strided_batched_double)
+TEST_P(GETRI_OUTOFPLACE, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GETRI_OUTOFPLACE, strided_batched_float_complex)
+TEST_P(GETRI_OUTOFPLACE, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRI_OUTOFPLACE, strided_batched_double_complex)
+TEST_P(GETRI_OUTOFPLACE, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRI_NPVT_OUTOFPLACE, strided_batched_float)
+TEST_P(GETRI_NPVT_OUTOFPLACE, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GETRI_NPVT_OUTOFPLACE, strided_batched_double)
+TEST_P(GETRI_NPVT_OUTOFPLACE, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GETRI_NPVT_OUTOFPLACE, strided_batched_float_complex)
+TEST_P(GETRI_NPVT_OUTOFPLACE, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRI_NPVT_OUTOFPLACE, strided_batched_double_complex)
+TEST_P(GETRI_NPVT_OUTOFPLACE, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/getrs_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/getrs_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/getrs_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/getrs_gtest.cpp
@@ -134,126 +134,126 @@ class GETRS_64 : public GETRS_BASE<int64_t>
 
 // non-batch tests
 
-TEST_P(GETRS, _float)
+TEST_P(GETRS, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRS, _double)
+TEST_P(GETRS, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRS, _float_complex)
+TEST_P(GETRS, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRS, _double_complex)
+TEST_P(GETRS, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GETRS_64, _float)
+TEST_P(GETRS_64, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRS_64, _double)
+TEST_P(GETRS_64, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRS_64, _float_complex)
+TEST_P(GETRS_64, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRS_64, _double_complex)
+TEST_P(GETRS_64, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GETRS, batched_float)
+TEST_P(GETRS, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GETRS, batched_double)
+TEST_P(GETRS, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GETRS, batched_float_complex)
+TEST_P(GETRS, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRS, batched_double_complex)
+TEST_P(GETRS, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRS_64, batched_float)
+TEST_P(GETRS_64, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GETRS_64, batched_double)
+TEST_P(GETRS_64, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GETRS_64, batched_float_complex)
+TEST_P(GETRS_64, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRS_64, batched_double_complex)
+TEST_P(GETRS_64, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(GETRS, strided_batched_float)
+TEST_P(GETRS, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GETRS, strided_batched_double)
+TEST_P(GETRS, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GETRS, strided_batched_float_complex)
+TEST_P(GETRS, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRS, strided_batched_double_complex)
+TEST_P(GETRS, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRS_64, strided_batched_float)
+TEST_P(GETRS_64, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GETRS_64, strided_batched_double)
+TEST_P(GETRS_64, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GETRS_64, strided_batched_float_complex)
+TEST_P(GETRS_64, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRS_64, strided_batched_double_complex)
+TEST_P(GETRS_64, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/getrs_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/getrs_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -134,126 +134,126 @@ class GETRS_64 : public GETRS_BASE<int64_t>
 
 // non-batch tests
 
-TEST_P(GETRS, __float)
+TEST_P(GETRS, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRS, __double)
+TEST_P(GETRS, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRS, __float_complex)
+TEST_P(GETRS, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRS, __double_complex)
+TEST_P(GETRS, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GETRS_64, __float)
+TEST_P(GETRS_64, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GETRS_64, __double)
+TEST_P(GETRS_64, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GETRS_64, __float_complex)
+TEST_P(GETRS_64, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GETRS_64, __double_complex)
+TEST_P(GETRS_64, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GETRS, batched__float)
+TEST_P(GETRS, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GETRS, batched__double)
+TEST_P(GETRS, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GETRS, batched__float_complex)
+TEST_P(GETRS, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRS, batched__double_complex)
+TEST_P(GETRS, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRS_64, batched__float)
+TEST_P(GETRS_64, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GETRS_64, batched__double)
+TEST_P(GETRS_64, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GETRS_64, batched__float_complex)
+TEST_P(GETRS_64, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRS_64, batched__double_complex)
+TEST_P(GETRS_64, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(GETRS, strided_batched__float)
+TEST_P(GETRS, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GETRS, strided_batched__double)
+TEST_P(GETRS, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GETRS, strided_batched__float_complex)
+TEST_P(GETRS, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRS, strided_batched__double_complex)
+TEST_P(GETRS, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GETRS_64, strided_batched__float)
+TEST_P(GETRS_64, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GETRS_64, strided_batched__double)
+TEST_P(GETRS_64, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GETRS_64, strided_batched__float_complex)
+TEST_P(GETRS_64, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GETRS_64, strided_batched__double_complex)
+TEST_P(GETRS_64, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/posv_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/posv_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -131,66 +131,66 @@ protected:
 
 // non-batch tests
 
-TEST_P(POSV, __float)
+TEST_P(POSV, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POSV, __double)
+TEST_P(POSV, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POSV, __float_complex)
+TEST_P(POSV, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POSV, __double_complex)
+TEST_P(POSV, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(POSV, batched__float)
+TEST_P(POSV, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(POSV, batched__double)
+TEST_P(POSV, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(POSV, batched__float_complex)
+TEST_P(POSV, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(POSV, batched__double_complex)
+TEST_P(POSV, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(POSV, strided_batched__float)
+TEST_P(POSV, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(POSV, strided_batched__double)
+TEST_P(POSV, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(POSV, strided_batched__float_complex)
+TEST_P(POSV, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(POSV, strided_batched__double_complex)
+TEST_P(POSV, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/posv_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/posv_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/posv_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/posv_gtest.cpp
@@ -131,66 +131,66 @@ protected:
 
 // non-batch tests
 
-TEST_P(POSV, _float)
+TEST_P(POSV, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POSV, _double)
+TEST_P(POSV, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POSV, _float_complex)
+TEST_P(POSV, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POSV, _double_complex)
+TEST_P(POSV, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(POSV, batched_float)
+TEST_P(POSV, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(POSV, batched_double)
+TEST_P(POSV, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(POSV, batched_float_complex)
+TEST_P(POSV, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(POSV, batched_double_complex)
+TEST_P(POSV, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(POSV, strided_batched_float)
+TEST_P(POSV, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(POSV, strided_batched_double)
+TEST_P(POSV, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(POSV, strided_batched_float_complex)
+TEST_P(POSV, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(POSV, strided_batched_double_complex)
+TEST_P(POSV, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/potf2_potrf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/potf2_potrf_gtest.cpp
@@ -147,206 +147,206 @@ class POTRF_64 : public POTF2_POTRF<true, int64_t>
 
 // non-batch tests
 
-TEST_P(POTF2, __float)
+TEST_P(POTF2, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTF2, __double)
+TEST_P(POTF2, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTF2, __float_complex)
+TEST_P(POTF2, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTF2, __double_complex)
+TEST_P(POTF2, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(POTF2_64, __float)
+TEST_P(POTF2_64, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTF2_64, __double)
+TEST_P(POTF2_64, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTF2_64, __float_complex)
+TEST_P(POTF2_64, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTF2_64, __double_complex)
+TEST_P(POTF2_64, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(POTRF, __float)
+TEST_P(POTRF, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTRF, __double)
+TEST_P(POTRF, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTRF, __float_complex)
+TEST_P(POTRF, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRF, __double_complex)
+TEST_P(POTRF, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(POTRF_64, __float)
+TEST_P(POTRF_64, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTRF_64, __double)
+TEST_P(POTRF_64, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTRF_64, __float_complex)
+TEST_P(POTRF_64, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRF_64, __double_complex)
+TEST_P(POTRF_64, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(POTF2, batched__float)
+TEST_P(POTF2, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(POTF2, batched__double)
+TEST_P(POTF2, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(POTF2, batched__float_complex)
+TEST_P(POTF2, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(POTF2, batched__double_complex)
+TEST_P(POTF2, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(POTRF, batched__float)
+TEST_P(POTRF, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(POTRF, batched__double)
+TEST_P(POTRF, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(POTRF, batched__float_complex)
+TEST_P(POTRF, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(POTRF, batched__double_complex)
+TEST_P(POTRF, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(POTF2, strided_batched__float)
+TEST_P(POTF2, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(POTF2, strided_batched__double)
+TEST_P(POTF2, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(POTF2, strided_batched__float_complex)
+TEST_P(POTF2, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(POTF2, strided_batched__double_complex)
+TEST_P(POTF2, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(POTF2_64, strided_batched__float)
+TEST_P(POTF2_64, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(POTF2_64, strided_batched__double)
+TEST_P(POTF2_64, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(POTF2_64, strided_batched__float_complex)
+TEST_P(POTF2_64, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(POTF2_64, strided_batched__double_complex)
+TEST_P(POTF2_64, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(POTRF, strided_batched__float)
+TEST_P(POTRF, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(POTRF, strided_batched__double)
+TEST_P(POTRF, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(POTRF, strided_batched__float_complex)
+TEST_P(POTRF, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(POTRF, strided_batched__double_complex)
+TEST_P(POTRF, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(POTRF_64, strided_batched__float)
+TEST_P(POTRF_64, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(POTRF_64, strided_batched__double)
+TEST_P(POTRF_64, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(POTRF_64, strided_batched__float_complex)
+TEST_P(POTRF_64, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(POTRF_64, strided_batched__double_complex)
+TEST_P(POTRF_64, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/potf2_potrf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/potf2_potrf_gtest.cpp
@@ -147,206 +147,206 @@ class POTRF_64 : public POTF2_POTRF<true, int64_t>
 
 // non-batch tests
 
-TEST_P(POTF2, _float)
+TEST_P(POTF2, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTF2, _double)
+TEST_P(POTF2, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTF2, _float_complex)
+TEST_P(POTF2, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTF2, _double_complex)
+TEST_P(POTF2, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(POTF2_64, _float)
+TEST_P(POTF2_64, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTF2_64, _double)
+TEST_P(POTF2_64, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTF2_64, _float_complex)
+TEST_P(POTF2_64, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTF2_64, _double_complex)
+TEST_P(POTF2_64, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(POTRF, _float)
+TEST_P(POTRF, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTRF, _double)
+TEST_P(POTRF, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTRF, _float_complex)
+TEST_P(POTRF, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRF, _double_complex)
+TEST_P(POTRF, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(POTRF_64, _float)
+TEST_P(POTRF_64, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTRF_64, _double)
+TEST_P(POTRF_64, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTRF_64, _float_complex)
+TEST_P(POTRF_64, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRF_64, _double_complex)
+TEST_P(POTRF_64, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(POTF2, batched_float)
+TEST_P(POTF2, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(POTF2, batched_double)
+TEST_P(POTF2, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(POTF2, batched_float_complex)
+TEST_P(POTF2, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(POTF2, batched_double_complex)
+TEST_P(POTF2, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(POTRF, batched_float)
+TEST_P(POTRF, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(POTRF, batched_double)
+TEST_P(POTRF, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(POTRF, batched_float_complex)
+TEST_P(POTRF, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(POTRF, batched_double_complex)
+TEST_P(POTRF, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(POTF2, strided_batched_float)
+TEST_P(POTF2, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(POTF2, strided_batched_double)
+TEST_P(POTF2, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(POTF2, strided_batched_float_complex)
+TEST_P(POTF2, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(POTF2, strided_batched_double_complex)
+TEST_P(POTF2, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(POTF2_64, strided_batched_float)
+TEST_P(POTF2_64, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(POTF2_64, strided_batched_double)
+TEST_P(POTF2_64, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(POTF2_64, strided_batched_float_complex)
+TEST_P(POTF2_64, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(POTF2_64, strided_batched_double_complex)
+TEST_P(POTF2_64, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(POTRF, strided_batched_float)
+TEST_P(POTRF, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(POTRF, strided_batched_double)
+TEST_P(POTRF, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(POTRF, strided_batched_float_complex)
+TEST_P(POTRF, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(POTRF, strided_batched_double_complex)
+TEST_P(POTRF, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(POTRF_64, strided_batched_float)
+TEST_P(POTRF_64, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(POTRF_64, strided_batched_double)
+TEST_P(POTRF_64, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(POTRF_64, strided_batched_float_complex)
+TEST_P(POTRF_64, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(POTRF_64, strided_batched_double_complex)
+TEST_P(POTRF_64, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/potri_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/potri_gtest.cpp
@@ -109,66 +109,66 @@ protected:
 
 // non-batch tests
 
-TEST_P(POTRI, _float)
+TEST_P(POTRI, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTRI, _double)
+TEST_P(POTRI, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTRI, _float_complex)
+TEST_P(POTRI, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRI, _double_complex)
+TEST_P(POTRI, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(POTRI, batched_float)
+TEST_P(POTRI, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(POTRI, batched_double)
+TEST_P(POTRI, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(POTRI, batched_float_complex)
+TEST_P(POTRI, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(POTRI, batched_double_complex)
+TEST_P(POTRI, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(POTRI, strided_batched_float)
+TEST_P(POTRI, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(POTRI, strided_batched_double)
+TEST_P(POTRI, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(POTRI, strided_batched_float_complex)
+TEST_P(POTRI, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(POTRI, strided_batched_double_complex)
+TEST_P(POTRI, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/potri_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/potri_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/potri_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/potri_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -109,66 +109,66 @@ protected:
 
 // non-batch tests
 
-TEST_P(POTRI, __float)
+TEST_P(POTRI, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTRI, __double)
+TEST_P(POTRI, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTRI, __float_complex)
+TEST_P(POTRI, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRI, __double_complex)
+TEST_P(POTRI, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(POTRI, batched__float)
+TEST_P(POTRI, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(POTRI, batched__double)
+TEST_P(POTRI, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(POTRI, batched__float_complex)
+TEST_P(POTRI, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(POTRI, batched__double_complex)
+TEST_P(POTRI, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(POTRI, strided_batched__float)
+TEST_P(POTRI, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(POTRI, strided_batched__double)
+TEST_P(POTRI, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(POTRI, strided_batched__float_complex)
+TEST_P(POTRI, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(POTRI, strided_batched__double_complex)
+TEST_P(POTRI, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/potrs_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/potrs_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -160,126 +160,126 @@ class POTRS_64 : public POTRS_BASE<int64_t>
 
 // non-batch tests
 
-TEST_P(POTRS, __float)
+TEST_P(POTRS, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTRS, __double)
+TEST_P(POTRS, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTRS, __float_complex)
+TEST_P(POTRS, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRS, __double_complex)
+TEST_P(POTRS, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(POTRS_64, __float)
+TEST_P(POTRS_64, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTRS_64, __double)
+TEST_P(POTRS_64, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTRS_64, __float_complex)
+TEST_P(POTRS_64, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRS_64, __double_complex)
+TEST_P(POTRS_64, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(POTRS, batched__float)
+TEST_P(POTRS, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(POTRS, batched__double)
+TEST_P(POTRS, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(POTRS, batched__float_complex)
+TEST_P(POTRS, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(POTRS, batched__double_complex)
+TEST_P(POTRS, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(POTRS_64, batched__float)
+TEST_P(POTRS_64, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(POTRS_64, batched__double)
+TEST_P(POTRS_64, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(POTRS_64, batched__float_complex)
+TEST_P(POTRS_64, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(POTRS_64, batched__double_complex)
+TEST_P(POTRS_64, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(POTRS, strided_batched__float)
+TEST_P(POTRS, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(POTRS, strided_batched__double)
+TEST_P(POTRS, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(POTRS, strided_batched__float_complex)
+TEST_P(POTRS, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(POTRS, strided_batched__double_complex)
+TEST_P(POTRS, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(POTRS_64, strided_batched__float)
+TEST_P(POTRS_64, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(POTRS_64, strided_batched__double)
+TEST_P(POTRS_64, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(POTRS_64, strided_batched__float_complex)
+TEST_P(POTRS_64, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(POTRS_64, strided_batched__double_complex)
+TEST_P(POTRS_64, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/potrs_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/potrs_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/potrs_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/potrs_gtest.cpp
@@ -160,126 +160,126 @@ class POTRS_64 : public POTRS_BASE<int64_t>
 
 // non-batch tests
 
-TEST_P(POTRS, _float)
+TEST_P(POTRS, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTRS, _double)
+TEST_P(POTRS, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTRS, _float_complex)
+TEST_P(POTRS, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRS, _double_complex)
+TEST_P(POTRS, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(POTRS_64, _float)
+TEST_P(POTRS_64, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(POTRS_64, _double)
+TEST_P(POTRS_64, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(POTRS_64, _float_complex)
+TEST_P(POTRS_64, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(POTRS_64, _double_complex)
+TEST_P(POTRS_64, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(POTRS, batched_float)
+TEST_P(POTRS, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(POTRS, batched_double)
+TEST_P(POTRS, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(POTRS, batched_float_complex)
+TEST_P(POTRS, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(POTRS, batched_double_complex)
+TEST_P(POTRS, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(POTRS_64, batched_float)
+TEST_P(POTRS_64, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(POTRS_64, batched_double)
+TEST_P(POTRS_64, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(POTRS_64, batched_float_complex)
+TEST_P(POTRS_64, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(POTRS_64, batched_double_complex)
+TEST_P(POTRS_64, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(POTRS, strided_batched_float)
+TEST_P(POTRS, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(POTRS, strided_batched_double)
+TEST_P(POTRS, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(POTRS, strided_batched_float_complex)
+TEST_P(POTRS, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(POTRS, strided_batched_double_complex)
+TEST_P(POTRS, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(POTRS_64, strided_batched_float)
+TEST_P(POTRS_64, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(POTRS_64, strided_batched_double)
+TEST_P(POTRS_64, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(POTRS_64, strided_batched_float_complex)
+TEST_P(POTRS_64, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(POTRS_64, strided_batched_double_complex)
+TEST_P(POTRS_64, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/syev_heev_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/syev_heev_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/syev_heev_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/syev_heev_gtest.cpp
@@ -123,126 +123,126 @@ class HEEV_HYBRID : public SYEV_HEEV<1>
 
 // non-batch tests
 
-TEST_P(SYEV, _float)
+TEST_P(SYEV, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEV, _double)
+TEST_P(SYEV, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEV, _float_complex)
+TEST_P(HEEV, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEV, _double_complex)
+TEST_P(HEEV, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYEV_HYBRID, _float)
+TEST_P(SYEV_HYBRID, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEV_HYBRID, _double)
+TEST_P(SYEV_HYBRID, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEV_HYBRID, _float_complex)
+TEST_P(HEEV_HYBRID, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEV_HYBRID, _double_complex)
+TEST_P(HEEV_HYBRID, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(SYEV, batched_float)
+TEST_P(SYEV, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYEV, batched_double)
+TEST_P(SYEV, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEEV, batched_float_complex)
+TEST_P(HEEV, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEV, batched_double_complex)
+TEST_P(HEEV, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(SYEV_HYBRID, batched_float)
+TEST_P(SYEV_HYBRID, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYEV_HYBRID, batched_double)
+TEST_P(SYEV_HYBRID, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEEV_HYBRID, batched_float_complex)
+TEST_P(HEEV_HYBRID, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEV_HYBRID, batched_double_complex)
+TEST_P(HEEV_HYBRID, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(SYEV, strided_batched_float)
+TEST_P(SYEV, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYEV, strided_batched_double)
+TEST_P(SYEV, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEEV, strided_batched_float_complex)
+TEST_P(HEEV, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEV, strided_batched_double_complex)
+TEST_P(HEEV, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(SYEV_HYBRID, strided_batched_float)
+TEST_P(SYEV_HYBRID, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYEV_HYBRID, strided_batched_double)
+TEST_P(SYEV_HYBRID, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEEV_HYBRID, strided_batched_float_complex)
+TEST_P(HEEV_HYBRID, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEV_HYBRID, strided_batched_double_complex)
+TEST_P(HEEV_HYBRID, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/syev_heev_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/syev_heev_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -123,126 +123,126 @@ class HEEV_HYBRID : public SYEV_HEEV<1>
 
 // non-batch tests
 
-TEST_P(SYEV, __float)
+TEST_P(SYEV, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEV, __double)
+TEST_P(SYEV, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEV, __float_complex)
+TEST_P(HEEV, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEV, __double_complex)
+TEST_P(HEEV, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYEV_HYBRID, __float)
+TEST_P(SYEV_HYBRID, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEV_HYBRID, __double)
+TEST_P(SYEV_HYBRID, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEV_HYBRID, __float_complex)
+TEST_P(HEEV_HYBRID, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEV_HYBRID, __double_complex)
+TEST_P(HEEV_HYBRID, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(SYEV, batched__float)
+TEST_P(SYEV, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYEV, batched__double)
+TEST_P(SYEV, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEEV, batched__float_complex)
+TEST_P(HEEV, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEV, batched__double_complex)
+TEST_P(HEEV, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(SYEV_HYBRID, batched__float)
+TEST_P(SYEV_HYBRID, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYEV_HYBRID, batched__double)
+TEST_P(SYEV_HYBRID, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEEV_HYBRID, batched__float_complex)
+TEST_P(HEEV_HYBRID, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEV_HYBRID, batched__double_complex)
+TEST_P(HEEV_HYBRID, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(SYEV, strided_batched__float)
+TEST_P(SYEV, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYEV, strided_batched__double)
+TEST_P(SYEV, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEEV, strided_batched__float_complex)
+TEST_P(HEEV, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEV, strided_batched__double_complex)
+TEST_P(HEEV, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(SYEV_HYBRID, strided_batched__float)
+TEST_P(SYEV_HYBRID, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYEV_HYBRID, strided_batched__double)
+TEST_P(SYEV_HYBRID, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEEV_HYBRID, strided_batched__float_complex)
+TEST_P(HEEV_HYBRID, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEV_HYBRID, strided_batched__double_complex)
+TEST_P(HEEV_HYBRID, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/syevd_heevd_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/syevd_heevd_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -123,126 +123,126 @@ class HEEVD_HYBRID : public SYEVD_HEEVD<1>
 
 // non-batch tests
 
-TEST_P(SYEVD, __float)
+TEST_P(SYEVD, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEVD, __double)
+TEST_P(SYEVD, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEVD, __float_complex)
+TEST_P(HEEVD, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEVD, __double_complex)
+TEST_P(HEEVD, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYEVD_HYBRID, __float)
+TEST_P(SYEVD_HYBRID, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEVD_HYBRID, __double)
+TEST_P(SYEVD_HYBRID, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEVD_HYBRID, __float_complex)
+TEST_P(HEEVD_HYBRID, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEVD_HYBRID, __double_complex)
+TEST_P(HEEVD_HYBRID, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(SYEVD, batched__float)
+TEST_P(SYEVD, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYEVD, batched__double)
+TEST_P(SYEVD, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEEVD, batched__float_complex)
+TEST_P(HEEVD, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEVD, batched__double_complex)
+TEST_P(HEEVD, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(SYEVD_HYBRID, batched__float)
+TEST_P(SYEVD_HYBRID, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYEVD_HYBRID, batched__double)
+TEST_P(SYEVD_HYBRID, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEEVD_HYBRID, batched__float_complex)
+TEST_P(HEEVD_HYBRID, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEVD_HYBRID, batched__double_complex)
+TEST_P(HEEVD_HYBRID, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(SYEVD, strided_batched__float)
+TEST_P(SYEVD, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYEVD, strided_batched__double)
+TEST_P(SYEVD, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEEVD, strided_batched__float_complex)
+TEST_P(HEEVD, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEVD, strided_batched__double_complex)
+TEST_P(HEEVD, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(SYEVD_HYBRID, strided_batched__float)
+TEST_P(SYEVD_HYBRID, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYEVD_HYBRID, strided_batched__double)
+TEST_P(SYEVD_HYBRID, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEEVD_HYBRID, strided_batched__float_complex)
+TEST_P(HEEVD_HYBRID, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEVD_HYBRID, strided_batched__double_complex)
+TEST_P(HEEVD_HYBRID, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/syevd_heevd_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/syevd_heevd_gtest.cpp
@@ -123,126 +123,126 @@ class HEEVD_HYBRID : public SYEVD_HEEVD<1>
 
 // non-batch tests
 
-TEST_P(SYEVD, _float)
+TEST_P(SYEVD, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEVD, _double)
+TEST_P(SYEVD, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEVD, _float_complex)
+TEST_P(HEEVD, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEVD, _double_complex)
+TEST_P(HEEVD, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYEVD_HYBRID, _float)
+TEST_P(SYEVD_HYBRID, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEVD_HYBRID, _double)
+TEST_P(SYEVD_HYBRID, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEVD_HYBRID, _float_complex)
+TEST_P(HEEVD_HYBRID, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEVD_HYBRID, _double_complex)
+TEST_P(HEEVD_HYBRID, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(SYEVD, batched_float)
+TEST_P(SYEVD, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYEVD, batched_double)
+TEST_P(SYEVD, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEEVD, batched_float_complex)
+TEST_P(HEEVD, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEVD, batched_double_complex)
+TEST_P(HEEVD, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(SYEVD_HYBRID, batched_float)
+TEST_P(SYEVD_HYBRID, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYEVD_HYBRID, batched_double)
+TEST_P(SYEVD_HYBRID, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEEVD_HYBRID, batched_float_complex)
+TEST_P(HEEVD_HYBRID, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEVD_HYBRID, batched_double_complex)
+TEST_P(HEEVD_HYBRID, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(SYEVD, strided_batched_float)
+TEST_P(SYEVD, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYEVD, strided_batched_double)
+TEST_P(SYEVD, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEEVD, strided_batched_float_complex)
+TEST_P(HEEVD, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEVD, strided_batched_double_complex)
+TEST_P(HEEVD, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(SYEVD_HYBRID, strided_batched_float)
+TEST_P(SYEVD_HYBRID, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYEVD_HYBRID, strided_batched_double)
+TEST_P(SYEVD_HYBRID, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEEVD_HYBRID, strided_batched_float_complex)
+TEST_P(HEEVD_HYBRID, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEVD_HYBRID, strided_batched_double_complex)
+TEST_P(HEEVD_HYBRID, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/syevd_heevd_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/syevd_heevd_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/syevdj_heevdj_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/syevdj_heevdj_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/syevdj_heevdj_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/syevdj_heevdj_gtest.cpp
@@ -113,66 +113,66 @@ class HEEVDJ : public SYEVDJ_HEEVDJ
 
 // non-batch tests
 
-TEST_P(SYEVDJ, _float)
+TEST_P(SYEVDJ, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEVDJ, _double)
+TEST_P(SYEVDJ, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEVDJ, _float_complex)
+TEST_P(HEEVDJ, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEVDJ, _double_complex)
+TEST_P(HEEVDJ, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(SYEVDJ, batched_float)
+TEST_P(SYEVDJ, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYEVDJ, batched_double)
+TEST_P(SYEVDJ, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEEVDJ, batched_float_complex)
+TEST_P(HEEVDJ, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEVDJ, batched_double_complex)
+TEST_P(HEEVDJ, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(SYEVDJ, strided_batched_float)
+TEST_P(SYEVDJ, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYEVDJ, strided_batched_double)
+TEST_P(SYEVDJ, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEEVDJ, strided_batched_float_complex)
+TEST_P(HEEVDJ, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEVDJ, strided_batched_double_complex)
+TEST_P(HEEVDJ, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/syevdj_heevdj_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/syevdj_heevdj_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -113,66 +113,66 @@ class HEEVDJ : public SYEVDJ_HEEVDJ
 
 // non-batch tests
 
-TEST_P(SYEVDJ, __float)
+TEST_P(SYEVDJ, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEVDJ, __double)
+TEST_P(SYEVDJ, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEVDJ, __float_complex)
+TEST_P(HEEVDJ, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEVDJ, __double_complex)
+TEST_P(HEEVDJ, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(SYEVDJ, batched__float)
+TEST_P(SYEVDJ, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYEVDJ, batched__double)
+TEST_P(SYEVDJ, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEEVDJ, batched__float_complex)
+TEST_P(HEEVDJ, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEVDJ, batched__double_complex)
+TEST_P(HEEVDJ, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(SYEVDJ, strided_batched__float)
+TEST_P(SYEVDJ, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYEVDJ, strided_batched__double)
+TEST_P(SYEVDJ, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEEVDJ, strided_batched__float_complex)
+TEST_P(HEEVDJ, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEVDJ, strided_batched__double_complex)
+TEST_P(HEEVDJ, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/syevdx_heevdx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/syevdx_heevdx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -165,86 +165,86 @@ class HEEVDX_INPLACE : public SYEVDX_HEEVDX_INPLACE
 
 // non-batch tests
 
-TEST_P(SYEVDX, __float)
+TEST_P(SYEVDX, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEVDX, __double)
+TEST_P(SYEVDX, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEVDX, __float_complex)
+TEST_P(HEEVDX, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEVDX, __double_complex)
+TEST_P(HEEVDX, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYEVDX_INPLACE, __float)
+TEST_P(SYEVDX_INPLACE, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEVDX_INPLACE, __double)
+TEST_P(SYEVDX_INPLACE, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEVDX_INPLACE, __float_complex)
+TEST_P(HEEVDX_INPLACE, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEVDX_INPLACE, __double_complex)
+TEST_P(HEEVDX_INPLACE, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(SYEVDX, batched__float)
+TEST_P(SYEVDX, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYEVDX, batched__double)
+TEST_P(SYEVDX, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEEVDX, batched__float_complex)
+TEST_P(HEEVDX, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEVDX, batched__double_complex)
+TEST_P(HEEVDX, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(SYEVDX, strided_batched__float)
+TEST_P(SYEVDX, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYEVDX, strided_batched__double)
+TEST_P(SYEVDX, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEEVDX, strided_batched__float_complex)
+TEST_P(HEEVDX, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEVDX, strided_batched__double_complex)
+TEST_P(HEEVDX, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/syevdx_heevdx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/syevdx_heevdx_gtest.cpp
@@ -165,86 +165,86 @@ class HEEVDX_INPLACE : public SYEVDX_HEEVDX_INPLACE
 
 // non-batch tests
 
-TEST_P(SYEVDX, _float)
+TEST_P(SYEVDX, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEVDX, _double)
+TEST_P(SYEVDX, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEVDX, _float_complex)
+TEST_P(HEEVDX, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEVDX, _double_complex)
+TEST_P(HEEVDX, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYEVDX_INPLACE, _float)
+TEST_P(SYEVDX_INPLACE, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEVDX_INPLACE, _double)
+TEST_P(SYEVDX_INPLACE, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEVDX_INPLACE, _float_complex)
+TEST_P(HEEVDX_INPLACE, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEVDX_INPLACE, _double_complex)
+TEST_P(HEEVDX_INPLACE, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(SYEVDX, batched_float)
+TEST_P(SYEVDX, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYEVDX, batched_double)
+TEST_P(SYEVDX, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEEVDX, batched_float_complex)
+TEST_P(HEEVDX, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEVDX, batched_double_complex)
+TEST_P(HEEVDX, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(SYEVDX, strided_batched_float)
+TEST_P(SYEVDX, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYEVDX, strided_batched_double)
+TEST_P(SYEVDX, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEEVDX, strided_batched_float_complex)
+TEST_P(HEEVDX, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEVDX, strided_batched_double_complex)
+TEST_P(HEEVDX, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/syevdx_heevdx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/syevdx_heevdx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/syevj_heevj_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/syevj_heevj_gtest.cpp
@@ -121,66 +121,66 @@ class HEEVJ : public SYEVJ_HEEVJ
 
 // non-batch tests
 
-TEST_P(SYEVJ, _float)
+TEST_P(SYEVJ, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEVJ, _double)
+TEST_P(SYEVJ, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEVJ, _float_complex)
+TEST_P(HEEVJ, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEVJ, _double_complex)
+TEST_P(HEEVJ, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(SYEVJ, batched_float)
+TEST_P(SYEVJ, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYEVJ, batched_double)
+TEST_P(SYEVJ, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEEVJ, batched_float_complex)
+TEST_P(HEEVJ, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEVJ, batched_double_complex)
+TEST_P(HEEVJ, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(SYEVJ, strided_batched_float)
+TEST_P(SYEVJ, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYEVJ, strided_batched_double)
+TEST_P(SYEVJ, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEEVJ, strided_batched_float_complex)
+TEST_P(HEEVJ, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEVJ, strided_batched_double_complex)
+TEST_P(HEEVJ, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/syevj_heevj_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/syevj_heevj_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/syevj_heevj_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/syevj_heevj_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -121,66 +121,66 @@ class HEEVJ : public SYEVJ_HEEVJ
 
 // non-batch tests
 
-TEST_P(SYEVJ, __float)
+TEST_P(SYEVJ, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEVJ, __double)
+TEST_P(SYEVJ, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEVJ, __float_complex)
+TEST_P(HEEVJ, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEVJ, __double_complex)
+TEST_P(HEEVJ, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(SYEVJ, batched__float)
+TEST_P(SYEVJ, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYEVJ, batched__double)
+TEST_P(SYEVJ, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEEVJ, batched__float_complex)
+TEST_P(HEEVJ, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEVJ, batched__double_complex)
+TEST_P(HEEVJ, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(SYEVJ, strided_batched__float)
+TEST_P(SYEVJ, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYEVJ, strided_batched__double)
+TEST_P(SYEVJ, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEEVJ, strided_batched__float_complex)
+TEST_P(HEEVJ, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEVJ, strided_batched__double_complex)
+TEST_P(HEEVJ, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/syevx_heevx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/syevx_heevx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/syevx_heevx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/syevx_heevx_gtest.cpp
@@ -132,66 +132,66 @@ class HEEVX : public SYEVX_HEEVX
 
 // non-batch tests
 
-TEST_P(SYEVX, _float)
+TEST_P(SYEVX, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEVX, _double)
+TEST_P(SYEVX, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEVX, _float_complex)
+TEST_P(HEEVX, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEVX, _double_complex)
+TEST_P(HEEVX, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(SYEVX, batched_float)
+TEST_P(SYEVX, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYEVX, batched_double)
+TEST_P(SYEVX, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEEVX, batched_float_complex)
+TEST_P(HEEVX, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEVX, batched_double_complex)
+TEST_P(HEEVX, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(SYEVX, strided_batched_float)
+TEST_P(SYEVX, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYEVX, strided_batched_double)
+TEST_P(SYEVX, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEEVX, strided_batched_float_complex)
+TEST_P(HEEVX, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEVX, strided_batched_double_complex)
+TEST_P(HEEVX, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/syevx_heevx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/syevx_heevx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -132,66 +132,66 @@ class HEEVX : public SYEVX_HEEVX
 
 // non-batch tests
 
-TEST_P(SYEVX, __float)
+TEST_P(SYEVX, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYEVX, __double)
+TEST_P(SYEVX, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEEVX, __float_complex)
+TEST_P(HEEVX, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEEVX, __double_complex)
+TEST_P(HEEVX, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(SYEVX, batched__float)
+TEST_P(SYEVX, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYEVX, batched__double)
+TEST_P(SYEVX, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEEVX, batched__float_complex)
+TEST_P(HEEVX, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEVX, batched__double_complex)
+TEST_P(HEEVX, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(SYEVX, strided_batched__float)
+TEST_P(SYEVX, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYEVX, strided_batched__double)
+TEST_P(SYEVX, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEEVX, strided_batched__float_complex)
+TEST_P(HEEVX, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEEVX, strided_batched__double_complex)
+TEST_P(HEEVX, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/sygsx_hegsx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/sygsx_hegsx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/sygsx_hegsx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/sygsx_hegsx_gtest.cpp
@@ -127,126 +127,126 @@ class HEGST : public SYGSX_HEGSX<true>
 
 // non-batch tests
 
-TEST_P(SYGS2, _float)
+TEST_P(SYGS2, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGS2, _double)
+TEST_P(SYGS2, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGS2, _float_complex)
+TEST_P(HEGS2, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGS2, _double_complex)
+TEST_P(HEGS2, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYGST, _float)
+TEST_P(SYGST, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGST, _double)
+TEST_P(SYGST, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGST, _float_complex)
+TEST_P(HEGST, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGST, _double_complex)
+TEST_P(HEGST, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(SYGS2, batched_float)
+TEST_P(SYGS2, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYGS2, batched_double)
+TEST_P(SYGS2, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEGS2, batched_float_complex)
+TEST_P(HEGS2, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGS2, batched_double_complex)
+TEST_P(HEGS2, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(SYGST, batched_float)
+TEST_P(SYGST, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYGST, batched_double)
+TEST_P(SYGST, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEGST, batched_float_complex)
+TEST_P(HEGST, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGST, batched_double_complex)
+TEST_P(HEGST, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(SYGS2, strided_batched_float)
+TEST_P(SYGS2, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYGS2, strided_batched_double)
+TEST_P(SYGS2, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEGS2, strided_batched_float_complex)
+TEST_P(HEGS2, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGS2, strided_batched_double_complex)
+TEST_P(HEGS2, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(SYGST, strided_batched_float)
+TEST_P(SYGST, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYGST, strided_batched_double)
+TEST_P(SYGST, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEGST, strided_batched_float_complex)
+TEST_P(HEGST, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGST, strided_batched_double_complex)
+TEST_P(HEGST, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/sygsx_hegsx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/sygsx_hegsx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -127,126 +127,126 @@ class HEGST : public SYGSX_HEGSX<true>
 
 // non-batch tests
 
-TEST_P(SYGS2, __float)
+TEST_P(SYGS2, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGS2, __double)
+TEST_P(SYGS2, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGS2, __float_complex)
+TEST_P(HEGS2, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGS2, __double_complex)
+TEST_P(HEGS2, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYGST, __float)
+TEST_P(SYGST, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGST, __double)
+TEST_P(SYGST, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGST, __float_complex)
+TEST_P(HEGST, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGST, __double_complex)
+TEST_P(HEGST, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(SYGS2, batched__float)
+TEST_P(SYGS2, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYGS2, batched__double)
+TEST_P(SYGS2, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEGS2, batched__float_complex)
+TEST_P(HEGS2, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGS2, batched__double_complex)
+TEST_P(HEGS2, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(SYGST, batched__float)
+TEST_P(SYGST, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYGST, batched__double)
+TEST_P(SYGST, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEGST, batched__float_complex)
+TEST_P(HEGST, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGST, batched__double_complex)
+TEST_P(HEGST, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(SYGS2, strided_batched__float)
+TEST_P(SYGS2, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYGS2, strided_batched__double)
+TEST_P(SYGS2, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEGS2, strided_batched__float_complex)
+TEST_P(HEGS2, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGS2, strided_batched__double_complex)
+TEST_P(HEGS2, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(SYGST, strided_batched__float)
+TEST_P(SYGST, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYGST, strided_batched__double)
+TEST_P(SYGST, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEGST, strided_batched__float_complex)
+TEST_P(HEGST, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGST, strided_batched__double_complex)
+TEST_P(HEGST, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/sygv_hegv_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/sygv_hegv_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/sygv_hegv_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/sygv_hegv_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -125,66 +125,66 @@ class HEGV : public SYGV_HEGV
 
 // non-batch tests
 
-TEST_P(SYGV, __float)
+TEST_P(SYGV, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGV, __double)
+TEST_P(SYGV, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGV, __float_complex)
+TEST_P(HEGV, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGV, __double_complex)
+TEST_P(HEGV, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(SYGV, batched__float)
+TEST_P(SYGV, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYGV, batched__double)
+TEST_P(SYGV, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEGV, batched__float_complex)
+TEST_P(HEGV, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGV, batched__double_complex)
+TEST_P(HEGV, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(SYGV, strided_batched__float)
+TEST_P(SYGV, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYGV, strided_batched__double)
+TEST_P(SYGV, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEGV, strided_batched__float_complex)
+TEST_P(HEGV, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGV, strided_batched__double_complex)
+TEST_P(HEGV, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/sygv_hegv_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/sygv_hegv_gtest.cpp
@@ -125,66 +125,66 @@ class HEGV : public SYGV_HEGV
 
 // non-batch tests
 
-TEST_P(SYGV, _float)
+TEST_P(SYGV, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGV, _double)
+TEST_P(SYGV, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGV, _float_complex)
+TEST_P(HEGV, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGV, _double_complex)
+TEST_P(HEGV, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(SYGV, batched_float)
+TEST_P(SYGV, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYGV, batched_double)
+TEST_P(SYGV, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEGV, batched_float_complex)
+TEST_P(HEGV, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGV, batched_double_complex)
+TEST_P(HEGV, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(SYGV, strided_batched_float)
+TEST_P(SYGV, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYGV, strided_batched_double)
+TEST_P(SYGV, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEGV, strided_batched_float_complex)
+TEST_P(HEGV, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGV, strided_batched_double_complex)
+TEST_P(HEGV, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/sygvd_hegvd_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/sygvd_hegvd_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/sygvd_hegvd_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/sygvd_hegvd_gtest.cpp
@@ -126,66 +126,66 @@ class HEGVD : public SYGVD_HEGVD
 
 // non-batch tests
 
-TEST_P(SYGVD, _float)
+TEST_P(SYGVD, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGVD, _double)
+TEST_P(SYGVD, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGVD, _float_complex)
+TEST_P(HEGVD, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGVD, _double_complex)
+TEST_P(HEGVD, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(SYGVD, batched_float)
+TEST_P(SYGVD, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYGVD, batched_double)
+TEST_P(SYGVD, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEGVD, batched_float_complex)
+TEST_P(HEGVD, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGVD, batched_double_complex)
+TEST_P(HEGVD, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(SYGVD, strided_batched_float)
+TEST_P(SYGVD, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYGVD, strided_batched_double)
+TEST_P(SYGVD, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEGVD, strided_batched_float_complex)
+TEST_P(HEGVD, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGVD, strided_batched_double_complex)
+TEST_P(HEGVD, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/sygvd_hegvd_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/sygvd_hegvd_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -126,66 +126,66 @@ class HEGVD : public SYGVD_HEGVD
 
 // non-batch tests
 
-TEST_P(SYGVD, __float)
+TEST_P(SYGVD, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGVD, __double)
+TEST_P(SYGVD, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGVD, __float_complex)
+TEST_P(HEGVD, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGVD, __double_complex)
+TEST_P(HEGVD, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(SYGVD, batched__float)
+TEST_P(SYGVD, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYGVD, batched__double)
+TEST_P(SYGVD, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEGVD, batched__float_complex)
+TEST_P(HEGVD, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGVD, batched__double_complex)
+TEST_P(HEGVD, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(SYGVD, strided_batched__float)
+TEST_P(SYGVD, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYGVD, strided_batched__double)
+TEST_P(SYGVD, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEGVD, strided_batched__float_complex)
+TEST_P(HEGVD, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGVD, strided_batched__double_complex)
+TEST_P(HEGVD, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/sygvdj_hegvdj_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/sygvdj_hegvdj_gtest.cpp
@@ -126,66 +126,66 @@ class HEGVDJ : public SYGVDJ_HEGVDJ
 
 // non-batch tests
 
-TEST_P(SYGVDJ, _float)
+TEST_P(SYGVDJ, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGVDJ, _double)
+TEST_P(SYGVDJ, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGVDJ, _float_complex)
+TEST_P(HEGVDJ, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGVDJ, _double_complex)
+TEST_P(HEGVDJ, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(SYGVDJ, batched_float)
+TEST_P(SYGVDJ, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYGVDJ, batched_double)
+TEST_P(SYGVDJ, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEGVDJ, batched_float_complex)
+TEST_P(HEGVDJ, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGVDJ, batched_double_complex)
+TEST_P(HEGVDJ, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(SYGVDJ, strided_batched_float)
+TEST_P(SYGVDJ, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYGVDJ, strided_batched_double)
+TEST_P(SYGVDJ, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEGVDJ, strided_batched_float_complex)
+TEST_P(HEGVDJ, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGVDJ, strided_batched_double_complex)
+TEST_P(HEGVDJ, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/sygvdj_hegvdj_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/sygvdj_hegvdj_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -126,66 +126,66 @@ class HEGVDJ : public SYGVDJ_HEGVDJ
 
 // non-batch tests
 
-TEST_P(SYGVDJ, __float)
+TEST_P(SYGVDJ, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGVDJ, __double)
+TEST_P(SYGVDJ, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGVDJ, __float_complex)
+TEST_P(HEGVDJ, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGVDJ, __double_complex)
+TEST_P(HEGVDJ, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(SYGVDJ, batched__float)
+TEST_P(SYGVDJ, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYGVDJ, batched__double)
+TEST_P(SYGVDJ, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEGVDJ, batched__float_complex)
+TEST_P(HEGVDJ, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGVDJ, batched__double_complex)
+TEST_P(HEGVDJ, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(SYGVDJ, strided_batched__float)
+TEST_P(SYGVDJ, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYGVDJ, strided_batched__double)
+TEST_P(SYGVDJ, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEGVDJ, strided_batched__float_complex)
+TEST_P(HEGVDJ, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGVDJ, strided_batched__double_complex)
+TEST_P(HEGVDJ, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/sygvdj_hegvdj_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/sygvdj_hegvdj_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/sygvdx_hegvdx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/sygvdx_hegvdx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/sygvdx_hegvdx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/sygvdx_hegvdx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -176,86 +176,86 @@ class HEGVDX_INPLACE : public SYGVDX_HEGVDX_INPLACE
 
 // non-batch tests
 
-TEST_P(SYGVDX, __float)
+TEST_P(SYGVDX, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGVDX, __double)
+TEST_P(SYGVDX, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGVDX, __float_complex)
+TEST_P(HEGVDX, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGVDX, __double_complex)
+TEST_P(HEGVDX, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYGVDX_INPLACE, __float)
+TEST_P(SYGVDX_INPLACE, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGVDX_INPLACE, __double)
+TEST_P(SYGVDX_INPLACE, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGVDX_INPLACE, __float_complex)
+TEST_P(HEGVDX_INPLACE, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGVDX_INPLACE, __double_complex)
+TEST_P(HEGVDX_INPLACE, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(SYGVDX, batched__float)
+TEST_P(SYGVDX, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYGVDX, batched__double)
+TEST_P(SYGVDX, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEGVDX, batched__float_complex)
+TEST_P(HEGVDX, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGVDX, batched__double_complex)
+TEST_P(HEGVDX, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(SYGVDX, strided_batched__float)
+TEST_P(SYGVDX, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYGVDX, strided_batched__double)
+TEST_P(SYGVDX, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEGVDX, strided_batched__float_complex)
+TEST_P(HEGVDX, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGVDX, strided_batched__double_complex)
+TEST_P(HEGVDX, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/sygvdx_hegvdx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/sygvdx_hegvdx_gtest.cpp
@@ -176,86 +176,86 @@ class HEGVDX_INPLACE : public SYGVDX_HEGVDX_INPLACE
 
 // non-batch tests
 
-TEST_P(SYGVDX, _float)
+TEST_P(SYGVDX, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGVDX, _double)
+TEST_P(SYGVDX, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGVDX, _float_complex)
+TEST_P(HEGVDX, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGVDX, _double_complex)
+TEST_P(HEGVDX, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYGVDX_INPLACE, _float)
+TEST_P(SYGVDX_INPLACE, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGVDX_INPLACE, _double)
+TEST_P(SYGVDX_INPLACE, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGVDX_INPLACE, _float_complex)
+TEST_P(HEGVDX_INPLACE, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGVDX_INPLACE, _double_complex)
+TEST_P(HEGVDX_INPLACE, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(SYGVDX, batched_float)
+TEST_P(SYGVDX, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYGVDX, batched_double)
+TEST_P(SYGVDX, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEGVDX, batched_float_complex)
+TEST_P(HEGVDX, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGVDX, batched_double_complex)
+TEST_P(HEGVDX, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(SYGVDX, strided_batched_float)
+TEST_P(SYGVDX, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYGVDX, strided_batched_double)
+TEST_P(SYGVDX, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEGVDX, strided_batched_float_complex)
+TEST_P(HEGVDX, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGVDX, strided_batched_double_complex)
+TEST_P(HEGVDX, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/sygvj_hegvj_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/sygvj_hegvj_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/sygvj_hegvj_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/sygvj_hegvj_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -128,66 +128,66 @@ class HEGVJ : public SYGVJ_HEGVJ
 
 // non-batch tests
 
-TEST_P(SYGVJ, __float)
+TEST_P(SYGVJ, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGVJ, __double)
+TEST_P(SYGVJ, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGVJ, __float_complex)
+TEST_P(HEGVJ, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGVJ, __double_complex)
+TEST_P(HEGVJ, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(SYGVJ, batched__float)
+TEST_P(SYGVJ, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYGVJ, batched__double)
+TEST_P(SYGVJ, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEGVJ, batched__float_complex)
+TEST_P(HEGVJ, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGVJ, batched__double_complex)
+TEST_P(HEGVJ, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(SYGVJ, strided_batched__float)
+TEST_P(SYGVJ, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYGVJ, strided_batched__double)
+TEST_P(SYGVJ, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEGVJ, strided_batched__float_complex)
+TEST_P(HEGVJ, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGVJ, strided_batched__double_complex)
+TEST_P(HEGVJ, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/sygvj_hegvj_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/sygvj_hegvj_gtest.cpp
@@ -128,66 +128,66 @@ class HEGVJ : public SYGVJ_HEGVJ
 
 // non-batch tests
 
-TEST_P(SYGVJ, _float)
+TEST_P(SYGVJ, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGVJ, _double)
+TEST_P(SYGVJ, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGVJ, _float_complex)
+TEST_P(HEGVJ, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGVJ, _double_complex)
+TEST_P(HEGVJ, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(SYGVJ, batched_float)
+TEST_P(SYGVJ, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYGVJ, batched_double)
+TEST_P(SYGVJ, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEGVJ, batched_float_complex)
+TEST_P(HEGVJ, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGVJ, batched_double_complex)
+TEST_P(HEGVJ, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(SYGVJ, strided_batched_float)
+TEST_P(SYGVJ, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYGVJ, strided_batched_double)
+TEST_P(SYGVJ, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEGVJ, strided_batched_float_complex)
+TEST_P(HEGVJ, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGVJ, strided_batched_double_complex)
+TEST_P(HEGVJ, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/sygvx_hegvx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/sygvx_hegvx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -140,66 +140,66 @@ class HEGVX : public SYGVX_HEGVX
 
 // non-batch tests
 
-TEST_P(SYGVX, __float)
+TEST_P(SYGVX, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGVX, __double)
+TEST_P(SYGVX, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGVX, __float_complex)
+TEST_P(HEGVX, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGVX, __double_complex)
+TEST_P(HEGVX, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(SYGVX, batched__float)
+TEST_P(SYGVX, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYGVX, batched__double)
+TEST_P(SYGVX, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEGVX, batched__float_complex)
+TEST_P(HEGVX, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGVX, batched__double_complex)
+TEST_P(HEGVX, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(SYGVX, strided_batched__float)
+TEST_P(SYGVX, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYGVX, strided_batched__double)
+TEST_P(SYGVX, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEGVX, strided_batched__float_complex)
+TEST_P(HEGVX, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGVX, strided_batched__double_complex)
+TEST_P(HEGVX, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/sygvx_hegvx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/sygvx_hegvx_gtest.cpp
@@ -140,66 +140,66 @@ class HEGVX : public SYGVX_HEGVX
 
 // non-batch tests
 
-TEST_P(SYGVX, _float)
+TEST_P(SYGVX, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGVX, _double)
+TEST_P(SYGVX, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGVX, _float_complex)
+TEST_P(HEGVX, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGVX, _double_complex)
+TEST_P(HEGVX, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(SYGVX, batched_float)
+TEST_P(SYGVX, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYGVX, batched_double)
+TEST_P(SYGVX, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HEGVX, batched_float_complex)
+TEST_P(HEGVX, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGVX, batched_double_complex)
+TEST_P(HEGVX, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(SYGVX, strided_batched_float)
+TEST_P(SYGVX, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYGVX, strided_batched_double)
+TEST_P(SYGVX, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HEGVX, strided_batched_float_complex)
+TEST_P(HEGVX, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HEGVX, strided_batched_double_complex)
+TEST_P(HEGVX, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/sygvx_hegvx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/sygvx_hegvx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/sytf2_sytrf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/sytf2_sytrf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/sytf2_sytrf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/sytf2_sytrf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -120,126 +120,126 @@ class SYTRF : public SYTF2_SYTRF<true>
 
 // non-batch tests
 
-TEST_P(SYTF2, __float)
+TEST_P(SYTF2, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYTF2, __double)
+TEST_P(SYTF2, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(SYTF2, __float_complex)
+TEST_P(SYTF2, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(SYTF2, __double_complex)
+TEST_P(SYTF2, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYTRF, __float)
+TEST_P(SYTRF, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYTRF, __double)
+TEST_P(SYTRF, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(SYTRF, __float_complex)
+TEST_P(SYTRF, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(SYTRF, __double_complex)
+TEST_P(SYTRF, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(SYTF2, batched__float)
+TEST_P(SYTF2, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYTF2, batched__double)
+TEST_P(SYTF2, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(SYTF2, batched__float_complex)
+TEST_P(SYTF2, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(SYTF2, batched__double_complex)
+TEST_P(SYTF2, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(SYTRF, batched__float)
+TEST_P(SYTRF, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYTRF, batched__double)
+TEST_P(SYTRF, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(SYTRF, batched__float_complex)
+TEST_P(SYTRF, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(SYTRF, batched__double_complex)
+TEST_P(SYTRF, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(SYTF2, strided_batched__float)
+TEST_P(SYTF2, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYTF2, strided_batched__double)
+TEST_P(SYTF2, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(SYTF2, strided_batched__float_complex)
+TEST_P(SYTF2, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(SYTF2, strided_batched__double_complex)
+TEST_P(SYTF2, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(SYTRF, strided_batched__float)
+TEST_P(SYTRF, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYTRF, strided_batched__double)
+TEST_P(SYTRF, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(SYTRF, strided_batched__float_complex)
+TEST_P(SYTRF, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(SYTRF, strided_batched__double_complex)
+TEST_P(SYTRF, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/sytf2_sytrf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/sytf2_sytrf_gtest.cpp
@@ -120,126 +120,126 @@ class SYTRF : public SYTF2_SYTRF<true>
 
 // non-batch tests
 
-TEST_P(SYTF2, _float)
+TEST_P(SYTF2, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYTF2, _double)
+TEST_P(SYTF2, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(SYTF2, _float_complex)
+TEST_P(SYTF2, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(SYTF2, _double_complex)
+TEST_P(SYTF2, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYTRF, _float)
+TEST_P(SYTRF, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYTRF, _double)
+TEST_P(SYTRF, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(SYTRF, _float_complex)
+TEST_P(SYTRF, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(SYTRF, _double_complex)
+TEST_P(SYTRF, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(SYTF2, batched_float)
+TEST_P(SYTF2, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYTF2, batched_double)
+TEST_P(SYTF2, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(SYTF2, batched_float_complex)
+TEST_P(SYTF2, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(SYTF2, batched_double_complex)
+TEST_P(SYTF2, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(SYTRF, batched_float)
+TEST_P(SYTRF, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYTRF, batched_double)
+TEST_P(SYTRF, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(SYTRF, batched_float_complex)
+TEST_P(SYTRF, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(SYTRF, batched_double_complex)
+TEST_P(SYTRF, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(SYTF2, strided_batched_float)
+TEST_P(SYTF2, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYTF2, strided_batched_double)
+TEST_P(SYTF2, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(SYTF2, strided_batched_float_complex)
+TEST_P(SYTF2, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(SYTF2, strided_batched_double_complex)
+TEST_P(SYTF2, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(SYTRF, strided_batched_float)
+TEST_P(SYTRF, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYTRF, strided_batched_double)
+TEST_P(SYTRF, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(SYTRF, strided_batched_float_complex)
+TEST_P(SYTRF, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(SYTRF, strided_batched_double_complex)
+TEST_P(SYTRF, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/sytxx_hetxx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/sytxx_hetxx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/sytxx_hetxx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/sytxx_hetxx_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -121,126 +121,126 @@ class HETRD : public SYTXX_HETXX<true>
 
 // non-batch tests
 
-TEST_P(SYTD2, __float)
+TEST_P(SYTD2, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYTD2, __double)
+TEST_P(SYTD2, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HETD2, __float_complex)
+TEST_P(HETD2, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HETD2, __double_complex)
+TEST_P(HETD2, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYTRD, __float)
+TEST_P(SYTRD, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYTRD, __double)
+TEST_P(SYTRD, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HETRD, __float_complex)
+TEST_P(HETRD, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HETRD, __double_complex)
+TEST_P(HETRD, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(SYTD2, batched__float)
+TEST_P(SYTD2, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYTD2, batched__double)
+TEST_P(SYTD2, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HETD2, batched__float_complex)
+TEST_P(HETD2, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HETD2, batched__double_complex)
+TEST_P(HETD2, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(SYTRD, batched__float)
+TEST_P(SYTRD, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYTRD, batched__double)
+TEST_P(SYTRD, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HETRD, batched__float_complex)
+TEST_P(HETRD, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HETRD, batched__double_complex)
+TEST_P(HETRD, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(SYTD2, strided_batched__float)
+TEST_P(SYTD2, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYTD2, strided_batched__double)
+TEST_P(SYTD2, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HETD2, strided_batched__float_complex)
+TEST_P(HETD2, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HETD2, strided_batched__double_complex)
+TEST_P(HETD2, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(SYTRD, strided_batched__float)
+TEST_P(SYTRD, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYTRD, strided_batched__double)
+TEST_P(SYTRD, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HETRD, strided_batched__float_complex)
+TEST_P(HETRD, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HETRD, strided_batched__double_complex)
+TEST_P(HETRD, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/sytxx_hetxx_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/sytxx_hetxx_gtest.cpp
@@ -121,126 +121,126 @@ class HETRD : public SYTXX_HETXX<true>
 
 // non-batch tests
 
-TEST_P(SYTD2, _float)
+TEST_P(SYTD2, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYTD2, _double)
+TEST_P(SYTD2, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HETD2, _float_complex)
+TEST_P(HETD2, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HETD2, _double_complex)
+TEST_P(HETD2, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(SYTRD, _float)
+TEST_P(SYTRD, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYTRD, _double)
+TEST_P(SYTRD, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HETRD, _float_complex)
+TEST_P(HETRD, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HETRD, _double_complex)
+TEST_P(HETRD, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(SYTD2, batched_float)
+TEST_P(SYTD2, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYTD2, batched_double)
+TEST_P(SYTD2, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HETD2, batched_float_complex)
+TEST_P(HETD2, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HETD2, batched_double_complex)
+TEST_P(HETD2, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
-TEST_P(SYTRD, batched_float)
+TEST_P(SYTRD, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(SYTRD, batched_double)
+TEST_P(SYTRD, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(HETRD, batched_float_complex)
+TEST_P(HETRD, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(HETRD, batched_double_complex)
+TEST_P(HETRD, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(SYTD2, strided_batched_float)
+TEST_P(SYTD2, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYTD2, strided_batched_double)
+TEST_P(SYTD2, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HETD2, strided_batched_float_complex)
+TEST_P(HETD2, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HETD2, strided_batched_double_complex)
+TEST_P(HETD2, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(SYTRD, strided_batched_float)
+TEST_P(SYTRD, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(SYTRD, strided_batched_double)
+TEST_P(SYTRD, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(HETRD, strided_batched_float_complex)
+TEST_P(HETRD, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(HETRD, strided_batched_double_complex)
+TEST_P(HETRD, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/trtri_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/trtri_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -122,66 +122,66 @@ protected:
 
 // non-batch tests
 
-TEST_P(TRTRI, __float)
+TEST_P(TRTRI, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(TRTRI, __double)
+TEST_P(TRTRI, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(TRTRI, __float_complex)
+TEST_P(TRTRI, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(TRTRI, __double_complex)
+TEST_P(TRTRI, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(TRTRI, batched__float)
+TEST_P(TRTRI, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(TRTRI, batched__double)
+TEST_P(TRTRI, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(TRTRI, batched__float_complex)
+TEST_P(TRTRI, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(TRTRI, batched__double_complex)
+TEST_P(TRTRI, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(TRTRI, strided_batched__float)
+TEST_P(TRTRI, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(TRTRI, strided_batched__double)
+TEST_P(TRTRI, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(TRTRI, strided_batched__float_complex)
+TEST_P(TRTRI, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(TRTRI, strided_batched__double_complex)
+TEST_P(TRTRI, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/lapack/trtri_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/trtri_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/lapack/trtri_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/trtri_gtest.cpp
@@ -122,66 +122,66 @@ protected:
 
 // non-batch tests
 
-TEST_P(TRTRI, _float)
+TEST_P(TRTRI, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(TRTRI, _double)
+TEST_P(TRTRI, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(TRTRI, _float_complex)
+TEST_P(TRTRI, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(TRTRI, _double_complex)
+TEST_P(TRTRI, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(TRTRI, batched_float)
+TEST_P(TRTRI, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(TRTRI, batched_double)
+TEST_P(TRTRI, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(TRTRI, batched_float_complex)
+TEST_P(TRTRI, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(TRTRI, batched_double_complex)
+TEST_P(TRTRI, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched tests
 
-TEST_P(TRTRI, strided_batched_float)
+TEST_P(TRTRI, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(TRTRI, strided_batched_double)
+TEST_P(TRTRI, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(TRTRI, strided_batched_float_complex)
+TEST_P(TRTRI, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(TRTRI, strided_batched_double_complex)
+TEST_P(TRTRI, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/managed_malloc_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/managed_malloc_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -96,22 +96,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(MANAGED_MALLOC, __float)
+TEST_P(MANAGED_MALLOC, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(MANAGED_MALLOC, __double)
+TEST_P(MANAGED_MALLOC, _double)
 {
     run_tests<double>();
 }
 
-TEST_P(MANAGED_MALLOC, __float_complex)
+TEST_P(MANAGED_MALLOC, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(MANAGED_MALLOC, __double_complex)
+TEST_P(MANAGED_MALLOC, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/managed_malloc_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/managed_malloc_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/managed_malloc_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/managed_malloc_gtest.cpp
@@ -96,22 +96,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(MANAGED_MALLOC, _float)
+TEST_P(MANAGED_MALLOC, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(MANAGED_MALLOC, _double)
+TEST_P(MANAGED_MALLOC, __double)
 {
     run_tests<double>();
 }
 
-TEST_P(MANAGED_MALLOC, _float_complex)
+TEST_P(MANAGED_MALLOC, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(MANAGED_MALLOC, _double_complex)
+TEST_P(MANAGED_MALLOC, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/refact/csrrf_analysis_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/refact/csrrf_analysis_gtest.cpp
@@ -126,22 +126,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(CSRRF_ANALYSIS, _float)
+TEST_P(CSRRF_ANALYSIS, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(CSRRF_ANALYSIS, _double)
+TEST_P(CSRRF_ANALYSIS, __double)
 {
     run_tests<double>();
 }
 
-/*TEST_P(CSRRF_ANALYSIS, _float_complex)
+/*TEST_P(CSRRF_ANALYSIS, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(CSRRF_ANALYSIS, _double_complex)
+TEST_P(CSRRF_ANALYSIS, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }*/

--- a/projects/rocsolver/clients/gtest/refact/csrrf_analysis_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/refact/csrrf_analysis_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/refact/csrrf_analysis_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/refact/csrrf_analysis_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -126,22 +126,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(CSRRF_ANALYSIS, __float)
+TEST_P(CSRRF_ANALYSIS, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(CSRRF_ANALYSIS, __double)
+TEST_P(CSRRF_ANALYSIS, _double)
 {
     run_tests<double>();
 }
 
-/*TEST_P(CSRRF_ANALYSIS, __float_complex)
+/*TEST_P(CSRRF_ANALYSIS, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(CSRRF_ANALYSIS, __double_complex)
+TEST_P(CSRRF_ANALYSIS, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }*/

--- a/projects/rocsolver/clients/gtest/refact/csrrf_refactchol_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/refact/csrrf_refactchol_gtest.cpp
@@ -117,22 +117,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(CSRRF_REFACTCHOL, _float)
+TEST_P(CSRRF_REFACTCHOL, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(CSRRF_REFACTCHOL, _double)
+TEST_P(CSRRF_REFACTCHOL, __double)
 {
     run_tests<double>();
 }
 
-/*TEST_P(CSRRF_REFACTCHOL, _float_complex)
+/*TEST_P(CSRRF_REFACTCHOL, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(CSRRF_REFACTCHOL, _double_complex)
+TEST_P(CSRRF_REFACTCHOL, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }*/

--- a/projects/rocsolver/clients/gtest/refact/csrrf_refactchol_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/refact/csrrf_refactchol_gtest.cpp
@@ -1,6 +1,6 @@
 
 /* **************************************************************************
- * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/refact/csrrf_refactchol_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/refact/csrrf_refactchol_gtest.cpp
@@ -1,6 +1,6 @@
 
 /* **************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -117,22 +117,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(CSRRF_REFACTCHOL, __float)
+TEST_P(CSRRF_REFACTCHOL, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(CSRRF_REFACTCHOL, __double)
+TEST_P(CSRRF_REFACTCHOL, _double)
 {
     run_tests<double>();
 }
 
-/*TEST_P(CSRRF_REFACTCHOL, __float_complex)
+/*TEST_P(CSRRF_REFACTCHOL, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(CSRRF_REFACTCHOL, __double_complex)
+TEST_P(CSRRF_REFACTCHOL, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }*/

--- a/projects/rocsolver/clients/gtest/refact/csrrf_refactlu_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/refact/csrrf_refactlu_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -116,22 +116,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(CSRRF_REFACTLU, __float)
+TEST_P(CSRRF_REFACTLU, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(CSRRF_REFACTLU, __double)
+TEST_P(CSRRF_REFACTLU, _double)
 {
     run_tests<double>();
 }
 
-/*TEST_P(CSRRF_REFACTLU, __float_complex)
+/*TEST_P(CSRRF_REFACTLU, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(CSRRF_REFACTLU, __double_complex)
+TEST_P(CSRRF_REFACTLU, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }*/

--- a/projects/rocsolver/clients/gtest/refact/csrrf_refactlu_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/refact/csrrf_refactlu_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/refact/csrrf_refactlu_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/refact/csrrf_refactlu_gtest.cpp
@@ -116,22 +116,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(CSRRF_REFACTLU, _float)
+TEST_P(CSRRF_REFACTLU, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(CSRRF_REFACTLU, _double)
+TEST_P(CSRRF_REFACTLU, __double)
 {
     run_tests<double>();
 }
 
-/*TEST_P(CSRRF_REFACTLU, _float_complex)
+/*TEST_P(CSRRF_REFACTLU, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(CSRRF_REFACTLU, _double_complex)
+TEST_P(CSRRF_REFACTLU, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }*/

--- a/projects/rocsolver/clients/gtest/refact/csrrf_solve_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/refact/csrrf_solve_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -136,22 +136,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(CSRRF_SOLVE, __float)
+TEST_P(CSRRF_SOLVE, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(CSRRF_SOLVE, __double)
+TEST_P(CSRRF_SOLVE, _double)
 {
     run_tests<double>();
 }
 
-/*TEST_P(CSRRF_SOLVE, __float_complex)
+/*TEST_P(CSRRF_SOLVE, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(CSRRF_SOLVE, __double_complex)
+TEST_P(CSRRF_SOLVE, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }*/

--- a/projects/rocsolver/clients/gtest/refact/csrrf_solve_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/refact/csrrf_solve_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/refact/csrrf_solve_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/refact/csrrf_solve_gtest.cpp
@@ -136,22 +136,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(CSRRF_SOLVE, _float)
+TEST_P(CSRRF_SOLVE, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(CSRRF_SOLVE, _double)
+TEST_P(CSRRF_SOLVE, __double)
 {
     run_tests<double>();
 }
 
-/*TEST_P(CSRRF_SOLVE, _float_complex)
+/*TEST_P(CSRRF_SOLVE, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(CSRRF_SOLVE, _double_complex)
+TEST_P(CSRRF_SOLVE, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }*/

--- a/projects/rocsolver/clients/gtest/refact/csrrf_splitlu_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/refact/csrrf_splitlu_gtest.cpp
@@ -109,22 +109,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(CSRRF_SPLITLU, _float)
+TEST_P(CSRRF_SPLITLU, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(CSRRF_SPLITLU, _double)
+TEST_P(CSRRF_SPLITLU, __double)
 {
     run_tests<double>();
 }
 
-/*TEST_P(CSRRF_SPLITLU, _float_complex)
+/*TEST_P(CSRRF_SPLITLU, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(CSRRF_SPLITLU, _double_complex)
+TEST_P(CSRRF_SPLITLU, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }*/

--- a/projects/rocsolver/clients/gtest/refact/csrrf_splitlu_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/refact/csrrf_splitlu_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/refact/csrrf_splitlu_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/refact/csrrf_splitlu_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -109,22 +109,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(CSRRF_SPLITLU, __float)
+TEST_P(CSRRF_SPLITLU, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(CSRRF_SPLITLU, __double)
+TEST_P(CSRRF_SPLITLU, _double)
 {
     run_tests<double>();
 }
 
-/*TEST_P(CSRRF_SPLITLU, __float_complex)
+/*TEST_P(CSRRF_SPLITLU, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(CSRRF_SPLITLU, __double_complex)
+TEST_P(CSRRF_SPLITLU, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }*/

--- a/projects/rocsolver/clients/gtest/refact/csrrf_sumlu_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/refact/csrrf_sumlu_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -121,22 +121,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(CSRRF_SUMLU, __float)
+TEST_P(CSRRF_SUMLU, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(CSRRF_SUMLU, __double)
+TEST_P(CSRRF_SUMLU, _double)
 {
     run_tests<double>();
 }
 
-/*TEST_P(CSRRF_SUMLU, __float_complex)
+/*TEST_P(CSRRF_SUMLU, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(CSRRF_SUMLU, __double_complex)
+TEST_P(CSRRF_SUMLU, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }*/

--- a/projects/rocsolver/clients/gtest/refact/csrrf_sumlu_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/refact/csrrf_sumlu_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/refact/csrrf_sumlu_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/refact/csrrf_sumlu_gtest.cpp
@@ -121,22 +121,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(CSRRF_SUMLU, _float)
+TEST_P(CSRRF_SUMLU, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(CSRRF_SUMLU, _double)
+TEST_P(CSRRF_SUMLU, __double)
 {
     run_tests<double>();
 }
 
-/*TEST_P(CSRRF_SUMLU, _float_complex)
+/*TEST_P(CSRRF_SUMLU, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(CSRRF_SUMLU, _double_complex)
+TEST_P(CSRRF_SUMLU, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }*/

--- a/projects/rocsolver/clients/gtest/refact/csrrf_workflow_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/refact/csrrf_workflow_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/refact/csrrf_workflow_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/refact/csrrf_workflow_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -106,22 +106,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(CSRRF_WORKFLOW, __float)
+TEST_P(CSRRF_WORKFLOW, _float)
 {
     run_tests<float>();
 }
 
-TEST_P(CSRRF_WORKFLOW, __double)
+TEST_P(CSRRF_WORKFLOW, _double)
 {
     run_tests<double>();
 }
 
-/*TEST_P(CSRRF_WORKFLOW, __float_complex)
+/*TEST_P(CSRRF_WORKFLOW, _float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(CSRRF_WORKFLOW, __double_complex)
+TEST_P(CSRRF_WORKFLOW, _double_complex)
 {
     run_tests<rocblas_double_complex>();
 }*/

--- a/projects/rocsolver/clients/gtest/refact/csrrf_workflow_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/refact/csrrf_workflow_gtest.cpp
@@ -106,22 +106,22 @@ protected:
 
 // non-batch tests
 
-TEST_P(CSRRF_WORKFLOW, _float)
+TEST_P(CSRRF_WORKFLOW, __float)
 {
     run_tests<float>();
 }
 
-TEST_P(CSRRF_WORKFLOW, _double)
+TEST_P(CSRRF_WORKFLOW, __double)
 {
     run_tests<double>();
 }
 
-/*TEST_P(CSRRF_WORKFLOW, _float_complex)
+/*TEST_P(CSRRF_WORKFLOW, __float_complex)
 {
     run_tests<rocblas_float_complex>();
 }
 
-TEST_P(CSRRF_WORKFLOW, _double_complex)
+TEST_P(CSRRF_WORKFLOW, __double_complex)
 {
     run_tests<rocblas_double_complex>();
 }*/

--- a/projects/rocsolver/clients/gtest/unit/gemm_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/unit/gemm_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -152,66 +152,66 @@ class GEMM_64 : public GEMM_BASE<int64_t>
 */
 // non-batch tests
 
-TEST_P(GEMM, __float)
+TEST_P(GEMM, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEMM, __double)
+TEST_P(GEMM, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEMM, __float_complex)
+TEST_P(GEMM, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEMM, __double_complex)
+TEST_P(GEMM, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GEMM, batched__float)
+TEST_P(GEMM, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GEMM, batched__double)
+TEST_P(GEMM, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GEMM, batched__float_complex)
+TEST_P(GEMM, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GEMM, batched__double_complex)
+TEST_P(GEMM, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(GEMM, strided_batched__float)
+TEST_P(GEMM, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GEMM, strided_batched__double)
+TEST_P(GEMM, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GEMM, strided_batched__float_complex)
+TEST_P(GEMM, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GEMM, strided_batched__double_complex)
+TEST_P(GEMM, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
@@ -220,66 +220,66 @@ TEST_P(GEMM, strided_batched__double_complex)
 
 // non-batch tests
 
-TEST_P(GEMM_64, __float)
+TEST_P(GEMM_64, _float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEMM_64, __double)
+TEST_P(GEMM_64, _double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEMM_64, __float_complex)
+TEST_P(GEMM_64, _float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEMM_64, __double_complex)
+TEST_P(GEMM_64, _double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GEMM_64, batched__float)
+TEST_P(GEMM_64, batched_float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GEMM_64, batched__double)
+TEST_P(GEMM_64, batched_double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GEMM_64, batched__float_complex)
+TEST_P(GEMM_64, batched_float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GEMM_64, batched__double_complex)
+TEST_P(GEMM_64, batched_double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(GEMM_64, strided_batched__float)
+TEST_P(GEMM_64, strided_batched_float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GEMM_64, strided_batched__double)
+TEST_P(GEMM_64, strided_batched_double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GEMM_64, strided_batched__float_complex)
+TEST_P(GEMM_64, strided_batched_float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GEMM_64, strided_batched__double_complex)
+TEST_P(GEMM_64, strided_batched_double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }

--- a/projects/rocsolver/clients/gtest/unit/gemm_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/unit/gemm_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/clients/gtest/unit/gemm_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/unit/gemm_gtest.cpp
@@ -152,66 +152,66 @@ class GEMM_64 : public GEMM_BASE<int64_t>
 */
 // non-batch tests
 
-TEST_P(GEMM, _float)
+TEST_P(GEMM, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEMM, _double)
+TEST_P(GEMM, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEMM, _float_complex)
+TEST_P(GEMM, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEMM, _double_complex)
+TEST_P(GEMM, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GEMM, batched_float)
+TEST_P(GEMM, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GEMM, batched_double)
+TEST_P(GEMM, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GEMM, batched_float_complex)
+TEST_P(GEMM, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GEMM, batched_double_complex)
+TEST_P(GEMM, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(GEMM, strided_batched_float)
+TEST_P(GEMM, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GEMM, strided_batched_double)
+TEST_P(GEMM, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GEMM, strided_batched_float_complex)
+TEST_P(GEMM, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GEMM, strided_batched_double_complex)
+TEST_P(GEMM, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }
@@ -220,66 +220,66 @@ TEST_P(GEMM, strided_batched_double_complex)
 
 // non-batch tests
 
-TEST_P(GEMM_64, _float)
+TEST_P(GEMM_64, __float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(GEMM_64, _double)
+TEST_P(GEMM_64, __double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(GEMM_64, _float_complex)
+TEST_P(GEMM_64, __float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(GEMM_64, _double_complex)
+TEST_P(GEMM_64, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }
 
 // batched tests
 
-TEST_P(GEMM_64, batched_float)
+TEST_P(GEMM_64, batched__float)
 {
     run_tests<true, true, float>();
 }
 
-TEST_P(GEMM_64, batched_double)
+TEST_P(GEMM_64, batched__double)
 {
     run_tests<true, true, double>();
 }
 
-TEST_P(GEMM_64, batched_float_complex)
+TEST_P(GEMM_64, batched__float_complex)
 {
     run_tests<true, true, rocblas_float_complex>();
 }
 
-TEST_P(GEMM_64, batched_double_complex)
+TEST_P(GEMM_64, batched__double_complex)
 {
     run_tests<true, true, rocblas_double_complex>();
 }
 
 // strided_batched cases
 
-TEST_P(GEMM_64, strided_batched_float)
+TEST_P(GEMM_64, strided_batched__float)
 {
     run_tests<false, true, float>();
 }
 
-TEST_P(GEMM_64, strided_batched_double)
+TEST_P(GEMM_64, strided_batched__double)
 {
     run_tests<false, true, double>();
 }
 
-TEST_P(GEMM_64, strided_batched_float_complex)
+TEST_P(GEMM_64, strided_batched__float_complex)
 {
     run_tests<false, true, rocblas_float_complex>();
 }
 
-TEST_P(GEMM_64, strided_batched_double_complex)
+TEST_P(GEMM_64, strided_batched__double_complex)
 {
     run_tests<false, true, rocblas_double_complex>();
 }


### PR DESCRIPTION
## Motivation

Identifiers with double underscores are [reserved in C++](https://en.cppreference.com/w/c/language/identifier.html).
GTest mentions this in their [FAQ](https://google.github.io/googletest/faq.html).

## Technical Details

Technically GTest recommends no underscores whatsoever.

## Test Plan

Run all tests.

## Test Result

All tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
