### PR TITLE
[MIOpen] Re-apply NHWC Winograd support with GetGroupConvLayout bug fix and regression tests

### DIFF
--- a/projects/miopen/src/buffer_info.cpp
+++ b/projects/miopen/src/buffer_info.cpp
@@ -73,9 +73,9 @@ MemLayout_t GetGroupConvLayout(MemLayout_t layout, bool IsDataBuffer)
             // group operations, so we return the layout unchanged and let the
             // transpose mechanism handle the conversion
             return MemLayout_t::NHWC;
-        case MemLayout_t::CHWN:
-        case MemLayout_t::HWCN:
-        case MemLayout_t::HWNC:
+        case MemLayout_t::CHWN: return MemLayout_t::CHWN;
+        case MemLayout_t::HWCN: return MemLayout_t::HWCN;
+        case MemLayout_t::HWNC: return MemLayout_t::HWNC;
         case MemLayout_t::NGCHW:
         case MemLayout_t::GNCHW:
         case MemLayout_t::CGNHW:
@@ -94,9 +94,9 @@ MemLayout_t GetGroupConvLayout(MemLayout_t layout, bool IsDataBuffer)
             // group operations, so we return the layout unchanged and let the
             // transpose mechanism handle the conversion
             return MemLayout_t::NHWC;
-        case MemLayout_t::CHWN:
-        case MemLayout_t::HWCN:
-        case MemLayout_t::HWNC:
+        case MemLayout_t::CHWN: return MemLayout_t::CHWN;
+        case MemLayout_t::HWCN: return MemLayout_t::HWCN;
+        case MemLayout_t::HWNC: return MemLayout_t::HWNC;
         case MemLayout_t::NGCHW:
         case MemLayout_t::GNCHW:
         case MemLayout_t::CGNHW:

--- a/projects/miopen/src/buffer_info.cpp
+++ b/projects/miopen/src/buffer_info.cpp
@@ -69,6 +69,10 @@ MemLayout_t GetGroupConvLayout(MemLayout_t layout, bool IsDataBuffer)
         case MemLayout_t::CNHW: return MemLayout_t::CGNHW;
         case MemLayout_t::NCHW: return MemLayout_t::NGCHW;
         case MemLayout_t::NHWC:
+            // For transposing solvers, NHWC data will be transposed to NCHW before
+            // group operations, so we return the layout unchanged and let the
+            // transpose mechanism handle the conversion
+            return MemLayout_t::NHWC;
         case MemLayout_t::CHWN:
         case MemLayout_t::HWCN:
         case MemLayout_t::HWNC:
@@ -86,6 +90,10 @@ MemLayout_t GetGroupConvLayout(MemLayout_t layout, bool IsDataBuffer)
         case MemLayout_t::CNHW: return MemLayout_t::GCNHW;
         case MemLayout_t::NCHW: return MemLayout_t::GNCHW;
         case MemLayout_t::NHWC:
+            // For transposing solvers, NHWC weights will be transposed to NCHW before
+            // group operations, so we return the layout unchanged and let the
+            // transpose mechanism handle the conversion
+            return MemLayout_t::NHWC;
         case MemLayout_t::CHWN:
         case MemLayout_t::HWCN:
         case MemLayout_t::HWNC:

--- a/projects/miopen/src/conv/problem_description.cpp
+++ b/projects/miopen/src/conv/problem_description.cpp
@@ -135,6 +135,9 @@ void ProblemDescription::HeuristicUpdateLayouts()
 
     // If we have preset layouts that are valid, and they are consistent with each other, then we do
     // not need to change them.
+    // Note: For transposed solvers that modify strides (e.g., NHWC→NCHW), the cached layout string
+    // may not be updated here. This is acceptable for degenerate dimensions (N=1, C=1, etc.) where
+    // strides satisfy multiple layouts, as solvers use actual strides rather than layout strings.
     if(!in_layout.empty() && in_layout == out_layout && in_layout == weights_layout &&
        std::find(supported_layouts.begin(), supported_layouts.end(), in_layout) !=
            supported_layouts.end() &&
@@ -150,9 +153,13 @@ void ProblemDescription::HeuristicUpdateLayouts()
     {
         for(const std::string& layout : supported_layouts)
         {
-            if(in.IsPossibleLayout4D5D(layout, mode) && out.IsPossibleLayout4D5D(layout, mode) &&
-               weights.IsPossibleLayout4D5D(layout, mode))
+            bool in_ok  = in.IsPossibleLayout4D5D(layout, mode);
+            bool out_ok = out.IsPossibleLayout4D5D(layout, mode);
+            bool wei_ok = weights.IsPossibleLayout4D5D(layout, mode);
+
+            if(in_ok && out_ok && wei_ok)
             {
+                // Update the cached layout strings to match the detected layout
                 in_layout      = layout;
                 weights_layout = layout;
                 out_layout     = layout;

--- a/projects/miopen/src/conv/problem_description.cpp
+++ b/projects/miopen/src/conv/problem_description.cpp
@@ -153,11 +153,8 @@ void ProblemDescription::HeuristicUpdateLayouts()
     {
         for(const std::string& layout : supported_layouts)
         {
-            bool in_ok  = in.IsPossibleLayout4D5D(layout, mode);
-            bool out_ok = out.IsPossibleLayout4D5D(layout, mode);
-            bool wei_ok = weights.IsPossibleLayout4D5D(layout, mode);
-
-            if(in_ok && out_ok && wei_ok)
+            if(in.IsPossibleLayout4D5D(layout, mode) && out.IsPossibleLayout4D5D(layout, mode) &&
+               weights.IsPossibleLayout4D5D(layout, mode))
             {
                 // Update the cached layout strings to match the detected layout
                 in_layout      = layout;

--- a/projects/miopen/src/convolution.cpp
+++ b/projects/miopen/src/convolution.cpp
@@ -380,7 +380,8 @@ bool ConvolutionDescriptor::IsWinograd3x3SupportedAndFast(
     if(!(problem.GetOutChannels() >= 16 && problem.GetOutChannels() % 2 == 0))
         return false;
 
-    return solver::conv::ConvBinWinograd3x3U{}.IsApplicable(ctx, problem);
+    return solver::conv::ConvBinWinograd3x3U{}.IsApplicable(ctx, problem) ||
+           solver::conv::TransposedConvBinWinograd3x3U{}.IsApplicable(ctx, problem);
 }
 
 std::size_t ConvolutionDescriptor::GetWorkSpaceSize(ExecutionContext ctx,

--- a/projects/miopen/src/include/miopen/conv/data_invoke_params.hpp
+++ b/projects/miopen/src/include/miopen/conv/data_invoke_params.hpp
@@ -29,7 +29,8 @@
 #include <miopen/scalar.hpp>
 #include <miopen/invoke_params.hpp>
 #include <miopen/conv/tensors.hpp>
-
+#include <miopen/conv/problem_description.hpp>
+#include <miopen/conv/wrw_invoke_params.hpp>
 namespace miopen {
 namespace conv {
 
@@ -76,6 +77,122 @@ struct DataInvokeParams : InvokeParams
 
     std::size_t GetWorkspaceSize() const { return workSpaceSize; }
     Data_t GetWorkspace() const { return workSpace; }
+};
+
+struct TransposeConvInvokeParams : InvokeParams
+{
+    // Flat tensor descriptors (required by TransposingSolver member pointers)
+    TensorDescriptor inDesc;
+    TensorDescriptor wDesc;
+    TensorDescriptor outDesc;
+
+    // Flat data pointers (required by TransposingSolver member pointers)
+    ConstData_t in = nullptr;
+    ConstData_t w  = nullptr;
+    Data_t out     = nullptr;
+
+    // Workspace
+    Data_t workspace          = nullptr;
+    std::size_t workspaceSize = 0;
+
+    // Additional conv params
+    bool gfx90aFp16alt = false;
+    Scalar alpha{1.0};
+    Scalar beta{0.0};
+
+    // WrW-specific data pointers (used when is_wrw == true)
+    // For WrW: w (weights slot) holds dw which is the output (Data_t),
+    //          out (output slot) holds x which is an input (ConstData_t)
+    Data_t w_as_output       = nullptr; // dw buffer pointer for WrW output transpose
+    ConstData_t out_as_input = nullptr; // x buffer pointer for WrW input transpose
+    bool is_wrw              = false;
+
+    TransposeConvInvokeParams() = default;
+
+    // Constructor from DataInvokeParams only (uses tensor descs from params.tensors)
+    explicit TransposeConvInvokeParams(const DataInvokeParams& params)
+        : InvokeParams{params.type},
+          inDesc(params.tensors.inDesc),
+          wDesc(params.tensors.wDesc),
+          outDesc(params.tensors.outDesc),
+          in(params.tensors.in),
+          w(params.tensors.w),
+          out(params.tensors.out),
+          workspace(params.workSpace),
+          workspaceSize(params.workSpaceSize),
+          gfx90aFp16alt(params.gfx90aFp16alt),
+          alpha(params.alpha),
+          beta(params.beta)
+    {
+    }
+
+    // Constructor from WrWInvokeParams
+    // Maps: in/inDesc = dy, w/wDesc = dw, out/outDesc = x
+    // Also sets w_as_output and out_as_input for correct transpose I/O semantics
+    explicit TransposeConvInvokeParams(const WrWInvokeParams& params)
+        : InvokeParams{params.type},
+          inDesc(params.tensors.dyDesc),
+          wDesc(params.tensors.dwDesc),
+          outDesc(params.tensors.xDesc),
+          in(params.tensors.dy),
+          w(params.tensors.dw),
+          out(nullptr), // not used for WrW — x is accessed via out_as_input
+          workspace(params.workSpace),
+          workspaceSize(params.workSpaceSize),
+          gfx90aFp16alt(params.gfx90aFp16alt),
+          alpha(params.alpha),
+          beta(params.beta),
+          w_as_output(params.tensors.dw),
+          out_as_input(params.tensors.x),
+          is_wrw(true)
+    {
+    }
+
+    // Constructor from existing DataInvokeParams + ProblemDescription
+    TransposeConvInvokeParams(const DataInvokeParams& params, const ProblemDescription& problem)
+        : InvokeParams{params.type},
+          inDesc(problem.GetIn()),
+          wDesc(problem.GetWeights()),
+          outDesc(problem.GetOut()),
+          in(params.tensors.in),
+          w(params.tensors.w),
+          out(params.tensors.out),
+          workspace(params.workSpace),
+          workspaceSize(params.workSpaceSize),
+          gfx90aFp16alt(params.gfx90aFp16alt),
+          alpha(params.alpha),
+          beta(params.beta)
+    {
+    }
+
+    std::size_t GetWorkspaceSize() const { return workspaceSize; }
+    Data_t GetWorkspace() const { return workspace; }
+
+    /// Convert to DataInvokeParams for inner solver invocation (Fwd/Bwd).
+    DataInvokeParams ToDataInvokeParams() const
+    {
+        return DataInvokeParams{type,
+                                ConvDataTensors{inDesc, in, wDesc, w, outDesc, out},
+                                workspace,
+                                workspaceSize,
+                                gfx90aFp16alt,
+                                alpha,
+                                beta};
+    }
+
+    /// Convert to WrWInvokeParams for inner solver invocation (WrW).
+    /// Maps back: inDesc/in → dy, wDesc/w_as_output → dw, outDesc/out_as_input → x
+    WrWInvokeParams ToWrWInvokeParams() const
+    {
+        return WrWInvokeParams{
+            type,
+            ConvWrwTensors{inDesc, in, outDesc, out_as_input, wDesc, w_as_output},
+            workspace,
+            workspaceSize,
+            gfx90aFp16alt,
+            alpha,
+            beta};
+    }
 };
 
 } // namespace conv

--- a/projects/miopen/src/include/miopen/conv/solvers.hpp
+++ b/projects/miopen/src/include/miopen/conv/solvers.hpp
@@ -35,6 +35,8 @@
 #include <miopen/miopen.h>
 #include <miopen/performance_config.hpp>
 #include <miopen/solver.hpp>
+#include <miopen/utility/transposing_solver.hpp>
+#include <miopen/conv/data_invoke_params.hpp>
 
 #include <initializer_list>
 #include <string>
@@ -4918,6 +4920,263 @@ struct MIOPEN_INTERNALS_EXPORT ConvDepthwiseFwd2D final
     uint32_t GetSupportedSolutionCount(const ExecutionContext&,
                                        const miopen::conv::ProblemDescription&) const;
 };
+/// Common base for ConvWinogradNHWC transposing solvers (tunable and non-tunable).
+/// Provides ConvertFromApiParams, ConvertForInnerSolver, Transpose, and GetTransposes.
+/// Template params:
+///   Derived    - CRTP derived class
+///   Inner      - the inner (NCHW) winograd solver
+///   SolverBase - ConvSolver or ConvTunableSolver<PerformanceConfigType>
+template <class Derived, class Inner, class SolverBase>
+struct ConvWinogradNHWCTransposingBase : TransposingSolver<Derived,
+                                                           SolverBase,
+                                                           miopen::conv::ProblemDescription,
+                                                           miopen::conv::TransposeConvInvokeParams,
+                                                           Inner>
+{
+    using Problem      = miopen::conv::ProblemDescription;
+    using InvokeParams = miopen::conv::TransposeConvInvokeParams;
+    using Base         = TransposingSolver<Derived, SolverBase, Problem, InvokeParams, Inner>;
+
+    /// Convert from API params to TransposeConvInvokeParams.
+    /// The API passes DataInvokeParams for Fwd/Bwd and WrWInvokeParams for WrW.
+    static InvokeParams ConvertFromApiParams(const AnyInvokeParams& any_params)
+    {
+        if(any_params.IsOfType<miopen::conv::WrWInvokeParams>())
+        {
+            const auto& wrw_params = any_params.CastTo<miopen::conv::WrWInvokeParams>();
+            return InvokeParams{wrw_params};
+        }
+        const auto& data_params = any_params.CastTo<miopen::conv::DataInvokeParams>();
+        return InvokeParams{data_params};
+    }
+
+    /// Convert TransposeConvInvokeParams back to the correct type for inner solver.
+    /// Inner Winograd solvers expect DataInvokeParams for Fwd/Bwd and WrWInvokeParams for WrW.
+    static AnyInvokeParams ConvertForInnerSolver(const InvokeParams& params)
+    {
+        if(params.is_wrw)
+            return params.ToWrWInvokeParams();
+        return params.ToDataInvokeParams();
+    }
+
+    /// Override Transpose to recompute layout strings after transposing tensors.
+    /// This is needed because conv::ProblemDescription caches layout strings at construction,
+    /// and they must be updated to reflect the new NCHW-like strides after transposition.
+    inline static Problem Transpose(const Problem& problem)
+    {
+        auto transposed_problem = Base::Transpose(problem);
+        // CRITICAL: Attempt to update cached layout strings to match transposed strides.
+        // Some inner solvers (e.g., RxSf2x3g1) check IsLayoutDefault() which validates
+        // cached layout strings. Note: For degenerate dimensions (N=1, C=1, etc.), the cached
+        // string may not be updated since strides satisfy multiple layouts. Solvers using
+        // IsPossibleLayout4D5D() will work correctly regardless as they check actual strides.
+        transposed_problem.HeuristicUpdateLayouts();
+        return transposed_problem;
+    }
+
+    inline static auto GetTransposes(const Problem& problem)
+    {
+        const bool is_wrw = problem.IsDirectionBackwardWrW();
+
+        // Layout string "NCDHW" supports both 4D (NCHW) and 5D (NCDHW) tensors:
+        // - For 4D tensors: Automatically interpreted as NCHW (D dimension is implicit/1)
+        // - For 5D tensors: Full NCDHW layout for 3D convolutions
+        // This makes the transposing solver future-proof for both 2D and 3D convolutions.
+        auto ret = std::array<ProblemTensorTransposeDescriptor<Problem, InvokeParams>, 3>{{
+            {
+                &Problem::GetIn,
+                &InvokeParams::inDesc,
+                &InvokeParams::in, // in (dy for WrW): always an input
+                nullptr,
+                "NCDHW", // transpose NHWC/NDHWC->NCHW/NCDHW
+                true,
+            },
+            {
+                &Problem::GetWeights,
+                &InvokeParams::wDesc,
+                is_wrw ? nullptr : &InvokeParams::w,           // Fwd/Bwd: w is input
+                is_wrw ? &InvokeParams::w_as_output : nullptr, // WrW: dw is output
+                "NCDHW", // weights: layout adapts to tensor dimensionality
+                !is_wrw, // Fwd/Bwd: input; WrW: output
+            },
+            {
+                &Problem::GetOut,
+                &InvokeParams::outDesc,
+                is_wrw ? &InvokeParams::out_as_input : nullptr, // WrW: x is input
+                is_wrw ? nullptr : &InvokeParams::out,          // Fwd/Bwd: out is output
+                "NCDHW", // out: layout adapts to tensor dimensionality
+                is_wrw,  // Fwd/Bwd: output; WrW: input
+            },
+        }};
+
+        return ret;
+    }
+};
+
+/// Non-tunable transposing wrapper for NHWC winograd solvers.
+template <class Inner>
+struct ConvWinogradNHWCTransposingSolver
+    : ConvWinogradNHWCTransposingBase<ConvWinogradNHWCTransposingSolver<Inner>, Inner, ConvSolver>
+{
+};
+
+/// Tunable transposing wrapper for NHWC winograd solvers.
+/// Uses ConvTunableSolver<Inner::PerformanceConfigType> as base so that the transposed
+/// solver properly exposes tuning methods (GetDefaultPerformanceConfig, IsValidPerformanceConfig,
+/// Search, GetSolution with config). The TransposingSolverGetSolution<..., true> specialization
+/// handles delegation of all tunable methods to the inner solver with transposed problems.
+template <class Inner>
+struct ConvWinogradNHWCTransposingTunableSolver
+    : ConvWinogradNHWCTransposingBase<ConvWinogradNHWCTransposingTunableSolver<Inner>,
+                                      Inner,
+                                      ConvTunableSolver<typename Inner::PerformanceConfigType>>
+{
+};
+
+struct MIOPEN_INTERNALS_EXPORT TransposedConvBinWinograd3x3U final
+    : ConvWinogradNHWCTransposingSolver<ConvBinWinograd3x3U>
+{
+    const std::string& SolverDbId() const { return GetSolverDbId<TransposedConvBinWinograd3x3U>(); }
+};
+
+struct MIOPEN_INTERNALS_EXPORT TransposedConvBinWinogradRxS final
+    : ConvWinogradNHWCTransposingSolver<ConvBinWinogradRxS>
+{
+    const std::string& SolverDbId() const { return GetSolverDbId<TransposedConvBinWinogradRxS>(); }
+};
+
+struct MIOPEN_INTERNALS_EXPORT TransposedConvBinWinogradRxSf2x3g1 final
+    : ConvWinogradNHWCTransposingSolver<ConvBinWinogradRxSf2x3g1>
+{
+    const std::string& SolverDbId() const
+    {
+        return GetSolverDbId<TransposedConvBinWinogradRxSf2x3g1>();
+    }
+};
+template <int WinoDataH, int WinoFilterH, int WinoDataW = WinoDataH, int WinoFilterW = WinoFilterH>
+struct TransposedConvMPBidirectWinograd final
+    : ConvWinogradNHWCTransposingSolver<
+          ConvMPBidirectWinograd<WinoDataH, WinoFilterH, WinoDataW, WinoFilterW>>
+{
+    const std::string& SolverDbId() const
+    {
+        return this->template GetSolverDbId<
+            TransposedConvMPBidirectWinograd<WinoDataH, WinoFilterH, WinoDataW, WinoFilterW>>();
+    }
+};
+
+#ifndef CONV_MP_BIDIRECTIONAL_WINOGRAD_CPP
+extern template struct TransposedConvMPBidirectWinograd<2, 3>;
+extern template struct TransposedConvMPBidirectWinograd<3, 3>;
+extern template struct TransposedConvMPBidirectWinograd<4, 3>;
+extern template struct TransposedConvMPBidirectWinograd<5, 3>;
+extern template struct TransposedConvMPBidirectWinograd<6, 3>;
+#endif
+
+template <int WinoDataH, int WinoFilterH, int WinoDataW = WinoDataH, int WinoFilterW = WinoFilterH>
+struct TransposedConvWinograd3x3MultipassWrW final
+    : ConvWinogradNHWCTransposingSolver<
+          ConvWinograd3x3MultipassWrW<WinoDataH, WinoFilterH, WinoDataW, WinoFilterW>>
+{
+    const std::string& SolverDbId() const
+    {
+        return this->template GetSolverDbId<TransposedConvWinograd3x3MultipassWrW<WinoDataH,
+                                                                                  WinoFilterH,
+                                                                                  WinoDataW,
+                                                                                  WinoFilterW>>();
+    }
+};
+
+#ifndef CONV_MULTIPASS_WINO3X3WRW_CPP
+extern template struct TransposedConvWinograd3x3MultipassWrW<3, 2>;
+extern template struct TransposedConvWinograd3x3MultipassWrW<3, 3>;
+extern template struct TransposedConvWinograd3x3MultipassWrW<3, 4>;
+extern template struct TransposedConvWinograd3x3MultipassWrW<3, 5>;
+extern template struct TransposedConvWinograd3x3MultipassWrW<3, 6>;
+extern template struct TransposedConvWinograd3x3MultipassWrW<7, 2>;
+extern template struct TransposedConvWinograd3x3MultipassWrW<7, 3>;
+extern template struct TransposedConvWinograd3x3MultipassWrW<1, 1, 7, 2>;
+extern template struct TransposedConvWinograd3x3MultipassWrW<1, 1, 7, 3>;
+extern template struct TransposedConvWinograd3x3MultipassWrW<7, 2, 1, 1>;
+extern template struct TransposedConvWinograd3x3MultipassWrW<7, 3, 1, 1>;
+extern template struct TransposedConvWinograd3x3MultipassWrW<5, 3>;
+extern template struct TransposedConvWinograd3x3MultipassWrW<5, 4>;
+#endif
+
+template <uint32_t Winodata, uint32_t Winofilter>
+struct TransposedConvWinoFuryRxS final
+    : ConvWinogradNHWCTransposingSolver<ConvWinoFuryRxS<Winodata, Winofilter>>
+{
+    const std::string& SolverDbId() const
+    {
+        return this->template GetSolverDbId<TransposedConvWinoFuryRxS<Winodata, Winofilter>>();
+    }
+};
+
+#ifndef CONV_WINO_FURY_RXS_CPP
+extern template struct TransposedConvWinoFuryRxS<2, 3>;
+#endif
+
+template <uint32_t Winodata, uint32_t Winofilter>
+struct TransposedConvWinoRageRxS final
+    : ConvWinogradNHWCTransposingSolver<ConvWinoRageRxS<Winodata, Winofilter>>
+{
+    const std::string& SolverDbId() const
+    {
+        return this->template GetSolverDbId<TransposedConvWinoRageRxS<Winodata, Winofilter>>();
+    }
+};
+
+#ifndef CONV_WINO_RAGE_RXS_CPP
+extern template struct TransposedConvWinoRageRxS<2, 3>;
+#endif
+
+// Tunable transposed Winograd solvers for NHWC layout support
+template <int Winodata, int Winofilter>
+struct TransposedConvBinWinoRxS final
+    : ConvWinogradNHWCTransposingTunableSolver<ConvBinWinoRxS<Winodata, Winofilter>>
+{
+    const std::string& SolverDbId() const override
+    {
+        return this->template GetSolverDbId<TransposedConvBinWinoRxS<Winodata, Winofilter>>();
+    }
+};
+
+// Suppress misleading clang warnings
+#ifndef CONV_BIN_WINO_RXS_CPP
+
+extern template struct TransposedConvBinWinoRxS<2, 3>;
+extern template struct TransposedConvBinWinoRxS<3, 2>;
+
+#endif
+
+template <int WinoDataH, int WinoFilterH, int WinoDataW = WinoDataH, int WinoFilterW = WinoFilterH>
+struct TransposedConvMPBidirectWinograd_xdlops final
+    : ConvWinogradNHWCTransposingTunableSolver<
+          ConvMPBidirectWinograd_xdlops<WinoDataH, WinoFilterH, WinoDataW, WinoFilterW>>
+{
+    const std::string& SolverDbId() const
+    {
+        return this->template GetSolverDbId<TransposedConvMPBidirectWinograd_xdlops<WinoDataH,
+                                                                                    WinoFilterH,
+                                                                                    WinoDataW,
+                                                                                    WinoFilterW>>();
+    }
+};
+
+// To suppress misleading clang warnings
+#if defined(__clang__) && defined(CONV_MP_BIDIRECTIONAL_WINOGRAD_CPP)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-template-vtables"
+#endif
+extern template struct TransposedConvMPBidirectWinograd_xdlops<2, 3>;
+extern template struct TransposedConvMPBidirectWinograd_xdlops<3, 3>;
+extern template struct TransposedConvMPBidirectWinograd_xdlops<4, 3>;
+extern template struct TransposedConvMPBidirectWinograd_xdlops<5, 3>;
+extern template struct TransposedConvMPBidirectWinograd_xdlops<6, 3>;
+#if defined(__clang__) && defined(CONV_MP_BIDIRECTIONAL_WINOGRAD_CPP)
+#pragma clang diagnostic pop
+#endif
 
 // Test helper functions for metadata validation
 // These functions return all CK kernel TypeStrings without problem-based filtering

--- a/projects/miopen/src/include/miopen/conv/solvers.hpp
+++ b/projects/miopen/src/include/miopen/conv/solvers.hpp
@@ -5033,19 +5033,17 @@ struct ConvWinogradNHWCTransposingTunableSolver
 {
 };
 
-struct MIOPEN_INTERNALS_EXPORT TransposedConvBinWinograd3x3U final
-    : ConvWinogradNHWCTransposingSolver<ConvBinWinograd3x3U>
+struct TransposedConvBinWinograd3x3U final : ConvWinogradNHWCTransposingSolver<ConvBinWinograd3x3U>
 {
     const std::string& SolverDbId() const { return GetSolverDbId<TransposedConvBinWinograd3x3U>(); }
 };
 
-struct MIOPEN_INTERNALS_EXPORT TransposedConvBinWinogradRxS final
-    : ConvWinogradNHWCTransposingSolver<ConvBinWinogradRxS>
+struct TransposedConvBinWinogradRxS final : ConvWinogradNHWCTransposingSolver<ConvBinWinogradRxS>
 {
     const std::string& SolverDbId() const { return GetSolverDbId<TransposedConvBinWinogradRxS>(); }
 };
 
-struct MIOPEN_INTERNALS_EXPORT TransposedConvBinWinogradRxSf2x3g1 final
+struct TransposedConvBinWinogradRxSf2x3g1 final
     : ConvWinogradNHWCTransposingSolver<ConvBinWinogradRxSf2x3g1>
 {
     const std::string& SolverDbId() const
@@ -5065,14 +5063,6 @@ struct TransposedConvMPBidirectWinograd final
     }
 };
 
-#ifndef CONV_MP_BIDIRECTIONAL_WINOGRAD_CPP
-extern template struct TransposedConvMPBidirectWinograd<2, 3>;
-extern template struct TransposedConvMPBidirectWinograd<3, 3>;
-extern template struct TransposedConvMPBidirectWinograd<4, 3>;
-extern template struct TransposedConvMPBidirectWinograd<5, 3>;
-extern template struct TransposedConvMPBidirectWinograd<6, 3>;
-#endif
-
 template <int WinoDataH, int WinoFilterH, int WinoDataW = WinoDataH, int WinoFilterW = WinoFilterH>
 struct TransposedConvWinograd3x3MultipassWrW final
     : ConvWinogradNHWCTransposingSolver<
@@ -5087,22 +5077,6 @@ struct TransposedConvWinograd3x3MultipassWrW final
     }
 };
 
-#ifndef CONV_MULTIPASS_WINO3X3WRW_CPP
-extern template struct TransposedConvWinograd3x3MultipassWrW<3, 2>;
-extern template struct TransposedConvWinograd3x3MultipassWrW<3, 3>;
-extern template struct TransposedConvWinograd3x3MultipassWrW<3, 4>;
-extern template struct TransposedConvWinograd3x3MultipassWrW<3, 5>;
-extern template struct TransposedConvWinograd3x3MultipassWrW<3, 6>;
-extern template struct TransposedConvWinograd3x3MultipassWrW<7, 2>;
-extern template struct TransposedConvWinograd3x3MultipassWrW<7, 3>;
-extern template struct TransposedConvWinograd3x3MultipassWrW<1, 1, 7, 2>;
-extern template struct TransposedConvWinograd3x3MultipassWrW<1, 1, 7, 3>;
-extern template struct TransposedConvWinograd3x3MultipassWrW<7, 2, 1, 1>;
-extern template struct TransposedConvWinograd3x3MultipassWrW<7, 3, 1, 1>;
-extern template struct TransposedConvWinograd3x3MultipassWrW<5, 3>;
-extern template struct TransposedConvWinograd3x3MultipassWrW<5, 4>;
-#endif
-
 template <uint32_t Winodata, uint32_t Winofilter>
 struct TransposedConvWinoFuryRxS final
     : ConvWinogradNHWCTransposingSolver<ConvWinoFuryRxS<Winodata, Winofilter>>
@@ -5112,10 +5086,6 @@ struct TransposedConvWinoFuryRxS final
         return this->template GetSolverDbId<TransposedConvWinoFuryRxS<Winodata, Winofilter>>();
     }
 };
-
-#ifndef CONV_WINO_FURY_RXS_CPP
-extern template struct TransposedConvWinoFuryRxS<2, 3>;
-#endif
 
 template <uint32_t Winodata, uint32_t Winofilter>
 struct TransposedConvWinoRageRxS final
@@ -5127,10 +5097,6 @@ struct TransposedConvWinoRageRxS final
     }
 };
 
-#ifndef CONV_WINO_RAGE_RXS_CPP
-extern template struct TransposedConvWinoRageRxS<2, 3>;
-#endif
-
 // Tunable transposed Winograd solvers for NHWC layout support
 template <int Winodata, int Winofilter>
 struct TransposedConvBinWinoRxS final
@@ -5141,14 +5107,6 @@ struct TransposedConvBinWinoRxS final
         return this->template GetSolverDbId<TransposedConvBinWinoRxS<Winodata, Winofilter>>();
     }
 };
-
-// Suppress misleading clang warnings
-#ifndef CONV_BIN_WINO_RXS_CPP
-
-extern template struct TransposedConvBinWinoRxS<2, 3>;
-extern template struct TransposedConvBinWinoRxS<3, 2>;
-
-#endif
 
 template <int WinoDataH, int WinoFilterH, int WinoDataW = WinoDataH, int WinoFilterW = WinoFilterH>
 struct TransposedConvMPBidirectWinograd_xdlops final

--- a/projects/miopen/src/include/miopen/invoke_params.hpp
+++ b/projects/miopen/src/include/miopen/invoke_params.hpp
@@ -28,6 +28,7 @@
 
 #include <miopen/common.hpp>
 #include <miopen/errors.hpp>
+#include <miopen/logger.hpp>
 
 #include <memory>
 #include <typeinfo>
@@ -121,6 +122,12 @@ public:
         if(!impl->CanCastTo(typeid(Actual)))
             MIOPEN_THROW("Attempt to cast AnyInvokeParams to invalid type.");
         return *reinterpret_cast<Actual*>(impl->GetRawPtr());
+    }
+
+    template <class Actual>
+    bool IsOfType() const
+    {
+        return impl && impl->CanCastTo(typeid(Actual));
     }
 
     operator bool() const { return impl != nullptr; }

--- a/projects/miopen/src/include/miopen/pooling/problem_description.hpp
+++ b/projects/miopen/src/include/miopen/pooling/problem_description.hpp
@@ -66,8 +66,6 @@ struct ProblemDescription : ProblemDescriptionBase,
     const PoolingDescriptor& GetPooling() const { return pooling; }
     const TensorDescriptor& GetXDesc() const { return xDesc; }
     const TensorDescriptor& GetYDesc() const { return yDesc; }
-    TensorDescriptor& GetXDesc() { return xDesc; }
-    TensorDescriptor& GetYDesc() { return yDesc; }
 
     const TensorDescriptor& GetDXDesc() const
     {

--- a/projects/miopen/src/include/miopen/pooling/solvers.hpp
+++ b/projects/miopen/src/include/miopen/pooling/solvers.hpp
@@ -305,22 +305,22 @@ struct PoolingFwdNCHWTransposingSolver
     using Problem      = miopen::pooling::ProblemDescription;
     using InvokeParams = miopen::pooling::FwdInvokeParams;
 
-    inline static auto GetTransposes()
+    inline static auto GetTransposes(const Problem& /*problem*/)
     {
         return std::array<ProblemTensorTransposeDescriptor<Problem, InvokeParams>, 2>{{
             {
                 &Problem::GetXDesc,
-                &Problem::GetXDesc,
                 &InvokeParams::xDesc,
-                {.as_input = &InvokeParams::x},
+                &InvokeParams::x, // x is input
+                nullptr,
                 "NCDHW",
                 true,
             },
             {
                 &Problem::GetYDesc,
-                &Problem::GetYDesc,
                 &InvokeParams::yDesc,
-                {.as_output = &InvokeParams::y},
+                nullptr,
+                &InvokeParams::y, // y is output
                 "NCDHW",
                 false,
             },
@@ -330,27 +330,23 @@ struct PoolingFwdNCHWTransposingSolver
 
 struct TransposedPoolingFwd2d final : PoolingFwdNCHWTransposingSolver<PoolingForward2d>
 {
-    const std::string& SolverDbId() const override
-    {
-        return GetSolverDbId<TransposedPoolingFwd2d>();
-    }
+    const std::string& SolverDbId() const { return GetSolverDbId<TransposedPoolingFwd2d>(); }
     PoolingForward2d::PerformanceConfigType
     GetDefaultPerformanceConfig(const ExecutionContext& ctx,
-                                const miopen::pooling::ProblemDescription& problem) const override
+                                const miopen::pooling::ProblemDescription& problem) const
     {
         return PoolingForward2d{}.GetDefaultPerformanceConfig(ctx, problem);
     }
-    bool
-    IsValidPerformanceConfig(const ExecutionContext& ctx,
-                             const miopen::pooling::ProblemDescription& problem,
-                             const PoolingForward2d::PerformanceConfigType& config) const override
+    bool IsValidPerformanceConfig(const ExecutionContext& ctx,
+                                  const miopen::pooling::ProblemDescription& problem,
+                                  const PoolingForward2d::PerformanceConfigType& config) const
     {
         return PoolingForward2d{}.IsValidPerformanceConfig(ctx, problem, config);
     }
     PoolingForward2d::PerformanceConfigType
     Search(const ExecutionContext& context,
            const miopen::pooling::ProblemDescription& problem,
-           const AnyInvokeParams& invoke_context) const override
+           const AnyInvokeParams& invoke_context) const
     {
         return PoolingForward2d{}.Search(context, problem, invoke_context);
     }
@@ -358,27 +354,23 @@ struct TransposedPoolingFwd2d final : PoolingFwdNCHWTransposingSolver<PoolingFor
 
 struct TransposedPoolingFwdNd final : PoolingFwdNCHWTransposingSolver<PoolingForwardNd>
 {
-    const std::string& SolverDbId() const override
-    {
-        return GetSolverDbId<TransposedPoolingFwdNd>();
-    }
+    const std::string& SolverDbId() const { return GetSolverDbId<TransposedPoolingFwdNd>(); }
     PoolingForwardNd::PerformanceConfigType
     GetDefaultPerformanceConfig(const ExecutionContext& ctx,
-                                const miopen::pooling::ProblemDescription& problem) const override
+                                const miopen::pooling::ProblemDescription& problem) const
     {
         return PoolingForwardNd{}.GetDefaultPerformanceConfig(ctx, problem);
     }
-    bool
-    IsValidPerformanceConfig(const ExecutionContext& ctx,
-                             const miopen::pooling::ProblemDescription& problem,
-                             const PoolingForwardNd::PerformanceConfigType& config) const override
+    bool IsValidPerformanceConfig(const ExecutionContext& ctx,
+                                  const miopen::pooling::ProblemDescription& problem,
+                                  const PoolingForwardNd::PerformanceConfigType& config) const
     {
         return PoolingForwardNd{}.IsValidPerformanceConfig(ctx, problem, config);
     }
     PoolingForwardNd::PerformanceConfigType
     Search(const ExecutionContext& context,
            const miopen::pooling::ProblemDescription& problem,
-           const AnyInvokeParams& invoke_context) const override
+           const AnyInvokeParams& invoke_context) const
     {
         return PoolingForwardNd{}.Search(context, problem, invoke_context);
     }
@@ -457,22 +449,22 @@ struct PoolingBwdNCHWTransposingSolver
     using Problem      = miopen::pooling::ProblemDescription;
     using InvokeParams = miopen::pooling::BwdInvokeParams;
 
-    inline static auto GetTransposes()
+    inline static auto GetTransposes(const Problem& /*problem*/)
     {
         return std::array<ProblemTensorTransposeDescriptor<Problem, InvokeParams>, 2>{{
             {
                 &Problem::GetXDesc,
-                &Problem::GetXDesc,
                 &InvokeParams::dxDesc,
-                {.as_output = &InvokeParams::dx},
+                nullptr,
+                &InvokeParams::dx, // dx is output
                 "NCDHW",
                 false,
             },
             {
                 &Problem::GetYDesc,
-                &Problem::GetYDesc,
                 &InvokeParams::dyDesc,
-                {.as_input = &InvokeParams::dy},
+                &InvokeParams::dy, // dy is input
+                nullptr,
                 "NCDHW",
                 true,
             },
@@ -482,27 +474,23 @@ struct PoolingBwdNCHWTransposingSolver
 
 struct TransposedPoolingBwd2d final : PoolingBwdNCHWTransposingSolver<PoolingBackward2d>
 {
-    const std::string& SolverDbId() const override
-    {
-        return GetSolverDbId<TransposedPoolingBwd2d>();
-    }
+    const std::string& SolverDbId() const { return GetSolverDbId<TransposedPoolingBwd2d>(); }
     PoolingBackward2d::PerformanceConfigType
     GetDefaultPerformanceConfig(const ExecutionContext& ctx,
-                                const miopen::pooling::ProblemDescription& problem) const override
+                                const miopen::pooling::ProblemDescription& problem) const
     {
         return PoolingBackward2d{}.GetDefaultPerformanceConfig(ctx, problem);
     }
-    bool
-    IsValidPerformanceConfig(const ExecutionContext& ctx,
-                             const miopen::pooling::ProblemDescription& problem,
-                             const PoolingBackward2d::PerformanceConfigType& config) const override
+    bool IsValidPerformanceConfig(const ExecutionContext& ctx,
+                                  const miopen::pooling::ProblemDescription& problem,
+                                  const PoolingBackward2d::PerformanceConfigType& config) const
     {
         return PoolingBackward2d{}.IsValidPerformanceConfig(ctx, problem, config);
     }
     PoolingBackward2d::PerformanceConfigType
     Search(const ExecutionContext& context,
            const miopen::pooling::ProblemDescription& problem,
-           const AnyInvokeParams& invoke_context) const override
+           const AnyInvokeParams& invoke_context) const
     {
         return PoolingBackward2d{}.Search(context, problem, invoke_context);
     }
@@ -510,27 +498,23 @@ struct TransposedPoolingBwd2d final : PoolingBwdNCHWTransposingSolver<PoolingBac
 
 struct TransposedPoolingBwdNd final : PoolingBwdNCHWTransposingSolver<PoolingBackwardNd>
 {
-    const std::string& SolverDbId() const override
-    {
-        return GetSolverDbId<TransposedPoolingBwdNd>();
-    }
+    const std::string& SolverDbId() const { return GetSolverDbId<TransposedPoolingBwdNd>(); }
     PoolingBackwardNd::PerformanceConfigType
     GetDefaultPerformanceConfig(const ExecutionContext& ctx,
-                                const miopen::pooling::ProblemDescription& problem) const override
+                                const miopen::pooling::ProblemDescription& problem) const
     {
         return PoolingBackwardNd{}.GetDefaultPerformanceConfig(ctx, problem);
     }
-    bool
-    IsValidPerformanceConfig(const ExecutionContext& ctx,
-                             const miopen::pooling::ProblemDescription& problem,
-                             const PoolingBackwardNd::PerformanceConfigType& config) const override
+    bool IsValidPerformanceConfig(const ExecutionContext& ctx,
+                                  const miopen::pooling::ProblemDescription& problem,
+                                  const PoolingBackwardNd::PerformanceConfigType& config) const
     {
         return PoolingBackwardNd{}.IsValidPerformanceConfig(ctx, problem, config);
     }
     PoolingBackwardNd::PerformanceConfigType
     Search(const ExecutionContext& context,
            const miopen::pooling::ProblemDescription& problem,
-           const AnyInvokeParams& invoke_context) const override
+           const AnyInvokeParams& invoke_context) const
     {
         return PoolingBackwardNd{}.Search(context, problem, invoke_context);
     }

--- a/projects/miopen/src/include/miopen/solver.hpp
+++ b/projects/miopen/src/include/miopen/solver.hpp
@@ -198,6 +198,8 @@ struct TunableSolverTrait
 template <class Context, class Problem, class PerformanceConfig>
 struct SolverBaseTunable : SolverInterfaceTunable<Context, Problem>, TunableSolverTrait
 {
+    using PerformanceConfigType = PerformanceConfig;
+
     bool IsTunable() const final { return true; };
 
     /// Initializes performance config to the default values.

--- a/projects/miopen/src/include/miopen/subbuffers.hpp
+++ b/projects/miopen/src/include/miopen/subbuffers.hpp
@@ -26,12 +26,15 @@
 
 #pragma once
 
+#include <miopen/config.hpp>
 #include <cstddef>
 
 namespace miopen {
 
 struct Handle;
 
-std::size_t GetSubbufferAlignment(const Handle* handle = nullptr);
+// Export required for test code to link. Unlike templates (weak linkage),
+// regular functions need explicit export for visibility in shared library.
+MIOPEN_INTERNALS_EXPORT std::size_t GetSubbufferAlignment(const Handle* handle = nullptr);
 
 } // namespace miopen

--- a/projects/miopen/src/include/miopen/utility/transposing_solver.hpp
+++ b/projects/miopen/src/include/miopen/utility/transposing_solver.hpp
@@ -162,15 +162,17 @@ struct UniversalTransposeSolver : TransposePseudoSolver
         auto sln = ConvSolution{};
 
         {
-            const auto tensor_space = problem.input.GetElementSize();
+            const auto tensor_space = problem.input.GetElementSpace();
             const auto cus          = ctx.GetStream().GetMaxComputeUnits();
             const auto build_params = GetDataTypeKBP(problem.input.GetType());
 
             constexpr std::size_t max_block_size = 256;
             const auto local_size                = max_block_size;
+            // Note: std::max/min without explicit template params to avoid cppcheck false
+            // positives when testing with -Dmax/-Dmin preprocessor defines
             const auto num_blocks =
-                std::max<std::size_t>(1, (tensor_space + local_size - 1) / local_size);
-            const auto capped_blocks = std::min<std::size_t>(num_blocks, cus * 4);
+                std::max(std::size_t{1}, (tensor_space + local_size - 1) / local_size);
+            const auto capped_blocks = std::min(num_blocks, cus * 4);
             const auto global_size   = capped_blocks * local_size;
 
             auto transposeKernel = KernelInfo{};
@@ -295,18 +297,19 @@ private:
     static TransposeSolution CreateTransposeSolution(const ExecutionContext& ctx,
                                                      const TensorDescriptor& desc)
     {
-        const auto& lens = desc.GetLengths();
+        const auto& lens     = desc.GetLengths();
+        constexpr int n_dims = BatchedTransposeTraits<TransposeSolution>::ndims;
+
         const uint32_t n = static_cast<uint32_t>(lens[0]);
         const uint32_t c = static_cast<uint32_t>(lens[1]);
 
-        constexpr int expected_dims = BatchedTransposeTraits<TransposeSolution>::ndims;
-        if constexpr(expected_dims == 4)
+        if constexpr(n_dims == 4)
         {
             const uint32_t h = static_cast<uint32_t>(lens[2]);
             const uint32_t w = static_cast<uint32_t>(lens[3]);
             return TransposeSolution(ctx, desc.GetType(), n, c, h, w);
         }
-        else // expected_dims == 5
+        else // n_dims == 5
         {
             const uint32_t d = static_cast<uint32_t>(lens[2]);
             const uint32_t h = static_cast<uint32_t>(lens[3]);
@@ -371,18 +374,13 @@ inline std::string SyncLayoutDims(const char* from, const char* to)
 template <class Problem, class InvokeParams>
 struct ProblemTensorTransposeDescriptor
 {
-    using DescriptorGetter      = TensorDescriptor& (Problem::*)();
     using ConstDescriptorGetter = const TensorDescriptor& (Problem::*)() const;
 
-    DescriptorGetter descriptor;
     ConstDescriptorGetter cdescriptor;
     TensorDescriptor InvokeParams::*rt_descriptor;
 
-    union
-    {
-        ConstData_t InvokeParams::*as_input;
-        Data_t InvokeParams::*as_output;
-    };
+    ConstData_t InvokeParams::*as_input = nullptr;
+    Data_t InvokeParams::*as_output     = nullptr;
 
     const char* to;
     bool is_input;
@@ -391,8 +389,10 @@ struct ProblemTensorTransposeDescriptor
     inline void Transpose(const Problem& src, Problem_& dest) const
     {
         const auto& desc_from = (src.*cdescriptor)();
-        auto& desc_to         = (dest.*descriptor)();
-        desc_to               = Transpose(desc_from);
+        // Use const_cast on the copy (dest) only - this is safe because we're mutating a copy,
+        // not the original problem. The copy is owned by the transposing solver and not shared.
+        auto& desc_to = const_cast<TensorDescriptor&>((dest.*cdescriptor)());
+        desc_to       = Transpose(desc_from);
     }
 
     inline void Transpose(const InvokeParams& src, InvokeParams& dest) const
@@ -526,17 +526,93 @@ private:
     std::vector<ProblemTensorTransposeInvoke> outputs;
 };
 
+/// Helper base that provides the correct GetSolution override based on whether
+/// the solver Base is tunable or non-tunable. Tunable solvers have
+/// GetSolution(ctx, problem, config) while non-tunable solvers have
+/// GetSolution(ctx, problem). This class inherits from Base so that
+/// TransposingSolver can inherit from it and get both Base and GetSolution.
+template <class Derived,
+          class Base,
+          class Problem,
+          class InvokeParams,
+          class Inner,
+          bool IsTunable = std::is_base_of<TunableSolverTrait, Base>::value>
+struct TransposingSolverGetSolution;
+
+// Forward declaration
 template <class Derived, class Base, class Problem, class InvokeParams, class Inner>
-struct TransposingSolver : Base
+struct TransposingSolver;
+
+/// Non-tunable specialization: provides GetSolution(ctx, problem)
+template <class Derived, class Base, class Problem, class InvokeParams, class Inner>
+struct TransposingSolverGetSolution<Derived, Base, Problem, InvokeParams, Inner, false> : Base
 {
+    ConvSolution GetSolution(const ExecutionContext& ctx, const Problem& problem) const override
+    {
+        auto transposed_problem = Derived::Transpose(problem);
+        ConvSolution sln        = Inner{}.GetSolution(ctx, transposed_problem);
+        return static_cast<const Derived*>(this)->WrapSolutionWithTranspose(
+            ctx, problem, transposed_problem, std::move(sln));
+    }
+};
+
+/// Tunable specialization: provides GetSolution(ctx, problem, config) and delegates
+/// GetDefaultPerformanceConfig, IsValidPerformanceConfig, and Search to the inner solver.
+template <class Derived, class Base, class Problem, class InvokeParams, class Inner>
+struct TransposingSolverGetSolution<Derived, Base, Problem, InvokeParams, Inner, true> : Base
+{
+    using PerformanceConfigType = typename Inner::PerformanceConfigType;
+
+    PerformanceConfigType GetDefaultPerformanceConfig(const ExecutionContext& ctx,
+                                                      const Problem& problem) const override
+    {
+        auto transposed_problem = Derived::Transpose(problem);
+        return Inner{}.GetDefaultPerformanceConfig(ctx, transposed_problem);
+    }
+
+    bool IsValidPerformanceConfig(const ExecutionContext& ctx,
+                                  const Problem& problem,
+                                  const PerformanceConfigType& config) const override
+    {
+        auto transposed_problem = Derived::Transpose(problem);
+        return Inner{}.IsValidPerformanceConfig(ctx, transposed_problem, config);
+    }
+
+    PerformanceConfigType Search(const ExecutionContext& ctx,
+                                 const Problem& problem,
+                                 const AnyInvokeParams& invoke_ctx) const override
+    {
+        auto transposed_problem = Derived::Transpose(problem);
+        return Inner{}.Search(ctx, transposed_problem, invoke_ctx);
+    }
+
+    ConvSolution GetSolution(const ExecutionContext& ctx,
+                             const Problem& problem,
+                             const PerformanceConfigType& config) const override
+    {
+        auto transposed_problem = Derived::Transpose(problem);
+        ConvSolution sln        = Inner{}.GetSolution(ctx, transposed_problem, config);
+        return static_cast<const Derived*>(this)->WrapSolutionWithTranspose(
+            ctx, problem, transposed_problem, std::move(sln));
+    }
+};
+
+template <class Derived, class Base, class Problem, class InvokeParams, class Inner>
+struct TransposingSolver : TransposingSolverGetSolution<Derived, Base, Problem, InvokeParams, Inner>
+{
+    // Allow the GetSolution helper to access Transpose and WrapSolutionWithTranspose
+    friend struct TransposingSolverGetSolution<Derived,
+                                               Base,
+                                               Problem,
+                                               InvokeParams,
+                                               Inner,
+                                               std::is_base_of<TunableSolverTrait, Base>::value>;
+
     using TransposeDescriptor = ProblemTensorTransposeDescriptor<Problem, InvokeParams>;
 
     /// TransposingSolver always needs workspace for transpose buffers.
     bool MayNeedWorkspace() const override { return true; }
 
-    /// Convert invoke params for inner solver invocation.
-    /// Override in derived class if inner solver expects a different params type.
-    /// Default: return params as AnyInvokeParams (pass-through).
     /// Convert from API invoke params to TransposingSolver invoke params.
     /// Override in derived class if API passes a different type than InvokeParams.
     /// Default: cast AnyInvokeParams directly to InvokeParams.
@@ -545,6 +621,9 @@ struct TransposingSolver : Base
         return any_params.CastTo<InvokeParams>();
     }
 
+    /// Convert invoke params for inner solver invocation.
+    /// Override in derived class if inner solver expects a different params type.
+    /// Default: return params as AnyInvokeParams (pass-through).
     static AnyInvokeParams ConvertForInnerSolver(const InvokeParams& params) { return params; }
 
     static std::vector<AnyTransposePseudoSolver> GetTransposeSolvers()
@@ -572,7 +651,7 @@ struct TransposingSolver : Base
         const auto transpose_solvers = Derived::GetTransposeSolversMap();
         auto any_difference          = false;
 
-        for(auto transpose : Derived::GetTransposes())
+        for(auto transpose : Derived::GetTransposes(problem))
         {
             decltype(auto) descriptor = (problem.*(transpose.cdescriptor))();
             const auto layout         = descriptor.GetLayout_str();
@@ -631,25 +710,41 @@ struct TransposingSolver : Base
     {
         // Use Derived::Transpose to allow derived classes to override (CRTP pattern)
         const auto transposed_problem = Derived::Transpose(problem);
-        auto ws_size                  = Inner{}.GetWorkspaceSize(ctx, transposed_problem);
 
-        for(const auto& transpose : Derived::GetTransposes())
+        // Calculate workspace needed by inner solver plus transpose buffers
+        auto ws_size = Inner{}.GetWorkspaceSize(ctx, transposed_problem);
+        for(const auto& transpose : Derived::GetTransposes(problem))
         {
             const auto& descriptor = (transposed_problem.*(transpose.cdescriptor))();
             const auto e_size      = get_data_size(descriptor.GetType());
-            ws_size += descriptor.GetElementSpace() * e_size;
+            const auto tensor_size = descriptor.GetElementSpace() * e_size;
+            ws_size += tensor_size;
         }
-
         return ws_size;
     }
 
-    ConvSolution GetSolution(const ExecutionContext& ctx,
-                             const Problem& problem,
-                             const typename Inner::PerformanceConfigType& config) const override
+    bool IsDynamic() const override
     {
-        // Use Derived::Transpose to allow derived classes to override (CRTP pattern)
-        auto transposed_problem = Derived::Transpose(problem);
-        ConvSolution sln        = Inner{}.GetSolution(ctx, transposed_problem, config);
+        // Transposed solvers ALWAYS require workspace for transpose buffers,
+        // so they can ONLY work in Find mode (not immediate mode with workspace=0).
+        return false;
+    }
+
+    float GetWti(const ExecutionContext& ctx, const Problem& problem) const override
+    {
+        // Delegate to inner solver's GetWti() to ensure transposed solvers
+        // are included in WTI fallback path when TunaNet doesn't predict them
+        const auto transposed_problem = Derived::Transpose(problem);
+        return Inner{}.GetWti(ctx, transposed_problem);
+    }
+
+    /// Wraps an inner solver's ConvSolution with transpose kernels.
+    /// Called by the GetSolution helper specializations.
+    ConvSolution WrapSolutionWithTranspose(const ExecutionContext& ctx,
+                                           const Problem& problem,
+                                           Problem& transposed_problem,
+                                           ConvSolution sln) const
+    {
         // NOLINTNEXTLINE (bugprone-unchecked-optional-access)
         auto old_factory             = sln.invoker_factory.value();
         const auto old_kernels_end   = sln.construction_params.size();
@@ -658,7 +753,7 @@ struct TransposingSolver : Base
         std::vector<std::tuple<TransposeDescriptor, InvokerFactory>> in_transpose_ifs,
             out_transpose_ifs;
 
-        for(auto transpose : Derived::GetTransposes())
+        for(auto transpose : Derived::GetTransposes(problem))
         {
             // For input transposes: use original problem's layout as source
             // For output transposes: use transposed problem's layout as source
@@ -729,10 +824,14 @@ struct TransposingSolver : Base
         if(in_transpose_ifs.size() + out_transpose_ifs.size() == 0)
             return sln;
 
-        const auto ws_size = Inner{}.GetWorkspaceSize(ctx, transposed_problem);
-
+        // Inner solver workspace is used as the starting offset for SegmentedGpuBuffer.
+        // The allocator carves out transpose buffers starting after the inner solver's region.
+        // Total workspace (inner + transpose) is reported via sln.workspace_sz so the caller
+        // allocates enough memory for both.
+        const auto inner_ws_size = Inner{}.GetWorkspaceSize(ctx, transposed_problem);
+        const auto total_ws_size = this->GetWorkspaceSize(ctx, problem);
         sln.invoker_factory =
-            [old_factory, old_kernels_end, ws_size, in_transpose_ifs, out_transpose_ifs](
+            [old_factory, old_kernels_end, in_transpose_ifs, out_transpose_ifs, inner_ws_size](
                 const std::vector<Kernel>& kernels) {
                 const auto inner_kernels =
                     std::vector<Kernel>{kernels.begin(), kernels.begin() + old_kernels_end};
@@ -757,14 +856,16 @@ struct TransposingSolver : Base
 
                 auto invoker = old_factory(inner_kernels);
 
-                return [invoker, in_transpose_invokers, out_transpose_invokers, ws_size](
+                return [invoker, in_transpose_invokers, out_transpose_invokers, inner_ws_size](
                            const Handle& handle, const AnyInvokeParams& any_params) {
                     const auto invoke_params = Derived::ConvertFromApiParams(any_params);
                     auto transposed_params   = invoke_params;
 
                     handle.ResetKernelTime();
 
-                    SegmentedGpuBuffer allocator{handle, invoke_params.workspace, ws_size};
+                    // Start allocating transpose buffers after the inner solver's workspace.
+                    // SegmentedGpuBuffer third parameter is the starting OFFSET, not size.
+                    SegmentedGpuBuffer allocator{handle, invoke_params.workspace, inner_ws_size};
 
                     ProblemTensorTransposeGroup transposeGroup{handle,
                                                                allocator,
@@ -782,6 +883,8 @@ struct TransposingSolver : Base
                 };
             };
 
+        sln.workspace_sz = total_ws_size;
+
         return sln;
     }
 
@@ -789,7 +892,7 @@ protected:
     inline static Problem Transpose(const Problem& problem)
     {
         auto transposed_problem = problem;
-        for(const auto& transpose : Derived::GetTransposes())
+        for(const auto& transpose : Derived::GetTransposes(problem))
             transpose.Transpose(problem, transposed_problem);
         return transposed_problem;
     }

--- a/projects/miopen/src/mlo_dir_conv.cpp
+++ b/projects/miopen/src/mlo_dir_conv.cpp
@@ -141,7 +141,25 @@ static auto GetWindogradSolvers()
         miopen::solver::conv::ConvMPBidirectWinograd_xdlops<5, 3>,
         miopen::solver::conv::ConvMPBidirectWinograd_xdlops<6, 3>,
         miopen::solver::conv::ConvWinoFuryRxS<2, 3>,
-        miopen::solver::conv::ConvWinoRageRxS<2, 3>>{};
+        miopen::solver::conv::ConvWinoRageRxS<2, 3>,
+        // Transposed Winograd solvers for NHWC layout support
+        miopen::solver::conv::TransposedConvBinWinograd3x3U,
+        miopen::solver::conv::TransposedConvBinWinogradRxS,
+        miopen::solver::conv::TransposedConvBinWinogradRxSf2x3g1,
+        miopen::solver::conv::TransposedConvWinoFuryRxS<2, 3>,
+        miopen::solver::conv::TransposedConvWinoRageRxS<2, 3>,
+        miopen::solver::conv::TransposedConvMPBidirectWinograd<2, 3>,
+        miopen::solver::conv::TransposedConvMPBidirectWinograd<3, 3>,
+        miopen::solver::conv::TransposedConvMPBidirectWinograd<4, 3>,
+        miopen::solver::conv::TransposedConvMPBidirectWinograd<5, 3>,
+        miopen::solver::conv::TransposedConvMPBidirectWinograd<6, 3>,
+        miopen::solver::conv::TransposedConvBinWinoRxS<2, 3>,
+        miopen::solver::conv::TransposedConvBinWinoRxS<3, 2>,
+        miopen::solver::conv::TransposedConvMPBidirectWinograd_xdlops<2, 3>,
+        miopen::solver::conv::TransposedConvMPBidirectWinograd_xdlops<3, 3>,
+        miopen::solver::conv::TransposedConvMPBidirectWinograd_xdlops<4, 3>,
+        miopen::solver::conv::TransposedConvMPBidirectWinograd_xdlops<5, 3>,
+        miopen::solver::conv::TransposedConvMPBidirectWinograd_xdlops<6, 3>>{};
 }
 
 static auto GetImplicitGemmWrWSolvers()
@@ -183,7 +201,28 @@ static auto GetWindogradWrWSolvers()
         miopen::solver::conv::ConvWinograd3x3MultipassWrW<5, 3>,
         miopen::solver::conv::ConvWinograd3x3MultipassWrW<5, 4>,
         miopen::solver::conv::ConvWinoFuryRxS<2, 3>,
-        miopen::solver::conv::ConvWinoRageRxS<2, 3>>{};
+        miopen::solver::conv::ConvWinoRageRxS<2, 3>,
+        // Transposed Winograd solvers for NHWC layout support
+        miopen::solver::conv::TransposedConvBinWinograd3x3U,
+        miopen::solver::conv::TransposedConvBinWinogradRxS,
+        miopen::solver::conv::TransposedConvBinWinogradRxSf2x3g1,
+        miopen::solver::conv::TransposedConvWinoFuryRxS<2, 3>,
+        miopen::solver::conv::TransposedConvWinoRageRxS<2, 3>,
+        miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<3, 2>,
+        miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<3, 3>,
+        miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<3, 4>,
+        miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<3, 5>,
+        miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<3, 6>,
+        miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<7, 2>,
+        miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<7, 3>,
+        miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<1, 1, 7, 2>,
+        miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<1, 1, 7, 3>,
+        miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<7, 2, 1, 1>,
+        miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<7, 3, 1, 1>,
+        miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<5, 3>,
+        miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<5, 4>,
+        miopen::solver::conv::TransposedConvBinWinoRxS<2, 3>,
+        miopen::solver::conv::TransposedConvBinWinoRxS<3, 2>>{};
 }
 
 static auto GetBwdWrW2DSolvers()

--- a/projects/miopen/src/solver.cpp
+++ b/projects/miopen/src/solver.cpp
@@ -699,8 +699,121 @@ inline SolverRegistrar::SolverRegistrar(IdRegistryData& registry)
     Register(registry, ++id, Primitive::Normalization, layernorm::LayernormBackward().SolverDbId());
 
     RegisterWithSolver(registry, ++id, conv::ConvDepthwiseFwd2D{}, miopenConvolutionAlgoDirect);
-    // IMPORTANT: New solvers should be added to the end of the function, and don't leave a white
-    // space between this comment and the newly registered solver(s)!
+
+    // Transposed Winograd solvers for NHWC layout support
+    RegisterWithSolver(
+        registry, ++id, conv::TransposedConvBinWinograd3x3U{}, miopenConvolutionAlgoWinograd);
+    MIOPEN_LOG_I("Registering TransposedConvBinWinograd3x3U with id=" << id);
+    RegisterWithSolver(
+        registry, ++id, conv::TransposedConvBinWinogradRxS{}, miopenConvolutionAlgoWinograd);
+    MIOPEN_LOG_I("Registering TransposedConvBinWinogradRxS with id=" << id);
+    RegisterWithSolver(
+        registry, ++id, conv::TransposedConvBinWinogradRxSf2x3g1{}, miopenConvolutionAlgoWinograd);
+    MIOPEN_LOG_I("Registering TransposedConvBinWinogradRxSf2x3g1 with id=" << id);
+    // Transposed non-tunable Winograd solvers
+    RegisterWithSolver(
+        registry, ++id, conv::TransposedConvWinoFuryRxS<2, 3>{}, miopenConvolutionAlgoWinograd);
+    RegisterWithSolver(
+        registry, ++id, conv::TransposedConvWinoRageRxS<2, 3>{}, miopenConvolutionAlgoWinograd);
+    RegisterWithSolver(registry,
+                       ++id,
+                       conv::TransposedConvMPBidirectWinograd<2, 3>{},
+                       miopenConvolutionAlgoWinograd);
+    RegisterWithSolver(registry,
+                       ++id,
+                       conv::TransposedConvMPBidirectWinograd<3, 3>{},
+                       miopenConvolutionAlgoWinograd);
+    RegisterWithSolver(registry,
+                       ++id,
+                       conv::TransposedConvMPBidirectWinograd<4, 3>{},
+                       miopenConvolutionAlgoWinograd);
+    RegisterWithSolver(registry,
+                       ++id,
+                       conv::TransposedConvMPBidirectWinograd<5, 3>{},
+                       miopenConvolutionAlgoWinograd);
+    RegisterWithSolver(registry,
+                       ++id,
+                       conv::TransposedConvMPBidirectWinograd<6, 3>{},
+                       miopenConvolutionAlgoWinograd);
+    RegisterWithSolver(registry,
+                       ++id,
+                       conv::TransposedConvWinograd3x3MultipassWrW<3, 2>{},
+                       miopenConvolutionAlgoWinograd);
+    RegisterWithSolver(registry,
+                       ++id,
+                       conv::TransposedConvWinograd3x3MultipassWrW<3, 3>{},
+                       miopenConvolutionAlgoWinograd);
+    RegisterWithSolver(registry,
+                       ++id,
+                       conv::TransposedConvWinograd3x3MultipassWrW<3, 4>{},
+                       miopenConvolutionAlgoWinograd);
+    RegisterWithSolver(registry,
+                       ++id,
+                       conv::TransposedConvWinograd3x3MultipassWrW<3, 5>{},
+                       miopenConvolutionAlgoWinograd);
+    RegisterWithSolver(registry,
+                       ++id,
+                       conv::TransposedConvWinograd3x3MultipassWrW<3, 6>{},
+                       miopenConvolutionAlgoWinograd);
+    RegisterWithSolver(registry,
+                       ++id,
+                       conv::TransposedConvWinograd3x3MultipassWrW<7, 2>{},
+                       miopenConvolutionAlgoWinograd);
+    RegisterWithSolver(registry,
+                       ++id,
+                       conv::TransposedConvWinograd3x3MultipassWrW<7, 3>{},
+                       miopenConvolutionAlgoWinograd);
+    RegisterWithSolver(registry,
+                       ++id,
+                       conv::TransposedConvWinograd3x3MultipassWrW<1, 1, 7, 2>{},
+                       miopenConvolutionAlgoWinograd);
+    RegisterWithSolver(registry,
+                       ++id,
+                       conv::TransposedConvWinograd3x3MultipassWrW<1, 1, 7, 3>{},
+                       miopenConvolutionAlgoWinograd);
+    RegisterWithSolver(registry,
+                       ++id,
+                       conv::TransposedConvWinograd3x3MultipassWrW<7, 2, 1, 1>{},
+                       miopenConvolutionAlgoWinograd);
+    RegisterWithSolver(registry,
+                       ++id,
+                       conv::TransposedConvWinograd3x3MultipassWrW<7, 3, 1, 1>{},
+                       miopenConvolutionAlgoWinograd);
+    RegisterWithSolver(registry,
+                       ++id,
+                       conv::TransposedConvWinograd3x3MultipassWrW<5, 3>{},
+                       miopenConvolutionAlgoWinograd);
+    RegisterWithSolver(registry,
+                       ++id,
+                       conv::TransposedConvWinograd3x3MultipassWrW<5, 4>{},
+                       miopenConvolutionAlgoWinograd);
+    // Transposed tunable Winograd solvers
+    RegisterWithSolver(
+        registry, ++id, conv::TransposedConvBinWinoRxS<2, 3>{}, miopenConvolutionAlgoWinograd);
+    RegisterWithSolver(
+        registry, ++id, conv::TransposedConvBinWinoRxS<3, 2>{}, miopenConvolutionAlgoWinograd);
+    RegisterWithSolver(registry,
+                       ++id,
+                       conv::TransposedConvMPBidirectWinograd_xdlops<2, 3>{},
+                       miopenConvolutionAlgoWinograd);
+    RegisterWithSolver(registry,
+                       ++id,
+                       conv::TransposedConvMPBidirectWinograd_xdlops<3, 3>{},
+                       miopenConvolutionAlgoWinograd);
+    RegisterWithSolver(registry,
+                       ++id,
+                       conv::TransposedConvMPBidirectWinograd_xdlops<4, 3>{},
+                       miopenConvolutionAlgoWinograd);
+    RegisterWithSolver(registry,
+                       ++id,
+                       conv::TransposedConvMPBidirectWinograd_xdlops<5, 3>{},
+                       miopenConvolutionAlgoWinograd);
+    RegisterWithSolver(registry,
+                       ++id,
+                       conv::TransposedConvMPBidirectWinograd_xdlops<6, 3>{},
+                       miopenConvolutionAlgoWinograd);
+    //  IMPORTANT: New solvers should be added to the end of the function, and don't leave a white
+    //  space between this comment and the newly registered solver(s)!
 }
 
 } // namespace solver

--- a/projects/miopen/src/solver.cpp
+++ b/projects/miopen/src/solver.cpp
@@ -703,13 +703,10 @@ inline SolverRegistrar::SolverRegistrar(IdRegistryData& registry)
     // Transposed Winograd solvers for NHWC layout support
     RegisterWithSolver(
         registry, ++id, conv::TransposedConvBinWinograd3x3U{}, miopenConvolutionAlgoWinograd);
-    MIOPEN_LOG_I("Registering TransposedConvBinWinograd3x3U with id=" << id);
     RegisterWithSolver(
         registry, ++id, conv::TransposedConvBinWinogradRxS{}, miopenConvolutionAlgoWinograd);
-    MIOPEN_LOG_I("Registering TransposedConvBinWinogradRxS with id=" << id);
     RegisterWithSolver(
         registry, ++id, conv::TransposedConvBinWinogradRxSf2x3g1{}, miopenConvolutionAlgoWinograd);
-    MIOPEN_LOG_I("Registering TransposedConvBinWinogradRxSf2x3g1 with id=" << id);
     // Transposed non-tunable Winograd solvers
     RegisterWithSolver(
         registry, ++id, conv::TransposedConvWinoFuryRxS<2, 3>{}, miopenConvolutionAlgoWinograd);

--- a/projects/miopen/src/solver/conv/conv_MP_bidirectional_winograd.cpp
+++ b/projects/miopen/src/solver/conv/conv_MP_bidirectional_winograd.cpp
@@ -227,7 +227,12 @@ static bool IsApplicableTransform(const ExecutionContext& ctx, const ProblemDesc
         }
     }
 
-    if(!problem.IsLayoutDefault())
+    // Use IsPossibleLayout4D5D to check actual tensor strides rather than cached layout string
+    // This allows transposed solvers to work correctly when they modify tensor strides
+    static const auto strict = TensorDescriptor::LayoutValidationMode::StrictDecreasingStrides;
+    if(!(problem.GetIn().IsPossibleLayout4D5D("NCHW", strict) &&
+         problem.GetWeights().IsPossibleLayout4D5D("NCHW", strict) &&
+         problem.GetOut().IsPossibleLayout4D5D("NCHW", strict)))
         return false;
 
     {
@@ -326,8 +331,15 @@ bool ConvMPBidirectWinograd<WinoDataH, WinoFilterH, WinoDataW, WinoFilterW>::IsA
     if(!problem.AllTensorsDimsFitIntoInt())
         return false;
 
-    if(!problem.IsLayoutDefault())
-        return false;
+    // Use IsPossibleLayout4D5D to check actual tensor strides rather than cached layout string
+    // This allows transposed solvers to work correctly when they modify tensor strides
+    {
+        static const auto strict = TensorDescriptor::LayoutValidationMode::StrictDecreasingStrides;
+        if(!(problem.GetIn().IsPossibleLayout4D5D("NCHW", strict) &&
+             problem.GetWeights().IsPossibleLayout4D5D("NCHW", strict) &&
+             problem.GetOut().IsPossibleLayout4D5D("NCHW", strict)))
+            return false;
+    }
 
     if(problem.IsTensorsCasted())
         return false;
@@ -735,6 +747,12 @@ template struct MIOPEN_INTERNALS_EXPORT ConvMPBidirectWinograd<4, 3>;
 template struct MIOPEN_INTERNALS_EXPORT ConvMPBidirectWinograd<5, 3>;
 template struct MIOPEN_INTERNALS_EXPORT ConvMPBidirectWinograd<6, 3>;
 
+template struct MIOPEN_INTERNALS_EXPORT TransposedConvMPBidirectWinograd<2, 3>;
+template struct MIOPEN_INTERNALS_EXPORT TransposedConvMPBidirectWinograd<3, 3>;
+template struct MIOPEN_INTERNALS_EXPORT TransposedConvMPBidirectWinograd<4, 3>;
+template struct MIOPEN_INTERNALS_EXPORT TransposedConvMPBidirectWinograd<5, 3>;
+template struct MIOPEN_INTERNALS_EXPORT TransposedConvMPBidirectWinograd<6, 3>;
+
 // ExecutionContext and ProblemDescription transformation
 // for winograd buffers calculation using xdlops_convolution
 template <int WinoDataH, int WinoFilterH, int WinoDataW, int WinoFilterW>
@@ -961,6 +979,12 @@ template struct ConvMPBidirectWinograd_xdlops<3, 3>;
 template struct ConvMPBidirectWinograd_xdlops<4, 3>;
 template struct ConvMPBidirectWinograd_xdlops<5, 3>;
 template struct ConvMPBidirectWinograd_xdlops<6, 3>;
+
+template struct TransposedConvMPBidirectWinograd_xdlops<2, 3>;
+template struct TransposedConvMPBidirectWinograd_xdlops<3, 3>;
+template struct TransposedConvMPBidirectWinograd_xdlops<4, 3>;
+template struct TransposedConvMPBidirectWinograd_xdlops<5, 3>;
+template struct TransposedConvMPBidirectWinograd_xdlops<6, 3>;
 
 } // namespace conv
 } // namespace solver

--- a/projects/miopen/src/solver/conv/conv_bin_wino3x3U.cpp
+++ b/projects/miopen/src/solver/conv/conv_bin_wino3x3U.cpp
@@ -71,7 +71,12 @@ bool ConvBinWinograd3x3U::IsApplicable(const ExecutionContext& ctx,
     if(!problem.AllTensorsDimsFitIntoInt())
         return false;
 
-    if(!problem.IsLayoutDefault())
+    // Use IsPossibleLayout4D5D to check actual tensor strides rather than cached layout string
+    // This allows transposed solvers to work correctly when they modify tensor strides
+    static const auto strict = TensorDescriptor::LayoutValidationMode::StrictDecreasingStrides;
+    if(!(problem.GetIn().IsPossibleLayout4D5D("NCHW", strict) &&
+         problem.GetWeights().IsPossibleLayout4D5D("NCHW", strict) &&
+         problem.GetOut().IsPossibleLayout4D5D("NCHW", strict)))
         return false;
 
     if(problem.IsTensorsCasted())
@@ -100,7 +105,7 @@ bool ConvBinWinograd3x3U::IsApplicable(const ExecutionContext& ctx,
         && problem.GetInChannels() >= (device_is_gfx8 ? 16 : 18)
         && problem.IsFp32()
         && problem.GetGroupCount() == 1
-        && problem.GetInLayout() == "NCHW";
+        && problem.GetIn().IsPossibleLayout4D5D("NCHW", strict);
         /// && (isForwardDirection() ? _weights_layout == "KCHW" : _weights_layout == "CKHW" )
         /// Actually, K<->C flpping is controlled by separate flag, so we can support either
         /// layout in both directions.

--- a/projects/miopen/src/solver/conv/conv_bin_winoRxS.cpp
+++ b/projects/miopen/src/solver/conv/conv_bin_winoRxS.cpp
@@ -32,6 +32,7 @@
 #include <miopen/kernel_build_params.hpp>
 #include <miopen/conv/data_invoke_params.hpp>
 #include <miopen/conv/tensors.hpp>
+#include <miopen/tensor.hpp>
 
 /// Global switch
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_AMD_WINOGRAD_RXS)
@@ -183,7 +184,14 @@ static inline bool IsShaderContraintsMet(const miopen::ExecutionContext& ctx,
             return false;
     }
     const auto grid_workgroup_count_x = ctx.GetStream().GetMaxComputeUnits();
-    if(!problem.IsLayoutDefault())
+
+    // Use IsPossibleLayout4D5D to check actual tensor strides rather than cached layout string
+    // This allows transposed solvers to work correctly when they modify tensor strides
+    static const auto strict =
+        miopen::TensorDescriptor::LayoutValidationMode::StrictDecreasingStrides;
+    if(!(problem.GetIn().IsPossibleLayout4D5D("NCHW", strict) &&
+         problem.GetWeights().IsPossibleLayout4D5D("NCHW", strict) &&
+         problem.GetOut().IsPossibleLayout4D5D("NCHW", strict)))
         return false;
 
     // clang-format off
@@ -272,6 +280,10 @@ bool ConvBinWinogradRxS::IsApplicable(const ExecutionContext& ctx,
         }
     }
 
+    // Use IsPossibleLayout4D5D to check actual tensor strides rather than cached layout string
+    // This allows transposed solvers to work correctly when they modify tensor strides
+    static const auto strict = TensorDescriptor::LayoutValidationMode::StrictDecreasingStrides;
+
     // clang-format off
     if (! (problem.GetKernelStrideW() <= 2 // -u inp_u 1 or 2
         && problem.GetKernelStrideW() == problem.GetKernelStrideH()
@@ -279,7 +291,7 @@ bool ConvBinWinogradRxS::IsApplicable(const ExecutionContext& ctx,
         && problem.GetDilationH() == 1
         && problem.GetBias() == 0
         && problem.GetGroupCount() == 1
-        && problem.GetInLayout() == "NCHW"))
+        && problem.GetIn().IsPossibleLayout4D5D("NCHW", strict)))
         return false;
     // clang-format on
 

--- a/projects/miopen/src/solver/conv/conv_multipass_wino3x3WrW.cpp
+++ b/projects/miopen/src/solver/conv/conv_multipass_wino3x3WrW.cpp
@@ -474,8 +474,16 @@ bool ConvWinograd3x3MultipassWrW<WinoDataH, WinoFilterH, WinoDataW, WinoFilterW>
         return false;
     if(problem.IsTensorsCasted())
         return false;
-    if(!problem.IsLayoutDefault())
-        return false;
+
+    // Use IsPossibleLayout4D5D to check actual tensor strides rather than cached layout string
+    // This allows transposed solvers to work correctly when they modify tensor strides
+    {
+        static const auto strict = TensorDescriptor::LayoutValidationMode::StrictDecreasingStrides;
+        if(!(problem.GetIn().IsPossibleLayout4D5D("NCHW", strict) &&
+             problem.GetWeights().IsPossibleLayout4D5D("NCHW", strict) &&
+             problem.GetOut().IsPossibleLayout4D5D("NCHW", strict)))
+            return false;
+    }
 
     const auto& target = ctx.GetStream().GetTargetProperties();
     if(target.isXnackEnabled())
@@ -524,8 +532,15 @@ bool ConvWinograd3x3MultipassWrW<WinoDataH, WinoFilterH, WinoDataW, WinoFilterW>
     {
         return false;
     }
-    if(!problem.IsLayoutDefault())
-        return false;
+    // Use IsPossibleLayout4D5D to check actual tensor strides rather than cached layout string
+    // This allows transposed solvers to work correctly when they modify tensor strides
+    {
+        static const auto strict = TensorDescriptor::LayoutValidationMode::StrictDecreasingStrides;
+        if(!(problem.GetIn().IsPossibleLayout4D5D("NCHW", strict) &&
+             problem.GetWeights().IsPossibleLayout4D5D("NCHW", strict) &&
+             problem.GetOut().IsPossibleLayout4D5D("NCHW", strict)))
+            return false;
+    }
 
     // clang-format off
     {
@@ -811,6 +826,20 @@ template struct MIOPEN_INTERNALS_EXPORT ConvWinograd3x3MultipassWrW<7, 2, 1, 1>;
 template struct MIOPEN_INTERNALS_EXPORT ConvWinograd3x3MultipassWrW<7, 3, 1, 1>;
 template struct MIOPEN_INTERNALS_EXPORT ConvWinograd3x3MultipassWrW<5, 3>;
 template struct MIOPEN_INTERNALS_EXPORT ConvWinograd3x3MultipassWrW<5, 4>;
+
+template struct MIOPEN_INTERNALS_EXPORT TransposedConvWinograd3x3MultipassWrW<3, 2>;
+template struct MIOPEN_INTERNALS_EXPORT TransposedConvWinograd3x3MultipassWrW<3, 3>;
+template struct MIOPEN_INTERNALS_EXPORT TransposedConvWinograd3x3MultipassWrW<3, 4>;
+template struct MIOPEN_INTERNALS_EXPORT TransposedConvWinograd3x3MultipassWrW<3, 5>;
+template struct MIOPEN_INTERNALS_EXPORT TransposedConvWinograd3x3MultipassWrW<3, 6>;
+template struct MIOPEN_INTERNALS_EXPORT TransposedConvWinograd3x3MultipassWrW<7, 2>;
+template struct MIOPEN_INTERNALS_EXPORT TransposedConvWinograd3x3MultipassWrW<7, 3>;
+template struct MIOPEN_INTERNALS_EXPORT TransposedConvWinograd3x3MultipassWrW<1, 1, 7, 2>;
+template struct MIOPEN_INTERNALS_EXPORT TransposedConvWinograd3x3MultipassWrW<1, 1, 7, 3>;
+template struct MIOPEN_INTERNALS_EXPORT TransposedConvWinograd3x3MultipassWrW<7, 2, 1, 1>;
+template struct MIOPEN_INTERNALS_EXPORT TransposedConvWinograd3x3MultipassWrW<7, 3, 1, 1>;
+template struct MIOPEN_INTERNALS_EXPORT TransposedConvWinograd3x3MultipassWrW<5, 3>;
+template struct MIOPEN_INTERNALS_EXPORT TransposedConvWinograd3x3MultipassWrW<5, 4>;
 
 } // namespace conv
 } // namespace solver

--- a/projects/miopen/src/solver/conv/conv_winoRxS.cpp
+++ b/projects/miopen/src/solver/conv/conv_winoRxS.cpp
@@ -312,8 +312,15 @@ inline bool IsShaderConstraintsMet(const ProblemDescription& problem,
             return false;
     }
 
-    if(!problem.IsLayoutDefault())
-        return false;
+    // Use IsPossibleLayout4D5D to check actual tensor strides rather than cached layout string
+    // This allows transposed solvers to work correctly when they modify tensor strides
+    {
+        static const auto strict = TensorDescriptor::LayoutValidationMode::StrictDecreasingStrides;
+        if(!(problem.GetIn().IsPossibleLayout4D5D("NCHW", strict) &&
+             problem.GetWeights().IsPossibleLayout4D5D("NCHW", strict) &&
+             problem.GetOut().IsPossibleLayout4D5D("NCHW", strict)))
+            return false;
+    }
 
     return IsWinogradV21Preferred<Winodata, Winofilter>(asic, problem)
                ? IsShaderConstraintsMetV21(problem, R, S, C, K, H, W, OH, OW, N)
@@ -686,13 +693,17 @@ static bool IsApplicableBase(const ExecutionContext& ctx, const ProblemDescripti
     if(name == "gfx90a" && problem.IsGfx90aFp16altRequired())
         return false;
 
+    // Use IsPossibleLayout4D5D to check actual tensor strides rather than cached layout string
+    // This allows transposed solvers to work correctly when they modify tensor strides
+    static const auto strict = TensorDescriptor::LayoutValidationMode::StrictDecreasingStrides;
+
     // clang-format off
     if (!((problem.GetKernelStrideW() == 1 || problem.GetKernelStrideW() == 2)
         && problem.GetKernelStrideW() == problem.GetKernelStrideH()
         && problem.GetDilationW() == 1
         && problem.GetDilationH() == 1
         && problem.GetBias() == 0
-        && problem.GetInLayout() == "NCHW"))
+        && problem.GetIn().IsPossibleLayout4D5D("NCHW", strict)))
         return false;
         // clang-format on
 
@@ -1150,6 +1161,7 @@ bool ConvBinWinogradRxSf2x3g1::IsApplicable(const ExecutionContext& ctx,
 {
     if(env::disabled(MIOPEN_DEBUG_AMD_WINOGRAD_RXS_F2X3_G1))
         return false;
+
     return IsApplicableBase<2, 3>(ctx, problem) && problem.GetGroupCount() == 1;
 }
 
@@ -1165,9 +1177,11 @@ ConvSolution ConvBinWinogradRxSf2x3g1::GetSolution(const ExecutionContext& ctx,
     const auto tunable = ConvBinWinoRxS<2, 3>{};
     return tunable.GetSolution(ctx, problem, tunable.GetDefaultPerformanceConfig(ctx, problem));
 }
-
 template struct MIOPEN_INTERNALS_EXPORT ConvBinWinoRxS<2, 3>;
 template struct MIOPEN_INTERNALS_EXPORT ConvBinWinoRxS<3, 2>;
+
+template struct MIOPEN_INTERNALS_EXPORT TransposedConvBinWinoRxS<2, 3>;
+template struct MIOPEN_INTERNALS_EXPORT TransposedConvBinWinoRxS<3, 2>;
 
 } // namespace conv
 } // namespace solver

--- a/projects/miopen/src/solver/conv/conv_wino_fury_RxS.cpp
+++ b/projects/miopen/src/solver/conv/conv_wino_fury_RxS.cpp
@@ -641,6 +641,7 @@ ConvWinoFuryRxS<Winodata, Winofilter>::GetSolution(const ExecutionContext& ctx,
 
 template struct MIOPEN_INTERNALS_EXPORT ConvWinoFuryRxS<2, 3>;
 // template struct MIOPEN_INTERNALS_EXPORT ConvWinoFuryRxS<3, 2>;
+template struct MIOPEN_INTERNALS_EXPORT TransposedConvWinoFuryRxS<2, 3>;
 
 } // namespace conv
 

--- a/projects/miopen/src/solver/conv/conv_wino_rage_RxS.cpp
+++ b/projects/miopen/src/solver/conv/conv_wino_rage_RxS.cpp
@@ -536,6 +536,7 @@ ConvWinoRageRxS<Winodata, Winofilter>::GetSolution(const ExecutionContext& ctx,
 }
 
 template struct MIOPEN_INTERNALS_EXPORT ConvWinoRageRxS<2, 3>;
+template struct MIOPEN_INTERNALS_EXPORT TransposedConvWinoRageRxS<2, 3>;
 
 } // namespace conv
 

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvBinWinograd3x3U.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvBinWinograd3x3U.cpp
@@ -91,3 +91,65 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          CPU_UnitTestConvSolverBinWinograd3x3UDevApplicabilityFwd_NONE,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(GetConvTestCases(miopenFloat)[0])));
+
+// =====================================================================
+// TransposedConvBinWinograd3x3U (NHWC layout)
+// =====================================================================
+
+namespace {
+
+auto GetConvTestCasesNHWC(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{{datatype, miopenTensorNHWC, {1, 20, 20, 20}},
+                 {datatype, miopenTensorNHWC, {20, 20, 3, 3}},
+                 datatype, {{1, 1}, {1, 1}, {1, 1}}},
+        // clang-format on
+    };
+}
+
+} // namespace
+
+using GPU_UnitTestConvSolverTransposedBinWinograd3x3UFwd_FP32 = GPU_UnitTestConvSolverFwd_FP32;
+using GPU_UnitTestConvSolverTransposedBinWinograd3x3UBwd_FP32 = GPU_UnitTestConvSolverBwd_FP32;
+
+using CPU_UnitTestConvSolverTransposedBinWinograd3x3UDevApplicabilityFwd_NONE =
+    CPU_UnitTestConvSolverDevApplicabilityFwd_NONE;
+
+TEST_P(GPU_UnitTestConvSolverTransposedBinWinograd3x3UFwd_FP32, TransposedConvBinWinograd3x3U)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinograd3x3U{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedBinWinograd3x3UBwd_FP32, TransposedConvBinWinograd3x3U)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinograd3x3U{});
+};
+
+TEST_P(CPU_UnitTestConvSolverTransposedBinWinograd3x3UDevApplicabilityFwd_NONE,
+       TransposedConvBinWinograd3x3U)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinograd3x3U{});
+};
+
+// Smoke tests
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedBinWinograd3x3UFwd_FP32,
+                         testing::Combine(testing::Values(GetTestParams()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenFloat))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedBinWinograd3x3UBwd_FP32,
+                         testing::Combine(testing::Values(GetTestParams()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenFloat))));
+
+// Device applicability test
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         CPU_UnitTestConvSolverTransposedBinWinograd3x3UDevApplicabilityFwd_NONE,
+                         testing::Combine(testing::Values(GetTestParams()),
+                                          testing::Values(GetConvTestCasesNHWC(miopenFloat)[0])));

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvBinWinogradRxS.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvBinWinogradRxS.cpp
@@ -221,6 +221,26 @@ auto GetConvTestCasesNHWCFloat()
     };
 }
 
+auto GetConvTestCasesNHWCFloatWrw()
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{{miopenFloat, miopenTensorNHWC, {1, 20, 20, 20}},
+                 {miopenFloat, miopenTensorNHWC, {20, 20, 3, 3}},
+                 miopenFloat, {{1, 1}, {1, 1}, {1, 1}}},
+        // Degenerate spatial dims (H=1, W=1) with 1x1 filter that has ambiguous layout strides
+        // so HeuristicUpdateLayouts() can't fix the layout string after NHWC->NCHW transposition.
+        // Targets GetSwappedNCLayout(NHWC)->CHWN
+        // then hits missing return in GetGroupConvLayout.
+        TestCase{{miopenFloat, miopenTensorNHWC, {2, 40, 1, 1}},
+                 {miopenFloat, miopenTensorNHWC, {8, 40, 1, 1}},
+                 miopenFloat, {{0, 0}, {1, 1}, {1, 1}}},
+        // clang-format on
+    };
+}
+
 } // namespace
 
 using GPU_UnitTestConvSolverTransposedBinWinogradRxSFwd_FP16 = GPU_UnitTestConvSolverFwd_FP16;
@@ -299,7 +319,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          GPU_UnitTestConvSolverTransposedBinWinogradRxSWrw_FP32,
                          testing::Combine(testing::Values(GetTestParamsFloat()),
                                           testing::Values(miopenConvolutionAlgoWinograd),
-                                          testing::ValuesIn(GetConvTestCasesNHWCFloat())));
+                                          testing::ValuesIn(GetConvTestCasesNHWCFloatWrw())));
 
 // Device applicability test
 INSTANTIATE_TEST_SUITE_P(Smoke,

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvBinWinogradRxS.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvBinWinogradRxS.cpp
@@ -175,3 +175,139 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          CPU_UnitTestConvSolverBinWinogradRxSDevApplicabilityFwd_FP32,
                          testing::Combine(testing::Values(GetTestParamsFloat()),
                                           testing::Values(GetConvTestCasesFloat()[0])));
+
+// =====================================================================
+// TransposedConvBinWinogradRxS (NHWC layout)
+// =====================================================================
+
+namespace {
+
+auto GetConvTestCasesNHWCHalfFwd()
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{{miopenHalf, miopenTensorNHWC, {1, 40, 20, 20}},
+                 {miopenHalf, miopenTensorNHWC, {20, 40, 3, 3}},
+                 miopenHalf, {{1, 1}, {1, 1}, {1, 1}}},
+        // clang-format on
+    };
+}
+
+auto GetConvTestCasesNHWCHalfBwd()
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{{miopenHalf, miopenTensorNHWC, {1, 20, 20, 20}},
+                 {miopenHalf, miopenTensorNHWC, {40, 20, 3, 3}},
+                 miopenHalf, {{1, 1}, {1, 1}, {1, 1}}},
+        // clang-format on
+    };
+}
+
+auto GetConvTestCasesNHWCFloat()
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{{miopenFloat, miopenTensorNHWC, {1, 20, 20, 20}},
+                 {miopenFloat, miopenTensorNHWC, {20, 20, 3, 3}},
+                 miopenFloat, {{1, 1}, {1, 1}, {1, 1}}},
+        // clang-format on
+    };
+}
+
+} // namespace
+
+using GPU_UnitTestConvSolverTransposedBinWinogradRxSFwd_FP16 = GPU_UnitTestConvSolverFwd_FP16;
+using GPU_UnitTestConvSolverTransposedBinWinogradRxSBwd_FP16 = GPU_UnitTestConvSolverBwd_FP16;
+using GPU_UnitTestConvSolverTransposedBinWinogradRxSFwd_FP32 = GPU_UnitTestConvSolverFwd_FP32;
+using GPU_UnitTestConvSolverTransposedBinWinogradRxSBwd_FP32 = GPU_UnitTestConvSolverBwd_FP32;
+using GPU_UnitTestConvSolverTransposedBinWinogradRxSWrw_FP32 = GPU_UnitTestConvSolverWrw_FP32;
+using CPU_UnitTestConvSolverTransposedBinWinogradRxSDevApplicabilityFwd_FP16 =
+    CPU_UnitTestConvSolverDevApplicabilityFwd_NONE;
+using CPU_UnitTestConvSolverTransposedBinWinogradRxSDevApplicabilityFwd_FP32 =
+    CPU_UnitTestConvSolverDevApplicabilityFwd_NONE;
+
+TEST_P(GPU_UnitTestConvSolverTransposedBinWinogradRxSFwd_FP16, TransposedConvBinWinogradRxS)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinogradRxS{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedBinWinogradRxSBwd_FP16, TransposedConvBinWinogradRxS)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinogradRxS{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedBinWinogradRxSFwd_FP32, TransposedConvBinWinogradRxS)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinogradRxS{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedBinWinogradRxSBwd_FP32, TransposedConvBinWinogradRxS)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinogradRxS{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedBinWinogradRxSWrw_FP32, TransposedConvBinWinogradRxS)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinogradRxS{});
+};
+
+TEST_P(CPU_UnitTestConvSolverTransposedBinWinogradRxSDevApplicabilityFwd_FP16,
+       TransposedConvBinWinogradRxS)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinogradRxS{});
+};
+
+TEST_P(CPU_UnitTestConvSolverTransposedBinWinogradRxSDevApplicabilityFwd_FP32,
+       TransposedConvBinWinogradRxS)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinogradRxS{});
+};
+
+// Smoke tests
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedBinWinogradRxSFwd_FP16,
+                         testing::Combine(testing::Values(GetTestParamsHalf()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWCHalfFwd())));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedBinWinogradRxSBwd_FP16,
+                         testing::Combine(testing::Values(GetTestParamsHalf()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWCHalfBwd())));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedBinWinogradRxSFwd_FP32,
+                         testing::Combine(testing::Values(GetTestParamsFloat()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWCFloat())));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedBinWinogradRxSBwd_FP32,
+                         testing::Combine(testing::Values(GetTestParamsFloat()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWCFloat())));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedBinWinogradRxSWrw_FP32,
+                         testing::Combine(testing::Values(GetTestParamsFloat()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWCFloat())));
+
+// Device applicability test
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         CPU_UnitTestConvSolverTransposedBinWinogradRxSDevApplicabilityFwd_FP16,
+                         testing::Combine(testing::Values(GetTestParamsHalf()),
+                                          testing::Values(GetConvTestCasesNHWCHalfFwd()[0])));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         CPU_UnitTestConvSolverTransposedBinWinogradRxSDevApplicabilityFwd_FP32,
+                         testing::Combine(testing::Values(GetTestParamsFloat()),
+                                          testing::Values(GetConvTestCasesNHWCFloat()[0])));

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvBinWinogradRxSf2x3.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvBinWinogradRxSf2x3.cpp
@@ -40,6 +40,12 @@ auto GetConvTestCases(miopenDataType_t datatype)
             datatype,
             {{1, 1}, {1, 1}, {1, 1}, 2}
         },
+        TestCase{
+            {datatype, {1, 20, 20, 20}},
+            {datatype, {20, 20, 3, 3}},
+            datatype,
+            {{1, 1}, {1, 1}, {1, 1}, 1}
+        },
         // clang-format on
     };
 }
@@ -188,6 +194,12 @@ auto GetConvTestCasesNHWC(miopenDataType_t datatype)
             {datatype, miopenTensorNHWC, {20, 20, 3, 3}},
             datatype,
             {{1, 1}, {1, 1}, {1, 1}, 2}
+        },
+        TestCase{
+            {datatype, miopenTensorNHWC, {1, 40, 20, 40}},
+            {datatype, miopenTensorNHWC, {20, 40, 3, 3}},
+            datatype,
+            {{1, 1}, {1, 1}, {1, 1}, 1}
         },
         // clang-format on
     };

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvBinWinogradRxSf2x3.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvBinWinogradRxSf2x3.cpp
@@ -170,3 +170,104 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          CPU_UnitTestConvSolverBinWinogradRxSf2x3DevApplicabilityFwd_FP32,
                          testing::Combine(testing::Values(GetTestParamsFloat()),
                                           testing::Values(GetConvTestCases(miopenFloat)[0])));
+
+// =====================================================================
+// TransposedConvBinWinoRxS<2, 3> (NHWC layout)
+// =====================================================================
+
+namespace {
+
+auto GetConvTestCasesNHWC(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{
+            {datatype, miopenTensorNHWC, {1, 40, 20, 20}},
+            {datatype, miopenTensorNHWC, {20, 20, 3, 3}},
+            datatype,
+            {{1, 1}, {1, 1}, {1, 1}, 2}
+        },
+        // clang-format on
+    };
+}
+
+} // namespace
+
+using GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3Fwd_FP16 = GPU_UnitTestConvSolverFwd_FP16;
+using GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3Bwd_FP16 = GPU_UnitTestConvSolverBwd_FP16;
+using GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3Wrw_FP16 = GPU_UnitTestConvSolverWrw_FP16;
+using GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3Fwd_FP32 = GPU_UnitTestConvSolverFwd_FP32;
+using GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3Bwd_FP32 = GPU_UnitTestConvSolverBwd_FP32;
+using GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3Wrw_FP32 = GPU_UnitTestConvSolverWrw_FP32;
+// Note: DevApplicability tests are not included for TransposedConvBinWinoRxS<2,3> because
+// the inner solver has group_count==1 restriction (WORKAROUND_ISSUE_1681) for Fwd/Bwd directions,
+// which doesn't apply uniformly across all devices listed in supported_gpus
+
+TEST_P(GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3Fwd_FP16, TransposedConvBinWinoRxSf2x3)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinoRxS<2, 3>{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3Bwd_FP16, TransposedConvBinWinoRxSf2x3)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinoRxS<2, 3>{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3Wrw_FP16, TransposedConvBinWinoRxSf2x3)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinoRxS<2, 3>{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3Fwd_FP32, TransposedConvBinWinoRxSf2x3)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinoRxS<2, 3>{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3Bwd_FP32, TransposedConvBinWinoRxSf2x3)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinoRxS<2, 3>{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3Wrw_FP32, TransposedConvBinWinoRxSf2x3)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinoRxS<2, 3>{});
+};
+
+// Smoke tests
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3Fwd_FP16,
+                         testing::Combine(testing::Values(GetTestParamsHalf()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3Bwd_FP16,
+                         testing::Combine(testing::Values(GetTestParamsHalf()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3Wrw_FP16,
+                         testing::Combine(testing::Values(GetTestParamsHalf()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3Fwd_FP32,
+                         testing::Combine(testing::Values(GetTestParamsFloat()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenFloat))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3Bwd_FP32,
+                         testing::Combine(testing::Values(GetTestParamsFloat()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenFloat))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3Wrw_FP32,
+                         testing::Combine(testing::Values(GetTestParamsFloat()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenFloat))));

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvBinWinogradRxSf2x3.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvBinWinogradRxSf2x3.cpp
@@ -40,6 +40,24 @@ auto GetConvTestCases(miopenDataType_t datatype)
             datatype,
             {{1, 1}, {1, 1}, {1, 1}, 2}
         },
+        // clang-format on
+    };
+}
+
+// g=1 test cases are WrW-only because WORKAROUND_ISSUE_1681 rejects g=1 for Fwd/Bwd
+// in ConvBinWinoRxS<2,3>. The g=1 Fwd/Bwd case is handled by ConvBinWinogradRxSf2x3g1.
+auto GetConvTestCasesWrw(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{
+            {datatype, {1, 40, 20, 20}},
+            {datatype, {20, 20, 3, 3}},
+            datatype,
+            {{1, 1}, {1, 1}, {1, 1}, 2}
+        },
         TestCase{
             {datatype, {1, 20, 20, 20}},
             {datatype, {20, 20, 3, 3}},
@@ -146,7 +164,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          GPU_UnitTestConvSolverBinWinogradRxSf2x3Wrw_FP16,
                          testing::Combine(testing::Values(GetTestParamsHalf()),
                                           testing::Values(miopenConvolutionAlgoWinograd),
-                                          testing::ValuesIn(GetConvTestCases(miopenHalf))));
+                                          testing::ValuesIn(GetConvTestCasesWrw(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
                          GPU_UnitTestConvSolverBinWinogradRxSf2x3Fwd_FP32,
@@ -164,7 +182,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          GPU_UnitTestConvSolverBinWinogradRxSf2x3Wrw_FP32,
                          testing::Combine(testing::Values(GetTestParamsFloat()),
                                           testing::Values(miopenConvolutionAlgoWinograd),
-                                          testing::ValuesIn(GetConvTestCases(miopenFloat))));
+                                          testing::ValuesIn(GetConvTestCasesWrw(miopenFloat))));
 
 // Device applicability test
 INSTANTIATE_TEST_SUITE_P(Smoke,
@@ -195,11 +213,38 @@ auto GetConvTestCasesNHWC(miopenDataType_t datatype)
             datatype,
             {{1, 1}, {1, 1}, {1, 1}, 2}
         },
+        // clang-format on
+    };
+}
+
+// g=1 NHWC test cases are WrW-only (WORKAROUND_ISSUE_1681 rejects g=1 Fwd/Bwd)
+auto GetConvTestCasesNHWCWrw(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{
+            {datatype, miopenTensorNHWC, {1, 40, 20, 20}},
+            {datatype, miopenTensorNHWC, {20, 20, 3, 3}},
+            datatype,
+            {{1, 1}, {1, 1}, {1, 1}, 2}
+        },
         TestCase{
             {datatype, miopenTensorNHWC, {1, 40, 20, 40}},
             {datatype, miopenTensorNHWC, {20, 40, 3, 3}},
             datatype,
             {{1, 1}, {1, 1}, {1, 1}, 1}
+        },
+        // Degenerate spatial dims (H=1, W=1) with 1x1 filter that has ambiguous layout strides
+        // so HeuristicUpdateLayouts() can't fix the layout string after NHWC->NCHW transposition.
+        // Targets GetSwappedNCLayout(NHWC)->CHWN
+        // then hits missing return in GetGroupConvLayout.
+        TestCase{
+            {datatype, miopenTensorNHWC, {2, 40, 1, 1}},
+            {datatype, miopenTensorNHWC, {8, 40, 1, 1}},
+            datatype,
+            {{0, 0}, {1, 1}, {1, 1}, 1}
         },
         // clang-format on
     };
@@ -264,7 +309,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3Wrw_FP16,
                          testing::Combine(testing::Values(GetTestParamsHalf()),
                                           testing::Values(miopenConvolutionAlgoWinograd),
-                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenHalf))));
+                                          testing::ValuesIn(GetConvTestCasesNHWCWrw(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
                          GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3Fwd_FP32,
@@ -282,4 +327,4 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3Wrw_FP32,
                          testing::Combine(testing::Values(GetTestParamsFloat()),
                                           testing::Values(miopenConvolutionAlgoWinograd),
-                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenFloat))));
+                                          testing::ValuesIn(GetConvTestCasesNHWCWrw(miopenFloat))));

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvBinWinogradRxSf2x3g1.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvBinWinogradRxSf2x3g1.cpp
@@ -201,3 +201,172 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          CPU_UnitTestConvSolverBinWinogradRxSf2x3g1DevApplicabilityFwd_FP32,
                          testing::Combine(testing::Values(GetTestParamsFloat()),
                                           testing::Values(GetConvTestCasesFloat()[0])));
+
+// =====================================================================
+// TransposedConvBinWinogradRxSf2x3g1 (NHWC layout)
+// =====================================================================
+
+namespace {
+
+auto GetConvTestCasesNHWCHalfFwd()
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{{miopenHalf, miopenTensorNHWC, {1, 40, 20, 20}},
+                 {miopenHalf, miopenTensorNHWC, {20, 40, 3, 3}},
+                 miopenHalf, {{1, 1}, {1, 1}, {1, 1}}},
+        // clang-format on
+    };
+}
+
+auto GetConvTestCasesNHWCHalfBwd()
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{{miopenHalf, miopenTensorNHWC, {1, 20, 20, 20}},
+                 {miopenHalf, miopenTensorNHWC, {40, 20, 3, 3}},
+                 miopenHalf, {{1, 1}, {1, 1}, {1, 1}}},
+        // clang-format on
+    };
+}
+
+auto GetConvTestCasesNHWCHalfWrw()
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{{miopenHalf, miopenTensorNHWC, {1, 20, 20, 20}},
+                 {miopenHalf, miopenTensorNHWC, {20, 20, 3, 3}},
+                 miopenHalf, {{1, 1}, {1, 1}, {1, 1}}},
+        // clang-format on
+    };
+}
+
+auto GetConvTestCasesNHWCFloat()
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{{miopenFloat, miopenTensorNHWC, {1, 20, 20, 20}},
+                 {miopenFloat, miopenTensorNHWC, {20, 20, 3, 3}},
+                 miopenFloat, {{1, 1}, {1, 1}, {1, 1}}},
+        // clang-format on
+    };
+}
+
+} // namespace
+
+using GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3g1Fwd_FP16 = GPU_UnitTestConvSolverFwd_FP16;
+using GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3g1Bwd_FP16 = GPU_UnitTestConvSolverBwd_FP16;
+using GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3g1Wrw_FP16 = GPU_UnitTestConvSolverWrw_FP16;
+using GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3g1Fwd_FP32 = GPU_UnitTestConvSolverFwd_FP32;
+using GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3g1Bwd_FP32 = GPU_UnitTestConvSolverBwd_FP32;
+using GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3g1Wrw_FP32 = GPU_UnitTestConvSolverWrw_FP32;
+using CPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3g1DevApplicabilityFwd_FP16 =
+    CPU_UnitTestConvSolverDevApplicabilityFwd_NONE;
+using CPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3g1DevApplicabilityFwd_FP32 =
+    CPU_UnitTestConvSolverDevApplicabilityFwd_NONE;
+
+TEST_P(GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3g1Fwd_FP16,
+       TransposedConvBinWinogradRxSf2x3g1)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinogradRxSf2x3g1{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3g1Bwd_FP16,
+       TransposedConvBinWinogradRxSf2x3g1)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinogradRxSf2x3g1{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3g1Wrw_FP16,
+       TransposedConvBinWinogradRxSf2x3g1)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinogradRxSf2x3g1{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3g1Fwd_FP32,
+       TransposedConvBinWinogradRxSf2x3g1)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinogradRxSf2x3g1{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3g1Bwd_FP32,
+       TransposedConvBinWinogradRxSf2x3g1)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinogradRxSf2x3g1{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3g1Wrw_FP32,
+       TransposedConvBinWinogradRxSf2x3g1)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinogradRxSf2x3g1{});
+};
+
+TEST_P(CPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3g1DevApplicabilityFwd_FP16,
+       TransposedConvBinWinogradRxSf2x3g1)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinogradRxSf2x3g1{});
+};
+
+TEST_P(CPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3g1DevApplicabilityFwd_FP32,
+       TransposedConvBinWinogradRxSf2x3g1)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinogradRxSf2x3g1{});
+};
+
+// Smoke tests
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3g1Fwd_FP16,
+                         testing::Combine(testing::Values(GetTestParamsHalf()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWCHalfFwd())));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3g1Bwd_FP16,
+                         testing::Combine(testing::Values(GetTestParamsHalf()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWCHalfBwd())));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3g1Wrw_FP16,
+                         testing::Combine(testing::Values(GetTestParamsHalf()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWCHalfWrw())));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3g1Fwd_FP32,
+                         testing::Combine(testing::Values(GetTestParamsFloat()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWCFloat())));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3g1Bwd_FP32,
+                         testing::Combine(testing::Values(GetTestParamsFloat()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWCFloat())));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3g1Wrw_FP32,
+                         testing::Combine(testing::Values(GetTestParamsFloat()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWCFloat())));
+
+// Device applicability test
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    CPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3g1DevApplicabilityFwd_FP16,
+    testing::Combine(testing::Values(GetTestParamsHalf()),
+                     testing::Values(GetConvTestCasesNHWCHalfFwd()[0])));
+
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    CPU_UnitTestConvSolverTransposedBinWinogradRxSf2x3g1DevApplicabilityFwd_FP32,
+    testing::Combine(testing::Values(GetTestParamsFloat()),
+                     testing::Values(GetConvTestCasesNHWCFloat()[0])));

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvBinWinogradRxSf3x2.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvBinWinogradRxSf3x2.cpp
@@ -232,6 +232,38 @@ auto GetConvTestCasesNHWC(miopenDataType_t datatype)
     };
 }
 
+auto GetConvTestCasesNHWCWrw(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{
+            {datatype, miopenTensorNHWC, {1, 40, 20, 20}},
+            {datatype, miopenTensorNHWC, {20, 20, 3, 3}},
+            datatype,
+            {{1, 1}, {1, 1}, {1, 1}, 2}
+        },
+        TestCase{
+            {datatype, miopenTensorNHWC, {1, 40, 20, 20}},
+            {datatype, miopenTensorNHWC, {20, 40, 3, 3}},
+            datatype,
+            {{1, 1}, {1, 1}, {1, 1}, 1}
+        },
+        // Degenerate spatial dims (H=1, W=1) with 1x1 filter that has ambiguous layout strides
+        // so HeuristicUpdateLayouts() can't fix the layout string after NHWC->NCHW transposition.
+        // Targets GetSwappedNCLayout(NHWC)->CHWN
+        // then hits missing return in GetGroupConvLayout.
+        TestCase{
+            {datatype, miopenTensorNHWC, {2, 40, 1, 1}},
+            {datatype, miopenTensorNHWC, {8, 40, 1, 1}},
+            datatype,
+            {{0, 0}, {1, 1}, {1, 1}, 1}
+        },
+        // clang-format on
+    };
+}
+
 } // namespace
 
 using GPU_UnitTestConvSolverTransposedBinWinogradRxSf3x2Fwd_FP16 = GPU_UnitTestConvSolverFwd_FP16;
@@ -304,7 +336,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          GPU_UnitTestConvSolverTransposedBinWinogradRxSf3x2Wrw_FP16,
                          testing::Combine(testing::Values(GetTestParamsHalf()),
                                           testing::Values(miopenConvolutionAlgoWinograd),
-                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenHalf))));
+                                          testing::ValuesIn(GetConvTestCasesNHWCWrw(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
                          GPU_UnitTestConvSolverTransposedBinWinogradRxSf3x2Fwd_FP32,
@@ -322,7 +354,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          GPU_UnitTestConvSolverTransposedBinWinogradRxSf3x2Wrw_FP32,
                          testing::Combine(testing::Values(GetTestParamsFloat()),
                                           testing::Values(miopenConvolutionAlgoWinograd),
-                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenFloat))));
+                                          testing::ValuesIn(GetConvTestCasesNHWCWrw(miopenFloat))));
 
 // Device applicability test
 INSTANTIATE_TEST_SUITE_P(Smoke,

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvBinWinogradRxSf3x2.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvBinWinogradRxSf3x2.cpp
@@ -67,6 +67,7 @@ auto GetConvTestCasesFloat()
 
     return std::vector{
         // clang-format off
+
         TestCase{{1, 20, 20, 20}, {20, 20, 3, 3}, {1, 1}, {1, 1}, {1, 1}, miopenFloat},
         // clang-format on
     };
@@ -220,6 +221,12 @@ auto GetConvTestCasesNHWC(miopenDataType_t datatype)
             {datatype, miopenTensorNHWC, {20, 20, 3, 3}},
             datatype,
             {{1, 1}, {1, 1}, {1, 1}, 2}
+        },
+        TestCase{
+            {datatype, miopenTensorNHWC, {1, 40, 20, 20}},
+            {datatype, miopenTensorNHWC, {20, 40, 3, 3}},
+            datatype,
+            {{1, 1}, {1, 1}, {1, 1}, 1}
         },
         // clang-format on
     };

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvBinWinogradRxSf3x2.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvBinWinogradRxSf3x2.cpp
@@ -202,3 +202,128 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          CPU_UnitTestConvSolverBinWinogradRxSf3x2DevApplicabilityFwd_FP32,
                          testing::Combine(testing::Values(GetTestParamsFloat()),
                                           testing::Values(GetConvTestCasesFloat()[0])));
+
+// =====================================================================
+// TransposedConvBinWinoRxS<3, 2> (NHWC layout)
+// =====================================================================
+
+namespace {
+
+auto GetConvTestCasesNHWC(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{
+            {datatype, miopenTensorNHWC, {1, 40, 20, 20}},
+            {datatype, miopenTensorNHWC, {20, 20, 3, 3}},
+            datatype,
+            {{1, 1}, {1, 1}, {1, 1}, 2}
+        },
+        // clang-format on
+    };
+}
+
+} // namespace
+
+using GPU_UnitTestConvSolverTransposedBinWinogradRxSf3x2Fwd_FP16 = GPU_UnitTestConvSolverFwd_FP16;
+using GPU_UnitTestConvSolverTransposedBinWinogradRxSf3x2Bwd_FP16 = GPU_UnitTestConvSolverBwd_FP16;
+using GPU_UnitTestConvSolverTransposedBinWinogradRxSf3x2Wrw_FP16 = GPU_UnitTestConvSolverWrw_FP16;
+using GPU_UnitTestConvSolverTransposedBinWinogradRxSf3x2Fwd_FP32 = GPU_UnitTestConvSolverFwd_FP32;
+using GPU_UnitTestConvSolverTransposedBinWinogradRxSf3x2Bwd_FP32 = GPU_UnitTestConvSolverBwd_FP32;
+using GPU_UnitTestConvSolverTransposedBinWinogradRxSf3x2Wrw_FP32 = GPU_UnitTestConvSolverWrw_FP32;
+using CPU_UnitTestConvSolverTransposedBinWinogradRxSf3x2DevApplicabilityFwd_FP16 =
+    CPU_UnitTestConvSolverDevApplicabilityFwd_NONE;
+using CPU_UnitTestConvSolverTransposedBinWinogradRxSf3x2DevApplicabilityFwd_FP32 =
+    CPU_UnitTestConvSolverDevApplicabilityFwd_NONE;
+
+TEST_P(GPU_UnitTestConvSolverTransposedBinWinogradRxSf3x2Fwd_FP16, TransposedConvBinWinoRxSf3x2)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinoRxS<3, 2>{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedBinWinogradRxSf3x2Bwd_FP16, TransposedConvBinWinoRxSf3x2)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinoRxS<3, 2>{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedBinWinogradRxSf3x2Wrw_FP16, TransposedConvBinWinoRxSf3x2)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinoRxS<3, 2>{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedBinWinogradRxSf3x2Fwd_FP32, TransposedConvBinWinoRxSf3x2)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinoRxS<3, 2>{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedBinWinogradRxSf3x2Bwd_FP32, TransposedConvBinWinoRxSf3x2)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinoRxS<3, 2>{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedBinWinogradRxSf3x2Wrw_FP32, TransposedConvBinWinoRxSf3x2)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinoRxS<3, 2>{});
+};
+
+TEST_P(CPU_UnitTestConvSolverTransposedBinWinogradRxSf3x2DevApplicabilityFwd_FP16,
+       TransposedConvBinWinoRxSf3x2)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinoRxS<3, 2>{});
+};
+
+TEST_P(CPU_UnitTestConvSolverTransposedBinWinogradRxSf3x2DevApplicabilityFwd_FP32,
+       TransposedConvBinWinoRxSf3x2)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvBinWinoRxS<3, 2>{});
+};
+
+// Smoke tests
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedBinWinogradRxSf3x2Fwd_FP16,
+                         testing::Combine(testing::Values(GetTestParamsHalf()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedBinWinogradRxSf3x2Bwd_FP16,
+                         testing::Combine(testing::Values(GetTestParamsHalf()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedBinWinogradRxSf3x2Wrw_FP16,
+                         testing::Combine(testing::Values(GetTestParamsHalf()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedBinWinogradRxSf3x2Fwd_FP32,
+                         testing::Combine(testing::Values(GetTestParamsFloat()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenFloat))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedBinWinogradRxSf3x2Bwd_FP32,
+                         testing::Combine(testing::Values(GetTestParamsFloat()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenFloat))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedBinWinogradRxSf3x2Wrw_FP32,
+                         testing::Combine(testing::Values(GetTestParamsFloat()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenFloat))));
+
+// Device applicability test
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         CPU_UnitTestConvSolverTransposedBinWinogradRxSf3x2DevApplicabilityFwd_FP16,
+                         testing::Combine(testing::Values(GetTestParamsHalf()),
+                                          testing::Values(GetConvTestCasesNHWC(miopenHalf)[0])));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         CPU_UnitTestConvSolverTransposedBinWinogradRxSf3x2DevApplicabilityFwd_FP32,
+                         testing::Combine(testing::Values(GetTestParamsFloat()),
+                                          testing::Values(GetConvTestCasesNHWC(miopenFloat)[0])));

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvMPBidirectWinograd.hpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvMPBidirectWinograd.hpp
@@ -216,3 +216,118 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          TESTSUITE_NAME_DEVAPP,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(GetConvTestCases(miopenFloat)[0])));
+
+// =====================================================================
+// TransposedConvMPBidirectWinograd (NHWC layout)
+// =====================================================================
+
+#define TRANSPOSED_SHORT_SOLVER_NAME \
+    CONCAT2(TransposedMPBidirectWinogradF, MAKE_SUFFIX_LOWER(WINO_DATA_H, WINO_FILTER_H))
+
+#define TRANSPOSED_SOLVER_NAME \
+    CONCAT2(TransposedConvMPBidirectWinogradF, MAKE_SUFFIX_LOWER(WINO_DATA_H, WINO_FILTER_H))
+
+#define TRANSPOSED_TESTSUITE_NAME(hw_type, direction, datatype) \
+    TESTSUITE_NAME_GENERIC_DIR(                                 \
+        hw_type, CONCAT2(UnitTestConvSolver, TRANSPOSED_SHORT_SOLVER_NAME), direction, datatype)
+
+#define TRANSPOSED_TESTSUITE_NAME_DEV_APP(hw_type, direction, datatype)              \
+    TESTSUITE_NAME_GENERIC_DIR(                                                      \
+        hw_type,                                                                     \
+        CONCAT3(UnitTestConvSolver, TRANSPOSED_SHORT_SOLVER_NAME, DevApplicability), \
+        direction,                                                                   \
+        datatype)
+
+#define TRANSPOSED_TESTSUITE_NAME_FWD_FP16 TRANSPOSED_TESTSUITE_NAME(GPU, Fwd, FP16)
+#define TRANSPOSED_TESTSUITE_NAME_BWD_FP16 TRANSPOSED_TESTSUITE_NAME(GPU, Bwd, FP16)
+#define TRANSPOSED_TESTSUITE_NAME_FWD_FP32 TRANSPOSED_TESTSUITE_NAME(GPU, Fwd, FP32)
+#define TRANSPOSED_TESTSUITE_NAME_BWD_FP32 TRANSPOSED_TESTSUITE_NAME(GPU, Bwd, FP32)
+
+#define TRANSPOSED_TESTSUITE_NAME_DEVAPP TRANSPOSED_TESTSUITE_NAME_DEV_APP(CPU, Fwd, NONE)
+
+namespace {
+
+auto GetConvTestCasesNHWC(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{{datatype, miopenTensorNHWC, {8, 8, 8, 8}},
+                 {datatype, miopenTensorNHWC, {8, 8, 3, 3}},
+                 datatype, {{0, 0}, {1, 1}, {1, 1}}},
+        // clang-format on
+    };
+}
+
+} // namespace
+
+using TRANSPOSED_TESTSUITE_NAME_FWD_FP16 = GPU_UnitTestConvSolverFwd_FP16;
+using TRANSPOSED_TESTSUITE_NAME_BWD_FP16 = GPU_UnitTestConvSolverBwd_FP16;
+using TRANSPOSED_TESTSUITE_NAME_FWD_FP32 = GPU_UnitTestConvSolverFwd_FP32;
+using TRANSPOSED_TESTSUITE_NAME_BWD_FP32 = GPU_UnitTestConvSolverBwd_FP32;
+using TRANSPOSED_TESTSUITE_NAME_DEVAPP   = CPU_UnitTestConvSolverDevApplicabilityFwd_NONE;
+
+TEST_P(TRANSPOSED_TESTSUITE_NAME_FWD_FP16, TRANSPOSED_SOLVER_NAME)
+{
+    SolverEnabler solver_enabler;
+    this->RunTest(
+        miopen::solver::conv::TransposedConvMPBidirectWinograd<WINO_DATA_H, WINO_FILTER_H>{});
+};
+
+TEST_P(TRANSPOSED_TESTSUITE_NAME_BWD_FP16, TRANSPOSED_SOLVER_NAME)
+{
+    SolverEnabler solver_enabler;
+    this->RunTest(
+        miopen::solver::conv::TransposedConvMPBidirectWinograd<WINO_DATA_H, WINO_FILTER_H>{});
+};
+
+TEST_P(TRANSPOSED_TESTSUITE_NAME_FWD_FP32, TRANSPOSED_SOLVER_NAME)
+{
+    SolverEnabler solver_enabler;
+    this->RunTest(
+        miopen::solver::conv::TransposedConvMPBidirectWinograd<WINO_DATA_H, WINO_FILTER_H>{});
+};
+
+TEST_P(TRANSPOSED_TESTSUITE_NAME_BWD_FP32, TRANSPOSED_SOLVER_NAME)
+{
+    SolverEnabler solver_enabler;
+    this->RunTest(
+        miopen::solver::conv::TransposedConvMPBidirectWinograd<WINO_DATA_H, WINO_FILTER_H>{});
+};
+
+TEST_P(TRANSPOSED_TESTSUITE_NAME_DEVAPP, TRANSPOSED_SOLVER_NAME)
+{
+    SolverEnabler solver_enabler;
+    this->RunTest(
+        miopen::solver::conv::TransposedConvMPBidirectWinograd<WINO_DATA_H, WINO_FILTER_H>{});
+};
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         TRANSPOSED_TESTSUITE_NAME_FWD_FP16,
+                         testing::Combine(testing::Values(GetTestParams()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         TRANSPOSED_TESTSUITE_NAME_BWD_FP16,
+                         testing::Combine(testing::Values(GetTestParams()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         TRANSPOSED_TESTSUITE_NAME_FWD_FP32,
+                         testing::Combine(testing::Values(GetTestParams()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenFloat))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         TRANSPOSED_TESTSUITE_NAME_BWD_FP32,
+                         testing::Combine(testing::Values(GetTestParams()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenFloat))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         TRANSPOSED_TESTSUITE_NAME_DEVAPP,
+                         testing::Combine(testing::Values(GetTestParams()),
+                                          testing::Values(GetConvTestCasesNHWC(miopenFloat)[0])));

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvWinoFuryRxS.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvWinoFuryRxS.cpp
@@ -138,10 +138,37 @@ auto GetConvTestCasesNHWC(miopenDataType_t datatype)
     };
 }
 
+auto GetConvTestCasesNHWCWrw(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{
+            {datatype, miopenTensorNHWC, {1, 16, 5, 5}},
+            {datatype, miopenTensorNHWC, {16, 16, 3, 3}},
+            datatype,
+            {{0, 0}, {1, 1}, {1, 1}}
+        },
+        // Degenerate spatial dims (H=1, W=1) with 1x1 filter that has ambiguous layout strides
+        // so HeuristicUpdateLayouts() can't fix the layout string after NHWC->NCHW transposition.
+        // Targets GetSwappedNCLayout(NHWC)->CHWN
+        // then hits missing return in GetGroupConvLayout.
+        TestCase{
+            {datatype, miopenTensorNHWC, {2, 40, 1, 1}},
+            {datatype, miopenTensorNHWC, {8, 40, 1, 1}},
+            datatype,
+            {{0, 0}, {1, 1}, {1, 1}}
+        },
+        // clang-format on
+    };
+}
+
 } // namespace
 
 using GPU_UnitTestConvSolverTransposedWinoFuryRxSFwd_FP16 = GPU_UnitTestConvSolverFwd_FP16;
 using GPU_UnitTestConvSolverTransposedWinoFuryRxSBwd_FP16 = GPU_UnitTestConvSolverBwd_FP16;
+using GPU_UnitTestConvSolverTransposedWinoFuryRxSWrw_FP16 = GPU_UnitTestConvSolverWrw_FP16;
 using CPU_UnitTestConvSolverTransposedWinoFuryRxSDevApplicabilityFwd_FP16 =
     CPU_UnitTestConvSolverDevApplicabilityFwd_NONE;
 
@@ -151,6 +178,11 @@ TEST_P(GPU_UnitTestConvSolverTransposedWinoFuryRxSFwd_FP16, TransposedConvWinoFu
 };
 
 TEST_P(GPU_UnitTestConvSolverTransposedWinoFuryRxSBwd_FP16, TransposedConvWinoFuryRxS)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinoFuryRxS<2, 3>{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinoFuryRxSWrw_FP16, TransposedConvWinoFuryRxS)
 {
     this->RunTest(miopen::solver::conv::TransposedConvWinoFuryRxS<2, 3>{});
 };
@@ -173,6 +205,12 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoWinograd),
                                           testing::ValuesIn(GetConvTestCasesNHWC(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinoFuryRxSWrw_FP16,
+                         testing::Combine(testing::Values(GetTestParams()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWCWrw(miopenHalf))));
 
 // Device applicability test
 INSTANTIATE_TEST_SUITE_P(Smoke,

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvWinoFuryRxS.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvWinoFuryRxS.cpp
@@ -115,3 +115,67 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          CPU_UnitTestConvSolverWinoFury2x3DevApplicabilityFwd_NONE,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(GetConvTestCases(miopenHalf)[0])));
+
+// =====================================================================
+// TransposedConvWinoFuryRxS (NHWC layout)
+// =====================================================================
+
+namespace {
+
+auto GetConvTestCasesNHWC(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{
+            {datatype, miopenTensorNHWC, {1, 20, 20, 20}},
+            {datatype, miopenTensorNHWC, {20, 20, 3, 3}},
+            datatype,
+            {{1, 1}, {1, 1}, {1, 1}}
+        },
+        // clang-format on
+    };
+}
+
+} // namespace
+
+using GPU_UnitTestConvSolverTransposedWinoFuryRxSFwd_FP16 = GPU_UnitTestConvSolverFwd_FP16;
+using GPU_UnitTestConvSolverTransposedWinoFuryRxSBwd_FP16 = GPU_UnitTestConvSolverBwd_FP16;
+using CPU_UnitTestConvSolverTransposedWinoFuryRxSDevApplicabilityFwd_FP16 =
+    CPU_UnitTestConvSolverDevApplicabilityFwd_NONE;
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinoFuryRxSFwd_FP16, TransposedConvWinoFuryRxS)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinoFuryRxS<2, 3>{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinoFuryRxSBwd_FP16, TransposedConvWinoFuryRxS)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinoFuryRxS<2, 3>{});
+};
+
+TEST_P(CPU_UnitTestConvSolverTransposedWinoFuryRxSDevApplicabilityFwd_FP16,
+       TransposedConvWinoFuryRxS)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinoFuryRxS<2, 3>{});
+};
+
+// Smoke tests
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinoFuryRxSFwd_FP16,
+                         testing::Combine(testing::Values(GetTestParams()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinoFuryRxSBwd_FP16,
+                         testing::Combine(testing::Values(GetTestParams()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenHalf))));
+
+// Device applicability test
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         CPU_UnitTestConvSolverTransposedWinoFuryRxSDevApplicabilityFwd_FP16,
+                         testing::Combine(testing::Values(GetTestParams()),
+                                          testing::Values(GetConvTestCasesNHWC(miopenHalf)[0])));

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvWinoRageRxS.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvWinoRageRxS.cpp
@@ -229,3 +229,79 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          CPU_UnitTestConvSolverWinoRage2x3DevApplicabilityFwd_BFP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(GetConvTestCases(miopenBFloat16)[0])));
+
+// =====================================================================
+// TransposedConvWinoRageRxS (NHWC layout)
+// =====================================================================
+
+namespace {
+
+auto GetConvTestCasesNHWC(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{
+            {datatype, miopenTensorNHWC, {1, 40, 20, 20}},
+            {datatype, miopenTensorNHWC, {20, 20, 3, 3}},
+            datatype,
+            {{1, 1}, {1, 1}, {1, 1}, 2}
+        },
+        // clang-format on
+    };
+}
+
+} // namespace
+
+using GPU_UnitTestConvSolverTransposedWinoRageRxSFwd_FP16 = GPU_UnitTestConvSolverFwd_FP16;
+using GPU_UnitTestConvSolverTransposedWinoRageRxSBwd_FP16 = GPU_UnitTestConvSolverBwd_FP16;
+using GPU_UnitTestConvSolverTransposedWinoRageRxSWrw_FP16 = GPU_UnitTestConvSolverWrw_FP16;
+using CPU_UnitTestConvSolverTransposedWinoRageRxSDevApplicabilityFwd_FP16 =
+    CPU_UnitTestConvSolverDevApplicabilityFwd_NONE;
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinoRageRxSFwd_FP16, TransposedConvWinoRageRxSf2x3)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinoRageRxS<2, 3>{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinoRageRxSBwd_FP16, TransposedConvWinoRageRxSf2x3)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinoRageRxS<2, 3>{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinoRageRxSWrw_FP16, TransposedConvWinoRageRxSf2x3)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinoRageRxS<2, 3>{});
+};
+
+TEST_P(CPU_UnitTestConvSolverTransposedWinoRageRxSDevApplicabilityFwd_FP16,
+       TransposedConvWinoRageRxSf2x3)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinoRageRxS<2, 3>{});
+};
+
+// Smoke tests
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinoRageRxSFwd_FP16,
+                         testing::Combine(testing::Values(GetTestParams()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinoRageRxSBwd_FP16,
+                         testing::Combine(testing::Values(GetTestParams()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinoRageRxSWrw_FP16,
+                         testing::Combine(testing::Values(GetTestParams()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenHalf))));
+
+// Device applicability test
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         CPU_UnitTestConvSolverTransposedWinoRageRxSDevApplicabilityFwd_FP16,
+                         testing::Combine(testing::Values(GetTestParamsFP16()),
+                                          testing::Values(GetConvTestCasesNHWC(miopenHalf)[0])));

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvWinoRageRxS.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvWinoRageRxS.cpp
@@ -248,16 +248,65 @@ auto GetConvTestCasesNHWC(miopenDataType_t datatype)
             datatype,
             {{1, 1}, {1, 1}, {1, 1}, 2}
         },
+        // g=1 regression test for GetGroupConvLayout NHWC WrW fix
+        TestCase{
+            {datatype, miopenTensorNHWC, {1, 20, 20, 20}},
+            {datatype, miopenTensorNHWC, {20, 20, 3, 3}},
+            datatype,
+            {{1, 1}, {1, 1}, {1, 1}}
+        },
+        // clang-format on
+    };
+}
+
+// WrW-specific NHWC test cases including degenerate spatial dimensions (H=1, W=1).
+// With degenerate dims, NCHW strides satisfy NHWC ordering, so HeuristicUpdateLayouts()
+// may fail to update the layout string after NHWC->NCHW transposition.
+// This exercises the GetGroupConvLayout fix for CHWN/HWCN/HWNC layouts.
+auto GetConvTestCasesNHWCWrw(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{
+            {datatype, miopenTensorNHWC, {1, 40, 20, 20}},
+            {datatype, miopenTensorNHWC, {20, 20, 3, 3}},
+            datatype,
+            {{1, 1}, {1, 1}, {1, 1}, 2}
+        },
+        // g=1 regression test for GetGroupConvLayout NHWC WrW fix
+        TestCase{
+            {datatype, miopenTensorNHWC, {1, 20, 20, 20}},
+            {datatype, miopenTensorNHWC, {20, 20, 3, 3}},
+            datatype,
+            {{1, 1}, {1, 1}, {1, 1}}
+        },
+        // Degenerate spatial dims (H=1, W=1) with 1x1 filter that has ambiguous layout strides
+        // so HeuristicUpdateLayouts() can't fix the layout string after NHWC->NCHW transposition.
+        // Targets GetSwappedNCLayout(NHWC)->CHWN
+        // then hits missing return in GetGroupConvLayout.
+        TestCase{
+            {datatype, miopenTensorNHWC, {2, 40, 1, 1}},
+            {datatype, miopenTensorNHWC, {8, 40, 1, 1}},
+            datatype,
+            {{0, 0}, {1, 1}, {1, 1}}
+        },
         // clang-format on
     };
 }
 
 } // namespace
 
-using GPU_UnitTestConvSolverTransposedWinoRageRxSFwd_FP16 = GPU_UnitTestConvSolverFwd_FP16;
-using GPU_UnitTestConvSolverTransposedWinoRageRxSBwd_FP16 = GPU_UnitTestConvSolverBwd_FP16;
-using GPU_UnitTestConvSolverTransposedWinoRageRxSWrw_FP16 = GPU_UnitTestConvSolverWrw_FP16;
+using GPU_UnitTestConvSolverTransposedWinoRageRxSFwd_FP16  = GPU_UnitTestConvSolverFwd_FP16;
+using GPU_UnitTestConvSolverTransposedWinoRageRxSBwd_FP16  = GPU_UnitTestConvSolverBwd_FP16;
+using GPU_UnitTestConvSolverTransposedWinoRageRxSWrw_FP16  = GPU_UnitTestConvSolverWrw_FP16;
+using GPU_UnitTestConvSolverTransposedWinoRageRxSFwd_BFP16 = GPU_UnitTestConvSolverFwd_BFP16;
+using GPU_UnitTestConvSolverTransposedWinoRageRxSBwd_BFP16 = GPU_UnitTestConvSolverBwd_BFP16;
+using GPU_UnitTestConvSolverTransposedWinoRageRxSWrw_BFP16 = GPU_UnitTestConvSolverWrw_BFP16;
 using CPU_UnitTestConvSolverTransposedWinoRageRxSDevApplicabilityFwd_FP16 =
+    CPU_UnitTestConvSolverDevApplicabilityFwd_NONE;
+using CPU_UnitTestConvSolverTransposedWinoRageRxSDevApplicabilityFwd_BFP16 =
     CPU_UnitTestConvSolverDevApplicabilityFwd_NONE;
 
 TEST_P(GPU_UnitTestConvSolverTransposedWinoRageRxSFwd_FP16, TransposedConvWinoRageRxSf2x3)
@@ -281,6 +330,27 @@ TEST_P(CPU_UnitTestConvSolverTransposedWinoRageRxSDevApplicabilityFwd_FP16,
     this->RunTest(miopen::solver::conv::TransposedConvWinoRageRxS<2, 3>{});
 };
 
+TEST_P(GPU_UnitTestConvSolverTransposedWinoRageRxSFwd_BFP16, TransposedConvWinoRageRxSf2x3)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinoRageRxS<2, 3>{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinoRageRxSBwd_BFP16, TransposedConvWinoRageRxSf2x3)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinoRageRxS<2, 3>{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinoRageRxSWrw_BFP16, TransposedConvWinoRageRxSf2x3)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinoRageRxS<2, 3>{});
+};
+
+TEST_P(CPU_UnitTestConvSolverTransposedWinoRageRxSDevApplicabilityFwd_BFP16,
+       TransposedConvWinoRageRxSf2x3)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinoRageRxS<2, 3>{});
+};
+
 // Smoke tests
 INSTANTIATE_TEST_SUITE_P(Smoke,
                          GPU_UnitTestConvSolverTransposedWinoRageRxSFwd_FP16,
@@ -298,10 +368,35 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          GPU_UnitTestConvSolverTransposedWinoRageRxSWrw_FP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoWinograd),
-                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenHalf))));
+                                          testing::ValuesIn(GetConvTestCasesNHWCWrw(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinoRageRxSFwd_BFP16,
+                         testing::Combine(testing::Values(GetTestParams()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenBFloat16))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinoRageRxSBwd_BFP16,
+                         testing::Combine(testing::Values(GetTestParams()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenBFloat16))));
+
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    GPU_UnitTestConvSolverTransposedWinoRageRxSWrw_BFP16,
+    testing::Combine(testing::Values(GetTestParams()),
+                     testing::Values(miopenConvolutionAlgoWinograd),
+                     testing::ValuesIn(GetConvTestCasesNHWCWrw(miopenBFloat16))));
 
 // Device applicability test
 INSTANTIATE_TEST_SUITE_P(Smoke,
                          CPU_UnitTestConvSolverTransposedWinoRageRxSDevApplicabilityFwd_FP16,
                          testing::Combine(testing::Values(GetTestParamsFP16()),
                                           testing::Values(GetConvTestCasesNHWC(miopenHalf)[0])));
+
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    CPU_UnitTestConvSolverTransposedWinoRageRxSDevApplicabilityFwd_BFP16,
+    testing::Combine(testing::Values(GetTestParams()),
+                     testing::Values(GetConvTestCasesNHWC(miopenBFloat16)[0])));

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvWinograd3x3MultipassWrWF1x1x7x2.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvWinograd3x3MultipassWrWF1x1x7x2.cpp
@@ -122,3 +122,70 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          CPU_UnitTestConvSolverWinograd3x3MultipassF1x1x7x2DevApplicabilityWrw_NONE,
                          testing::Combine(testing::Values(GetTestParamsFP32()),
                                           testing::Values(GetConvTestCases(miopenFloat)[0])));
+
+// =====================================================================
+// TransposedConvWinograd3x3MultipassWrW<1, 1, 7, 2> (NHWC layout)
+// =====================================================================
+
+namespace {
+
+auto GetConvTestCasesNHWC(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{{datatype, miopenTensorNHWC, {1, 16, 24, 24}},
+                 {datatype, miopenTensorNHWC, {16, 16, 1, 7}},
+                 datatype, {{0, 3}, {1, 1}, {1, 1}}},
+        // clang-format on
+    };
+}
+
+} // namespace
+
+using GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF1x1x7x2Wrw_FP16 =
+    GPU_UnitTestConvSolverWrw_FP16;
+using GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF1x1x7x2Wrw_FP32 =
+    GPU_UnitTestConvSolverWrw_FP32;
+
+using CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF1x1x7x2DevApplicabilityWrw_NONE =
+    CPU_UnitTestConvSolverDevApplicabilityWrw_NONE;
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF1x1x7x2Wrw_FP16,
+       TransposedConvWinograd3x3MultipassWrWF1x1x7x2)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<1, 1, 7, 2>{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF1x1x7x2Wrw_FP32,
+       TransposedConvWinograd3x3MultipassWrWF1x1x7x2)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<1, 1, 7, 2>{});
+};
+
+TEST_P(CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF1x1x7x2DevApplicabilityWrw_NONE,
+       TransposedConvWinograd3x3MultipassWrWF1x1x7x2)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<1, 1, 7, 2>{});
+};
+
+// Smoke tests
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF1x1x7x2Wrw_FP16,
+                         testing::Combine(testing::Values(GetTestParamsFP16()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF1x1x7x2Wrw_FP32,
+                         testing::Combine(testing::Values(GetTestParamsFP32()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenFloat))));
+
+// Device applicability test
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF1x1x7x2DevApplicabilityWrw_NONE,
+    testing::Combine(testing::Values(GetTestParamsFP32()),
+                     testing::Values(GetConvTestCasesNHWC(miopenFloat)[0])));

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvWinograd3x3MultipassWrWF1x1x7x3.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvWinograd3x3MultipassWrWF1x1x7x3.cpp
@@ -122,3 +122,70 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          CPU_UnitTestConvSolverWinograd3x3MultipassF1x1x7x3DevApplicabilityWrw_NONE,
                          testing::Combine(testing::Values(GetTestParamsFP32()),
                                           testing::Values(GetConvTestCases(miopenFloat)[0])));
+
+// =====================================================================
+// TransposedConvWinograd3x3MultipassWrW<1, 1, 7, 3> (NHWC layout)
+// =====================================================================
+
+namespace {
+
+auto GetConvTestCasesNHWC(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{{datatype, miopenTensorNHWC, {1, 16, 24, 24}},
+                 {datatype, miopenTensorNHWC, {16, 16, 1, 7}},
+                 datatype, {{0, 3}, {1, 1}, {1, 1}}},
+        // clang-format on
+    };
+}
+
+} // namespace
+
+using GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF1x1x7x3Wrw_FP16 =
+    GPU_UnitTestConvSolverWrw_FP16;
+using GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF1x1x7x3Wrw_FP32 =
+    GPU_UnitTestConvSolverWrw_FP32;
+
+using CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF1x1x7x3DevApplicabilityWrw_NONE =
+    CPU_UnitTestConvSolverDevApplicabilityWrw_NONE;
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF1x1x7x3Wrw_FP16,
+       TransposedConvWinograd3x3MultipassWrWF1x1x7x3)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<1, 1, 7, 3>{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF1x1x7x3Wrw_FP32,
+       TransposedConvWinograd3x3MultipassWrWF1x1x7x3)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<1, 1, 7, 3>{});
+};
+
+TEST_P(CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF1x1x7x3DevApplicabilityWrw_NONE,
+       TransposedConvWinograd3x3MultipassWrWF1x1x7x3)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<1, 1, 7, 3>{});
+};
+
+// Smoke tests
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF1x1x7x3Wrw_FP16,
+                         testing::Combine(testing::Values(GetTestParamsFP16()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF1x1x7x3Wrw_FP32,
+                         testing::Combine(testing::Values(GetTestParamsFP32()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenFloat))));
+
+// Device applicability test
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF1x1x7x3DevApplicabilityWrw_NONE,
+    testing::Combine(testing::Values(GetTestParamsFP32()),
+                     testing::Values(GetConvTestCasesNHWC(miopenFloat)[0])));

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvWinograd3x3MultipassWrWF3x2.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvWinograd3x3MultipassWrWF3x2.cpp
@@ -119,3 +119,70 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          CPU_UnitTestConvSolverWinograd3x3MultipassF3x2DevApplicabilityWrw_NONE,
                          testing::Combine(testing::Values(GetTestParamsFP32()),
                                           testing::Values(GetConvTestCases(miopenFloat)[0])));
+
+// =====================================================================
+// TransposedConvWinograd3x3MultipassWrW<3, 2> (NHWC layout)
+// =====================================================================
+
+namespace {
+
+auto GetConvTestCasesNHWC(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{{datatype, miopenTensorNHWC, {1, 16, 24, 24}},
+                 {datatype, miopenTensorNHWC, {16, 16, 3, 3}},
+                 datatype, {{1, 1}, {2, 2}, {1, 1}}},
+        // clang-format on
+    };
+}
+
+} // namespace
+
+using GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x2Wrw_FP16 =
+    GPU_UnitTestConvSolverWrw_FP16;
+using GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x2Wrw_FP32 =
+    GPU_UnitTestConvSolverWrw_FP32;
+
+using CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x2DevApplicabilityWrw_NONE =
+    CPU_UnitTestConvSolverDevApplicabilityWrw_NONE;
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x2Wrw_FP16,
+       TransposedConvWinograd3x3MultipassWrWF3x2)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<3, 2>{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x2Wrw_FP32,
+       TransposedConvWinograd3x3MultipassWrWF3x2)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<3, 2>{});
+};
+
+TEST_P(CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x2DevApplicabilityWrw_NONE,
+       TransposedConvWinograd3x3MultipassWrWF3x2)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<3, 2>{});
+};
+
+// Smoke tests
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x2Wrw_FP16,
+                         testing::Combine(testing::Values(GetTestParamsFP16()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x2Wrw_FP32,
+                         testing::Combine(testing::Values(GetTestParamsFP32()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenFloat))));
+
+// Device applicability test
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x2DevApplicabilityWrw_NONE,
+    testing::Combine(testing::Values(GetTestParamsFP32()),
+                     testing::Values(GetConvTestCasesNHWC(miopenFloat)[0])));

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvWinograd3x3MultipassWrWF3x3.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvWinograd3x3MultipassWrWF3x3.cpp
@@ -119,3 +119,70 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          CPU_UnitTestConvSolverWinograd3x3MultipassF3x3DevApplicabilityWrw_NONE,
                          testing::Combine(testing::Values(GetTestParamsFP32()),
                                           testing::Values(GetConvTestCases(miopenFloat)[0])));
+
+// =====================================================================
+// TransposedConvWinograd3x3MultipassWrW<3, 3> (NHWC layout)
+// =====================================================================
+
+namespace {
+
+auto GetConvTestCasesNHWC(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{{datatype, miopenTensorNHWC, {1, 16, 24, 24}},
+                 {datatype, miopenTensorNHWC, {16, 16, 3, 3}},
+                 datatype, {{1, 1}, {2, 2}, {1, 1}}},
+        // clang-format on
+    };
+}
+
+} // namespace
+
+using GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x3Wrw_FP16 =
+    GPU_UnitTestConvSolverWrw_FP16;
+using GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x3Wrw_FP32 =
+    GPU_UnitTestConvSolverWrw_FP32;
+
+using CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x3DevApplicabilityWrw_NONE =
+    CPU_UnitTestConvSolverDevApplicabilityWrw_NONE;
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x3Wrw_FP16,
+       TransposedConvWinograd3x3MultipassWrWF3x3)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<3, 3>{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x3Wrw_FP32,
+       TransposedConvWinograd3x3MultipassWrWF3x3)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<3, 3>{});
+};
+
+TEST_P(CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x3DevApplicabilityWrw_NONE,
+       TransposedConvWinograd3x3MultipassWrWF3x3)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<3, 3>{});
+};
+
+// Smoke tests
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x3Wrw_FP16,
+                         testing::Combine(testing::Values(GetTestParamsFP16()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x3Wrw_FP32,
+                         testing::Combine(testing::Values(GetTestParamsFP32()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenFloat))));
+
+// Device applicability test
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x3DevApplicabilityWrw_NONE,
+    testing::Combine(testing::Values(GetTestParamsFP32()),
+                     testing::Values(GetConvTestCasesNHWC(miopenFloat)[0])));

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvWinograd3x3MultipassWrWF3x4.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvWinograd3x3MultipassWrWF3x4.cpp
@@ -167,3 +167,70 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          CPU_UnitTestConvSolverWinograd3x3MultipassF3x4DevApplicabilityWrw_NONE,
                          testing::Combine(testing::Values(GetTestParamsFP32()),
                                           testing::Values(GetConvTestCases(miopenFloat)[0])));
+
+// =====================================================================
+// TransposedConvWinograd3x3MultipassWrW<3, 4> (NHWC layout)
+// =====================================================================
+
+namespace {
+
+auto GetConvTestCasesNHWC(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{{datatype, miopenTensorNHWC, {1, 16, 24, 24}},
+                 {datatype, miopenTensorNHWC, {16, 16, 3, 3}},
+                 datatype, {{1, 1}, {1, 1}, {1, 1}}},
+        // clang-format on
+    };
+}
+
+} // namespace
+
+using GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x4Wrw_FP16 =
+    GPU_UnitTestConvSolverWrw_FP16;
+using GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x4Wrw_FP32 =
+    GPU_UnitTestConvSolverWrw_FP32;
+
+using CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x4DevApplicabilityWrw_NONE =
+    CPU_UnitTestConvSolverDevApplicabilityWrw_NONE;
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x4Wrw_FP16,
+       TransposedConvWinograd3x3MultipassWrWF3x4)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<3, 4>{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x4Wrw_FP32,
+       TransposedConvWinograd3x3MultipassWrWF3x4)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<3, 4>{});
+};
+
+TEST_P(CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x4DevApplicabilityWrw_NONE,
+       TransposedConvWinograd3x3MultipassWrWF3x4)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<3, 4>{});
+};
+
+// Smoke tests
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x4Wrw_FP16,
+                         testing::Combine(testing::Values(GetTestParamsFP16()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x4Wrw_FP32,
+                         testing::Combine(testing::Values(GetTestParamsFP32()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenFloat))));
+
+// Device applicability test
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x4DevApplicabilityWrw_NONE,
+    testing::Combine(testing::Values(GetTestParamsFP32()),
+                     testing::Values(GetConvTestCasesNHWC(miopenFloat)[0])));

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvWinograd3x3MultipassWrWF3x5.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvWinograd3x3MultipassWrWF3x5.cpp
@@ -167,3 +167,70 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          CPU_UnitTestConvSolverWinograd3x3MultipassF3x5DevApplicabilityWrw_NONE,
                          testing::Combine(testing::Values(GetTestParamsFP32()),
                                           testing::Values(GetConvTestCases(miopenFloat)[0])));
+
+// =====================================================================
+// TransposedConvWinograd3x3MultipassWrW<3, 5> (NHWC layout)
+// =====================================================================
+
+namespace {
+
+auto GetConvTestCasesNHWC(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{{datatype, miopenTensorNHWC, {1, 16, 24, 24}},
+                 {datatype, miopenTensorNHWC, {16, 16, 3, 3}},
+                 datatype, {{1, 1}, {1, 1}, {1, 1}}},
+        // clang-format on
+    };
+}
+
+} // namespace
+
+using GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x5Wrw_FP16 =
+    GPU_UnitTestConvSolverWrw_FP16;
+using GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x5Wrw_FP32 =
+    GPU_UnitTestConvSolverWrw_FP32;
+
+using CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x5DevApplicabilityWrw_NONE =
+    CPU_UnitTestConvSolverDevApplicabilityWrw_NONE;
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x5Wrw_FP16,
+       TransposedConvWinograd3x3MultipassWrWF3x5)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<3, 5>{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x5Wrw_FP32,
+       TransposedConvWinograd3x3MultipassWrWF3x5)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<3, 5>{});
+};
+
+TEST_P(CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x5DevApplicabilityWrw_NONE,
+       TransposedConvWinograd3x3MultipassWrWF3x5)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<3, 5>{});
+};
+
+// Smoke tests
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x5Wrw_FP16,
+                         testing::Combine(testing::Values(GetTestParamsFP16()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x5Wrw_FP32,
+                         testing::Combine(testing::Values(GetTestParamsFP32()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenFloat))));
+
+// Device applicability test
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x5DevApplicabilityWrw_NONE,
+    testing::Combine(testing::Values(GetTestParamsFP32()),
+                     testing::Values(GetConvTestCasesNHWC(miopenFloat)[0])));

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvWinograd3x3MultipassWrWF3x6.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvWinograd3x3MultipassWrWF3x6.cpp
@@ -167,3 +167,70 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          CPU_UnitTestConvSolverWinograd3x3MultipassF3x6DevApplicabilityWrw_NONE,
                          testing::Combine(testing::Values(GetTestParamsFP32()),
                                           testing::Values(GetConvTestCases(miopenFloat)[0])));
+
+// =====================================================================
+// TransposedConvWinograd3x3MultipassWrW<3, 6> (NHWC layout)
+// =====================================================================
+
+namespace {
+
+auto GetConvTestCasesNHWC(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{{datatype, miopenTensorNHWC, {1, 16, 24, 24}},
+                 {datatype, miopenTensorNHWC, {16, 16, 3, 3}},
+                 datatype, {{1, 1}, {1, 1}, {1, 1}}},
+        // clang-format on
+    };
+}
+
+} // namespace
+
+using GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x6Wrw_FP16 =
+    GPU_UnitTestConvSolverWrw_FP16;
+using GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x6Wrw_FP32 =
+    GPU_UnitTestConvSolverWrw_FP32;
+
+using CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x6DevApplicabilityWrw_NONE =
+    CPU_UnitTestConvSolverDevApplicabilityWrw_NONE;
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x6Wrw_FP16,
+       TransposedConvWinograd3x3MultipassWrWF3x6)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<3, 6>{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x6Wrw_FP32,
+       TransposedConvWinograd3x3MultipassWrWF3x6)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<3, 6>{});
+};
+
+TEST_P(CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x6DevApplicabilityWrw_NONE,
+       TransposedConvWinograd3x3MultipassWrWF3x6)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<3, 6>{});
+};
+
+// Smoke tests
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x6Wrw_FP16,
+                         testing::Combine(testing::Values(GetTestParamsFP16()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x6Wrw_FP32,
+                         testing::Combine(testing::Values(GetTestParamsFP32()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenFloat))));
+
+// Device applicability test
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF3x6DevApplicabilityWrw_NONE,
+    testing::Combine(testing::Values(GetTestParamsFP32()),
+                     testing::Values(GetConvTestCasesNHWC(miopenFloat)[0])));

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvWinograd3x3MultipassWrWF5x3.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvWinograd3x3MultipassWrWF5x3.cpp
@@ -119,3 +119,70 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          CPU_UnitTestConvSolverWinograd3x3MultipassF5x3DevApplicabilityWrw_NONE,
                          testing::Combine(testing::Values(GetTestParamsFP32()),
                                           testing::Values(GetConvTestCases(miopenFloat)[0])));
+
+// =====================================================================
+// TransposedConvWinograd3x3MultipassWrW<5, 3> (NHWC layout)
+// =====================================================================
+
+namespace {
+
+auto GetConvTestCasesNHWC(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{{datatype, miopenTensorNHWC, {1, 16, 24, 24}},
+                 {datatype, miopenTensorNHWC, {16, 16, 5, 5}},
+                 datatype, {{2, 2}, {1, 1}, {1, 1}}},
+        // clang-format on
+    };
+}
+
+} // namespace
+
+using GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF5x3Wrw_FP16 =
+    GPU_UnitTestConvSolverWrw_FP16;
+using GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF5x3Wrw_FP32 =
+    GPU_UnitTestConvSolverWrw_FP32;
+
+using CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF5x3DevApplicabilityWrw_NONE =
+    CPU_UnitTestConvSolverDevApplicabilityWrw_NONE;
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF5x3Wrw_FP16,
+       TransposedConvWinograd3x3MultipassWrWF5x3)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<5, 3>{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF5x3Wrw_FP32,
+       TransposedConvWinograd3x3MultipassWrWF5x3)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<5, 3>{});
+};
+
+TEST_P(CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF5x3DevApplicabilityWrw_NONE,
+       TransposedConvWinograd3x3MultipassWrWF5x3)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<5, 3>{});
+};
+
+// Smoke tests
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF5x3Wrw_FP16,
+                         testing::Combine(testing::Values(GetTestParamsFP16()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF5x3Wrw_FP32,
+                         testing::Combine(testing::Values(GetTestParamsFP32()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenFloat))));
+
+// Device applicability test
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF5x3DevApplicabilityWrw_NONE,
+    testing::Combine(testing::Values(GetTestParamsFP32()),
+                     testing::Values(GetConvTestCasesNHWC(miopenFloat)[0])));

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvWinograd3x3MultipassWrWF5x4.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvWinograd3x3MultipassWrWF5x4.cpp
@@ -119,3 +119,70 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          CPU_UnitTestConvSolverWinograd3x3MultipassF5x4DevApplicabilityWrw_NONE,
                          testing::Combine(testing::Values(GetTestParamsFP32()),
                                           testing::Values(GetConvTestCases(miopenFloat)[0])));
+
+// =====================================================================
+// TransposedConvWinograd3x3MultipassWrW<5, 4> (NHWC layout)
+// =====================================================================
+
+namespace {
+
+auto GetConvTestCasesNHWC(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{{datatype, miopenTensorNHWC, {1, 16, 24, 24}},
+                 {datatype, miopenTensorNHWC, {16, 16, 5, 5}},
+                 datatype, {{2, 2}, {1, 1}, {1, 1}}},
+        // clang-format on
+    };
+}
+
+} // namespace
+
+using GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF5x4Wrw_FP16 =
+    GPU_UnitTestConvSolverWrw_FP16;
+using GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF5x4Wrw_FP32 =
+    GPU_UnitTestConvSolverWrw_FP32;
+
+using CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF5x4DevApplicabilityWrw_NONE =
+    CPU_UnitTestConvSolverDevApplicabilityWrw_NONE;
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF5x4Wrw_FP16,
+       TransposedConvWinograd3x3MultipassWrWF5x4)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<5, 4>{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF5x4Wrw_FP32,
+       TransposedConvWinograd3x3MultipassWrWF5x4)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<5, 4>{});
+};
+
+TEST_P(CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF5x4DevApplicabilityWrw_NONE,
+       TransposedConvWinograd3x3MultipassWrWF5x4)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<5, 4>{});
+};
+
+// Smoke tests
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF5x4Wrw_FP16,
+                         testing::Combine(testing::Values(GetTestParamsFP16()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF5x4Wrw_FP32,
+                         testing::Combine(testing::Values(GetTestParamsFP32()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenFloat))));
+
+// Device applicability test
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF5x4DevApplicabilityWrw_NONE,
+    testing::Combine(testing::Values(GetTestParamsFP32()),
+                     testing::Values(GetConvTestCasesNHWC(miopenFloat)[0])));

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvWinograd3x3MultipassWrWF7x2.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvWinograd3x3MultipassWrWF7x2.cpp
@@ -119,3 +119,70 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          CPU_UnitTestConvSolverWinograd3x3MultipassF7x2DevApplicabilityWrw_NONE,
                          testing::Combine(testing::Values(GetTestParamsFP32()),
                                           testing::Values(GetConvTestCases(miopenFloat)[0])));
+
+// =====================================================================
+// TransposedConvWinograd3x3MultipassWrW<7, 2> (NHWC layout)
+// =====================================================================
+
+namespace {
+
+auto GetConvTestCasesNHWC(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{{datatype, miopenTensorNHWC, {1, 16, 24, 24}},
+                 {datatype, miopenTensorNHWC, {16, 16, 7, 7}},
+                 datatype, {{3, 3}, {1, 1}, {1, 1}}},
+        // clang-format on
+    };
+}
+
+} // namespace
+
+using GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x2Wrw_FP16 =
+    GPU_UnitTestConvSolverWrw_FP16;
+using GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x2Wrw_FP32 =
+    GPU_UnitTestConvSolverWrw_FP32;
+
+using CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x2DevApplicabilityWrw_NONE =
+    CPU_UnitTestConvSolverDevApplicabilityWrw_NONE;
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x2Wrw_FP16,
+       TransposedConvWinograd3x3MultipassWrWF7x2)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<7, 2>{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x2Wrw_FP32,
+       TransposedConvWinograd3x3MultipassWrWF7x2)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<7, 2>{});
+};
+
+TEST_P(CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x2DevApplicabilityWrw_NONE,
+       TransposedConvWinograd3x3MultipassWrWF7x2)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<7, 2>{});
+};
+
+// Smoke tests
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x2Wrw_FP16,
+                         testing::Combine(testing::Values(GetTestParamsFP16()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x2Wrw_FP32,
+                         testing::Combine(testing::Values(GetTestParamsFP32()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenFloat))));
+
+// Device applicability test
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x2DevApplicabilityWrw_NONE,
+    testing::Combine(testing::Values(GetTestParamsFP32()),
+                     testing::Values(GetConvTestCasesNHWC(miopenFloat)[0])));

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvWinograd3x3MultipassWrWF7x2x1x1.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvWinograd3x3MultipassWrWF7x2x1x1.cpp
@@ -113,3 +113,70 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          CPU_UnitTestConvSolverWinograd3x3MultipassF7x2x1x1DevApplicabilityWrw_NONE,
                          testing::Combine(testing::Values(GetTestParamsFP32()),
                                           testing::Values(GetConvTestCases(miopenFloat)[0])));
+
+// =====================================================================
+// TransposedConvWinograd3x3MultipassWrW<7, 2, 1, 1> (NHWC layout)
+// =====================================================================
+
+namespace {
+
+auto GetConvTestCasesNHWC(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{{datatype, miopenTensorNHWC, {1, 16, 24, 24}},
+                 {datatype, miopenTensorNHWC, {16, 16, 7, 1}},
+                 datatype, {{3, 0}, {1, 1}, {1, 1}}},
+        // clang-format on
+    };
+}
+
+} // namespace
+
+using GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x2x1x1Wrw_FP16 =
+    GPU_UnitTestConvSolverWrw_FP16;
+using GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x2x1x1Wrw_FP32 =
+    GPU_UnitTestConvSolverWrw_FP32;
+
+using CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x2x1x1DevApplicabilityWrw_NONE =
+    CPU_UnitTestConvSolverDevApplicabilityWrw_NONE;
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x2x1x1Wrw_FP16,
+       TransposedConvWinograd3x3MultipassWrWF7x2x1x1)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<7, 2, 1, 1>{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x2x1x1Wrw_FP32,
+       TransposedConvWinograd3x3MultipassWrWF7x2x1x1)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<7, 2, 1, 1>{});
+};
+
+TEST_P(CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x2x1x1DevApplicabilityWrw_NONE,
+       TransposedConvWinograd3x3MultipassWrWF7x2x1x1)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<7, 2, 1, 1>{});
+};
+
+// Smoke tests
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x2x1x1Wrw_FP16,
+                         testing::Combine(testing::Values(GetTestParamsFP16()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x2x1x1Wrw_FP32,
+                         testing::Combine(testing::Values(GetTestParamsFP32()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenFloat))));
+
+// Device applicability test
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x2x1x1DevApplicabilityWrw_NONE,
+    testing::Combine(testing::Values(GetTestParamsFP32()),
+                     testing::Values(GetConvTestCasesNHWC(miopenFloat)[0])));

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvWinograd3x3MultipassWrWF7x3.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvWinograd3x3MultipassWrWF7x3.cpp
@@ -119,3 +119,70 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          CPU_UnitTestConvSolverWinograd3x3MultipassF7x3DevApplicabilityWrw_NONE,
                          testing::Combine(testing::Values(GetTestParamsFP32()),
                                           testing::Values(GetConvTestCases(miopenFloat)[0])));
+
+// =====================================================================
+// TransposedConvWinograd3x3MultipassWrW<7, 3> (NHWC layout)
+// =====================================================================
+
+namespace {
+
+auto GetConvTestCasesNHWC(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{{datatype, miopenTensorNHWC, {1, 16, 24, 24}},
+                 {datatype, miopenTensorNHWC, {16, 16, 7, 7}},
+                 datatype, {{3, 3}, {1, 1}, {1, 1}}},
+        // clang-format on
+    };
+}
+
+} // namespace
+
+using GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x3Wrw_FP16 =
+    GPU_UnitTestConvSolverWrw_FP16;
+using GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x3Wrw_FP32 =
+    GPU_UnitTestConvSolverWrw_FP32;
+
+using CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x3DevApplicabilityWrw_NONE =
+    CPU_UnitTestConvSolverDevApplicabilityWrw_NONE;
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x3Wrw_FP16,
+       TransposedConvWinograd3x3MultipassWrWF7x3)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<7, 3>{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x3Wrw_FP32,
+       TransposedConvWinograd3x3MultipassWrWF7x3)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<7, 3>{});
+};
+
+TEST_P(CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x3DevApplicabilityWrw_NONE,
+       TransposedConvWinograd3x3MultipassWrWF7x3)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<7, 3>{});
+};
+
+// Smoke tests
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x3Wrw_FP16,
+                         testing::Combine(testing::Values(GetTestParamsFP16()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x3Wrw_FP32,
+                         testing::Combine(testing::Values(GetTestParamsFP32()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenFloat))));
+
+// Device applicability test
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x3DevApplicabilityWrw_NONE,
+    testing::Combine(testing::Values(GetTestParamsFP32()),
+                     testing::Values(GetConvTestCasesNHWC(miopenFloat)[0])));

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvWinograd3x3MultipassWrWF7x3x1x1.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvWinograd3x3MultipassWrWF7x3x1x1.cpp
@@ -113,3 +113,70 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          CPU_UnitTestConvSolverWinograd3x3MultipassF7x3x1x1DevApplicabilityWrw_NONE,
                          testing::Combine(testing::Values(GetTestParamsFP32()),
                                           testing::Values(GetConvTestCases(miopenFloat)[0])));
+
+// =====================================================================
+// TransposedConvWinograd3x3MultipassWrW<7, 3, 1, 1> (NHWC layout)
+// =====================================================================
+
+namespace {
+
+auto GetConvTestCasesNHWC(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{{datatype, miopenTensorNHWC, {1, 16, 24, 24}},
+                 {datatype, miopenTensorNHWC, {16, 16, 7, 1}},
+                 datatype, {{3, 0}, {1, 1}, {1, 1}}},
+        // clang-format on
+    };
+}
+
+} // namespace
+
+using GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x3x1x1Wrw_FP16 =
+    GPU_UnitTestConvSolverWrw_FP16;
+using GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x3x1x1Wrw_FP32 =
+    GPU_UnitTestConvSolverWrw_FP32;
+
+using CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x3x1x1DevApplicabilityWrw_NONE =
+    CPU_UnitTestConvSolverDevApplicabilityWrw_NONE;
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x3x1x1Wrw_FP16,
+       TransposedConvWinograd3x3MultipassWrWF7x3x1x1)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<7, 3, 1, 1>{});
+};
+
+TEST_P(GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x3x1x1Wrw_FP32,
+       TransposedConvWinograd3x3MultipassWrWF7x3x1x1)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<7, 3, 1, 1>{});
+};
+
+TEST_P(CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x3x1x1DevApplicabilityWrw_NONE,
+       TransposedConvWinograd3x3MultipassWrWF7x3x1x1)
+{
+    this->RunTest(miopen::solver::conv::TransposedConvWinograd3x3MultipassWrW<7, 3, 1, 1>{});
+};
+
+// Smoke tests
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x3x1x1Wrw_FP16,
+                         testing::Combine(testing::Values(GetTestParamsFP16()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x3x1x1Wrw_FP32,
+                         testing::Combine(testing::Values(GetTestParamsFP32()),
+                                          testing::Values(miopenConvolutionAlgoWinograd),
+                                          testing::ValuesIn(GetConvTestCasesNHWC(miopenFloat))));
+
+// Device applicability test
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    CPU_UnitTestConvSolverTransposedWinograd3x3MultipassF7x3x1x1DevApplicabilityWrw_NONE,
+    testing::Combine(testing::Values(GetTestParamsFP32()),
+                     testing::Values(GetConvTestCasesNHWC(miopenFloat)[0])));


### PR DESCRIPTION
## Motivation

PR #4945 added NHWC layout support for Winograd convolution solvers via a transposing solver pattern (NHWC → NCHW + Winograd + NCHW → NHWC). It was reverted because transposed Winograd solvers in the WrW direction would throw `"Internal error in GetGroupConvLayout: Unknown MemLayout_t"` when processing NHWC inputs with degenerate spatial dimensions (H=1, W=1) and g=1.

This PR re-applies #4945, fixes the root cause, adds targeted regression tests for the bug, closes test coverage gaps, and cleans up unnecessary `extern template` / `MIOPEN_INTERNALS_EXPORT` usage on the transposed solver structs.

## Technical Details

### Bug: `GetGroupConvLayout` throws on NC-swapped layouts (buffer_info.cpp)

In the WrW direction, transposed Winograd solvers call `GetSwappedNCLayout()` which transforms `NHWC → CHWN`. The `GetGroupConvLayout()` switch statement has `case` entries for `CHWN`, `HWCN`, and `HWNC` but they fell through to `MIOPEN_THROW` instead of returning respective layouts.

**Trigger condition:** The bug only manifests when *all three tensors* (input, weights, output) have degenerate spatial dimensions (H=1 and W=1 with 1x1 filters). In this case, NCHW strides satisfy NHWC ordering, so `HeuristicUpdateLayouts()` cannot detect that the layout has already been transposed to NCHW. The layout string stays `"NHWC"`, and `GetSwappedNCLayout(NHWC) → CHWN` hits the missing return.

With non-degenerate dimensions (e.g., 3x3 filters), `HeuristicUpdateLayouts()` correctly detects NCHW after transposition, so `GetGroupConvLayout` never receives the swapped layout.

**Fix:** Add explicit `return` statements for the `CHWN`, `HWCN`, and `HWNC` cases in both branches (data buffer and weight buffer) of `GetGroupConvLayout()`.

**Affected solvers (WrW + NHWC only):**
- `TransposedConvBinWinoRxS<2,3>` and `<3,2>` — via `ConvBinWinoRxS::GetSolution()` → `GetGroupConvLayout()`
- `TransposedConvBinWinogradRxS` — via `ConvBinWinogradRxS::GetSolution()` → `GetGroupConvLayout()`
- `TransposedConvWinoRageRxS<2,3>` — via `WinoShaderArgsV2::SetStrides()` → `GetGroupConvLayout()`
- `TransposedConvWinoFuryRxS<2,3>` — via `WinoShaderArgsV2::SetStrides()` → `GetGroupConvLayout()`

**Not affected:** Multipass Winograd solvers (13 variants) — they use a different `GetSolution()` that never calls `GetGroupConvLayout`. Bidirectional Winograd solvers — they only support Fwd/Bwd, not WrW.

### Commit-by-commit walkthrough

**1. `685d69b` — Revert "Revert [MIOpen] Add NHWC Layout Support for Winograd Convolution Solvers (#4945)"**

Re-applies the original #4945 changeset (41 files, ~2560 lines):
- 14+ transposed Winograd solver variants registered in `solver.cpp`
- `TransposingSolver` CRTP base class and `TransposeInvokeParams` infrastructure
- 50+ unit tests covering FP16/FP32, Fwd/Bwd/WrW directions across all solver families
- Initial `buffer_info.cpp` change that introduced the `CHWN`/`HWCN`/`HWNC` cases (without the return statements — the bug)

**2. `2192eb2` — Add g=1 grouped convolution test cases for regression coverage**

Adds g=1 (non-grouped path) NHWC test cases to `ConvBinWinogradRxSf2x3` and `ConvBinWinogradRxSf3x2`:
- Previous test cases only used g=2 (grouped convolution); the bug only triggers with g=1 NHWC WrW
- Separates `GetConvTestCasesWrw()` from `GetConvTestCases()` for `ConvBinWinogradRxSf2x3` because `WORKAROUND_ISSUE_1681` rejects g=1 for Fwd/Bwd in `ConvBinWinoRxS<2,3>` — only WrW supports g=1

**3. `8e60712` — Adding degenerate test cases**

Adds degenerate spatial dimension test cases (`{N, C, 1, 1}` input + `{K, C, 1, 1}` filter) to 5 test files covering all 5 affected solvers. These are the exact shapes that reproduce the `GetGroupConvLayout` throw:
- `ConvBinWinogradRxS` — adds `GetConvTestCasesNHWCFloatWrw()` with degenerate case
- `ConvBinWinogradRxSf2x3` — adds degenerate case to `GetConvTestCasesNHWCWrw()`
- `ConvBinWinogradRxSf3x2` — adds `GetConvTestCasesNHWCWrw()` with degenerate case
- `ConvWinoFuryRxS` — adds `GetConvTestCasesNHWCWrw()` with degenerate case + missing WrW transposed test
- `ConvWinoRageRxS` — adds `GetConvTestCasesNHWCWrw()` with degenerate case + BFP16 transposed tests (Fwd/Bwd/WrW)

**Without the buffer_info.cpp fix, these degenerate test cases throw:**

```
C++ exception with description "buffer_info.cpp:107: Internal error in GetGroupConvLayout:
Unknown MemLayout_t" thrown in the test body.
```

Also closes coverage gaps:
- `ConvWinoFuryRxS`: adds missing `TransposedConvWinoFuryRxSWrw_FP16` test (previously only had Fwd/Bwd)
- `ConvWinoRageRxS`: adds BFP16 transposed NHWC tests (the original driver bug used `convbfp16`)

**4. `52bc1cf` — Add MemLayout_t support for NC Swap, CHWN, HWCN, HWNC**

The actual bug fix: adds `return` statements for the `CHWN`, `HWCN`, and `HWNC` cases in `GetGroupConvLayout()`. Both the `IsDataBuffer=true` and `IsDataBuffer=false` branches are fixed.

**5. `bff6954b96` — Remove transposed Winograd exports to gtest and MIOPEN_INTERNALS_EXPORT**

Cleanup:
- Removes `MIOPEN_INTERNALS_EXPORT` from `TransposedConvBinWinograd3x3U`, `TransposedConvBinWinogradRxS`, `TransposedConvBinWinogradRxSf2x3g1` — templates use weak linkage and don't need export macros
- Removes all `extern template` declarations for transposed solvers (`TransposedConvMPBidirectWinograd`, `TransposedConvWinograd3x3MultipassWrW`, `TransposedConvWinoFuryRxS`, `TransposedConvWinoRageRxS`, `TransposedConvBinWinoRxS`) — these are lightweight CRTP wrappers that don't benefit from extern template optimization
- Removes debug `MIOPEN_LOG_I("Registering ...")` statements from solver registration
- Removed dead code from previous commits in `HeuristicUpdateLayouts`

## Test Plan

- [ ] Build succeeds with `-DCMAKE_BUILD_TYPE=release -DBUILD_DEV=Off`
- [ ] Run all 5 affected transposed Winograd test binaries:
  ```bash
  ./bin/test_unit_conv_solver_ConvBinWinogradRxS --gtest_filter="*Transposed*"
  ./bin/test_unit_conv_solver_ConvBinWinogradRxSf2x3 --gtest_filter="*Transposed*"
  ./bin/test_unit_conv_solver_ConvBinWinogradRxSf3x2 --gtest_filter="*Transposed*"
  ./bin/test_unit_conv_solver_ConvWinoFuryRxS --gtest_filter="*Transposed*"
  ./bin/test_unit_conv_solver_ConvWinoRageRxS --gtest_filter="*Transposed*"
- [ ] Verify degenerate spatial dimension tests pass (these throw without the fix)
- [ ] Reproduce original bug scenario:
`./bin/MIOpenDriver convbfp16 -n 2 -c 224 -H 1 -W 1 -k 8 -y 1 -x 1 \
  -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 \
  --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 4 -t 1`


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
