### PR TITLE
[hipblaslt] Fix grouped GEMM TFLOPS calculation in BenchmarkTimer

### DIFF
--- a/projects/hipblaslt/tensilelite/client/src/BenchmarkTimer.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/BenchmarkTimer.cpp
@@ -178,7 +178,9 @@ namespace TensileLite
                 if(auto problem = dynamic_cast<ContractionProblemGroupedGemm*>(m_problem))
                 {
                     pp        = m_solution->projectedPerformance(problem->gemms[0], m_hardware);
-                    flopCount = problem->gemms[0].flopCount();
+                    flopCount = 0.0;
+                    for(auto& gemm : problem->gemms)
+                        flopCount += gemm.flopCount();
                 }
                 else if(auto problem = dynamic_cast<ContractionProblemGemm*>(m_problem))
                 {

--- a/projects/hipblaslt/tensilelite/client/src/ProgressListener.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/ProgressListener.cpp
@@ -100,6 +100,10 @@ namespace TensileLite
             if(auto groupedProblem = dynamic_cast<const ContractionProblemGroupedGemm*>(problem))
             {
                 writeReport(groupedProblem->gemms[0]);
+                double totalFlops = 0.0;
+                for(auto& it : groupedProblem->gemms)
+                    totalFlops += it.flopCount();
+                m_reporter->report(ResultKey::TotalFlops, totalFlops);
                 std::vector<std::vector<size_t>> sizes;
                 for(auto& it : groupedProblem->gemms)
                     sizes.push_back(it.problemSizes());


### PR DESCRIPTION
Internal Jira ticket
https://amd-hub.atlassian.net/browse/AIHPBLAS-1455

The postSolution() method only counted FLOPs from the first sub-gemm (problem->gemms[0].flopCount()) when calculating TFLOPS for grouped GEMM operations. This caused reported TFLOPS to be underreported by a factor of N for N-group grouped GEMMs.

Fix: sum flopCount() across all sub-gemms in the group.

## Submission Checklist

- [ -] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
