### PR TITLE
[hipDNN] Add INT64 data type support

### DIFF
--- a/projects/hipdnn/backend/include/HipdnnDataType.h
+++ b/projects/hipdnn/backend/include/HipdnnDataType.h
@@ -27,4 +27,5 @@ typedef enum
     HIPDNN_DATA_INT4 = 11, ///< 4-bit signed integer
     HIPDNN_DATA_FP6_E2M3 = 12, ///< 6-bit floating point (E2M3)
     HIPDNN_DATA_FP6_E3M2 = 13, ///< 6-bit floating point (E3M2)
+    HIPDNN_DATA_INT64 = 14, ///< 64-bit signed integer
 } hipdnnDataType_t;

--- a/projects/hipdnn/backend/src/BackendEnumStringUtils.hpp
+++ b/projects/hipdnn/backend/src/BackendEnumStringUtils.hpp
@@ -89,6 +89,8 @@ inline const char* hipdnnGetDataTypeString(hipdnnDataType_t type)
         return "HIPDNN_DATA_FP6_E2M3";
     case HIPDNN_DATA_FP6_E3M2:
         return "HIPDNN_DATA_FP6_E3M2";
+    case HIPDNN_DATA_INT64:
+        return "HIPDNN_DATA_INT64";
     default:
         return "HIPDNN_DATA_UNKNOWN";
     }

--- a/projects/hipdnn/backend/src/descriptors/DataTypeConversion.cpp
+++ b/projects/hipdnn/backend/src/descriptors/DataTypeConversion.cpp
@@ -40,6 +40,8 @@ hipdnn_data_sdk::data_objects::DataType toSdkDataType(hipdnnDataType_t type)
         return DataType::FP6_E2M3;
     case HIPDNN_DATA_FP6_E3M2:
         return DataType::FP6_E3M2;
+    case HIPDNN_DATA_INT64:
+        return DataType::INT64;
     default:
         throw HipdnnException(HIPDNN_STATUS_BAD_PARAM, "Unsupported hipdnnDataType_t value");
     }
@@ -79,6 +81,8 @@ hipdnnDataType_t fromSdkDataType(hipdnn_data_sdk::data_objects::DataType type)
         return HIPDNN_DATA_FP6_E2M3;
     case DataType::FP6_E3M2:
         return HIPDNN_DATA_FP6_E3M2;
+    case DataType::INT64:
+        return HIPDNN_DATA_INT64;
     default:
         throw HipdnnException(HIPDNN_STATUS_BAD_PARAM, "Unsupported SDK DataType");
     }
@@ -103,6 +107,8 @@ int64_t getDataTypeByteSize(hipdnn_data_sdk::data_objects::DataType type)
     case DataType::FP8_E4M3:
     case DataType::FP8_E5M2:
         return 1;
+    case DataType::INT64:
+        return 8;
     default:
         throw HipdnnException(HIPDNN_STATUS_BAD_PARAM, "Unsupported DataType for byte size");
     }

--- a/projects/hipdnn/backend/src/descriptors/TensorDescriptor.cpp
+++ b/projects/hipdnn/backend/src/descriptors/TensorDescriptor.cpp
@@ -262,6 +262,13 @@ void TensorDescriptor::setTensorValue(hipdnnBackendAttributeType_t attributeType
         _data.value.Set(Int32Value(val));
         break;
     }
+    case DataType::INT64:
+    {
+        int64_t val;
+        std::memcpy(&val, bytes, sizeof(int64_t));
+        _data.value.Set(Int64Value(val));
+        break;
+    }
     case DataType::UINT8:
     case DataType::INT8:
     case DataType::FP8_E4M3:
@@ -366,6 +373,16 @@ void TensorDescriptor::getTensorValue(hipdnnBackendAttributeType_t attributeType
         std::memcpy(output, &nativeVal, sizeof(int32_t));
         break;
     }
+    case DataType::INT64:
+    {
+        const auto* val = _data.value.AsInt64Value();
+        THROW_IF_TRUE(val == nullptr,
+                      HIPDNN_STATUS_BAD_PARAM,
+                      "TensorDescriptor::getAttribute(): value type mismatch");
+        auto nativeVal = val->value();
+        std::memcpy(output, &nativeVal, sizeof(int64_t));
+        break;
+    }
     case DataType::UINT8:
     case DataType::INT8:
     {
@@ -458,6 +475,9 @@ std::string TensorDescriptor::toString() const
             break;
         case TensorValue::Int32Value:
             str += std::to_string(_data.value.AsInt32Value()->value());
+            break;
+        case TensorValue::Int64Value:
+            str += std::to_string(_data.value.AsInt64Value()->value());
             break;
         case TensorValue::Float8Value:
             str += std::to_string(_data.value.AsFloat8Value()->value());

--- a/projects/hipdnn/backend/tests/TestBackendEnumStringUtils.cpp
+++ b/projects/hipdnn/backend/tests/TestBackendEnumStringUtils.cpp
@@ -817,6 +817,7 @@ TEST(TestBackendEnumStringUtils, GetDataTypeString)
     EXPECT_STREQ(hipdnnGetDataTypeString(HIPDNN_DATA_INT4), "HIPDNN_DATA_INT4");
     EXPECT_STREQ(hipdnnGetDataTypeString(HIPDNN_DATA_FP6_E2M3), "HIPDNN_DATA_FP6_E2M3");
     EXPECT_STREQ(hipdnnGetDataTypeString(HIPDNN_DATA_FP6_E3M2), "HIPDNN_DATA_FP6_E3M2");
+    EXPECT_STREQ(hipdnnGetDataTypeString(HIPDNN_DATA_INT64), "HIPDNN_DATA_INT64");
 
     EXPECT_STREQ(hipdnnGetDataTypeString(static_cast<hipdnnDataType_t>(-1)), "HIPDNN_DATA_UNKNOWN");
 }

--- a/projects/hipdnn/backend/tests/descriptors/TestDataTypeConversion.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestDataTypeConversion.cpp
@@ -62,7 +62,8 @@ INSTANTIATE_TEST_SUITE_P(
         DataTypeConversionParam{HIPDNN_DATA_UINT8, DataType::UINT8, 1, "Uint8"},
         DataTypeConversionParam{HIPDNN_DATA_BFLOAT16, DataType::BFLOAT16, 2, "Bfloat16"},
         DataTypeConversionParam{HIPDNN_DATA_FP8_E4M3, DataType::FP8_E4M3, 1, "Fp8E4M3"},
-        DataTypeConversionParam{HIPDNN_DATA_FP8_E5M2, DataType::FP8_E5M2, 1, "Fp8E5M2"}),
+        DataTypeConversionParam{HIPDNN_DATA_FP8_E5M2, DataType::FP8_E5M2, 1, "Fp8E5M2"},
+        DataTypeConversionParam{HIPDNN_DATA_INT64, DataType::INT64, 8, "Int64"}),
     [](const ::testing::TestParamInfo<DataTypeConversionParam>& info) { return info.param.name; });
 
 // =============================================================================

--- a/projects/hipdnn/backend/tests/descriptors/TestTensorDescriptor.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestTensorDescriptor.cpp
@@ -853,6 +853,21 @@ TEST_F(TestTensorDescriptor, SetAttributeValueInt32)
     ASSERT_EQ(stored->value(), 42);
 }
 
+TEST_F(TestTensorDescriptor, SetAttributeValueInt64)
+{
+    auto desc = getDescriptor();
+    auto dataType = HIPDNN_DATA_INT64;
+    desc->setAttribute(HIPDNN_ATTR_TENSOR_DATA_TYPE, HIPDNN_TYPE_DATA_TYPE, 1, &dataType);
+    int64_t val = 123456789012345LL;
+
+    ASSERT_NO_THROW(
+        desc->setAttribute(HIPDNN_ATTR_TENSOR_VALUE_EXT, HIPDNN_TYPE_CHAR, sizeof(int64_t), &val));
+
+    auto* stored = desc->getData().value.AsInt64Value();
+    ASSERT_NE(stored, nullptr);
+    ASSERT_EQ(stored->value(), 123456789012345LL);
+}
+
 TEST_F(TestTensorDescriptor, SetAttributeValueFloat16)
 {
     auto desc = getDescriptor();
@@ -1016,6 +1031,32 @@ TEST_F(TestTensorDescriptor, GetAttributeValueInt32)
 
     ASSERT_EQ(retrieved, 42);
     ASSERT_EQ(elementCount, static_cast<int64_t>(sizeof(int32_t)));
+}
+
+TEST_F(TestTensorDescriptor, GetAttributeValueInt64)
+{
+    auto desc = getDescriptor();
+    auto dataType = HIPDNN_DATA_INT64;
+    desc->setAttribute(HIPDNN_ATTR_TENSOR_DATA_TYPE, HIPDNN_TYPE_DATA_TYPE, 1, &dataType);
+    int64_t setVal = 123456789012345LL;
+    desc->setAttribute(HIPDNN_ATTR_TENSOR_VALUE_EXT, HIPDNN_TYPE_CHAR, sizeof(int64_t), &setVal);
+
+    std::vector<int64_t> dims = {1, 3, 32, 32};
+    std::vector<int64_t> strides = {3072, 1024, 32, 1};
+    desc->setAttribute(HIPDNN_ATTR_TENSOR_DIMENSIONS, HIPDNN_TYPE_INT64, 4, dims.data());
+    desc->setAttribute(HIPDNN_ATTR_TENSOR_STRIDES, HIPDNN_TYPE_INT64, 4, strides.data());
+    desc->finalize();
+
+    int64_t retrieved = 0;
+    int64_t elementCount = 0;
+    ASSERT_NO_THROW(desc->getAttribute(HIPDNN_ATTR_TENSOR_VALUE_EXT,
+                                       HIPDNN_TYPE_CHAR,
+                                       sizeof(int64_t),
+                                       &elementCount,
+                                       &retrieved));
+
+    ASSERT_EQ(retrieved, 123456789012345LL);
+    ASSERT_EQ(elementCount, static_cast<int64_t>(sizeof(int64_t)));
 }
 
 TEST_F(TestTensorDescriptor, GetAttributeValueFloat16)
@@ -1191,7 +1232,8 @@ INSTANTIATE_TEST_SUITE_P(
                       DataTypeRoundTripParam{HIPDNN_DATA_UINT8, DataType::UINT8, "Uint8"},
                       DataTypeRoundTripParam{HIPDNN_DATA_BFLOAT16, DataType::BFLOAT16, "BFloat16"},
                       DataTypeRoundTripParam{HIPDNN_DATA_FP8_E4M3, DataType::FP8_E4M3, "Fp8E4M3"},
-                      DataTypeRoundTripParam{HIPDNN_DATA_FP8_E5M2, DataType::FP8_E5M2, "Fp8E5M2"}),
+                      DataTypeRoundTripParam{HIPDNN_DATA_FP8_E5M2, DataType::FP8_E5M2, "Fp8E5M2"},
+                      DataTypeRoundTripParam{HIPDNN_DATA_INT64, DataType::INT64, "Int64"}),
     [](const ::testing::TestParamInfo<DataTypeRoundTripParam>& info) { return info.param.name; });
 
 // =============================================================================
@@ -1321,4 +1363,36 @@ TEST_F(TestTensorDescriptor, SetGetValueFp8E5M2)
                                        &retrieved));
     ASSERT_EQ(retrieved.data, setVal.data);
     ASSERT_EQ(elementCount, static_cast<int64_t>(sizeof(retrieved)));
+}
+
+TEST_F(TestTensorDescriptor, SetGetValueInt64)
+{
+    auto desc = getDescriptor();
+    auto dataType = HIPDNN_DATA_INT64;
+    desc->setAttribute(HIPDNN_ATTR_TENSOR_DATA_TYPE, HIPDNN_TYPE_DATA_TYPE, 1, &dataType);
+
+    int64_t setVal = 9876543210LL;
+    ASSERT_NO_THROW(desc->setAttribute(
+        HIPDNN_ATTR_TENSOR_VALUE_EXT, HIPDNN_TYPE_CHAR, sizeof(int64_t), &setVal));
+
+    auto* stored = desc->getData().value.AsInt64Value();
+    ASSERT_NE(stored, nullptr);
+    ASSERT_EQ(stored->value(), 9876543210LL);
+
+    // Round-trip through getAttribute
+    std::vector<int64_t> dims = {1, 3, 32, 32};
+    std::vector<int64_t> strides = {3072, 1024, 32, 1};
+    desc->setAttribute(HIPDNN_ATTR_TENSOR_DIMENSIONS, HIPDNN_TYPE_INT64, 4, dims.data());
+    desc->setAttribute(HIPDNN_ATTR_TENSOR_STRIDES, HIPDNN_TYPE_INT64, 4, strides.data());
+    desc->finalize();
+
+    int64_t retrieved = 0;
+    int64_t elementCount = 0;
+    ASSERT_NO_THROW(desc->getAttribute(HIPDNN_ATTR_TENSOR_VALUE_EXT,
+                                       HIPDNN_TYPE_CHAR,
+                                       sizeof(int64_t),
+                                       &elementCount,
+                                       &retrieved));
+    ASSERT_EQ(retrieved, 9876543210LL);
+    ASSERT_EQ(elementCount, static_cast<int64_t>(sizeof(int64_t)));
 }

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/v24_12_23/hipdnn_data_sdk/data_objects/data_types_generated.h
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/v24_12_23/hipdnn_data_sdk/data_objects/data_types_generated.h
@@ -33,11 +33,12 @@ enum class DataType : int8_t {
   FP6_E2M3 = 12,
   FP6_E3M2 = 13,
   INT4 = 14,
+  INT64 = 15,
   MIN = UNSET,
-  MAX = INT4
+  MAX = INT64
 };
 
-inline const DataType (&EnumValuesDataType())[15] {
+inline const DataType (&EnumValuesDataType())[16] {
   static const DataType values[] = {
     DataType::UNSET,
     DataType::FLOAT,
@@ -53,13 +54,14 @@ inline const DataType (&EnumValuesDataType())[15] {
     DataType::FP4_E2M1,
     DataType::FP6_E2M3,
     DataType::FP6_E3M2,
-    DataType::INT4
+    DataType::INT4,
+    DataType::INT64
   };
   return values;
 }
 
 inline const char * const *EnumNamesDataType() {
-  static const char * const names[16] = {
+  static const char * const names[17] = {
     "UNSET",
     "FLOAT",
     "HALF",
@@ -75,13 +77,14 @@ inline const char * const *EnumNamesDataType() {
     "FP6_E2M3",
     "FP6_E3M2",
     "INT4",
+    "INT64",
     nullptr
   };
   return names;
 }
 
 inline const char *EnumNameDataType(DataType e) {
-  if (::flatbuffers::IsOutRange(e, DataType::UNSET, DataType::INT4)) return "";
+  if (::flatbuffers::IsOutRange(e, DataType::UNSET, DataType::INT64)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesDataType()[index];
 }

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/v24_12_23/hipdnn_data_sdk/data_objects/tensor_attributes_generated.h
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/v24_12_23/hipdnn_data_sdk/data_objects/tensor_attributes_generated.h
@@ -235,14 +235,6 @@ struct TensorValueUnion {
     return type == TensorValue::Int32Value ?
       reinterpret_cast<const hipdnn_data_sdk::data_objects::Int32Value *>(value) : nullptr;
   }
-  hipdnn_data_sdk::data_objects::Int64Value *AsInt64Value() {
-    return type == TensorValue::Int64Value ?
-      reinterpret_cast<hipdnn_data_sdk::data_objects::Int64Value *>(value) : nullptr;
-  }
-  const hipdnn_data_sdk::data_objects::Int64Value *AsInt64Value() const {
-    return type == TensorValue::Int64Value ?
-      reinterpret_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(value) : nullptr;
-  }
   hipdnn_data_sdk::data_objects::Float64Value *AsFloat64Value() {
     return type == TensorValue::Float64Value ?
       reinterpret_cast<hipdnn_data_sdk::data_objects::Float64Value *>(value) : nullptr;
@@ -250,6 +242,14 @@ struct TensorValueUnion {
   const hipdnn_data_sdk::data_objects::Float64Value *AsFloat64Value() const {
     return type == TensorValue::Float64Value ?
       reinterpret_cast<const hipdnn_data_sdk::data_objects::Float64Value *>(value) : nullptr;
+  }
+  hipdnn_data_sdk::data_objects::Int64Value *AsInt64Value() {
+    return type == TensorValue::Int64Value ?
+      reinterpret_cast<hipdnn_data_sdk::data_objects::Int64Value *>(value) : nullptr;
+  }
+  const hipdnn_data_sdk::data_objects::Int64Value *AsInt64Value() const {
+    return type == TensorValue::Int64Value ?
+      reinterpret_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(value) : nullptr;
   }
 };
 
@@ -280,13 +280,13 @@ inline bool operator==(const TensorValueUnion &lhs, const TensorValueUnion &rhs)
       return *(reinterpret_cast<const hipdnn_data_sdk::data_objects::Int32Value *>(lhs.value)) ==
              *(reinterpret_cast<const hipdnn_data_sdk::data_objects::Int32Value *>(rhs.value));
     }
-    case TensorValue::Int64Value: {
-      return *(reinterpret_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(lhs.value)) ==
-             *(reinterpret_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(rhs.value));
-    }
     case TensorValue::Float64Value: {
       return *(reinterpret_cast<const hipdnn_data_sdk::data_objects::Float64Value *>(lhs.value)) ==
              *(reinterpret_cast<const hipdnn_data_sdk::data_objects::Float64Value *>(rhs.value));
+    }
+    case TensorValue::Int64Value: {
+      return *(reinterpret_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(lhs.value)) ==
+             *(reinterpret_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(rhs.value));
     }
     default: {
       return false;
@@ -823,11 +823,11 @@ inline bool VerifyTensorValue(::flatbuffers::Verifier &verifier, const void *obj
     case TensorValue::Int32Value: {
       return verifier.VerifyField<hipdnn_data_sdk::data_objects::Int32Value>(static_cast<const uint8_t *>(obj), 0, 4);
     }
-    case TensorValue::Int64Value: {
-      return verifier.VerifyField<hipdnn_data_sdk::data_objects::Int64Value>(static_cast<const uint8_t *>(obj), 0, 8);
-    }
     case TensorValue::Float64Value: {
       return verifier.VerifyField<hipdnn_data_sdk::data_objects::Float64Value>(static_cast<const uint8_t *>(obj), 0, 8);
+    }
+    case TensorValue::Int64Value: {
+      return verifier.VerifyField<hipdnn_data_sdk::data_objects::Int64Value>(static_cast<const uint8_t *>(obj), 0, 8);
     }
     default: return true;
   }
@@ -868,13 +868,13 @@ inline void *TensorValueUnion::UnPack(const void *obj, TensorValue type, const :
       auto ptr = reinterpret_cast<const hipdnn_data_sdk::data_objects::Int32Value *>(obj);
       return new hipdnn_data_sdk::data_objects::Int32Value(*ptr);
     }
-    case TensorValue::Int64Value: {
-      auto ptr = reinterpret_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(obj);
-      return new hipdnn_data_sdk::data_objects::Int64Value(*ptr);
-    }
     case TensorValue::Float64Value: {
       auto ptr = reinterpret_cast<const hipdnn_data_sdk::data_objects::Float64Value *>(obj);
       return new hipdnn_data_sdk::data_objects::Float64Value(*ptr);
+    }
+    case TensorValue::Int64Value: {
+      auto ptr = reinterpret_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(obj);
+      return new hipdnn_data_sdk::data_objects::Int64Value(*ptr);
     }
     default: return nullptr;
   }
@@ -903,12 +903,12 @@ inline ::flatbuffers::Offset<void> TensorValueUnion::Pack(::flatbuffers::FlatBuf
       auto ptr = reinterpret_cast<const hipdnn_data_sdk::data_objects::Int32Value *>(value);
       return _fbb.CreateStruct(*ptr).Union();
     }
-    case TensorValue::Int64Value: {
-      auto ptr = reinterpret_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(value);
-      return _fbb.CreateStruct(*ptr).Union();
-    }
     case TensorValue::Float64Value: {
       auto ptr = reinterpret_cast<const hipdnn_data_sdk::data_objects::Float64Value *>(value);
+      return _fbb.CreateStruct(*ptr).Union();
+    }
+    case TensorValue::Int64Value: {
+      auto ptr = reinterpret_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(value);
       return _fbb.CreateStruct(*ptr).Union();
     }
     default: return 0;
@@ -937,12 +937,12 @@ inline TensorValueUnion::TensorValueUnion(const TensorValueUnion &u) : type(u.ty
       value = new hipdnn_data_sdk::data_objects::Int32Value(*reinterpret_cast<hipdnn_data_sdk::data_objects::Int32Value *>(u.value));
       break;
     }
-    case TensorValue::Int64Value: {
-      value = new hipdnn_data_sdk::data_objects::Int64Value(*reinterpret_cast<hipdnn_data_sdk::data_objects::Int64Value *>(u.value));
-      break;
-    }
     case TensorValue::Float64Value: {
       value = new hipdnn_data_sdk::data_objects::Float64Value(*reinterpret_cast<hipdnn_data_sdk::data_objects::Float64Value *>(u.value));
+      break;
+    }
+    case TensorValue::Int64Value: {
+      value = new hipdnn_data_sdk::data_objects::Int64Value(*reinterpret_cast<hipdnn_data_sdk::data_objects::Int64Value *>(u.value));
       break;
     }
     default:
@@ -977,13 +977,13 @@ inline void TensorValueUnion::Reset() {
       delete ptr;
       break;
     }
-    case TensorValue::Int64Value: {
-      auto ptr = reinterpret_cast<hipdnn_data_sdk::data_objects::Int64Value *>(value);
+    case TensorValue::Float64Value: {
+      auto ptr = reinterpret_cast<hipdnn_data_sdk::data_objects::Float64Value *>(value);
       delete ptr;
       break;
     }
-    case TensorValue::Float64Value: {
-      auto ptr = reinterpret_cast<hipdnn_data_sdk::data_objects::Float64Value *>(value);
+    case TensorValue::Int64Value: {
+      auto ptr = reinterpret_cast<hipdnn_data_sdk::data_objects::Int64Value *>(value);
       delete ptr;
       break;
     }

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/v24_12_23/hipdnn_data_sdk/data_objects/tensor_attributes_generated.h
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/v24_12_23/hipdnn_data_sdk/data_objects/tensor_attributes_generated.h
@@ -28,6 +28,8 @@ struct Float8Value;
 
 struct Int32Value;
 
+struct Int64Value;
+
 struct Float64Value;
 
 struct TensorAttributes;
@@ -44,6 +46,8 @@ bool operator==(const Float8Value &lhs, const Float8Value &rhs);
 bool operator!=(const Float8Value &lhs, const Float8Value &rhs);
 bool operator==(const Int32Value &lhs, const Int32Value &rhs);
 bool operator!=(const Int32Value &lhs, const Int32Value &rhs);
+bool operator==(const Int64Value &lhs, const Int64Value &rhs);
+bool operator!=(const Int64Value &lhs, const Int64Value &rhs);
 bool operator==(const Float64Value &lhs, const Float64Value &rhs);
 bool operator!=(const Float64Value &lhs, const Float64Value &rhs);
 bool operator==(const TensorAttributesT &lhs, const TensorAttributesT &rhs);
@@ -56,12 +60,13 @@ enum class TensorValue : uint8_t {
   BFloat16Value = 3,
   Float8Value = 4,
   Int32Value = 5,
-  Float64Value = 6,
+  Int64Value = 6,
+  Float64Value = 7,
   MIN = NONE,
   MAX = Float64Value
 };
 
-inline const TensorValue (&EnumValuesTensorValue())[7] {
+inline const TensorValue (&EnumValuesTensorValue())[8] {
   static const TensorValue values[] = {
     TensorValue::NONE,
     TensorValue::Float32Value,
@@ -69,19 +74,21 @@ inline const TensorValue (&EnumValuesTensorValue())[7] {
     TensorValue::BFloat16Value,
     TensorValue::Float8Value,
     TensorValue::Int32Value,
+    TensorValue::Int64Value,
     TensorValue::Float64Value
   };
   return values;
 }
 
 inline const char * const *EnumNamesTensorValue() {
-  static const char * const names[8] = {
+  static const char * const names[9] = {
     "NONE",
     "Float32Value",
     "Float16Value",
     "BFloat16Value",
     "Float8Value",
     "Int32Value",
+    "Int64Value",
     "Float64Value",
     nullptr
   };
@@ -118,6 +125,10 @@ template<> struct TensorValueTraits<hipdnn_data_sdk::data_objects::Int32Value> {
   static const TensorValue enum_value = TensorValue::Int32Value;
 };
 
+template<> struct TensorValueTraits<hipdnn_data_sdk::data_objects::Int64Value> {
+  static const TensorValue enum_value = TensorValue::Int64Value;
+};
+
 template<> struct TensorValueTraits<hipdnn_data_sdk::data_objects::Float64Value> {
   static const TensorValue enum_value = TensorValue::Float64Value;
 };
@@ -144,6 +155,10 @@ template<> struct TensorValueUnionTraits<hipdnn_data_sdk::data_objects::Float8Va
 
 template<> struct TensorValueUnionTraits<hipdnn_data_sdk::data_objects::Int32Value> {
   static const TensorValue enum_value = TensorValue::Int32Value;
+};
+
+template<> struct TensorValueUnionTraits<hipdnn_data_sdk::data_objects::Int64Value> {
+  static const TensorValue enum_value = TensorValue::Int64Value;
 };
 
 template<> struct TensorValueUnionTraits<hipdnn_data_sdk::data_objects::Float64Value> {
@@ -220,6 +235,14 @@ struct TensorValueUnion {
     return type == TensorValue::Int32Value ?
       reinterpret_cast<const hipdnn_data_sdk::data_objects::Int32Value *>(value) : nullptr;
   }
+  hipdnn_data_sdk::data_objects::Int64Value *AsInt64Value() {
+    return type == TensorValue::Int64Value ?
+      reinterpret_cast<hipdnn_data_sdk::data_objects::Int64Value *>(value) : nullptr;
+  }
+  const hipdnn_data_sdk::data_objects::Int64Value *AsInt64Value() const {
+    return type == TensorValue::Int64Value ?
+      reinterpret_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(value) : nullptr;
+  }
   hipdnn_data_sdk::data_objects::Float64Value *AsFloat64Value() {
     return type == TensorValue::Float64Value ?
       reinterpret_cast<hipdnn_data_sdk::data_objects::Float64Value *>(value) : nullptr;
@@ -256,6 +279,10 @@ inline bool operator==(const TensorValueUnion &lhs, const TensorValueUnion &rhs)
     case TensorValue::Int32Value: {
       return *(reinterpret_cast<const hipdnn_data_sdk::data_objects::Int32Value *>(lhs.value)) ==
              *(reinterpret_cast<const hipdnn_data_sdk::data_objects::Int32Value *>(rhs.value));
+    }
+    case TensorValue::Int64Value: {
+      return *(reinterpret_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(lhs.value)) ==
+             *(reinterpret_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(rhs.value));
     }
     case TensorValue::Float64Value: {
       return *(reinterpret_cast<const hipdnn_data_sdk::data_objects::Float64Value *>(lhs.value)) ==
@@ -424,6 +451,36 @@ inline bool operator!=(const Int32Value &lhs, const Int32Value &rhs) {
 }
 
 
+FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(8) Int64Value FLATBUFFERS_FINAL_CLASS {
+ private:
+  int64_t value_;
+
+ public:
+  Int64Value()
+      : value_(0) {
+  }
+  Int64Value(int64_t _value)
+      : value_(::flatbuffers::EndianScalar(_value)) {
+  }
+  int64_t value() const {
+    return ::flatbuffers::EndianScalar(value_);
+  }
+  void mutate_value(int64_t _value) {
+    ::flatbuffers::WriteScalar(&value_, _value);
+  }
+};
+FLATBUFFERS_STRUCT_END(Int64Value, 8);
+
+inline bool operator==(const Int64Value &lhs, const Int64Value &rhs) {
+  return
+      (lhs.value() == rhs.value());
+}
+
+inline bool operator!=(const Int64Value &lhs, const Int64Value &rhs) {
+    return !(lhs == rhs);
+}
+
+
 FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(8) Float64Value FLATBUFFERS_FINAL_CLASS {
  private:
   double value_;
@@ -536,6 +593,9 @@ struct TensorAttributes FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const hipdnn_data_sdk::data_objects::Int32Value *value_as_Int32Value() const {
     return value_type() == hipdnn_data_sdk::data_objects::TensorValue::Int32Value ? static_cast<const hipdnn_data_sdk::data_objects::Int32Value *>(value()) : nullptr;
   }
+  const hipdnn_data_sdk::data_objects::Int64Value *value_as_Int64Value() const {
+    return value_type() == hipdnn_data_sdk::data_objects::TensorValue::Int64Value ? static_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(value()) : nullptr;
+  }
   const hipdnn_data_sdk::data_objects::Float64Value *value_as_Float64Value() const {
     return value_type() == hipdnn_data_sdk::data_objects::TensorValue::Float64Value ? static_cast<const hipdnn_data_sdk::data_objects::Float64Value *>(value()) : nullptr;
   }
@@ -581,6 +641,10 @@ template<> inline const hipdnn_data_sdk::data_objects::Float8Value *TensorAttrib
 
 template<> inline const hipdnn_data_sdk::data_objects::Int32Value *TensorAttributes::value_as<hipdnn_data_sdk::data_objects::Int32Value>() const {
   return value_as_Int32Value();
+}
+
+template<> inline const hipdnn_data_sdk::data_objects::Int64Value *TensorAttributes::value_as<hipdnn_data_sdk::data_objects::Int64Value>() const {
+  return value_as_Int64Value();
 }
 
 template<> inline const hipdnn_data_sdk::data_objects::Float64Value *TensorAttributes::value_as<hipdnn_data_sdk::data_objects::Float64Value>() const {
@@ -759,6 +823,9 @@ inline bool VerifyTensorValue(::flatbuffers::Verifier &verifier, const void *obj
     case TensorValue::Int32Value: {
       return verifier.VerifyField<hipdnn_data_sdk::data_objects::Int32Value>(static_cast<const uint8_t *>(obj), 0, 4);
     }
+    case TensorValue::Int64Value: {
+      return verifier.VerifyField<hipdnn_data_sdk::data_objects::Int64Value>(static_cast<const uint8_t *>(obj), 0, 8);
+    }
     case TensorValue::Float64Value: {
       return verifier.VerifyField<hipdnn_data_sdk::data_objects::Float64Value>(static_cast<const uint8_t *>(obj), 0, 8);
     }
@@ -801,6 +868,10 @@ inline void *TensorValueUnion::UnPack(const void *obj, TensorValue type, const :
       auto ptr = reinterpret_cast<const hipdnn_data_sdk::data_objects::Int32Value *>(obj);
       return new hipdnn_data_sdk::data_objects::Int32Value(*ptr);
     }
+    case TensorValue::Int64Value: {
+      auto ptr = reinterpret_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(obj);
+      return new hipdnn_data_sdk::data_objects::Int64Value(*ptr);
+    }
     case TensorValue::Float64Value: {
       auto ptr = reinterpret_cast<const hipdnn_data_sdk::data_objects::Float64Value *>(obj);
       return new hipdnn_data_sdk::data_objects::Float64Value(*ptr);
@@ -832,6 +903,10 @@ inline ::flatbuffers::Offset<void> TensorValueUnion::Pack(::flatbuffers::FlatBuf
       auto ptr = reinterpret_cast<const hipdnn_data_sdk::data_objects::Int32Value *>(value);
       return _fbb.CreateStruct(*ptr).Union();
     }
+    case TensorValue::Int64Value: {
+      auto ptr = reinterpret_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(value);
+      return _fbb.CreateStruct(*ptr).Union();
+    }
     case TensorValue::Float64Value: {
       auto ptr = reinterpret_cast<const hipdnn_data_sdk::data_objects::Float64Value *>(value);
       return _fbb.CreateStruct(*ptr).Union();
@@ -860,6 +935,10 @@ inline TensorValueUnion::TensorValueUnion(const TensorValueUnion &u) : type(u.ty
     }
     case TensorValue::Int32Value: {
       value = new hipdnn_data_sdk::data_objects::Int32Value(*reinterpret_cast<hipdnn_data_sdk::data_objects::Int32Value *>(u.value));
+      break;
+    }
+    case TensorValue::Int64Value: {
+      value = new hipdnn_data_sdk::data_objects::Int64Value(*reinterpret_cast<hipdnn_data_sdk::data_objects::Int64Value *>(u.value));
       break;
     }
     case TensorValue::Float64Value: {
@@ -895,6 +974,11 @@ inline void TensorValueUnion::Reset() {
     }
     case TensorValue::Int32Value: {
       auto ptr = reinterpret_cast<hipdnn_data_sdk::data_objects::Int32Value *>(value);
+      delete ptr;
+      break;
+    }
+    case TensorValue::Int64Value: {
+      auto ptr = reinterpret_cast<hipdnn_data_sdk::data_objects::Int64Value *>(value);
       delete ptr;
       break;
     }

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/v24_12_23/hipdnn_data_sdk/data_objects/tensor_attributes_generated.h
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/v24_12_23/hipdnn_data_sdk/data_objects/tensor_attributes_generated.h
@@ -28,9 +28,9 @@ struct Float8Value;
 
 struct Int32Value;
 
-struct Int64Value;
-
 struct Float64Value;
+
+struct Int64Value;
 
 struct TensorAttributes;
 struct TensorAttributesBuilder;
@@ -46,10 +46,10 @@ bool operator==(const Float8Value &lhs, const Float8Value &rhs);
 bool operator!=(const Float8Value &lhs, const Float8Value &rhs);
 bool operator==(const Int32Value &lhs, const Int32Value &rhs);
 bool operator!=(const Int32Value &lhs, const Int32Value &rhs);
-bool operator==(const Int64Value &lhs, const Int64Value &rhs);
-bool operator!=(const Int64Value &lhs, const Int64Value &rhs);
 bool operator==(const Float64Value &lhs, const Float64Value &rhs);
 bool operator!=(const Float64Value &lhs, const Float64Value &rhs);
+bool operator==(const Int64Value &lhs, const Int64Value &rhs);
+bool operator!=(const Int64Value &lhs, const Int64Value &rhs);
 bool operator==(const TensorAttributesT &lhs, const TensorAttributesT &rhs);
 bool operator!=(const TensorAttributesT &lhs, const TensorAttributesT &rhs);
 
@@ -60,10 +60,10 @@ enum class TensorValue : uint8_t {
   BFloat16Value = 3,
   Float8Value = 4,
   Int32Value = 5,
-  Int64Value = 6,
-  Float64Value = 7,
+  Float64Value = 6,
+  Int64Value = 7,
   MIN = NONE,
-  MAX = Float64Value
+  MAX = Int64Value
 };
 
 inline const TensorValue (&EnumValuesTensorValue())[8] {
@@ -74,8 +74,8 @@ inline const TensorValue (&EnumValuesTensorValue())[8] {
     TensorValue::BFloat16Value,
     TensorValue::Float8Value,
     TensorValue::Int32Value,
-    TensorValue::Int64Value,
-    TensorValue::Float64Value
+    TensorValue::Float64Value,
+    TensorValue::Int64Value
   };
   return values;
 }
@@ -88,15 +88,15 @@ inline const char * const *EnumNamesTensorValue() {
     "BFloat16Value",
     "Float8Value",
     "Int32Value",
-    "Int64Value",
     "Float64Value",
+    "Int64Value",
     nullptr
   };
   return names;
 }
 
 inline const char *EnumNameTensorValue(TensorValue e) {
-  if (::flatbuffers::IsOutRange(e, TensorValue::NONE, TensorValue::Float64Value)) return "";
+  if (::flatbuffers::IsOutRange(e, TensorValue::NONE, TensorValue::Int64Value)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesTensorValue()[index];
 }
@@ -125,12 +125,12 @@ template<> struct TensorValueTraits<hipdnn_data_sdk::data_objects::Int32Value> {
   static const TensorValue enum_value = TensorValue::Int32Value;
 };
 
-template<> struct TensorValueTraits<hipdnn_data_sdk::data_objects::Int64Value> {
-  static const TensorValue enum_value = TensorValue::Int64Value;
-};
-
 template<> struct TensorValueTraits<hipdnn_data_sdk::data_objects::Float64Value> {
   static const TensorValue enum_value = TensorValue::Float64Value;
+};
+
+template<> struct TensorValueTraits<hipdnn_data_sdk::data_objects::Int64Value> {
+  static const TensorValue enum_value = TensorValue::Int64Value;
 };
 
 template<typename T> struct TensorValueUnionTraits {
@@ -157,12 +157,12 @@ template<> struct TensorValueUnionTraits<hipdnn_data_sdk::data_objects::Int32Val
   static const TensorValue enum_value = TensorValue::Int32Value;
 };
 
-template<> struct TensorValueUnionTraits<hipdnn_data_sdk::data_objects::Int64Value> {
-  static const TensorValue enum_value = TensorValue::Int64Value;
-};
-
 template<> struct TensorValueUnionTraits<hipdnn_data_sdk::data_objects::Float64Value> {
   static const TensorValue enum_value = TensorValue::Float64Value;
+};
+
+template<> struct TensorValueUnionTraits<hipdnn_data_sdk::data_objects::Int64Value> {
+  static const TensorValue enum_value = TensorValue::Int64Value;
 };
 
 struct TensorValueUnion {
@@ -451,36 +451,6 @@ inline bool operator!=(const Int32Value &lhs, const Int32Value &rhs) {
 }
 
 
-FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(8) Int64Value FLATBUFFERS_FINAL_CLASS {
- private:
-  int64_t value_;
-
- public:
-  Int64Value()
-      : value_(0) {
-  }
-  Int64Value(int64_t _value)
-      : value_(::flatbuffers::EndianScalar(_value)) {
-  }
-  int64_t value() const {
-    return ::flatbuffers::EndianScalar(value_);
-  }
-  void mutate_value(int64_t _value) {
-    ::flatbuffers::WriteScalar(&value_, _value);
-  }
-};
-FLATBUFFERS_STRUCT_END(Int64Value, 8);
-
-inline bool operator==(const Int64Value &lhs, const Int64Value &rhs) {
-  return
-      (lhs.value() == rhs.value());
-}
-
-inline bool operator!=(const Int64Value &lhs, const Int64Value &rhs) {
-    return !(lhs == rhs);
-}
-
-
 FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(8) Float64Value FLATBUFFERS_FINAL_CLASS {
  private:
   double value_;
@@ -507,6 +477,36 @@ inline bool operator==(const Float64Value &lhs, const Float64Value &rhs) {
 }
 
 inline bool operator!=(const Float64Value &lhs, const Float64Value &rhs) {
+    return !(lhs == rhs);
+}
+
+
+FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(8) Int64Value FLATBUFFERS_FINAL_CLASS {
+ private:
+  int64_t value_;
+
+ public:
+  Int64Value()
+      : value_(0) {
+  }
+  Int64Value(int64_t _value)
+      : value_(::flatbuffers::EndianScalar(_value)) {
+  }
+  int64_t value() const {
+    return ::flatbuffers::EndianScalar(value_);
+  }
+  void mutate_value(int64_t _value) {
+    ::flatbuffers::WriteScalar(&value_, _value);
+  }
+};
+FLATBUFFERS_STRUCT_END(Int64Value, 8);
+
+inline bool operator==(const Int64Value &lhs, const Int64Value &rhs) {
+  return
+      (lhs.value() == rhs.value());
+}
+
+inline bool operator!=(const Int64Value &lhs, const Int64Value &rhs) {
     return !(lhs == rhs);
 }
 
@@ -593,11 +593,11 @@ struct TensorAttributes FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const hipdnn_data_sdk::data_objects::Int32Value *value_as_Int32Value() const {
     return value_type() == hipdnn_data_sdk::data_objects::TensorValue::Int32Value ? static_cast<const hipdnn_data_sdk::data_objects::Int32Value *>(value()) : nullptr;
   }
-  const hipdnn_data_sdk::data_objects::Int64Value *value_as_Int64Value() const {
-    return value_type() == hipdnn_data_sdk::data_objects::TensorValue::Int64Value ? static_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(value()) : nullptr;
-  }
   const hipdnn_data_sdk::data_objects::Float64Value *value_as_Float64Value() const {
     return value_type() == hipdnn_data_sdk::data_objects::TensorValue::Float64Value ? static_cast<const hipdnn_data_sdk::data_objects::Float64Value *>(value()) : nullptr;
+  }
+  const hipdnn_data_sdk::data_objects::Int64Value *value_as_Int64Value() const {
+    return value_type() == hipdnn_data_sdk::data_objects::TensorValue::Int64Value ? static_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(value()) : nullptr;
   }
   void *mutable_value() {
     return GetPointer<void *>(VT_VALUE);
@@ -643,12 +643,12 @@ template<> inline const hipdnn_data_sdk::data_objects::Int32Value *TensorAttribu
   return value_as_Int32Value();
 }
 
-template<> inline const hipdnn_data_sdk::data_objects::Int64Value *TensorAttributes::value_as<hipdnn_data_sdk::data_objects::Int64Value>() const {
-  return value_as_Int64Value();
-}
-
 template<> inline const hipdnn_data_sdk::data_objects::Float64Value *TensorAttributes::value_as<hipdnn_data_sdk::data_objects::Float64Value>() const {
   return value_as_Float64Value();
+}
+
+template<> inline const hipdnn_data_sdk::data_objects::Int64Value *TensorAttributes::value_as<hipdnn_data_sdk::data_objects::Int64Value>() const {
+  return value_as_Int64Value();
 }
 
 struct TensorAttributesBuilder {

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/v25_9_23/hipdnn_data_sdk/data_objects/data_types_generated.h
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/v25_9_23/hipdnn_data_sdk/data_objects/data_types_generated.h
@@ -33,11 +33,12 @@ enum class DataType : int8_t {
   FP6_E2M3 = 12,
   FP6_E3M2 = 13,
   INT4 = 14,
+  INT64 = 15,
   MIN = UNSET,
-  MAX = INT4
+  MAX = INT64
 };
 
-inline const DataType (&EnumValuesDataType())[15] {
+inline const DataType (&EnumValuesDataType())[16] {
   static const DataType values[] = {
     DataType::UNSET,
     DataType::FLOAT,
@@ -53,13 +54,14 @@ inline const DataType (&EnumValuesDataType())[15] {
     DataType::FP4_E2M1,
     DataType::FP6_E2M3,
     DataType::FP6_E3M2,
-    DataType::INT4
+    DataType::INT4,
+    DataType::INT64
   };
   return values;
 }
 
 inline const char * const *EnumNamesDataType() {
-  static const char * const names[16] = {
+  static const char * const names[17] = {
     "UNSET",
     "FLOAT",
     "HALF",
@@ -75,13 +77,14 @@ inline const char * const *EnumNamesDataType() {
     "FP6_E2M3",
     "FP6_E3M2",
     "INT4",
+    "INT64",
     nullptr
   };
   return names;
 }
 
 inline const char *EnumNameDataType(DataType e) {
-  if (::flatbuffers::IsOutRange(e, DataType::UNSET, DataType::INT4)) return "";
+  if (::flatbuffers::IsOutRange(e, DataType::UNSET, DataType::INT64)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesDataType()[index];
 }

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/v25_9_23/hipdnn_data_sdk/data_objects/tensor_attributes_generated.h
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/v25_9_23/hipdnn_data_sdk/data_objects/tensor_attributes_generated.h
@@ -28,9 +28,9 @@ struct Float8Value;
 
 struct Int32Value;
 
-struct Int64Value;
-
 struct Float64Value;
+
+struct Int64Value;
 
 struct TensorAttributes;
 struct TensorAttributesBuilder;
@@ -46,10 +46,10 @@ bool operator==(const Float8Value &lhs, const Float8Value &rhs);
 bool operator!=(const Float8Value &lhs, const Float8Value &rhs);
 bool operator==(const Int32Value &lhs, const Int32Value &rhs);
 bool operator!=(const Int32Value &lhs, const Int32Value &rhs);
-bool operator==(const Int64Value &lhs, const Int64Value &rhs);
-bool operator!=(const Int64Value &lhs, const Int64Value &rhs);
 bool operator==(const Float64Value &lhs, const Float64Value &rhs);
 bool operator!=(const Float64Value &lhs, const Float64Value &rhs);
+bool operator==(const Int64Value &lhs, const Int64Value &rhs);
+bool operator!=(const Int64Value &lhs, const Int64Value &rhs);
 bool operator==(const TensorAttributesT &lhs, const TensorAttributesT &rhs);
 bool operator!=(const TensorAttributesT &lhs, const TensorAttributesT &rhs);
 
@@ -60,10 +60,10 @@ enum class TensorValue : uint8_t {
   BFloat16Value = 3,
   Float8Value = 4,
   Int32Value = 5,
-  Int64Value = 6,
-  Float64Value = 7,
+  Float64Value = 6,
+  Int64Value = 7,
   MIN = NONE,
-  MAX = Float64Value
+  MAX = Int64Value
 };
 
 inline const TensorValue (&EnumValuesTensorValue())[8] {
@@ -74,8 +74,8 @@ inline const TensorValue (&EnumValuesTensorValue())[8] {
     TensorValue::BFloat16Value,
     TensorValue::Float8Value,
     TensorValue::Int32Value,
-    TensorValue::Int64Value,
-    TensorValue::Float64Value
+    TensorValue::Float64Value,
+    TensorValue::Int64Value
   };
   return values;
 }
@@ -88,15 +88,15 @@ inline const char * const *EnumNamesTensorValue() {
     "BFloat16Value",
     "Float8Value",
     "Int32Value",
-    "Int64Value",
     "Float64Value",
+    "Int64Value",
     nullptr
   };
   return names;
 }
 
 inline const char *EnumNameTensorValue(TensorValue e) {
-  if (::flatbuffers::IsOutRange(e, TensorValue::NONE, TensorValue::Float64Value)) return "";
+  if (::flatbuffers::IsOutRange(e, TensorValue::NONE, TensorValue::Int64Value)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesTensorValue()[index];
 }
@@ -125,12 +125,12 @@ template<> struct TensorValueTraits<hipdnn_data_sdk::data_objects::Int32Value> {
   static const TensorValue enum_value = TensorValue::Int32Value;
 };
 
-template<> struct TensorValueTraits<hipdnn_data_sdk::data_objects::Int64Value> {
-  static const TensorValue enum_value = TensorValue::Int64Value;
-};
-
 template<> struct TensorValueTraits<hipdnn_data_sdk::data_objects::Float64Value> {
   static const TensorValue enum_value = TensorValue::Float64Value;
+};
+
+template<> struct TensorValueTraits<hipdnn_data_sdk::data_objects::Int64Value> {
+  static const TensorValue enum_value = TensorValue::Int64Value;
 };
 
 template<typename T> struct TensorValueUnionTraits {
@@ -157,12 +157,12 @@ template<> struct TensorValueUnionTraits<hipdnn_data_sdk::data_objects::Int32Val
   static const TensorValue enum_value = TensorValue::Int32Value;
 };
 
-template<> struct TensorValueUnionTraits<hipdnn_data_sdk::data_objects::Int64Value> {
-  static const TensorValue enum_value = TensorValue::Int64Value;
-};
-
 template<> struct TensorValueUnionTraits<hipdnn_data_sdk::data_objects::Float64Value> {
   static const TensorValue enum_value = TensorValue::Float64Value;
+};
+
+template<> struct TensorValueUnionTraits<hipdnn_data_sdk::data_objects::Int64Value> {
+  static const TensorValue enum_value = TensorValue::Int64Value;
 };
 
 struct TensorValueUnion {
@@ -235,14 +235,6 @@ struct TensorValueUnion {
     return type == TensorValue::Int32Value ?
       reinterpret_cast<const hipdnn_data_sdk::data_objects::Int32Value *>(value) : nullptr;
   }
-  hipdnn_data_sdk::data_objects::Int64Value *AsInt64Value() {
-    return type == TensorValue::Int64Value ?
-      reinterpret_cast<hipdnn_data_sdk::data_objects::Int64Value *>(value) : nullptr;
-  }
-  const hipdnn_data_sdk::data_objects::Int64Value *AsInt64Value() const {
-    return type == TensorValue::Int64Value ?
-      reinterpret_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(value) : nullptr;
-  }
   hipdnn_data_sdk::data_objects::Float64Value *AsFloat64Value() {
     return type == TensorValue::Float64Value ?
       reinterpret_cast<hipdnn_data_sdk::data_objects::Float64Value *>(value) : nullptr;
@@ -250,6 +242,14 @@ struct TensorValueUnion {
   const hipdnn_data_sdk::data_objects::Float64Value *AsFloat64Value() const {
     return type == TensorValue::Float64Value ?
       reinterpret_cast<const hipdnn_data_sdk::data_objects::Float64Value *>(value) : nullptr;
+  }
+  hipdnn_data_sdk::data_objects::Int64Value *AsInt64Value() {
+    return type == TensorValue::Int64Value ?
+      reinterpret_cast<hipdnn_data_sdk::data_objects::Int64Value *>(value) : nullptr;
+  }
+  const hipdnn_data_sdk::data_objects::Int64Value *AsInt64Value() const {
+    return type == TensorValue::Int64Value ?
+      reinterpret_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(value) : nullptr;
   }
 };
 
@@ -280,13 +280,13 @@ inline bool operator==(const TensorValueUnion &lhs, const TensorValueUnion &rhs)
       return *(reinterpret_cast<const hipdnn_data_sdk::data_objects::Int32Value *>(lhs.value)) ==
              *(reinterpret_cast<const hipdnn_data_sdk::data_objects::Int32Value *>(rhs.value));
     }
-    case TensorValue::Int64Value: {
-      return *(reinterpret_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(lhs.value)) ==
-             *(reinterpret_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(rhs.value));
-    }
     case TensorValue::Float64Value: {
       return *(reinterpret_cast<const hipdnn_data_sdk::data_objects::Float64Value *>(lhs.value)) ==
              *(reinterpret_cast<const hipdnn_data_sdk::data_objects::Float64Value *>(rhs.value));
+    }
+    case TensorValue::Int64Value: {
+      return *(reinterpret_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(lhs.value)) ==
+             *(reinterpret_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(rhs.value));
     }
     default: {
       return false;
@@ -451,36 +451,6 @@ inline bool operator!=(const Int32Value &lhs, const Int32Value &rhs) {
 }
 
 
-FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(8) Int64Value FLATBUFFERS_FINAL_CLASS {
- private:
-  int64_t value_;
-
- public:
-  Int64Value()
-      : value_(0) {
-  }
-  Int64Value(int64_t _value)
-      : value_(::flatbuffers::EndianScalar(_value)) {
-  }
-  int64_t value() const {
-    return ::flatbuffers::EndianScalar(value_);
-  }
-  void mutate_value(int64_t _value) {
-    ::flatbuffers::WriteScalar(&value_, _value);
-  }
-};
-FLATBUFFERS_STRUCT_END(Int64Value, 8);
-
-inline bool operator==(const Int64Value &lhs, const Int64Value &rhs) {
-  return
-      (lhs.value() == rhs.value());
-}
-
-inline bool operator!=(const Int64Value &lhs, const Int64Value &rhs) {
-    return !(lhs == rhs);
-}
-
-
 FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(8) Float64Value FLATBUFFERS_FINAL_CLASS {
  private:
   double value_;
@@ -507,6 +477,36 @@ inline bool operator==(const Float64Value &lhs, const Float64Value &rhs) {
 }
 
 inline bool operator!=(const Float64Value &lhs, const Float64Value &rhs) {
+    return !(lhs == rhs);
+}
+
+
+FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(8) Int64Value FLATBUFFERS_FINAL_CLASS {
+ private:
+  int64_t value_;
+
+ public:
+  Int64Value()
+      : value_(0) {
+  }
+  Int64Value(int64_t _value)
+      : value_(::flatbuffers::EndianScalar(_value)) {
+  }
+  int64_t value() const {
+    return ::flatbuffers::EndianScalar(value_);
+  }
+  void mutate_value(int64_t _value) {
+    ::flatbuffers::WriteScalar(&value_, _value);
+  }
+};
+FLATBUFFERS_STRUCT_END(Int64Value, 8);
+
+inline bool operator==(const Int64Value &lhs, const Int64Value &rhs) {
+  return
+      (lhs.value() == rhs.value());
+}
+
+inline bool operator!=(const Int64Value &lhs, const Int64Value &rhs) {
     return !(lhs == rhs);
 }
 
@@ -593,11 +593,11 @@ struct TensorAttributes FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const hipdnn_data_sdk::data_objects::Int32Value *value_as_Int32Value() const {
     return value_type() == hipdnn_data_sdk::data_objects::TensorValue::Int32Value ? static_cast<const hipdnn_data_sdk::data_objects::Int32Value *>(value()) : nullptr;
   }
-  const hipdnn_data_sdk::data_objects::Int64Value *value_as_Int64Value() const {
-    return value_type() == hipdnn_data_sdk::data_objects::TensorValue::Int64Value ? static_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(value()) : nullptr;
-  }
   const hipdnn_data_sdk::data_objects::Float64Value *value_as_Float64Value() const {
     return value_type() == hipdnn_data_sdk::data_objects::TensorValue::Float64Value ? static_cast<const hipdnn_data_sdk::data_objects::Float64Value *>(value()) : nullptr;
+  }
+  const hipdnn_data_sdk::data_objects::Int64Value *value_as_Int64Value() const {
+    return value_type() == hipdnn_data_sdk::data_objects::TensorValue::Int64Value ? static_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(value()) : nullptr;
   }
   void *mutable_value() {
     return GetPointer<void *>(VT_VALUE);
@@ -643,12 +643,12 @@ template<> inline const hipdnn_data_sdk::data_objects::Int32Value *TensorAttribu
   return value_as_Int32Value();
 }
 
-template<> inline const hipdnn_data_sdk::data_objects::Int64Value *TensorAttributes::value_as<hipdnn_data_sdk::data_objects::Int64Value>() const {
-  return value_as_Int64Value();
-}
-
 template<> inline const hipdnn_data_sdk::data_objects::Float64Value *TensorAttributes::value_as<hipdnn_data_sdk::data_objects::Float64Value>() const {
   return value_as_Float64Value();
+}
+
+template<> inline const hipdnn_data_sdk::data_objects::Int64Value *TensorAttributes::value_as<hipdnn_data_sdk::data_objects::Int64Value>() const {
+  return value_as_Int64Value();
 }
 
 struct TensorAttributesBuilder {
@@ -823,11 +823,11 @@ inline bool VerifyTensorValue(::flatbuffers::Verifier &verifier, const void *obj
     case TensorValue::Int32Value: {
       return verifier.VerifyField<hipdnn_data_sdk::data_objects::Int32Value>(static_cast<const uint8_t *>(obj), 0, 4);
     }
-    case TensorValue::Int64Value: {
-      return verifier.VerifyField<hipdnn_data_sdk::data_objects::Int64Value>(static_cast<const uint8_t *>(obj), 0, 8);
-    }
     case TensorValue::Float64Value: {
       return verifier.VerifyField<hipdnn_data_sdk::data_objects::Float64Value>(static_cast<const uint8_t *>(obj), 0, 8);
+    }
+    case TensorValue::Int64Value: {
+      return verifier.VerifyField<hipdnn_data_sdk::data_objects::Int64Value>(static_cast<const uint8_t *>(obj), 0, 8);
     }
     default: return true;
   }
@@ -868,13 +868,13 @@ inline void *TensorValueUnion::UnPack(const void *obj, TensorValue type, const :
       auto ptr = reinterpret_cast<const hipdnn_data_sdk::data_objects::Int32Value *>(obj);
       return new hipdnn_data_sdk::data_objects::Int32Value(*ptr);
     }
-    case TensorValue::Int64Value: {
-      auto ptr = reinterpret_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(obj);
-      return new hipdnn_data_sdk::data_objects::Int64Value(*ptr);
-    }
     case TensorValue::Float64Value: {
       auto ptr = reinterpret_cast<const hipdnn_data_sdk::data_objects::Float64Value *>(obj);
       return new hipdnn_data_sdk::data_objects::Float64Value(*ptr);
+    }
+    case TensorValue::Int64Value: {
+      auto ptr = reinterpret_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(obj);
+      return new hipdnn_data_sdk::data_objects::Int64Value(*ptr);
     }
     default: return nullptr;
   }
@@ -903,12 +903,12 @@ inline ::flatbuffers::Offset<void> TensorValueUnion::Pack(::flatbuffers::FlatBuf
       auto ptr = reinterpret_cast<const hipdnn_data_sdk::data_objects::Int32Value *>(value);
       return _fbb.CreateStruct(*ptr).Union();
     }
-    case TensorValue::Int64Value: {
-      auto ptr = reinterpret_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(value);
-      return _fbb.CreateStruct(*ptr).Union();
-    }
     case TensorValue::Float64Value: {
       auto ptr = reinterpret_cast<const hipdnn_data_sdk::data_objects::Float64Value *>(value);
+      return _fbb.CreateStruct(*ptr).Union();
+    }
+    case TensorValue::Int64Value: {
+      auto ptr = reinterpret_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(value);
       return _fbb.CreateStruct(*ptr).Union();
     }
     default: return 0;
@@ -937,12 +937,12 @@ inline TensorValueUnion::TensorValueUnion(const TensorValueUnion &u) : type(u.ty
       value = new hipdnn_data_sdk::data_objects::Int32Value(*reinterpret_cast<hipdnn_data_sdk::data_objects::Int32Value *>(u.value));
       break;
     }
-    case TensorValue::Int64Value: {
-      value = new hipdnn_data_sdk::data_objects::Int64Value(*reinterpret_cast<hipdnn_data_sdk::data_objects::Int64Value *>(u.value));
-      break;
-    }
     case TensorValue::Float64Value: {
       value = new hipdnn_data_sdk::data_objects::Float64Value(*reinterpret_cast<hipdnn_data_sdk::data_objects::Float64Value *>(u.value));
+      break;
+    }
+    case TensorValue::Int64Value: {
+      value = new hipdnn_data_sdk::data_objects::Int64Value(*reinterpret_cast<hipdnn_data_sdk::data_objects::Int64Value *>(u.value));
       break;
     }
     default:
@@ -977,13 +977,13 @@ inline void TensorValueUnion::Reset() {
       delete ptr;
       break;
     }
-    case TensorValue::Int64Value: {
-      auto ptr = reinterpret_cast<hipdnn_data_sdk::data_objects::Int64Value *>(value);
+    case TensorValue::Float64Value: {
+      auto ptr = reinterpret_cast<hipdnn_data_sdk::data_objects::Float64Value *>(value);
       delete ptr;
       break;
     }
-    case TensorValue::Float64Value: {
-      auto ptr = reinterpret_cast<hipdnn_data_sdk::data_objects::Float64Value *>(value);
+    case TensorValue::Int64Value: {
+      auto ptr = reinterpret_cast<hipdnn_data_sdk::data_objects::Int64Value *>(value);
       delete ptr;
       break;
     }

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/v25_9_23/hipdnn_data_sdk/data_objects/tensor_attributes_generated.h
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/v25_9_23/hipdnn_data_sdk/data_objects/tensor_attributes_generated.h
@@ -28,6 +28,8 @@ struct Float8Value;
 
 struct Int32Value;
 
+struct Int64Value;
+
 struct Float64Value;
 
 struct TensorAttributes;
@@ -44,6 +46,8 @@ bool operator==(const Float8Value &lhs, const Float8Value &rhs);
 bool operator!=(const Float8Value &lhs, const Float8Value &rhs);
 bool operator==(const Int32Value &lhs, const Int32Value &rhs);
 bool operator!=(const Int32Value &lhs, const Int32Value &rhs);
+bool operator==(const Int64Value &lhs, const Int64Value &rhs);
+bool operator!=(const Int64Value &lhs, const Int64Value &rhs);
 bool operator==(const Float64Value &lhs, const Float64Value &rhs);
 bool operator!=(const Float64Value &lhs, const Float64Value &rhs);
 bool operator==(const TensorAttributesT &lhs, const TensorAttributesT &rhs);
@@ -56,12 +60,13 @@ enum class TensorValue : uint8_t {
   BFloat16Value = 3,
   Float8Value = 4,
   Int32Value = 5,
-  Float64Value = 6,
+  Int64Value = 6,
+  Float64Value = 7,
   MIN = NONE,
   MAX = Float64Value
 };
 
-inline const TensorValue (&EnumValuesTensorValue())[7] {
+inline const TensorValue (&EnumValuesTensorValue())[8] {
   static const TensorValue values[] = {
     TensorValue::NONE,
     TensorValue::Float32Value,
@@ -69,19 +74,21 @@ inline const TensorValue (&EnumValuesTensorValue())[7] {
     TensorValue::BFloat16Value,
     TensorValue::Float8Value,
     TensorValue::Int32Value,
+    TensorValue::Int64Value,
     TensorValue::Float64Value
   };
   return values;
 }
 
 inline const char * const *EnumNamesTensorValue() {
-  static const char * const names[8] = {
+  static const char * const names[9] = {
     "NONE",
     "Float32Value",
     "Float16Value",
     "BFloat16Value",
     "Float8Value",
     "Int32Value",
+    "Int64Value",
     "Float64Value",
     nullptr
   };
@@ -118,6 +125,10 @@ template<> struct TensorValueTraits<hipdnn_data_sdk::data_objects::Int32Value> {
   static const TensorValue enum_value = TensorValue::Int32Value;
 };
 
+template<> struct TensorValueTraits<hipdnn_data_sdk::data_objects::Int64Value> {
+  static const TensorValue enum_value = TensorValue::Int64Value;
+};
+
 template<> struct TensorValueTraits<hipdnn_data_sdk::data_objects::Float64Value> {
   static const TensorValue enum_value = TensorValue::Float64Value;
 };
@@ -144,6 +155,10 @@ template<> struct TensorValueUnionTraits<hipdnn_data_sdk::data_objects::Float8Va
 
 template<> struct TensorValueUnionTraits<hipdnn_data_sdk::data_objects::Int32Value> {
   static const TensorValue enum_value = TensorValue::Int32Value;
+};
+
+template<> struct TensorValueUnionTraits<hipdnn_data_sdk::data_objects::Int64Value> {
+  static const TensorValue enum_value = TensorValue::Int64Value;
 };
 
 template<> struct TensorValueUnionTraits<hipdnn_data_sdk::data_objects::Float64Value> {
@@ -220,6 +235,14 @@ struct TensorValueUnion {
     return type == TensorValue::Int32Value ?
       reinterpret_cast<const hipdnn_data_sdk::data_objects::Int32Value *>(value) : nullptr;
   }
+  hipdnn_data_sdk::data_objects::Int64Value *AsInt64Value() {
+    return type == TensorValue::Int64Value ?
+      reinterpret_cast<hipdnn_data_sdk::data_objects::Int64Value *>(value) : nullptr;
+  }
+  const hipdnn_data_sdk::data_objects::Int64Value *AsInt64Value() const {
+    return type == TensorValue::Int64Value ?
+      reinterpret_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(value) : nullptr;
+  }
   hipdnn_data_sdk::data_objects::Float64Value *AsFloat64Value() {
     return type == TensorValue::Float64Value ?
       reinterpret_cast<hipdnn_data_sdk::data_objects::Float64Value *>(value) : nullptr;
@@ -256,6 +279,10 @@ inline bool operator==(const TensorValueUnion &lhs, const TensorValueUnion &rhs)
     case TensorValue::Int32Value: {
       return *(reinterpret_cast<const hipdnn_data_sdk::data_objects::Int32Value *>(lhs.value)) ==
              *(reinterpret_cast<const hipdnn_data_sdk::data_objects::Int32Value *>(rhs.value));
+    }
+    case TensorValue::Int64Value: {
+      return *(reinterpret_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(lhs.value)) ==
+             *(reinterpret_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(rhs.value));
     }
     case TensorValue::Float64Value: {
       return *(reinterpret_cast<const hipdnn_data_sdk::data_objects::Float64Value *>(lhs.value)) ==
@@ -424,6 +451,36 @@ inline bool operator!=(const Int32Value &lhs, const Int32Value &rhs) {
 }
 
 
+FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(8) Int64Value FLATBUFFERS_FINAL_CLASS {
+ private:
+  int64_t value_;
+
+ public:
+  Int64Value()
+      : value_(0) {
+  }
+  Int64Value(int64_t _value)
+      : value_(::flatbuffers::EndianScalar(_value)) {
+  }
+  int64_t value() const {
+    return ::flatbuffers::EndianScalar(value_);
+  }
+  void mutate_value(int64_t _value) {
+    ::flatbuffers::WriteScalar(&value_, _value);
+  }
+};
+FLATBUFFERS_STRUCT_END(Int64Value, 8);
+
+inline bool operator==(const Int64Value &lhs, const Int64Value &rhs) {
+  return
+      (lhs.value() == rhs.value());
+}
+
+inline bool operator!=(const Int64Value &lhs, const Int64Value &rhs) {
+    return !(lhs == rhs);
+}
+
+
 FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(8) Float64Value FLATBUFFERS_FINAL_CLASS {
  private:
   double value_;
@@ -536,6 +593,9 @@ struct TensorAttributes FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const hipdnn_data_sdk::data_objects::Int32Value *value_as_Int32Value() const {
     return value_type() == hipdnn_data_sdk::data_objects::TensorValue::Int32Value ? static_cast<const hipdnn_data_sdk::data_objects::Int32Value *>(value()) : nullptr;
   }
+  const hipdnn_data_sdk::data_objects::Int64Value *value_as_Int64Value() const {
+    return value_type() == hipdnn_data_sdk::data_objects::TensorValue::Int64Value ? static_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(value()) : nullptr;
+  }
   const hipdnn_data_sdk::data_objects::Float64Value *value_as_Float64Value() const {
     return value_type() == hipdnn_data_sdk::data_objects::TensorValue::Float64Value ? static_cast<const hipdnn_data_sdk::data_objects::Float64Value *>(value()) : nullptr;
   }
@@ -581,6 +641,10 @@ template<> inline const hipdnn_data_sdk::data_objects::Float8Value *TensorAttrib
 
 template<> inline const hipdnn_data_sdk::data_objects::Int32Value *TensorAttributes::value_as<hipdnn_data_sdk::data_objects::Int32Value>() const {
   return value_as_Int32Value();
+}
+
+template<> inline const hipdnn_data_sdk::data_objects::Int64Value *TensorAttributes::value_as<hipdnn_data_sdk::data_objects::Int64Value>() const {
+  return value_as_Int64Value();
 }
 
 template<> inline const hipdnn_data_sdk::data_objects::Float64Value *TensorAttributes::value_as<hipdnn_data_sdk::data_objects::Float64Value>() const {
@@ -759,6 +823,9 @@ inline bool VerifyTensorValue(::flatbuffers::Verifier &verifier, const void *obj
     case TensorValue::Int32Value: {
       return verifier.VerifyField<hipdnn_data_sdk::data_objects::Int32Value>(static_cast<const uint8_t *>(obj), 0, 4);
     }
+    case TensorValue::Int64Value: {
+      return verifier.VerifyField<hipdnn_data_sdk::data_objects::Int64Value>(static_cast<const uint8_t *>(obj), 0, 8);
+    }
     case TensorValue::Float64Value: {
       return verifier.VerifyField<hipdnn_data_sdk::data_objects::Float64Value>(static_cast<const uint8_t *>(obj), 0, 8);
     }
@@ -801,6 +868,10 @@ inline void *TensorValueUnion::UnPack(const void *obj, TensorValue type, const :
       auto ptr = reinterpret_cast<const hipdnn_data_sdk::data_objects::Int32Value *>(obj);
       return new hipdnn_data_sdk::data_objects::Int32Value(*ptr);
     }
+    case TensorValue::Int64Value: {
+      auto ptr = reinterpret_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(obj);
+      return new hipdnn_data_sdk::data_objects::Int64Value(*ptr);
+    }
     case TensorValue::Float64Value: {
       auto ptr = reinterpret_cast<const hipdnn_data_sdk::data_objects::Float64Value *>(obj);
       return new hipdnn_data_sdk::data_objects::Float64Value(*ptr);
@@ -832,6 +903,10 @@ inline ::flatbuffers::Offset<void> TensorValueUnion::Pack(::flatbuffers::FlatBuf
       auto ptr = reinterpret_cast<const hipdnn_data_sdk::data_objects::Int32Value *>(value);
       return _fbb.CreateStruct(*ptr).Union();
     }
+    case TensorValue::Int64Value: {
+      auto ptr = reinterpret_cast<const hipdnn_data_sdk::data_objects::Int64Value *>(value);
+      return _fbb.CreateStruct(*ptr).Union();
+    }
     case TensorValue::Float64Value: {
       auto ptr = reinterpret_cast<const hipdnn_data_sdk::data_objects::Float64Value *>(value);
       return _fbb.CreateStruct(*ptr).Union();
@@ -860,6 +935,10 @@ inline TensorValueUnion::TensorValueUnion(const TensorValueUnion &u) : type(u.ty
     }
     case TensorValue::Int32Value: {
       value = new hipdnn_data_sdk::data_objects::Int32Value(*reinterpret_cast<hipdnn_data_sdk::data_objects::Int32Value *>(u.value));
+      break;
+    }
+    case TensorValue::Int64Value: {
+      value = new hipdnn_data_sdk::data_objects::Int64Value(*reinterpret_cast<hipdnn_data_sdk::data_objects::Int64Value *>(u.value));
       break;
     }
     case TensorValue::Float64Value: {
@@ -895,6 +974,11 @@ inline void TensorValueUnion::Reset() {
     }
     case TensorValue::Int32Value: {
       auto ptr = reinterpret_cast<hipdnn_data_sdk::data_objects::Int32Value *>(value);
+      delete ptr;
+      break;
+    }
+    case TensorValue::Int64Value: {
+      auto ptr = reinterpret_cast<hipdnn_data_sdk::data_objects::Int64Value *>(value);
       delete ptr;
       break;
     }

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/FlatbufferUtils.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/FlatbufferUtils.hpp
@@ -87,6 +87,12 @@ TargetType extractValueFromTensorValue(const data_objects::TensorAttributesT& te
             return static_cast<TargetType>(val->value());
         }
         break;
+    case data_objects::DataType::INT64:
+        if(auto val = tensorAttr.value.AsInt64Value())
+        {
+            return static_cast<TargetType>(val->value());
+        }
+        break;
     case data_objects::DataType::UINT8:
         if(auto val = tensorAttr.value.AsFloat8Value())
         {

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/json/Common.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/json/Common.hpp
@@ -100,6 +100,7 @@ NLOHMANN_JSON_SERIALIZE_ENUM(DataType,
                                  {DataType::INT4, "int4"},
                                  {DataType::FP6_E2M3, "fp6_e2m3"},
                                  {DataType::FP6_E3M2, "fp6_e3m2"},
+                                 {DataType::INT64, "int64"},
                              }
 
 )
@@ -112,6 +113,7 @@ NLOHMANN_JSON_SERIALIZE_ENUM(TensorValue,
                                  {TensorValue::BFloat16Value, "BFloat16Value"},
                                  {TensorValue::Float8Value, "Float8Value"},
                                  {TensorValue::Int32Value, "Int32Value"},
+                                 {TensorValue::Int64Value, "Int64Value"},
                                  {TensorValue::Float64Value, "Float64Value"},
                              }
 

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/json/TensorAttributes.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/json/TensorAttributes.hpp
@@ -43,6 +43,9 @@ inline void to_json(nlohmann::json& tensorAttrJson,
         case data_objects::TensorValue::Int32Value:
             tensorAttrJson["value"] = tensorAttr.value_as_Int32Value()->value();
             break;
+        case data_objects::TensorValue::Int64Value:
+            tensorAttrJson["value"] = tensorAttr.value_as_Int64Value()->value();
+            break;
         case data_objects::TensorValue::Float64Value:
             tensorAttrJson["value"] = tensorAttr.value_as_Float64Value()->value();
             break;
@@ -109,6 +112,13 @@ inline auto to<data_objects::TensorAttributes>(flatbuffers::FlatBufferBuilder& b
             auto val = entry.at("value").get<int32_t>();
             const data_objects::Int32Value intVal(val);
             valueOffset = builder.CreateStruct(intVal).Union();
+            break;
+        }
+        case data_objects::TensorValue::Int64Value:
+        {
+            auto val = entry.at("value").get<int64_t>();
+            const data_objects::Int64Value int64Val(val);
+            valueOffset = builder.CreateStruct(int64Val).Union();
             break;
         }
         case data_objects::TensorValue::Float64Value:

--- a/projects/hipdnn/data_sdk/schemas/data_types.fbs
+++ b/projects/hipdnn/data_sdk/schemas/data_types.fbs
@@ -19,4 +19,5 @@ enum DataType : byte {
     FP6_E2M3 = 12,
     FP6_E3M2 = 13,
     INT4 = 14,
+    INT64 = 15,
 }

--- a/projects/hipdnn/data_sdk/schemas/tensor_attributes.fbs
+++ b/projects/hipdnn/data_sdk/schemas/tensor_attributes.fbs
@@ -25,12 +25,12 @@ struct Int32Value {
   value: int;
 }
 
-struct Int64Value {
-  value: long;
-}
-
 struct Float64Value {
   value: double;
+}
+
+struct Int64Value {
+  value: long;
 }
 
 // Note: FP4 and FP6 MX formats (e.g., FP4_E2M1, FP6_E2M3, FP6_E3M2) are intentionally
@@ -42,8 +42,8 @@ union TensorValue {
   BFloat16Value,
   Float8Value,
   Int32Value,
-  Int64Value,
-  Float64Value
+  Float64Value,
+  Int64Value
 }
 
 table TensorAttributes {

--- a/projects/hipdnn/data_sdk/schemas/tensor_attributes.fbs
+++ b/projects/hipdnn/data_sdk/schemas/tensor_attributes.fbs
@@ -25,6 +25,10 @@ struct Int32Value {
   value: int;
 }
 
+struct Int64Value {
+  value: long;
+}
+
 struct Float64Value {
   value: double;
 }
@@ -38,6 +42,7 @@ union TensorValue {
   BFloat16Value,
   Float8Value,
   Int32Value,
+  Int64Value,
   Float64Value
 }
 

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
@@ -181,6 +181,7 @@ enum class DataType
     INT4 = 12, ///< 4-bit signed integer
     FP6_E2M3 = 13, ///< 6-bit floating point (2 exponent, 3 mantissa bits)
     FP6_E3M2 = 14, ///< 6-bit floating point (3 exponent, 2 mantissa bits)
+    INT64 = 15, ///< 64-bit signed integer
 };
 typedef DataType DataType_t; ///< @brief Type alias for DataType
 
@@ -318,6 +319,10 @@ DataType getDataTypeEnumFromType()
     else if constexpr(std::is_same_v<T, int32_t>)
     {
         return DataType::INT32;
+    }
+    else if constexpr(std::is_same_v<T, int64_t>)
+    {
+        return DataType::INT64;
     }
     else if constexpr(std::is_same_v<T, int8_t>)
     {
@@ -702,6 +707,8 @@ inline hipdnn_data_sdk::data_objects::DataType toSdkType(const DataType& type)
         return hipdnn_data_sdk::data_objects::DataType::FP6_E2M3;
     case DataType::FP6_E3M2:
         return hipdnn_data_sdk::data_objects::DataType::FP6_E3M2;
+    case DataType::INT64:
+        return hipdnn_data_sdk::data_objects::DataType::INT64;
     default:
         return hipdnn_data_sdk::data_objects::DataType::UNSET;
     }
@@ -740,6 +747,8 @@ inline hipdnn_frontend::DataType fromSdkType(const hipdnn_data_sdk::data_objects
         return hipdnn_frontend::DataType::FP6_E2M3;
     case hipdnn_data_sdk::data_objects::DataType::FP6_E3M2:
         return hipdnn_frontend::DataType::FP6_E3M2;
+    case hipdnn_data_sdk::data_objects::DataType::INT64:
+        return hipdnn_frontend::DataType::INT64;
     default:
         return hipdnn_frontend::DataType::NOT_SET;
     }
@@ -846,6 +855,8 @@ inline std::optional<hipdnnDataType_t> toHipdnnDataType(const DataType& type)
         return HIPDNN_DATA_FP6_E2M3;
     case DataType::FP6_E3M2:
         return HIPDNN_DATA_FP6_E3M2;
+    case DataType::INT64:
+        return HIPDNN_DATA_INT64;
     case DataType::NOT_SET:
     default:
         return std::nullopt;
@@ -892,6 +903,8 @@ inline std::pair<DataType, Error> fromHipdnnDataType(hipdnnDataType_t type)
         return {DataType::FP6_E2M3, {}};
     case HIPDNN_DATA_FP6_E3M2:
         return {DataType::FP6_E3M2, {}};
+    case HIPDNN_DATA_INT64:
+        return {DataType::INT64, {}};
     default:
         return {DataType::NOT_SET,
                 {ErrorCode::HIPDNN_BACKEND_ERROR,
@@ -1286,6 +1299,8 @@ inline const char* to_string(const DataType& type)
         return "fp6_e2m3";
     case DataType::FP6_E3M2:
         return "fp6_e3m2";
+    case DataType::INT64:
+        return "int64";
     default:
         return "unknown";
     }

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/TensorAttributes.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/TensorAttributes.hpp
@@ -77,14 +77,14 @@ class TensorAttributes
 public:
     /// Variant type for storing pass-by-value scalar values
     using ValueVariant
-        = std::variant<std::monostate, double, float, half, bfloat16, uint8_t, int32_t>;
+        = std::variant<std::monostate, double, float, half, bfloat16, uint8_t, int32_t, int64_t>;
 
     /// @brief Default constructor
     TensorAttributes() = default;
 
     /**
      * @brief Construct a pass-by-value tensor from a scalar
-     * @tparam T Scalar type (float, double, half, hip_bfloat16, uint8_t, int32_t)
+     * @tparam T Scalar type (float, double, half, hip_bfloat16, uint8_t, int32_t, int64_t)
      * @param scalar The scalar value to store in the tensor
      */
     template <typename T>
@@ -119,7 +119,7 @@ public:
 
     /**
      * @brief Set a pass-by-value scalar in this tensor
-     * @tparam T Scalar type (float, double, half, hip_bfloat16, uint8_t, int32_t)
+     * @tparam T Scalar type (float, double, half, hip_bfloat16, uint8_t, int32_t, int64_t)
      * @param v The scalar value
      * @return Reference to this for method chaining
      */
@@ -132,7 +132,8 @@ public:
                                          std::is_same<T, half>,
                                          std::is_same<T, bfloat16>,
                                          std::is_same<T, uint8_t>,
-                                         std::is_same<T, int32_t>>,
+                                         std::is_same<T, int32_t>,
+                                         std::is_same<T, int64_t>>,
                       "Unsupported type for Tensor_attributes::set_value");
         _value = v;
         _dataType = getDataTypeEnumFromType<T>();
@@ -443,6 +444,12 @@ public:
                     return {hipdnn_data_sdk::data_objects::TensorValue::Int32Value,
                             builder.CreateStruct(int32Val).Union()};
                 }
+                else if constexpr(std::is_same_v<T, int64_t>)
+                {
+                    const hipdnn_data_sdk::data_objects::Int64Value int64Val(arg);
+                    return {hipdnn_data_sdk::data_objects::TensorValue::Int64Value,
+                            builder.CreateStruct(int64Val).Union()};
+                }
                 else
                 {
                     // For std::monostate case
@@ -517,6 +524,9 @@ public:
                 break;
             case hipdnn_data_sdk::data_objects::TensorValue::Int32Value:
                 tensor->set_value(fb->value_as_Int32Value()->value());
+                break;
+            case hipdnn_data_sdk::data_objects::TensorValue::Int64Value:
+                tensor->set_value(fb->value_as_Int64Value()->value());
                 break;
             default:
                 break;

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/detail/DescriptorUnpackHelpers.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/detail/DescriptorUnpackHelpers.hpp
@@ -389,6 +389,13 @@ template <typename T>
             tensor->set_value(val);
             break;
         }
+        case DataType::INT64:
+        {
+            int64_t val = 0;
+            std::memcpy(&val, valueBytes.data(), sizeof(int64_t));
+            tensor->set_value(val);
+            break;
+        }
         case DataType::UINT8:
         case DataType::INT8:
         case DataType::FP8_E4M3:

--- a/projects/hipdnn/frontend/tests/TestDescriptorUnpackHelpers.cpp
+++ b/projects/hipdnn/frontend/tests/TestDescriptorUnpackHelpers.cpp
@@ -536,6 +536,144 @@ TEST_F(TestUnpackTensorAttributes, UnpackTensorAttributesRestoresPassByValue)
     EXPECT_FLOAT_EQ(tensor->get_pass_by_value<float>().value(), K_SCALAR_VALUE);
 }
 
+TEST_F(TestUnpackTensorAttributes, UnpackTensorAttributesRestoresPassByValueInt64)
+{
+    static constexpr int64_t K_SCALAR_VALUE = 123456789012345LL;
+
+    // UID
+    EXPECT_CALL(
+        *_mockBackend,
+        backendGetAttribute(_fakeDesc, HIPDNN_ATTR_TENSOR_UNIQUE_ID, HIPDNN_TYPE_INT64, 1, _, _))
+        .WillOnce(DoAll(SetArgPointee<4>(int64_t{1}),
+                        Invoke([](hipdnnBackendDescriptor_t,
+                                  hipdnnBackendAttributeName_t,
+                                  hipdnnBackendAttributeType_t,
+                                  int64_t,
+                                  int64_t*,
+                                  void* arrayOfElements) {
+                            auto uid = K_UID;
+                            std::memcpy(arrayOfElements, &uid, sizeof(int64_t));
+                        }),
+                        Return(HIPDNN_STATUS_SUCCESS)));
+
+    // Name (empty)
+    EXPECT_CALL(
+        *_mockBackend,
+        backendGetAttribute(_fakeDesc, HIPDNN_ATTR_TENSOR_NAME_EXT, HIPDNN_TYPE_CHAR, _, _, _))
+        .WillOnce(DoAll(SetArgPointee<4>(int64_t{0}), Return(HIPDNN_STATUS_SUCCESS)));
+
+    // Data type (INT64)
+    EXPECT_CALL(*_mockBackend,
+                backendGetAttribute(
+                    _fakeDesc, HIPDNN_ATTR_TENSOR_DATA_TYPE, HIPDNN_TYPE_DATA_TYPE, 1, _, _))
+        .WillOnce(DoAll(SetArgPointee<4>(int64_t{1}),
+                        Invoke([](hipdnnBackendDescriptor_t,
+                                  hipdnnBackendAttributeName_t,
+                                  hipdnnBackendAttributeType_t,
+                                  int64_t,
+                                  int64_t*,
+                                  void* arrayOfElements) {
+                            auto dt = HIPDNN_DATA_INT64;
+                            std::memcpy(arrayOfElements, &dt, sizeof(hipdnnDataType_t));
+                        }),
+                        Return(HIPDNN_STATUS_SUCCESS)));
+
+    // Dims: scalar tensor has dims = {1}
+    EXPECT_CALL(
+        *_mockBackend,
+        backendGetAttribute(_fakeDesc, HIPDNN_ATTR_TENSOR_DIMENSIONS, HIPDNN_TYPE_INT64, _, _, _))
+        .WillOnce(DoAll(SetArgPointee<4>(int64_t{1}), Return(HIPDNN_STATUS_SUCCESS)))
+        .WillOnce(DoAll(SetArgPointee<4>(int64_t{1}),
+                        Invoke([](hipdnnBackendDescriptor_t,
+                                  hipdnnBackendAttributeName_t,
+                                  hipdnnBackendAttributeType_t,
+                                  int64_t,
+                                  int64_t*,
+                                  void* arrayOfElements) {
+                            int64_t dim = 1;
+                            std::memcpy(arrayOfElements, &dim, sizeof(int64_t));
+                        }),
+                        Return(HIPDNN_STATUS_SUCCESS)));
+
+    // Strides: scalar tensor has strides = {1}
+    EXPECT_CALL(
+        *_mockBackend,
+        backendGetAttribute(_fakeDesc, HIPDNN_ATTR_TENSOR_STRIDES, HIPDNN_TYPE_INT64, _, _, _))
+        .WillOnce(DoAll(SetArgPointee<4>(int64_t{1}), Return(HIPDNN_STATUS_SUCCESS)))
+        .WillOnce(DoAll(SetArgPointee<4>(int64_t{1}),
+                        Invoke([](hipdnnBackendDescriptor_t,
+                                  hipdnnBackendAttributeName_t,
+                                  hipdnnBackendAttributeType_t,
+                                  int64_t,
+                                  int64_t*,
+                                  void* arrayOfElements) {
+                            int64_t stride = 1;
+                            std::memcpy(arrayOfElements, &stride, sizeof(int64_t));
+                        }),
+                        Return(HIPDNN_STATUS_SUCCESS)));
+
+    // is_virtual: false
+    EXPECT_CALL(
+        *_mockBackend,
+        backendGetAttribute(_fakeDesc, HIPDNN_ATTR_TENSOR_IS_VIRTUAL, HIPDNN_TYPE_BOOLEAN, 1, _, _))
+        .WillOnce(DoAll(SetArgPointee<4>(int64_t{1}),
+                        Invoke([](hipdnnBackendDescriptor_t,
+                                  hipdnnBackendAttributeName_t,
+                                  hipdnnBackendAttributeType_t,
+                                  int64_t,
+                                  int64_t*,
+                                  void* arrayOfElements) {
+                            auto val = false;
+                            std::memcpy(arrayOfElements, &val, sizeof(bool));
+                        }),
+                        Return(HIPDNN_STATUS_SUCCESS)));
+
+    // IS_BY_VALUE: true
+    EXPECT_CALL(*_mockBackend,
+                backendGetAttribute(
+                    _fakeDesc, HIPDNN_ATTR_TENSOR_IS_BY_VALUE_EXT, HIPDNN_TYPE_BOOLEAN, 1, _, _))
+        .WillOnce(DoAll(SetArgPointee<4>(int64_t{1}),
+                        Invoke([](hipdnnBackendDescriptor_t,
+                                  hipdnnBackendAttributeName_t,
+                                  hipdnnBackendAttributeType_t,
+                                  int64_t,
+                                  int64_t*,
+                                  void* arrayOfElements) {
+                            auto val = true;
+                            std::memcpy(arrayOfElements, &val, sizeof(bool));
+                        }),
+                        Return(HIPDNN_STATUS_SUCCESS)));
+
+    // TENSOR_VALUE: return the raw int64_t bytes
+    EXPECT_CALL(
+        *_mockBackend,
+        backendGetAttribute(_fakeDesc, HIPDNN_ATTR_TENSOR_VALUE_EXT, HIPDNN_TYPE_CHAR, _, _, _))
+        .WillOnce(DoAll(SetArgPointee<4>(static_cast<int64_t>(sizeof(int64_t))),
+                        Invoke([](hipdnnBackendDescriptor_t,
+                                  hipdnnBackendAttributeName_t,
+                                  hipdnnBackendAttributeType_t,
+                                  int64_t,
+                                  int64_t*,
+                                  void* arrayOfElements) {
+                            auto val = K_SCALAR_VALUE;
+                            std::memcpy(arrayOfElements, &val, sizeof(int64_t));
+                        }),
+                        Return(HIPDNN_STATUS_SUCCESS)));
+
+    std::shared_ptr<TensorAttributes> tensor;
+    auto err = unpackTensorAttributes(_fakeDesc, tensor);
+
+    EXPECT_TRUE(err.is_good()) << err.get_message();
+    ASSERT_NE(tensor, nullptr);
+    EXPECT_EQ(tensor->get_uid(), K_UID);
+    EXPECT_EQ(tensor->get_data_type(), DataType::INT64);
+    EXPECT_EQ(tensor->get_dim(), (std::vector<int64_t>{1}));
+    EXPECT_EQ(tensor->get_stride(), (std::vector<int64_t>{1}));
+    EXPECT_TRUE(tensor->get_pass_by_value());
+    ASSERT_TRUE(tensor->get_pass_by_value<int64_t>().has_value());
+    EXPECT_EQ(tensor->get_pass_by_value<int64_t>().value(), K_SCALAR_VALUE);
+}
+
 TEST_F(TestUnpackTensorAttributes, UnpackTensorAttributesPassByValuePreserves4dDims)
 {
     static constexpr float K_SCALAR_VALUE = 1e-5f;

--- a/projects/hipdnn/frontend/tests/TestGraphSerialization.cpp
+++ b/projects/hipdnn/frontend/tests/TestGraphSerialization.cpp
@@ -1293,6 +1293,26 @@ TEST_P(TestGraphSerializationRoundTrip, PassByValueTensor)
     roundTripAndCompare(graph);
 }
 
+TEST_P(TestGraphSerializationRoundTrip, PassByValueTensorInt64)
+{
+    Graph graph;
+    graph.set_name("pass_by_value_int64_test");
+    graph.set_compute_data_type(DataType::FLOAT);
+
+    auto x = createTensor("x", {1, 64, 32, 32}, DataType::FLOAT, 1);
+
+    // Create a scalar pass-by-value INT64 tensor (e.g., for SDPA seed/offset)
+    auto seed = std::make_shared<TensorAttributes>(int64_t{42});
+    seed->set_uid(2);
+
+    // Scale x by seed using MUL
+    PointwiseAttributes mulAttrs;
+    mulAttrs.set_mode(PointwiseMode::MUL);
+    graph.pointwise(x, seed, mulAttrs);
+
+    roundTripAndCompare(graph);
+}
+
 TEST_P(TestGraphSerializationRoundTrip, TensorLike)
 {
     Graph graph;

--- a/projects/hipdnn/frontend/tests/TestNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestNode.cpp
@@ -44,7 +44,13 @@ TEST(TestNode, PostValidateNodeComputeDataType)
            {DataType::INT32, ErrorCode::OK},
            {DataType::INT8, ErrorCode::OK},
            {DataType::FP8_E4M3, ErrorCode::OK},
-           {DataType::FP8_E5M2, ErrorCode::OK}};
+           {DataType::FP8_E5M2, ErrorCode::OK},
+           {DataType::FP8_E8M0, ErrorCode::OK},
+           {DataType::FP4_E2M1, ErrorCode::OK},
+           {DataType::INT4, ErrorCode::OK},
+           {DataType::FP6_E2M3, ErrorCode::OK},
+           {DataType::FP6_E3M2, ErrorCode::OK},
+           {DataType::INT64, ErrorCode::OK}};
 
     for(auto [dataType, errorCode] : expectedResults)
     {

--- a/projects/hipdnn/frontend/tests/TestTensorAttributes.cpp
+++ b/projects/hipdnn/frontend/tests/TestTensorAttributes.cpp
@@ -209,7 +209,13 @@ TEST(TestTensorAttributes, ValidateDataType)
            {DataType::INT32, ErrorCode::OK},
            {DataType::INT8, ErrorCode::OK},
            {DataType::FP8_E4M3, ErrorCode::OK},
-           {DataType::FP8_E5M2, ErrorCode::OK}};
+           {DataType::FP8_E5M2, ErrorCode::OK},
+           {DataType::FP8_E8M0, ErrorCode::OK},
+           {DataType::FP4_E2M1, ErrorCode::OK},
+           {DataType::INT4, ErrorCode::OK},
+           {DataType::FP6_E2M3, ErrorCode::OK},
+           {DataType::FP6_E3M2, ErrorCode::OK},
+           {DataType::INT64, ErrorCode::OK}};
 
     for(auto [dataType, errorCode] : expectedResults)
     {

--- a/projects/hipdnn/frontend/tests/TestTensorValueAttributes.cpp
+++ b/projects/hipdnn/frontend/tests/TestTensorValueAttributes.cpp
@@ -237,6 +237,36 @@ TEST(TestTensorValueAttributes, PackUnpackInt32Value)
     EXPECT_EQ(int32Val->value(), K_INT32_VALUE);
 }
 
+TEST(TestTensorValueAttributes, PackUnpackInt64Value)
+{
+    constexpr int64_t K_INT64_VALUE = 123456789012345LL;
+
+    hipdnn_frontend::graph::TensorAttributes tensor;
+    tensor.set_uid(13)
+        .set_name("int64_tensor")
+        .set_data_type(hipdnn_frontend::DataType::INT64)
+        .set_is_virtual(false)
+        .set_value(K_INT64_VALUE);
+
+    flatbuffers::FlatBufferBuilder builder;
+    auto fbOffset = tensor.pack_attributes(builder);
+    builder.Finish(fbOffset);
+
+    auto bufferPointer = builder.GetBufferPointer();
+    auto fbTensor = flatbuffers::GetRoot<TensorAttributes>(bufferPointer);
+
+    EXPECT_EQ(fbTensor->value_type(), TensorValue::Int64Value);
+    auto i64val = fbTensor->value_as_Int64Value();
+    ASSERT_NE(i64val, nullptr);
+    EXPECT_EQ(i64val->value(), K_INT64_VALUE);
+
+    auto unpacked = std::unique_ptr<TensorAttributesT>(fbTensor->UnPack());
+    ASSERT_EQ(unpacked->value.type, TensorValue::Int64Value);
+    auto* int64Val = unpacked->value.AsInt64Value();
+    ASSERT_NE(int64Val, nullptr);
+    EXPECT_EQ(int64Val->value(), K_INT64_VALUE);
+}
+
 TEST(TestTensorValueAttributes, PackUnpackEmptyValue)
 {
     hipdnn_frontend::graph::TensorAttributes tensor;
@@ -275,15 +305,26 @@ TEST(TestTensorValueAttributes, TypeSafety)
     EXPECT_FALSE(tensor.get_pass_by_value<bfloat16>().has_value());
     EXPECT_FALSE(tensor.get_pass_by_value<uint8_t>().has_value());
     EXPECT_FALSE(tensor.get_pass_by_value<int32_t>().has_value());
+    EXPECT_FALSE(tensor.get_pass_by_value<int64_t>().has_value());
     EXPECT_FALSE(tensor.get_pass_by_value<double>().has_value());
 
     tensor.set_value(int32_t{123});
 
     EXPECT_FALSE(tensor.get_pass_by_value<float>().has_value());
+    EXPECT_FALSE(tensor.get_pass_by_value<int64_t>().has_value());
 
     auto intOpt = tensor.get_pass_by_value<int32_t>();
     ASSERT_TRUE(intOpt.has_value());
     EXPECT_EQ(intOpt.value(), 123);
+
+    tensor.set_value(int64_t{456789012345LL});
+
+    EXPECT_FALSE(tensor.get_pass_by_value<float>().has_value());
+    EXPECT_FALSE(tensor.get_pass_by_value<int32_t>().has_value());
+
+    auto int64Opt = tensor.get_pass_by_value<int64_t>();
+    ASSERT_TRUE(int64Opt.has_value());
+    EXPECT_EQ(int64Opt.value(), 456789012345LL);
 }
 
 TEST(TestTensorValueAttributes, NumericLimits)
@@ -299,6 +340,11 @@ TEST(TestTensorValueAttributes, NumericLimits)
     auto intOpt = tensor.get_pass_by_value<int32_t>();
     ASSERT_TRUE(intOpt.has_value());
     EXPECT_EQ(intOpt.value(), std::numeric_limits<int32_t>::min());
+
+    tensor.set_value(std::numeric_limits<int64_t>::min());
+    auto int64Opt = tensor.get_pass_by_value<int64_t>();
+    ASSERT_TRUE(int64Opt.has_value());
+    EXPECT_EQ(int64Opt.value(), std::numeric_limits<int64_t>::min());
 
     tensor.set_value(std::numeric_limits<uint8_t>::max());
     auto uint8Opt = tensor.get_pass_by_value<uint8_t>();

--- a/projects/hipdnn/frontend/tests/TestTypes.cpp
+++ b/projects/hipdnn/frontend/tests/TestTypes.cpp
@@ -23,6 +23,7 @@ TEST(TestTypes, ToSdkTypeDataTypes)
     EXPECT_EQ(toSdkType(DataType::INT4), hipdnn_data_sdk::data_objects::DataType::INT4);
     EXPECT_EQ(toSdkType(DataType::FP6_E2M3), hipdnn_data_sdk::data_objects::DataType::FP6_E2M3);
     EXPECT_EQ(toSdkType(DataType::FP6_E3M2), hipdnn_data_sdk::data_objects::DataType::FP6_E3M2);
+    EXPECT_EQ(toSdkType(DataType::INT64), hipdnn_data_sdk::data_objects::DataType::INT64);
     EXPECT_EQ(toSdkType(DataType::NOT_SET), hipdnn_data_sdk::data_objects::DataType::UNSET);
 }
 
@@ -44,6 +45,7 @@ TEST(TestTypes, FromSdkTypeDataTypes)
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::INT4), DataType::INT4);
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::FP6_E2M3), DataType::FP6_E2M3);
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::FP6_E3M2), DataType::FP6_E3M2);
+    EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::INT64), DataType::INT64);
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::UNSET), DataType::NOT_SET);
 }
 
@@ -89,6 +91,7 @@ TEST(TestTypes, GetDataTypeEnumFromType)
     EXPECT_EQ(getDataTypeEnumFromType<int8_t>(), DataType::INT8);
     EXPECT_EQ(getDataTypeEnumFromType<fp8_e4m3>(), DataType::FP8_E4M3);
     EXPECT_EQ(getDataTypeEnumFromType<fp8_e5m2>(), DataType::FP8_E5M2);
+    EXPECT_EQ(getDataTypeEnumFromType<int64_t>(), DataType::INT64);
 
     EXPECT_EQ(getDataTypeEnumFromType<float*>(), DataType::NOT_SET);
     EXPECT_EQ(getDataTypeEnumFromType<char>(), DataType::NOT_SET);
@@ -112,6 +115,7 @@ TEST(TestTypes, DataTypeToString)
     EXPECT_STREQ(to_string(DataType::INT4), "int4");
     EXPECT_STREQ(to_string(DataType::FP6_E2M3), "fp6_e2m3");
     EXPECT_STREQ(to_string(DataType::FP6_E3M2), "fp6_e3m2");
+    EXPECT_STREQ(to_string(DataType::INT64), "int64");
     EXPECT_STREQ(to_string(DataType::NOT_SET), "unknown");
 }
 
@@ -175,6 +179,10 @@ TEST(TestTypes, DataTypeStreamOperator)
 
     oss << DataType::FP6_E3M2;
     EXPECT_EQ(oss.str(), "fp6_e3m2");
+    oss.str("");
+
+    oss << DataType::INT64;
+    EXPECT_EQ(oss.str(), "int64");
     oss.str("");
 
     oss << DataType::NOT_SET;
@@ -286,6 +294,7 @@ TEST(TestTypes, ToHipdnnDataType)
     EXPECT_EQ(toHipdnnDataType(DataType::INT4), HIPDNN_DATA_INT4);
     EXPECT_EQ(toHipdnnDataType(DataType::FP6_E2M3), HIPDNN_DATA_FP6_E2M3);
     EXPECT_EQ(toHipdnnDataType(DataType::FP6_E3M2), HIPDNN_DATA_FP6_E3M2);
+    EXPECT_EQ(toHipdnnDataType(DataType::INT64), HIPDNN_DATA_INT64);
     EXPECT_EQ(toHipdnnDataType(DataType::NOT_SET), std::nullopt);
 }
 
@@ -314,6 +323,7 @@ TEST(TestTypes, FromHipdnnDataTypeAllValidTypes)
     check(HIPDNN_DATA_INT4, DataType::INT4);
     check(HIPDNN_DATA_FP6_E2M3, DataType::FP6_E2M3);
     check(HIPDNN_DATA_FP6_E3M2, DataType::FP6_E3M2);
+    check(HIPDNN_DATA_INT64, DataType::INT64);
 }
 
 TEST(TestTypes, FromHipdnnDataTypeUnknownReturnsError)
@@ -345,7 +355,8 @@ TEST(TestTypes, FromHipdnnDataTypeRoundTrip)
                    DataType::FP4_E2M1,
                    DataType::INT4,
                    DataType::FP6_E2M3,
-                   DataType::FP6_E3M2})
+                   DataType::FP6_E3M2,
+                   DataType::INT64})
     {
         auto hipdnnOpt = toHipdnnDataType(dt);
         ASSERT_TRUE(hipdnnOpt.has_value()) << "toHipdnnDataType failed for " << to_string(dt);

--- a/projects/hipdnn/python/src/types_bindings.cpp
+++ b/projects/hipdnn/python/src/types_bindings.cpp
@@ -23,7 +23,13 @@ void types_bindings(nb::module_& m)
         .value("INT32", DataType::INT32)
         .value("INT8", DataType::INT8)
         .value("FP8_E4M3", DataType::FP8_E4M3)
-        .value("FP8_E5M2", DataType::FP8_E5M2);
+        .value("FP8_E5M2", DataType::FP8_E5M2)
+        .value("FP8_E8M0", DataType::FP8_E8M0)
+        .value("FP4_E2M1", DataType::FP4_E2M1)
+        .value("INT4", DataType::INT4)
+        .value("FP6_E2M3", DataType::FP6_E2M3)
+        .value("FP6_E3M2", DataType::FP6_E3M2)
+        .value("INT64", DataType::INT64);
 
     // Bind ConvolutionMode enum
     nb::enum_<ConvolutionMode>(m, "ConvolutionMode")

--- a/projects/hipdnn/tests/frontend/IntegrationBatchnormBackwardDescriptorLifting.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationBatchnormBackwardDescriptorLifting.cpp
@@ -30,6 +30,7 @@ class TestableGraph : public Graph
 public:
     using Graph::build_operation_graph;
     using Graph::deserialize_via_backend;
+    using Graph::fromBackendDescriptor;
     using Graph::get_raw_graph_descriptor;
 
     const std::vector<std::shared_ptr<INode>>& getSubNodes() const

--- a/projects/hipdnn/tests/frontend/IntegrationBatchnormInferenceNodeVarianceExtDescriptorLifting.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationBatchnormInferenceNodeVarianceExtDescriptorLifting.cpp
@@ -31,6 +31,7 @@ class TestableGraph : public Graph
 public:
     using Graph::build_operation_graph;
     using Graph::deserialize_via_backend;
+    using Graph::fromBackendDescriptor;
     using Graph::get_raw_graph_descriptor;
 
     const std::vector<std::shared_ptr<INode>>& getSubNodes() const

--- a/projects/hipdnn/tests/frontend/IntegrationConvolutionDgradDescriptorLifting.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationConvolutionDgradDescriptorLifting.cpp
@@ -30,6 +30,7 @@ class TestableGraph : public Graph
 public:
     using Graph::build_operation_graph;
     using Graph::deserialize_via_backend;
+    using Graph::fromBackendDescriptor;
     using Graph::get_raw_graph_descriptor;
 
     const std::vector<std::shared_ptr<INode>>& getSubNodes() const


### PR DESCRIPTION
## Summary

- Adds `INT64` as a full pass-by-value tensor data type to hipDNN (following the `INT32` pattern), enabling INT64 scalar tensors needed for SDPA dropout seed/offset
- Wires INT64 through all layers: FBS schema, backend C API, frontend enum, conversions, JSON serialization, FlatBuffer utilities, Python bindings, and generated headers (v24_12_23 + v25_9_23)
- Adds comprehensive tests at every layer: backend string/conversion/tensor tests, frontend type/unpack/serialization tests, and pack/unpack/type-safety tests

## Test plan

- [x] hipDNN superbuild compiles cleanly (hipdnn + miopen-provider)
- [x] All 1540+ hipDNN unit tests pass
- [x] JSON serialization round-trip verified
- [x] Binary/FlatBuffer serialization round-trip verified
- [x] Pass-by-value set/get round-trip verified
- [x] CI passes

Closes #5943

🤖 Generated with [Claude Code](https://claude.com/claude-code)