### PR TITLE
[CK] Replace inline asm tile loads with intrinsics in FMHA forward qr_async pipeline

### DIFF
--- a/projects/composablekernel/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs_async.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs_async.hpp
@@ -13,7 +13,7 @@
 namespace ck_tile {
 
 // a variation of qr/ks/vs, where we use async copy to load k (potentially v in the future)
-template <typename Problem_, typename Policy_ = BlockFmhaPipelineQRKSVSAsyncDefaultPolicy>
+template <typename Problem_, typename Policy_ = BlockFmhaPipelineQRKSVSAsyncIntrinsicPolicy>
 struct BlockFmhaPipelineQRKSVSAsync
 {
     using Problem               = remove_cvref_t<Problem_>;
@@ -225,32 +225,43 @@ struct BlockFmhaPipelineQRKSVSAsync
 
         constexpr auto LdsSeq = Policy::template GetLdsBufferSequence<Problem>();
 
-        // K tile in LDS
-        auto k_lds_ptr   = reinterpret_cast<KDataType*>(smem_ptr);
+        // K tile in LDS — per-buffer typed pointer windows
+        constexpr auto single_buf_size = Policy::template GetSingleSmemElementSpaceSize<Problem>();
+        auto k_lds_ptr                 = reinterpret_cast<KDataType*>(smem_ptr);
+
         auto k_lds_store = generate_tuple(
             [&](auto i_buf) {
                 return make_tile_window(
                     make_tensor_view<address_space_enum::lds>(
-                        k_lds_ptr, Policy::template MakeKLdsStoreBlockDescriptor<Problem>(i_buf)),
-                    Policy::template MakeKLdsStoreBlockDescriptor<Problem>(i_buf).get_lengths(),
-                    {0, 0, 0});
+                        k_lds_ptr + i_buf * single_buf_size,
+                        Policy::template MakeKLdsStoreBlockDescriptor<Problem>()),
+                    Policy::template MakeKLdsStoreBlockDescriptor<Problem>().get_lengths(),
+                    {0, 0});
             },
             number<Policy::NumKVLdsBuffers>{});
 
-        auto k_lds_Load_view = make_tensor_view<address_space_enum::lds>(
-            k_lds_ptr, Policy::template MakeKLdsLoadBlockDescriptor<Problem>());
+        auto k_lds_load = generate_tuple(
+            [&](auto i_buf) {
+                return make_tile_window(
+                    make_tensor_view<address_space_enum::lds>(
+                        k_lds_ptr + i_buf * single_buf_size,
+                        Policy::template MakeKLdsLoadBlockDescriptor<Problem>()),
+                    Policy::template MakeKLdsLoadBlockDescriptor<Problem>().get_lengths(),
+                    {0, 0});
+            },
+            number<Policy::NumKVLdsBuffers>{});
 
-        auto k_lds_load =
-            make_tile_window(k_lds_Load_view,
-                             Policy::template MakeKLdsLoadBlockDescriptor<Problem>().get_lengths(),
-                             {0, 0});
-
-        // V tile in LDS
-        auto v_lds = make_tensor_view<address_space_enum::lds>(
-            reinterpret_cast<VDataType*>(smem_ptr),
-            Policy::template MakeVLdsBlockDescriptor<Problem>());
-        auto v_lds_window = make_tile_window(
-            v_lds, Policy::template MakeVLdsBlockDescriptor<Problem>().get_lengths(), {0, 0});
+        // V tile in LDS — per-buffer typed pointer windows
+        auto v_lds = generate_tuple(
+            [&](auto i_buf) {
+                return make_tile_window(
+                    make_tensor_view<address_space_enum::lds>(
+                        reinterpret_cast<VDataType*>(k_lds_ptr + i_buf * single_buf_size),
+                        Policy::template MakeVLdsBlockDescriptor<Problem>()),
+                    Policy::template MakeVLdsBlockDescriptor<Problem>().get_lengths(),
+                    {0, 0});
+            },
+            number<Policy::NumKVLdsBuffers>{});
 
         // Block GEMM
         constexpr auto gemm_0 = Policy::template GetQKBlockGemm<Problem>();
@@ -260,15 +271,8 @@ struct BlockFmhaPipelineQRKSVSAsync
                                               q_dram_block_window_tmp.get_window_lengths(),
                                               q_dram_block_window_tmp.get_window_origin(),
                                               Policy::template MakeQRegTileDistribution<Problem>());
-        q_dram_window.init_raw();
 
-        // TODO: we use async Copy for K, which is inline asm
-        // a side effect is we have to use inline asm for q as well
-        auto q = decltype(load_tile(q_dram_window)){};
-        // TODO: start from rocm-6.2, compiler will have problem if manually set clear of q.
-        // however, q would be cleared in the constructor of static distributed tensor
-        // set_tile(q, number<0>{}); // use per-dword clear to avoid scratch
-        load_tile_raw(q, q_dram_window);
+        auto q = load_tile(q_dram_window);
         __builtin_amdgcn_sched_barrier(0);
 
         using SaccBlockTileType = decltype(gemm_0.MakeCBlockTile());
@@ -337,8 +341,8 @@ struct BlockFmhaPipelineQRKSVSAsync
         {
             if(num_total_loop <= 0)
             {
-                buffer_load_fence(0); // rocm-7.1.1, if whole tile is masked out, need to fence(0)
-                                      // otherwise will have compute error(maybe compiler bug?)
+                s_waitcnt<0>(); // rocm-7.1.1, if whole tile is masked out, need to fence(0)
+                                // otherwise will have compute error(maybe compiler bug?)
                 if constexpr(kStoreLSE)
                 {
                     auto lse =
@@ -364,16 +368,7 @@ struct BlockFmhaPipelineQRKSVSAsync
             k_dram_block_window.get_window_origin(),
             Policy::template MakeKDramTileDistribution<Problem>()); // K DRAM tile window for
                                                                     // load
-        k_dram_window.init_raw();
         constexpr auto k_oob_ck = bool_constant<true>{};
-        constexpr auto k_pre_np = [&]() {
-            if constexpr(kPadSeqLenK &&
-                         (BiasEnum == BlockAttentionBiasEnum::ELEMENTWISE_BIAS ||
-                          (BiasEnum != BlockAttentionBiasEnum::NO_BIAS && kHasDropout)))
-                return bool_constant<true>{};
-            else
-                return bool_constant<false>{};
-        }();
 
         const auto bias_origin = bias_dram_block_window_tmp.get_window_origin();
         auto bias_dram_window =
@@ -392,12 +387,11 @@ struct BlockFmhaPipelineQRKSVSAsync
                              Policy::template MakeVDramTileDistribution<Problem>());
 
         // prefetch K tile
-        async_load_tile_raw(
-            k_lds_store(LdsSeq.at(number<0>{})), k_dram_window, number<-1>{}, k_oob_ck, k_pre_np);
+        async_load_tile(k_lds_store(LdsSeq.at(number<0>{})), k_dram_window, number<-1>{}, k_oob_ck);
         move_tile_window(k_dram_window, {0, kK0});
         __builtin_amdgcn_sched_barrier(0);
 
-        buffer_load_fence(k_dram_window.get_num_of_access(), q.get_thread_buffer());
+        s_waitcnt<k_dram_window.get_num_of_access()>();
         (void)q_element_func; // ??? rocm-6.x if use q element func will have scratch on hdim=64/32
         // auto q_tile = q;      // tile_elementwise_in(q_element_func, q);
 
@@ -422,23 +416,20 @@ struct BlockFmhaPipelineQRKSVSAsync
             if constexpr(k0_loops > 1)
             {
                 static_for<0, k0_loops - 1, 1>{}([&](auto i_k0) {
-                    async_load_tile_raw(k_lds_store(number<LdsSeq.at(number<i_k0 + 1>{})>{}),
-                                        k_dram_window,
-                                        number<-1>{},
-                                        k_oob_ck,
-                                        k_pre_np);
+                    async_load_tile(k_lds_store(number<LdsSeq.at(number<i_k0 + 1>{})>{}),
+                                    k_dram_window,
+                                    number<-1>{},
+                                    k_oob_ck);
                     if constexpr(i_k0 < k0_loops - 1)
                         move_tile_window(k_dram_window, {0, kK0});
 
-                    async_load_fence(k_dram_window.get_num_of_access());
+                    s_waitcnt<k_dram_window.get_num_of_access()>();
                     __builtin_amdgcn_s_barrier();
                     __builtin_amdgcn_sched_barrier(0);
                     gemm_0(s_acc,
                            get_slice_tile(
                                q, sequence<0, i_k0 * kK0>{}, sequence<kM0, (i_k0 + 1) * kK0>{}),
-                           get_slice_tile(k_lds_load,
-                                          sequence<(LdsSeq.at(number<i_k0>{})) * kN0, 0>{},
-                                          sequence<(LdsSeq.at(number<i_k0>{}) + 1) * kN0, kK0>{}));
+                           k_lds_load(LdsSeq.at(number<i_k0>{})));
                 });
             }
 
@@ -447,20 +438,17 @@ struct BlockFmhaPipelineQRKSVSAsync
             if constexpr(k0_loops <= 2)
                 __builtin_amdgcn_sched_barrier(0);
 
-            async_load_fence();
+            s_waitcnt<0>();
             __builtin_amdgcn_s_barrier();
 
             const auto bias_tile = load_tile(bias_dram_window); // load bias tile
             auto v_buf           = load_tile(v_dram_window, number<-1>{}, bool_constant<false>{});
             __builtin_amdgcn_sched_barrier(0);
             { // tail
-                gemm_0(
-                    s_acc,
-                    get_slice_tile(
-                        q, sequence<0, (k0_loops - 1) * kK0>{}, sequence<kM0, k0_loops * kK0>{}),
-                    get_slice_tile(k_lds_load,
-                                   sequence<(LdsSeq.at(number<k0_loops - 1>{})) * kN0, 0>{},
-                                   sequence<(LdsSeq.at(number<k0_loops - 1>{}) + 1) * kN0, kK0>{}));
+                gemm_0(s_acc,
+                       get_slice_tile(
+                           q, sequence<0, (k0_loops - 1) * kK0>{}, sequence<kM0, k0_loops * kK0>{}),
+                       k_lds_load(LdsSeq.at(number<k0_loops - 1>{})));
             }
             __builtin_amdgcn_sched_barrier(1);
             // dequant
@@ -610,22 +598,13 @@ struct BlockFmhaPipelineQRKSVSAsync
                     Policy::template MakeShuffledVRegBlockDescriptor<Problem>());
                 shuffle_tile(v_shuffle_tmp, v_buf);
 
-                auto v_lds_window_tmp =
-                    get_slice_tile(v_lds_window,
-                                   sequence<(LdsSeq.at(number<k0_loops>{})) * kN1, 0>{},
-                                   sequence<(LdsSeq.at(number<k0_loops>{}) + 1) * kN1, kK1>{});
-
                 store_tile(
-                    v_lds_window_tmp,
+                    v_lds(LdsSeq.at(number<k0_loops>{})),
                     tile_elementwise_in(v_element_func, v_shuffle_tmp)); // store the prefetch
             }
             else
             {
-                auto v_lds_window_tmp =
-                    get_slice_tile(v_lds_window,
-                                   sequence<(LdsSeq.at(number<k0_loops>{})) * kN1, 0>{},
-                                   sequence<(LdsSeq.at(number<k0_loops>{}) + 1) * kN1, kK1>{});
-                store_tile(v_lds_window_tmp,
+                store_tile(v_lds(LdsSeq.at(number<k0_loops>{})),
                            tile_elementwise_in(v_element_func, v_buf)); // store the prefetch
             }
 
@@ -811,31 +790,20 @@ struct BlockFmhaPipelineQRKSVSAsync
                     gemm_1(o_acc_,
                            get_slice_tile(
                                p, sequence<0, i_k1 * kK1>{}, sequence<kM0, (i_k1 + 1) * kK1>{}),
-                           get_slice_tile(
-                               v_lds_window,
-                               sequence<(LdsSeq.at(number<k0_loops + i_k1>{})) * kN1, 0>{},
-                               sequence<(LdsSeq.at(number<k0_loops + i_k1>{}) + 1) * kN1, kK1>{}));
+                           v_lds(LdsSeq.at(number<k0_loops + i_k1>{})));
 
                     if constexpr(std::is_same_v<VLayout, ck_tile::tensor_layout::gemm::RowMajor>)
                     {
                         auto v_shuffle_tmp = make_static_distributed_tensor<VDataType>(
                             Policy::template MakeShuffledVRegBlockDescriptor<Problem>());
                         shuffle_tile(v_shuffle_tmp, v_buf);
-                        auto v_lds_window_tmp = get_slice_tile(
-                            v_lds_window,
-                            sequence<(LdsSeq.at(number<k0_loops + i_k1 + 1>{})) * kN1, 0>{},
-                            sequence<(LdsSeq.at(number<k0_loops + i_k1 + 1>{}) + 1) * kN1, kK1>{});
-                        store_tile(v_lds_window_tmp,
+                        store_tile(v_lds(LdsSeq.at(number<k0_loops + i_k1 + 1>{})),
                                    tile_elementwise_in(v_element_func,
                                                        v_shuffle_tmp)); // store the prefetch
                     }
                     else
                     {
-                        auto v_lds_window_tmp = get_slice_tile(
-                            v_lds_window,
-                            sequence<(LdsSeq.at(number<k0_loops + i_k1 + 1>{})) * kN1, 0>{},
-                            sequence<(LdsSeq.at(number<k0_loops + i_k1 + 1>{}) + 1) * kN1, kK1>{});
-                        store_tile(v_lds_window_tmp,
+                        store_tile(v_lds(LdsSeq.at(number<k0_loops + i_k1 + 1>{})),
                                    tile_elementwise_in(v_element_func, v_buf)); // store next v_buf
                     }
                     if constexpr(i_k1 < k1_loops - 1)
@@ -860,23 +828,16 @@ struct BlockFmhaPipelineQRKSVSAsync
                 if constexpr(k1_loops >= 2 &&
                              LdsSeq.at(number<0>{}) == LdsSeq.at(number<k0_loops + k1_loops - 2>{}))
                     __builtin_amdgcn_s_barrier();
-                async_load_tile_raw(k_lds_store(LdsSeq.at(number<0>{})),
-                                    k_dram_window,
-                                    number<-1>{},
-                                    k_oob_ck,
-                                    k_pre_np);
+                async_load_tile(
+                    k_lds_store(LdsSeq.at(number<0>{})), k_dram_window, number<-1>{}, k_oob_ck);
                 move_tile_window(k_dram_window, {0, kK0});
             }
             // tail
             {
                 block_sync_lds();
-                gemm_1(
-                    o_acc_,
-                    get_slice_tile(p, sequence<0, (k1_loops - 1) * kK1>{}, sequence<kM0, kN0>{}),
-                    get_slice_tile(
-                        v_lds_window,
-                        sequence<(LdsSeq.at(number<k0_loops + k1_loops - 1>{})) * kN1, 0>{},
-                        sequence<(LdsSeq.at(number<k0_loops + k1_loops - 1>{}) + 1) * kN1, kK1>{}));
+                gemm_1(o_acc_,
+                       get_slice_tile(p, sequence<0, (k1_loops - 1) * kK1>{}, sequence<kM0, kN0>{}),
+                       v_lds(LdsSeq.at(number<k0_loops + k1_loops - 1>{})));
             }
 
             if constexpr(QScaleEnum == BlockAttentionQuantScaleEnum::BLOCKSCALE)

--- a/projects/composablekernel/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs_async_default_policy.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs_async_default_policy.hpp
@@ -15,4 +15,10 @@ using BlockFmhaPipelineQRKSVSAsyncDefaultPolicy =
                                         /* NumPrefetchK = */ 3,
                                         /* NumPrefetchV = */ 3>;
 
+// NEW alias — qr_async pipeline only (intrinsic-based loads, 2D LDS descriptors)
+using BlockFmhaPipelineQRKSVSAsyncIntrinsicPolicy =
+    BlockFmhaPipelineQXKSVSAsyncPolicy</* QLoadOnce = */ true,
+                                       /* NumPrefetchK = */ 3,
+                                       /* NumPrefetchV = */ 3>;
+
 } // namespace ck_tile

--- a/projects/composablekernel/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qx_ks_vs_custom_policy.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qx_ks_vs_custom_policy.hpp
@@ -1176,4 +1176,144 @@ struct BlockFmhaPipelineQXKSVSCustomPolicy : BlockFmhaPipelineQXCustomPolicy<QLo
     }
 };
 
+// Policy subclass for qr_async pipeline using intrinsic-based loads (non-raw)
+// Produces 2D LDS descriptors and per-buffer layouts (no baked IBuf offset)
+template <bool QLoadOnce_, index_t NumPrefetchK_, index_t NumPrefetchV_>
+struct BlockFmhaPipelineQXKSVSAsyncPolicy : BlockFmhaPipelineQXKSVSCustomPolicy<QLoadOnce_,
+                                                                                /*AsyncCopy_=*/true,
+                                                                                NumPrefetchK_,
+                                                                                NumPrefetchV_>
+{
+    using Base =
+        BlockFmhaPipelineQXKSVSCustomPolicy<QLoadOnce_, true, NumPrefetchK_, NumPrefetchV_>;
+
+    // 2D K LDS store descriptor: (merged_issues_warps, merged_lanes)
+    // No IBuf offset — each buffer gets its own typed pointer in the pipeline
+    template <typename Problem>
+    CK_TILE_HOST_DEVICE static constexpr auto MakeKLdsStoreBlockDescriptor()
+    {
+        constexpr index_t kNPerBlock = Problem::BlockFmhaShape::kN0;
+        constexpr index_t kKPerBlock = Problem::BlockFmhaShape::kK1;
+        constexpr index_t NumWarps   = Problem::BlockFmhaShape::NumWarps;
+        constexpr index_t WarpSize   = ck_tile::get_warp_size();
+
+        constexpr index_t KPack   = Base::template GetSmemKPackK<Problem>();
+        constexpr index_t KVector = Base::template GetAlignmentK<Problem>();
+        constexpr index_t kPad    = KPack;
+
+        static_assert(WarpSize * KVector >= kKPerBlock && WarpSize * KVector % kKPerBlock == 0);
+        constexpr index_t LanesPerK  = kKPerBlock / KVector;
+        constexpr index_t LaneGroups = WarpSize / LanesPerK;
+        constexpr index_t NumIssues  = kNPerBlock / (LaneGroups * NumWarps);
+
+        constexpr auto k_lds_block_desc_0 =
+            make_naive_tensor_descriptor(make_tuple(number<NumIssues>{},
+                                                    number<LaneGroups>{},
+                                                    number<NumWarps>{},
+                                                    number<LanesPerK>{},
+                                                    number<KVector>{}),
+                                         make_tuple(number<NumWarps*(WarpSize * KVector + kPad)>{},
+                                                    number<kKPerBlock>{},
+                                                    number<WarpSize * KVector + kPad>{},
+                                                    number<KVector>{},
+                                                    number<1>{}),
+                                         number<KVector>{},
+                                         number<1>{});
+
+        constexpr auto k_lds_block_desc = transform_tensor_descriptor(
+            k_lds_block_desc_0,
+            make_tuple(make_merge_transform(make_tuple(
+                           number<NumIssues>{}, number<LaneGroups>{}, number<NumWarps>{})),
+                       make_merge_transform(make_tuple(number<LanesPerK>{}, number<KVector>{}))),
+            make_tuple(sequence<0, 1, 2>{}, sequence<3, 4>{}),
+            make_tuple(sequence<0>{}, sequence<1>{}));
+
+        return k_lds_block_desc;
+    }
+
+    // Per-buffer K LDS load descriptor: no NumKVLdsBuffers dimension
+    template <typename Problem>
+    CK_TILE_HOST_DEVICE static constexpr auto MakeKLdsLoadBlockDescriptor()
+    {
+        constexpr index_t kNPerBlock = Problem::BlockFmhaShape::kN0;
+        constexpr index_t kKPerBlock = Problem::BlockFmhaShape::kK1;
+        constexpr index_t NumWarps   = Problem::BlockFmhaShape::NumWarps;
+        constexpr index_t WarpSize   = ck_tile::get_warp_size();
+
+        constexpr index_t KPack   = Base::template GetSmemKPackK<Problem>();
+        constexpr index_t KVector = Base::template GetAlignmentK<Problem>();
+        constexpr index_t kPad    = KPack;
+
+        static_assert(WarpSize * KVector >= kKPerBlock && WarpSize * KVector % kKPerBlock == 0);
+        constexpr index_t LanesPerK  = kKPerBlock / KVector;
+        constexpr index_t LaneGroups = WarpSize / LanesPerK;
+        constexpr index_t NumIssues  = kNPerBlock / (LaneGroups * NumWarps);
+
+        constexpr auto k_lds_block_desc_0 =
+            make_naive_tensor_descriptor(make_tuple(number<NumIssues>{},
+                                                    number<NumWarps>{},
+                                                    number<LaneGroups>{},
+                                                    number<kKPerBlock / KPack>{},
+                                                    number<KPack>{}),
+                                         make_tuple(number<NumWarps*(WarpSize * KVector + kPad)>{},
+                                                    number<WarpSize * KVector + kPad>{},
+                                                    number<kKPerBlock>{},
+                                                    number<KPack>{},
+                                                    number<1>{}),
+                                         number<KPack>{},
+                                         number<1>{});
+
+        constexpr auto k_lds_block_desc = transform_tensor_descriptor(
+            k_lds_block_desc_0,
+            make_tuple(
+                make_merge_transform(
+                    make_tuple(number<NumIssues>{}, number<LaneGroups>{}, number<NumWarps>{})),
+                make_merge_transform(make_tuple(number<kKPerBlock / KPack>{}, number<KPack>{}))),
+            make_tuple(sequence<0, 2, 1>{}, sequence<3, 4>{}),
+            make_tuple(sequence<0>{}, sequence<1>{}));
+
+        return k_lds_block_desc;
+    }
+
+    // Per-buffer V LDS descriptor: no NumKVLdsBuffers dimension
+    // Used for both store and load
+    template <typename Problem>
+    CK_TILE_HOST_DEVICE static constexpr auto MakeVLdsBlockDescriptor()
+    {
+        using VDataType         = remove_cvref_t<typename Problem::VDataType>;
+        constexpr index_t Banks = get_n_lds_banks();
+        constexpr index_t PixelsPerRow =
+            Banks * 4 * numeric_traits<VDataType>::PackedSize / sizeof(VDataType);
+        constexpr index_t kKPack = Base::template GetSmemKPackV<Problem>();
+        static_assert(PixelsPerRow % kKPack == 0);
+        constexpr index_t NPerRow    = PixelsPerRow / kKPack;
+        constexpr index_t kNPerBlock = Problem::BlockFmhaShape::kN1;
+        constexpr index_t kKPerBlock = Problem::BlockFmhaShape::kK1;
+        static_assert(kNPerBlock % NPerRow == 0);
+        static_assert(kKPerBlock % kKPack == 0);
+
+        constexpr auto v_lds_block_desc_0 = make_naive_tensor_descriptor(
+            make_tuple(number<kKPerBlock / kKPack>{},
+                       number<kNPerBlock / NPerRow>{},
+                       number<NPerRow>{},
+                       number<kKPack>{}),
+            make_tuple(number<(kNPerBlock / NPerRow) * (PixelsPerRow + kKPack)>{},
+                       number<PixelsPerRow + kKPack>{},
+                       number<kKPack>{},
+                       number<1>{}),
+            number<kKPack>{},
+            number<1>{});
+
+        constexpr auto v_lds_block_desc = transform_tensor_descriptor(
+            v_lds_block_desc_0,
+            make_tuple(
+                make_merge_transform(make_tuple(number<kNPerBlock / NPerRow>{}, number<NPerRow>{})),
+                make_merge_transform(make_tuple(number<kKPerBlock / kKPack>{}, number<kKPack>{}))),
+            make_tuple(sequence<1, 2>{}, sequence<0, 3>{}),
+            make_tuple(sequence<0>{}, sequence<1>{}));
+
+        return v_lds_block_desc;
+    }
+};
+
 } // namespace ck_tile


### PR DESCRIPTION
## Summary

- Replace `async_load_tile_raw()`/`load_tile_raw()` with `async_load_tile()`/`load_tile()` in the qr_async FMHA pipeline so the compiler can track memory operations and insert correct `s_waitcnt` instructions to guard against RAW hazards when VGPR spills occur
- Add `BlockFmhaPipelineQXKSVSAsyncPolicy` subclass with 2D LDS descriptors (no baked IBuf offset) to support per-buffer typed pointer windows required by the intrinsic-based loads
- Replace `buffer_load_fence`/`async_load_fence` with `s_waitcnt<>()` and `get_slice_tile()` LDS indexing with direct per-buffer window indexing

## Motivation

The `_raw` variants use inline `asm volatile` which is opaque to the compiler's instruction scheduler. When VGPR spills occur, the compiler cannot insert `s_waitcnt` instructions to guard spill/reload operations, leading to potential RAW data hazards. The intrinsic-based equivalents make loads visible to the compiler, enabling correct instruction scheduling.

## Performance (d=128, bhsd layout, qr_async pipeline, gfx950)

Benchmarked with `qr_async_trload` and `qr_async_trload_v3` pipelines disabled so that all problem sizes dispatch to the `qr_async` pipeline under test.

| dtype | batch | seqlen | Baseline TFlops | Modified TFlops | Delta |
|-------|-------|--------|-----------------|-----------------|-------|
| fp16  | 32    | 512    | 473.54          | 415.57          | -12.2% |
| fp16  | 16    | 1024   | 536.35          | 507.92          | -5.3% |
| fp16  | 8     | 2048   | 618.88          | 596.30          | -3.6% |
| fp16  | 4     | 4096   | 716.94          | 695.53          | -3.0% |
| fp16  | 2     | 8192   | 794.15          | 776.22          | -2.3% |
| fp16  | 1     | 16384  | 837.06          | 814.16          | -2.7% |
| bf16  | 32    | 512    | 480.50          | 414.93          | -13.6% |
| bf16  | 16    | 1024   | 572.66          | 495.86          | -13.4% |
| bf16  | 8     | 2048   | 663.33          | 574.89          | -13.3% |
| bf16  | 4     | 4096   | 758.58          | 660.80          | -12.9% |
| bf16  | 2     | 8192   | 841.63          | 771.90          | -8.3% |
| bf16  | 1     | 16384  | 872.00          | 810.22          | -7.1% |

## VGPR spill investigation (ongoing)

The performance regression is caused by increased VGPR spill pressure in M0=128 tile kernels. The intrinsic-based loads make memory operations visible to the register allocator, which expands register live ranges.

**Kernel spill summary (qr_async, gfx950):**

|                     | Baseline | Modified | Delta |
|---------------------|----------|----------|-------|
| Spilling kernels    | 44/96    | 48/96    | +4    |
| Max VGPR spills     | 60       | 96       | +36   |
| Max scratch (bytes) | 240      | 256      | +16   |

**Dispatched kernel spill comparison (exact variants used by benchmark):**

| Kernel variant      | Baseline spills | Modified spills | Spill delta | Baseline scratch | Modified scratch | Scratch delta |
|---------------------|-----------------|-----------------|-------------|------------------|------------------|---------------|
| fp16, padK=false    | 18              | 37              | +19         | 76 B             | 88 B             | +12 B         |
| fp16, padK=true     | 3               | 43              | +40         | 16 B             | 96 B             | +80 B         |
| bf16, padK=false    | 18              | 25              | +7          | 76 B             | 56 B             | -20 B         |
| bf16, padK=true     | 0               | 33              | +33         | 0 B              | 88 B             | +88 B         |

Note: All M0=64 tile kernels remain spill-free in both baseline and modified. The baseline M0=128 kernels already spill (44/96), so this is an inherently register-pressure-constrained tile size. The tradeoff is: `_raw` has fewer spills but the compiler can't insert correct `s_waitcnt` for spill/reload; intrinsics have more spills but the compiler correctly manages `s_waitcnt`.
