### PR TITLE
Allow independent K/V head counts in SDPA GQA validation

### DIFF
--- a/projects/hipdnn/frontend/include/hipdnn_frontend/node/SdpaBpropNode.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/node/SdpaBpropNode.hpp
@@ -129,22 +129,22 @@ public:
                             "SdpaBpropNode: seq_kv mismatch between K and V: "
                                 + std::to_string(seqKvK) + " vs " + std::to_string(seqKvV));
 
-        // Rule 5: num_kv_heads: K[-3] == V[-3]; num_heads % num_kv_heads == 0 (GQA/MQA)
+        // Rule 5: num_heads % K_heads == 0; num_heads % V_heads == 0 (GQA/MQA)
         const auto numHeads = qDims[1];
         const auto numKvHeadsK = kDims[1];
         const auto numKvHeadsV = vDims[1];
-        HIPDNN_RETURN_IF_NE(numKvHeadsK,
-                            numKvHeadsV,
-                            ErrorCode::INVALID_VALUE,
-                            "SdpaBpropNode: num_kv_heads mismatch between K and V: "
-                                + std::to_string(numKvHeadsK) + " vs "
-                                + std::to_string(numKvHeadsV));
         HIPDNN_RETURN_IF_TRUE(numHeads % numKvHeadsK != 0,
                               ErrorCode::INVALID_VALUE,
-                              "SdpaBpropNode: num_heads must be divisible by num_kv_heads for "
+                              "SdpaBpropNode: num_heads must be divisible by num_kv_heads_k for "
                               "GQA/MQA. num_heads="
                                   + std::to_string(numHeads)
-                                  + ", num_kv_heads=" + std::to_string(numKvHeadsK));
+                                  + ", num_kv_heads_k=" + std::to_string(numKvHeadsK));
+        HIPDNN_RETURN_IF_TRUE(numHeads % numKvHeadsV != 0,
+                              ErrorCode::INVALID_VALUE,
+                              "SdpaBpropNode: num_heads must be divisible by num_kv_heads_v for "
+                              "GQA/MQA. num_heads="
+                                  + std::to_string(numHeads)
+                                  + ", num_kv_heads_v=" + std::to_string(numKvHeadsV));
 
         // Rule 6: dO must match O shape [batch, num_heads, seq_q, head_dim_v]
         const auto& oDims = o->get_dim();

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/node/SdpaBpropNode.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/node/SdpaBpropNode.hpp
@@ -131,20 +131,28 @@ public:
 
         // Rule 5: num_heads % K_heads == 0; num_heads % V_heads == 0 (GQA/MQA)
         const auto numHeads = qDims[1];
-        const auto numKvHeadsK = kDims[1];
-        const auto numKvHeadsV = vDims[1];
-        HIPDNN_RETURN_IF_TRUE(numHeads % numKvHeadsK != 0,
+        const auto numHeadsK = kDims[1];
+        const auto numHeadsV = vDims[1];
+        HIPDNN_RETURN_IF_TRUE(numHeadsK <= 0,
                               ErrorCode::INVALID_VALUE,
-                              "SdpaBpropNode: num_heads must be divisible by num_kv_heads_k for "
+                              "SdpaBpropNode: num_heads_k must be positive, got "
+                                  + std::to_string(numHeadsK));
+        HIPDNN_RETURN_IF_TRUE(numHeads % numHeadsK != 0,
+                              ErrorCode::INVALID_VALUE,
+                              "SdpaBpropNode: num_heads must be divisible by num_heads_k for "
                               "GQA/MQA. num_heads="
                                   + std::to_string(numHeads)
-                                  + ", num_kv_heads_k=" + std::to_string(numKvHeadsK));
-        HIPDNN_RETURN_IF_TRUE(numHeads % numKvHeadsV != 0,
+                                  + ", num_heads_k=" + std::to_string(numHeadsK));
+        HIPDNN_RETURN_IF_TRUE(numHeadsV <= 0,
                               ErrorCode::INVALID_VALUE,
-                              "SdpaBpropNode: num_heads must be divisible by num_kv_heads_v for "
+                              "SdpaBpropNode: num_heads_v must be positive, got "
+                                  + std::to_string(numHeadsV));
+        HIPDNN_RETURN_IF_TRUE(numHeads % numHeadsV != 0,
+                              ErrorCode::INVALID_VALUE,
+                              "SdpaBpropNode: num_heads must be divisible by num_heads_v for "
                               "GQA/MQA. num_heads="
                                   + std::to_string(numHeads)
-                                  + ", num_kv_heads_v=" + std::to_string(numKvHeadsV));
+                                  + ", num_heads_v=" + std::to_string(numHeadsV));
 
         // Rule 6: dO must match O shape [batch, num_heads, seq_q, head_dim_v]
         const auto& oDims = o->get_dim();

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/node/SdpaFpropNode.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/node/SdpaFpropNode.hpp
@@ -92,22 +92,22 @@ public:
                             "SdpaFpropNode: seq_kv mismatch between K and V: "
                                 + std::to_string(seqKvK) + " vs " + std::to_string(seqKvV));
 
-        // Rule 4: num_kv_heads: K[-3] == V[-3]; num_heads % num_kv_heads == 0 (GQA/MQA)
+        // Rule 4: num_heads % K_heads == 0; num_heads % V_heads == 0 (GQA/MQA)
         const auto numHeads = qDims[1];
         const auto numKvHeadsK = kDims[1];
         const auto numKvHeadsV = vDims[1];
-        HIPDNN_RETURN_IF_NE(numKvHeadsK,
-                            numKvHeadsV,
-                            ErrorCode::INVALID_VALUE,
-                            "SdpaFpropNode: num_kv_heads mismatch between K and V: "
-                                + std::to_string(numKvHeadsK) + " vs "
-                                + std::to_string(numKvHeadsV));
         HIPDNN_RETURN_IF_TRUE(numHeads % numKvHeadsK != 0,
                               ErrorCode::INVALID_VALUE,
-                              "SdpaFpropNode: num_heads must be divisible by num_kv_heads for "
+                              "SdpaFpropNode: num_heads must be divisible by num_kv_heads_k for "
                               "GQA/MQA. num_heads="
                                   + std::to_string(numHeads)
-                                  + ", num_kv_heads=" + std::to_string(numKvHeadsK));
+                                  + ", num_kv_heads_k=" + std::to_string(numKvHeadsK));
+        HIPDNN_RETURN_IF_TRUE(numHeads % numKvHeadsV != 0,
+                              ErrorCode::INVALID_VALUE,
+                              "SdpaFpropNode: num_heads must be divisible by num_kv_heads_v for "
+                              "GQA/MQA. num_heads="
+                                  + std::to_string(numHeads)
+                                  + ", num_kv_heads_v=" + std::to_string(numKvHeadsV));
 
         // Rule 5: Optional attention mask validation
         const auto attnMask = attributes.get_bias();

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/node/SdpaFpropNode.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/node/SdpaFpropNode.hpp
@@ -94,20 +94,28 @@ public:
 
         // Rule 4: num_heads % K_heads == 0; num_heads % V_heads == 0 (GQA/MQA)
         const auto numHeads = qDims[1];
-        const auto numKvHeadsK = kDims[1];
-        const auto numKvHeadsV = vDims[1];
-        HIPDNN_RETURN_IF_TRUE(numHeads % numKvHeadsK != 0,
+        const auto numHeadsK = kDims[1];
+        const auto numHeadsV = vDims[1];
+        HIPDNN_RETURN_IF_TRUE(numHeadsK <= 0,
                               ErrorCode::INVALID_VALUE,
-                              "SdpaFpropNode: num_heads must be divisible by num_kv_heads_k for "
+                              "SdpaFpropNode: num_heads_k must be positive, got "
+                                  + std::to_string(numHeadsK));
+        HIPDNN_RETURN_IF_TRUE(numHeads % numHeadsK != 0,
+                              ErrorCode::INVALID_VALUE,
+                              "SdpaFpropNode: num_heads must be divisible by num_heads_k for "
                               "GQA/MQA. num_heads="
                                   + std::to_string(numHeads)
-                                  + ", num_kv_heads_k=" + std::to_string(numKvHeadsK));
-        HIPDNN_RETURN_IF_TRUE(numHeads % numKvHeadsV != 0,
+                                  + ", num_heads_k=" + std::to_string(numHeadsK));
+        HIPDNN_RETURN_IF_TRUE(numHeadsV <= 0,
                               ErrorCode::INVALID_VALUE,
-                              "SdpaFpropNode: num_heads must be divisible by num_kv_heads_v for "
+                              "SdpaFpropNode: num_heads_v must be positive, got "
+                                  + std::to_string(numHeadsV));
+        HIPDNN_RETURN_IF_TRUE(numHeads % numHeadsV != 0,
+                              ErrorCode::INVALID_VALUE,
+                              "SdpaFpropNode: num_heads must be divisible by num_heads_v for "
                               "GQA/MQA. num_heads="
                                   + std::to_string(numHeads)
-                                  + ", num_kv_heads_v=" + std::to_string(numKvHeadsV));
+                                  + ", num_heads_v=" + std::to_string(numHeadsV));
 
         // Rule 5: Optional attention mask validation
         const auto attnMask = attributes.get_bias();

--- a/projects/hipdnn/frontend/tests/TestSdpaBpropNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestSdpaBpropNode.cpp
@@ -99,6 +99,19 @@ TEST(TestSdpaBpropNode, PreValidateFailsZeroKvHeads)
     EXPECT_EQ(err.code, error_code_t::INVALID_VALUE);
 }
 
+TEST(TestSdpaBpropNode, PreValidateFailsZeroVHeads)
+{
+    // V has 0 heads — should fail positivity check
+    auto q = makeTensor4D(2, 8, 16, 64);
+    auto k = makeTensor4D(2, 8, 32, 64);
+    auto v = makeTensor4D(2, 0, 32, 64);
+    auto attrs = makeMinimalAttrs(q, k, v);
+    const GraphAttributes graphAttrs;
+    const SdpaBpropNode node(std::move(attrs), graphAttrs);
+    auto err = node.pre_validate_node();
+    EXPECT_EQ(err.code, error_code_t::INVALID_VALUE);
+}
+
 TEST(TestSdpaBpropNode, PreValidateFailsInvalidGQAKHeads)
 {
     // Q=8 heads, K=3 (8%3!=0), V=4 (8%4==0) — K invalid, V valid

--- a/projects/hipdnn/frontend/tests/TestSdpaBpropNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestSdpaBpropNode.cpp
@@ -287,14 +287,27 @@ TEST(TestSdpaBpropNode, PreValidateFailsSeqKvMismatch)
     EXPECT_EQ(err.code, error_code_t::INVALID_VALUE);
 }
 
-TEST(TestSdpaBpropNode, PreValidateFailsNumKvHeadsMismatchKV)
+TEST(TestSdpaBpropNode, PreValidateSucceedsGQADifferentKVHeads)
 {
-    // K num_kv_heads=2, V num_kv_heads=4 — must match
+    // K num_kv_heads=2, V num_kv_heads=4 — both divide Q num_heads=8
     auto q = makeTensor4D(2, 8, 16, 64);
     auto k = makeTensor4D(2, 2, 32, 64);
-    auto v = makeTensor4D(2, 4, 32, 64); // num_kv_heads mismatch
+    auto v = makeTensor4D(2, 4, 32, 64);
     auto attrs = makeMinimalAttrs(q, k, v);
 
+    const GraphAttributes graphAttrs;
+    const SdpaBpropNode node(std::move(attrs), graphAttrs);
+    auto err = node.pre_validate_node();
+    EXPECT_EQ(err.code, error_code_t::OK) << err.err_msg;
+}
+
+TEST(TestSdpaBpropNode, PreValidateFailsInvalidGQAVHeads)
+{
+    // Q=8 heads, K=2 (valid), V=3 (8%3!=0)
+    auto q = makeTensor4D(2, 8, 16, 64);
+    auto k = makeTensor4D(2, 2, 32, 64);
+    auto v = makeTensor4D(2, 3, 32, 64);
+    auto attrs = makeMinimalAttrs(q, k, v);
     const GraphAttributes graphAttrs;
     const SdpaBpropNode node(std::move(attrs), graphAttrs);
     auto err = node.pre_validate_node();

--- a/projects/hipdnn/frontend/tests/TestSdpaBpropNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestSdpaBpropNode.cpp
@@ -86,6 +86,32 @@ TEST(TestSdpaBpropNode, PreValidateSucceedsMQA)
     EXPECT_EQ(err.code, error_code_t::OK) << err.err_msg;
 }
 
+TEST(TestSdpaBpropNode, PreValidateFailsZeroKvHeads)
+{
+    // K has 0 heads — should fail positivity check before divisibility
+    auto q = makeTensor4D(2, 8, 16, 64);
+    auto k = makeTensor4D(2, 0, 32, 64);
+    auto v = makeTensor4D(2, 8, 32, 64);
+    auto attrs = makeMinimalAttrs(q, k, v);
+    const GraphAttributes graphAttrs;
+    const SdpaBpropNode node(std::move(attrs), graphAttrs);
+    auto err = node.pre_validate_node();
+    EXPECT_EQ(err.code, error_code_t::INVALID_VALUE);
+}
+
+TEST(TestSdpaBpropNode, PreValidateFailsInvalidGQAKHeads)
+{
+    // Q=8 heads, K=3 (8%3!=0), V=4 (8%4==0) — K invalid, V valid
+    auto q = makeTensor4D(2, 8, 16, 64);
+    auto k = makeTensor4D(2, 3, 32, 64);
+    auto v = makeTensor4D(2, 4, 32, 64);
+    auto attrs = makeMinimalAttrs(q, k, v);
+    const GraphAttributes graphAttrs;
+    const SdpaBpropNode node(std::move(attrs), graphAttrs);
+    auto err = node.pre_validate_node();
+    EXPECT_EQ(err.code, error_code_t::INVALID_VALUE);
+}
+
 TEST(TestSdpaBpropNode, PreValidateFailsMissingQ)
 {
     SdpaBackwardAttributes attrs;

--- a/projects/hipdnn/frontend/tests/TestSdpaFpropNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestSdpaFpropNode.cpp
@@ -117,6 +117,19 @@ TEST(TestSdpaFpropNode, PreValidateFailsZeroKvHeads)
     EXPECT_EQ(err.code, error_code_t::INVALID_VALUE);
 }
 
+TEST(TestSdpaFpropNode, PreValidateFailsZeroVHeads)
+{
+    // V has 0 heads — should fail positivity check
+    auto q = makeTensor4D(2, 8, 16, 64);
+    auto k = makeTensor4D(2, 8, 32, 64);
+    auto v = makeTensor4D(2, 0, 32, 64);
+    auto attrs = makeMinimalAttrs(q, k, v);
+    const GraphAttributes graphAttrs;
+    const SdpaFpropNode node(std::move(attrs), graphAttrs);
+    auto err = node.pre_validate_node();
+    EXPECT_EQ(err.code, error_code_t::INVALID_VALUE);
+}
+
 TEST(TestSdpaFpropNode, PreValidateFailsInvalidGQAKHeads)
 {
     // Q=8 heads, K=3 (8%3!=0), V=4 (8%4==0) — K invalid, V valid

--- a/projects/hipdnn/frontend/tests/TestSdpaFpropNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestSdpaFpropNode.cpp
@@ -104,6 +104,32 @@ TEST(TestSdpaFpropNode, PreValidateFailsInvalidGQAVHeads)
     EXPECT_EQ(err.code, error_code_t::INVALID_VALUE);
 }
 
+TEST(TestSdpaFpropNode, PreValidateFailsZeroKvHeads)
+{
+    // K has 0 heads — should fail positivity check before divisibility
+    auto q = makeTensor4D(2, 8, 16, 64);
+    auto k = makeTensor4D(2, 0, 32, 64);
+    auto v = makeTensor4D(2, 8, 32, 64);
+    auto attrs = makeMinimalAttrs(q, k, v);
+    const GraphAttributes graphAttrs;
+    const SdpaFpropNode node(std::move(attrs), graphAttrs);
+    auto err = node.pre_validate_node();
+    EXPECT_EQ(err.code, error_code_t::INVALID_VALUE);
+}
+
+TEST(TestSdpaFpropNode, PreValidateFailsInvalidGQAKHeads)
+{
+    // Q=8 heads, K=3 (8%3!=0), V=4 (8%4==0) — K invalid, V valid
+    auto q = makeTensor4D(2, 8, 16, 64);
+    auto k = makeTensor4D(2, 3, 32, 64);
+    auto v = makeTensor4D(2, 4, 32, 64);
+    auto attrs = makeMinimalAttrs(q, k, v);
+    const GraphAttributes graphAttrs;
+    const SdpaFpropNode node(std::move(attrs), graphAttrs);
+    auto err = node.pre_validate_node();
+    EXPECT_EQ(err.code, error_code_t::INVALID_VALUE);
+}
+
 TEST(TestSdpaFpropNode, PreValidateFailsMissingQ)
 {
     SdpaAttributes attrs;

--- a/projects/hipdnn/frontend/tests/TestSdpaFpropNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestSdpaFpropNode.cpp
@@ -78,6 +78,32 @@ TEST(TestSdpaFpropNode, PreValidateSucceedsMQA)
     EXPECT_EQ(err.code, error_code_t::OK) << err.err_msg;
 }
 
+TEST(TestSdpaFpropNode, PreValidateSucceedsGQADifferentKVHeads)
+{
+    // Q=32 heads, K=8, V=4 — independent GQA broadcast
+    auto q = makeTensor4D(2, 32, 128, 64);
+    auto k = makeTensor4D(2, 8, 128, 64);
+    auto v = makeTensor4D(2, 4, 128, 64);
+    auto attrs = makeMinimalAttrs(q, k, v);
+    const GraphAttributes graphAttrs;
+    const SdpaFpropNode node(std::move(attrs), graphAttrs);
+    auto err = node.pre_validate_node();
+    EXPECT_EQ(err.code, error_code_t::OK) << err.err_msg;
+}
+
+TEST(TestSdpaFpropNode, PreValidateFailsInvalidGQAVHeads)
+{
+    // Q=8 heads, K=2 (valid), V=3 (8%3!=0)
+    auto q = makeTensor4D(2, 8, 16, 64);
+    auto k = makeTensor4D(2, 2, 32, 64);
+    auto v = makeTensor4D(2, 3, 32, 64);
+    auto attrs = makeMinimalAttrs(q, k, v);
+    const GraphAttributes graphAttrs;
+    const SdpaFpropNode node(std::move(attrs), graphAttrs);
+    auto err = node.pre_validate_node();
+    EXPECT_EQ(err.code, error_code_t::INVALID_VALUE);
+}
+
 TEST(TestSdpaFpropNode, PreValidateFailsMissingQ)
 {
     SdpaAttributes attrs;

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceSdpa.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceSdpa.hpp
@@ -23,7 +23,7 @@ class CpuFpReferenceSdpa
 public:
     /// SDPA forward: O = softmax(Q @ K^T * scale) @ V
     ///
-    /// Supports GQA/MQA: numHeads must be divisible by numKvHeads.
+    /// Supports GQA/MQA: numHeads must be divisible by both numKvHeadsK and numKvHeadsV.
     /// Optionally adds an additive attention mask before softmax.
     ///
     /// @param q              Query tensor [B, H, Sq, D]
@@ -69,11 +69,11 @@ public:
         const auto numHeads = q.dims()[1];
         const auto seqQ = q.dims()[2];
         const auto headDim = q.dims()[3];
-        const auto numKvHeads = k.dims()[1];
+        const auto numKvHeadsK = k.dims()[1];
         const auto seqKv = k.dims()[2];
         const auto headDimV = v.dims()[3];
-        if(batch <= 0 || numHeads <= 0 || seqQ <= 0 || headDim <= 0 || numKvHeads <= 0 || seqKv <= 0
-           || headDimV <= 0)
+        if(batch <= 0 || numHeads <= 0 || seqQ <= 0 || headDim <= 0 || numKvHeadsK <= 0
+           || seqKv <= 0 || headDimV <= 0)
         {
             throw std::invalid_argument("CpuFpReferenceSdpa: all dimensions must be positive");
         }
@@ -88,10 +88,11 @@ public:
             throw std::invalid_argument("CpuFpReferenceSdpa: Q head_dim (" + std::to_string(headDim)
                                         + ") != K head_dim (" + std::to_string(k.dims()[3]) + ")");
         }
-        if(v.dims()[1] != numKvHeads)
+        const auto numKvHeadsV = v.dims()[1];
+        if(numHeads % numKvHeadsV != 0)
         {
             throw std::invalid_argument(
-                "CpuFpReferenceSdpa: K and V must have same number of heads");
+                "CpuFpReferenceSdpa: numHeads must be divisible by numKvHeadsV");
         }
         if(v.dims()[2] != seqKv)
         {
@@ -101,13 +102,14 @@ public:
         {
             throw std::invalid_argument("CpuFpReferenceSdpa: output shape must be [B, H, Sq, Dv]");
         }
-        if(numHeads % numKvHeads != 0)
+        if(numHeads % numKvHeadsK != 0)
         {
             throw std::invalid_argument(
-                "CpuFpReferenceSdpa: numHeads must be divisible by numKvHeads");
+                "CpuFpReferenceSdpa: numHeads must be divisible by numKvHeadsK");
         }
 
-        const auto headsPerKvHead = numHeads / numKvHeads;
+        const auto headsPerKvHeadK = numHeads / numKvHeadsK;
+        const auto headsPerKvHeadV = numHeads / numKvHeadsV;
 
         const float scale = attnScaleValue.has_value()
                                 ? attnScaleValue.value()
@@ -119,7 +121,8 @@ public:
             const auto b = indices[0];
             const auto h = indices[1];
             const auto sq = indices[2];
-            const auto kvHead = h / headsPerKvHead;
+            const auto kvHeadK = h / headsPerKvHeadK;
+            const auto kvHeadV = h / headsPerKvHeadV;
 
             // Step 1: Compute scaled dot-product scores S[skv]
             std::vector<float> scores(static_cast<size_t>(seqKv));
@@ -130,7 +133,7 @@ public:
                 {
                     dot += static_cast<float>(q.getHostValue(std::vector<int64_t>{b, h, sq, d}))
                            * static_cast<float>(
-                               k.getHostValue(std::vector<int64_t>{b, kvHead, skv, d}));
+                               k.getHostValue(std::vector<int64_t>{b, kvHeadK, skv, d}));
                 }
                 scores[static_cast<size_t>(skv)] = dot * scale;
             }
@@ -193,7 +196,7 @@ public:
                 {
                     acc += probs[static_cast<size_t>(skv)]
                            * static_cast<float>(
-                               v.getHostValue(std::vector<int64_t>{b, kvHead, skv, dv}));
+                               v.getHostValue(std::vector<int64_t>{b, kvHeadV, skv, dv}));
                 }
                 o.setHostValue(hipdnn_test_sdk::detail::safeConvert<ODataType>(acc),
                                std::vector<int64_t>{b, h, sq, dv});

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceSdpa.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceSdpa.hpp
@@ -23,7 +23,7 @@ class CpuFpReferenceSdpa
 public:
     /// SDPA forward: O = softmax(Q @ K^T * scale) @ V
     ///
-    /// Supports GQA/MQA: numHeads must be divisible by both numKvHeadsK and numKvHeadsV.
+    /// Supports GQA/MQA: numHeads must be divisible by both numHeadsK and numHeadsV.
     /// Optionally adds an additive attention mask before softmax.
     ///
     /// @param q              Query tensor [B, H, Sq, D]
@@ -69,11 +69,12 @@ public:
         const auto numHeads = q.dims()[1];
         const auto seqQ = q.dims()[2];
         const auto headDim = q.dims()[3];
-        const auto numKvHeadsK = k.dims()[1];
+        const auto numHeadsK = k.dims()[1];
+        const auto numHeadsV = v.dims()[1];
         const auto seqKv = k.dims()[2];
         const auto headDimV = v.dims()[3];
-        if(batch <= 0 || numHeads <= 0 || seqQ <= 0 || headDim <= 0 || numKvHeadsK <= 0
-           || seqKv <= 0 || headDimV <= 0)
+        if(batch <= 0 || numHeads <= 0 || seqQ <= 0 || headDim <= 0 || numHeadsK <= 0
+           || numHeadsV <= 0 || seqKv <= 0 || headDimV <= 0)
         {
             throw std::invalid_argument("CpuFpReferenceSdpa: all dimensions must be positive");
         }
@@ -88,11 +89,10 @@ public:
             throw std::invalid_argument("CpuFpReferenceSdpa: Q head_dim (" + std::to_string(headDim)
                                         + ") != K head_dim (" + std::to_string(k.dims()[3]) + ")");
         }
-        const auto numKvHeadsV = v.dims()[1];
-        if(numHeads % numKvHeadsV != 0)
+        if(numHeads % numHeadsV != 0)
         {
             throw std::invalid_argument(
-                "CpuFpReferenceSdpa: numHeads must be divisible by numKvHeadsV");
+                "CpuFpReferenceSdpa: numHeads must be divisible by numHeadsV");
         }
         if(v.dims()[2] != seqKv)
         {
@@ -102,14 +102,14 @@ public:
         {
             throw std::invalid_argument("CpuFpReferenceSdpa: output shape must be [B, H, Sq, Dv]");
         }
-        if(numHeads % numKvHeadsK != 0)
+        if(numHeads % numHeadsK != 0)
         {
             throw std::invalid_argument(
-                "CpuFpReferenceSdpa: numHeads must be divisible by numKvHeadsK");
+                "CpuFpReferenceSdpa: numHeads must be divisible by numHeadsK");
         }
 
-        const auto headsPerKvHeadK = numHeads / numKvHeadsK;
-        const auto headsPerKvHeadV = numHeads / numKvHeadsV;
+        const auto headsPerHeadK = numHeads / numHeadsK;
+        const auto headsPerHeadV = numHeads / numHeadsV;
 
         const float scale = attnScaleValue.has_value()
                                 ? attnScaleValue.value()
@@ -121,8 +121,8 @@ public:
             const auto b = indices[0];
             const auto h = indices[1];
             const auto sq = indices[2];
-            const auto kvHeadK = h / headsPerKvHeadK;
-            const auto kvHeadV = h / headsPerKvHeadV;
+            const auto kvHeadK = h / headsPerHeadK;
+            const auto kvHeadV = h / headsPerHeadV;
 
             // Step 1: Compute scaled dot-product scores S[skv]
             std::vector<float> scores(static_cast<size_t>(seqKv));

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceSdpa.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceSdpa.cpp
@@ -255,29 +255,64 @@ TEST(TestCpuFpReferenceSdpaFp64, MqaSupport)
 
 TEST(TestCpuFpReferenceSdpaFp64, GqaDifferentKVHeads)
 {
-    // H=4, Hk=2, Hv=1: K has 2 heads, V has 1 head.
-    // Skv=1 → softmax trivially 1.0 → O = V[b, kvHeadV, 0, :]
-    // headsPerKvHeadV = 4/1 = 4, so all Q heads map to V[kvHead=0]
+    // H=4, Hk=2, Hv=1, Skv=2: K has 2 heads, V has 1 head.
+    // With Skv=2, distinct K-head values produce different attention patterns,
+    // verifying both K-head and V-head mappings.
+    // K head 0: [1,0] at skv=0, [0,0] at skv=1 → Q·K biased toward skv=0
+    // K head 1: [0,0] at skv=0, [1,0] at skv=1 → Q·K biased toward skv=1
+    // V head 0: [1,2] at skv=0, [3,4] at skv=1
+    // Q heads 0,1 → K head 0 (biased toward V[skv=0]=[1,2])
+    // Q heads 2,3 → K head 1 (biased toward V[skv=1]=[3,4])
     Tensor<double> q({1, 4, 1, 2});
-    Tensor<double> k({1, 2, 1, 2});
-    Tensor<double> v({1, 1, 1, 2});
+    Tensor<double> k({1, 2, 2, 2});
+    Tensor<double> v({1, 1, 2, 2});
     Tensor<double> o({1, 4, 1, 2});
 
     q.fillWithValue(0.0);
     k.fillWithValue(0.0);
 
-    v.setHostValue(7.0, 0, 0, 0, 0);
-    v.setHostValue(8.0, 0, 0, 0, 1); // V[kvHead=0] = [7, 8]
+    // Q: all heads have query [1, 0]
+    for(int64_t h = 0; h < 4; ++h)
+    {
+        q.setHostValue(1.0, 0, h, 0, 0);
+    }
+
+    // K head 0: [1,0] at skv=0, [0,0] at skv=1
+    k.setHostValue(1.0, 0, 0, 0, 0);
+    // K head 1: [0,0] at skv=0, [1,0] at skv=1
+    k.setHostValue(1.0, 0, 1, 1, 0);
+
+    // V head 0: [1,2] at skv=0, [3,4] at skv=1
+    v.setHostValue(1.0, 0, 0, 0, 0);
+    v.setHostValue(2.0, 0, 0, 0, 1);
+    v.setHostValue(3.0, 0, 0, 1, 0);
+    v.setHostValue(4.0, 0, 0, 1, 1);
 
     CpuFpReferenceSdpa::forward(q, k, v, o);
 
+    const float scale = 1.0f / std::sqrt(2.0f);
+    const float eLow = std::exp(-scale);
+    const float sumExp = 1.0f + eLow;
+    const float pHigh = 1.0f / sumExp;
+    const float pLow = eLow / sumExp;
     const double tol = 1e-5;
 
-    // All Q heads map to V[kvHeadV=0] = [7, 8]
-    for(int64_t h = 0; h < 4; ++h)
+    // Q heads 0,1 → K head 0 → biased toward skv=0: O ≈ pHigh*V[0] + pLow*V[1]
+    const auto expectedK0D0 = static_cast<double>(pHigh * 1.0f + pLow * 3.0f);
+    const auto expectedK0D1 = static_cast<double>(pHigh * 2.0f + pLow * 4.0f);
+    for(int64_t h = 0; h < 2; ++h)
     {
-        EXPECT_NEAR(o.getHostValue(0, h, 0, 0), 7.0, tol);
-        EXPECT_NEAR(o.getHostValue(0, h, 0, 1), 8.0, tol);
+        EXPECT_NEAR(o.getHostValue(0, h, 0, 0), expectedK0D0, tol);
+        EXPECT_NEAR(o.getHostValue(0, h, 0, 1), expectedK0D1, tol);
+    }
+
+    // Q heads 2,3 → K head 1 → biased toward skv=1: O ≈ pLow*V[0] + pHigh*V[1]
+    const auto expectedK1D0 = static_cast<double>(pLow * 1.0f + pHigh * 3.0f);
+    const auto expectedK1D1 = static_cast<double>(pLow * 2.0f + pHigh * 4.0f);
+    for(int64_t h = 2; h < 4; ++h)
+    {
+        EXPECT_NEAR(o.getHostValue(0, h, 0, 0), expectedK1D0, tol);
+        EXPECT_NEAR(o.getHostValue(0, h, 0, 1), expectedK1D1, tol);
     }
 }
 

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceSdpa.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceSdpa.cpp
@@ -455,24 +455,6 @@ TEST(TestCpuFpReferenceSdpaFp64, CausalMaskFutureTokensHaveNoEffect)
     }
 }
 
-TEST(TestCpuFpReferenceSdpaFp64, ThrowsOnZeroVHeads)
-{
-    // V with 0 heads {1, 0, 1, 2} should throw — the Tensor constructor itself
-    // rejects non-positive dimensions before forward() is reached
-    EXPECT_ANY_THROW({
-        Tensor<double> q({1, 2, 1, 2});
-        Tensor<double> k({1, 2, 1, 2});
-        Tensor<double> v({1, 0, 1, 2});
-        Tensor<double> o({1, 2, 1, 2});
-
-        q.fillWithValue(0.0);
-        k.fillWithValue(0.0);
-        v.fillWithValue(0.0);
-
-        CpuFpReferenceSdpa::forward(q, k, v, o);
-    });
-}
-
 // ---------------------------------------------------------------------------
 // Multi-type smoke test
 // ---------------------------------------------------------------------------

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceSdpa.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceSdpa.cpp
@@ -253,6 +253,34 @@ TEST(TestCpuFpReferenceSdpaFp64, MqaSupport)
     }
 }
 
+TEST(TestCpuFpReferenceSdpaFp64, GqaDifferentKVHeads)
+{
+    // H=4, Hk=2, Hv=1: K has 2 heads, V has 1 head.
+    // Skv=1 → softmax trivially 1.0 → O = V[b, kvHeadV, 0, :]
+    // headsPerKvHeadV = 4/1 = 4, so all Q heads map to V[kvHead=0]
+    Tensor<double> q({1, 4, 1, 2});
+    Tensor<double> k({1, 2, 1, 2});
+    Tensor<double> v({1, 1, 1, 2});
+    Tensor<double> o({1, 4, 1, 2});
+
+    q.fillWithValue(0.0);
+    k.fillWithValue(0.0);
+
+    v.setHostValue(7.0, 0, 0, 0, 0);
+    v.setHostValue(8.0, 0, 0, 0, 1); // V[kvHead=0] = [7, 8]
+
+    CpuFpReferenceSdpa::forward(q, k, v, o);
+
+    const double tol = 1e-5;
+
+    // All Q heads map to V[kvHeadV=0] = [7, 8]
+    for(int64_t h = 0; h < 4; ++h)
+    {
+        EXPECT_NEAR(o.getHostValue(0, h, 0, 0), 7.0, tol);
+        EXPECT_NEAR(o.getHostValue(0, h, 0, 1), 8.0, tol);
+    }
+}
+
 TEST(TestCpuFpReferenceSdpaFp64, AttnMaskBroadcastRank2)
 {
     // Rank-2 mask [1, Skv]: dim[0]=1 broadcasts over all sq (and also over batch and head

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceSdpa.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceSdpa.cpp
@@ -420,6 +420,21 @@ TEST(TestCpuFpReferenceSdpaFp64, CausalMaskFutureTokensHaveNoEffect)
     }
 }
 
+TEST(TestCpuFpReferenceSdpaFp64, ThrowsOnZeroVHeads)
+{
+    // V with 0 heads {1, 0, 1, 2} should throw due to positivity check
+    Tensor<double> q({1, 2, 1, 2});
+    Tensor<double> k({1, 2, 1, 2});
+    Tensor<double> v({1, 0, 1, 2});
+    Tensor<double> o({1, 2, 1, 2});
+
+    q.fillWithValue(0.0);
+    k.fillWithValue(0.0);
+    v.fillWithValue(0.0);
+
+    EXPECT_THROW(CpuFpReferenceSdpa::forward(q, k, v, o), std::invalid_argument);
+}
+
 // ---------------------------------------------------------------------------
 // Multi-type smoke test
 // ---------------------------------------------------------------------------

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceSdpa.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceSdpa.cpp
@@ -457,17 +457,20 @@ TEST(TestCpuFpReferenceSdpaFp64, CausalMaskFutureTokensHaveNoEffect)
 
 TEST(TestCpuFpReferenceSdpaFp64, ThrowsOnZeroVHeads)
 {
-    // V with 0 heads {1, 0, 1, 2} should throw due to positivity check
-    Tensor<double> q({1, 2, 1, 2});
-    Tensor<double> k({1, 2, 1, 2});
-    Tensor<double> v({1, 0, 1, 2});
-    Tensor<double> o({1, 2, 1, 2});
+    // V with 0 heads {1, 0, 1, 2} should throw — the Tensor constructor itself
+    // rejects non-positive dimensions before forward() is reached
+    EXPECT_ANY_THROW({
+        Tensor<double> q({1, 2, 1, 2});
+        Tensor<double> k({1, 2, 1, 2});
+        Tensor<double> v({1, 0, 1, 2});
+        Tensor<double> o({1, 2, 1, 2});
 
-    q.fillWithValue(0.0);
-    k.fillWithValue(0.0);
-    v.fillWithValue(0.0);
+        q.fillWithValue(0.0);
+        k.fillWithValue(0.0);
+        v.fillWithValue(0.0);
 
-    EXPECT_THROW(CpuFpReferenceSdpa::forward(q, k, v, o), std::invalid_argument);
+        CpuFpReferenceSdpa::forward(q, k, v, o);
+    });
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Remove the `K.heads == V.heads` equality constraint from SDPA forward/backward validation, replacing it with independent divisibility checks: `Q.heads % K.heads == 0` AND `Q.heads % V.heads == 0`
- Update the CPU reference implementation to use separate head mappings for K and V tensor indexing
- Add positive and negative tests for the new independent K/V head count validation

Fixes #5888

## Test plan

- [x] Build passes (clean Release build, no ASAN)
- [x] All 6/6 unit test suites pass (100%)
- [x] New tests: `PreValidateSucceedsGQADifferentKVHeads` (Q=32, K=8, V=4)
- [x] New tests: `PreValidateFailsInvalidGQAVHeads` (Q=8, K=2, V=3)
- [x] New test: `GqaDifferentKVHeads` CPU reference (H=4, Hk=2, Hv=1)
- [x] Existing GQA/MQA tests still pass
- [x] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)