### PR TITLE
[CK][Windows]: fmha_fwd_head_grouping guard posix headers and use of posix only functions on Windows

### DIFF
--- a/projects/composablekernel/example/ck_tile/01_fmha/fmha_fwd_head_grouping.hpp
+++ b/projects/composablekernel/example/ck_tile/01_fmha/fmha_fwd_head_grouping.hpp
@@ -8,7 +8,9 @@
 #include <algorithm>
 #include <cctype>
 #include <cstdio>
+#ifndef _WIN32
 #include <dirent.h>
+#endif
 #include <fstream>
 #include <iostream>
 #include <limits>
@@ -102,6 +104,8 @@ inline std::optional<kfd_device_location> get_current_kfd_location()
                                ((props.pciBusID & 0xff) << 8) | ((props.pciDeviceID & 0x1f) << 3)};
 }
 
+#ifndef _WIN32
+
 inline std::optional<std::string> find_matching_kfd_node(const kfd_device_location& loc)
 {
     constexpr const char* kKfdNodesDir = "/sys/class/kfd/kfd/topology/nodes";
@@ -175,6 +179,25 @@ inline size_t get_kfd_sysfs_llc_cache_bytes()
 
     return read_kfd_node_l3_bytes(*node);
 }
+
+#else
+
+inline std::optional<std::string> find_matching_kfd_node(const kfd_device_location& loc)
+{
+	return std::nullopt;
+}
+
+inline size_t read_kfd_node_l3_bytes(const std::string& node_name)
+{
+	return 0;
+}
+
+inline size_t get_kfd_sysfs_llc_cache_bytes()
+{
+    return 0;
+}
+
+#endif // _WIN32
 
 inline size_t get_default_llc_cache_bytes_for_arch(const std::string& arch);
 


### PR DESCRIPTION
## Motivation

The purpose is to fix the build errors when compiling for Windows when `fmha_fwd_head_grouping.hpp` is included.

## Technical Details

This checks if `_WIN32` is defined and prevents including posix headers and use of posix functions. There is currently no way to get the L3 cache size. If the architecture is not one of the ones currently hardcoded with the L3 cache size, it will return the default error value.

## Test Plan

Tested locally building flash-attention with CK on Windows. (See comments here https://github.com/Dao-AILab/flash-attention/pull/2400#issuecomment-4150369788)

## Test Result

Builds successfully only when using setuptools that include the distutils patch here https://github.com/pypa/distutils/pull/406

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


@Snektron @0xDELUXA