### PR TITLE
[hip-kernel-provider] Refactor applicability checks

### DIFF
--- a/dnn-providers/hip-kernel-provider/src/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/src/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(
     engines/plans/layernorm/LayernormFwdPlan.cpp
     engines/plans/layernorm/LayernormPlanBuilder.cpp
     engines/plans/layernorm/LayernormUtilities.cpp
+    engines/plans/ApplicabilityChecks.cpp
 )
 if(ENABLE_ASM_SDPA_ENGINE)
     add_subdirectory(engines/asm_sdpa_engine)

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/ApplicabilityChecks.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/ApplicabilityChecks.cpp
@@ -1,0 +1,189 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_plugin_sdk/PluginException.hpp>
+
+#include "ApplicabilityChecks.hpp"
+#include "HipKernelUtils.hpp"
+
+namespace hip_kernel_provider
+{
+
+// --- Tensor Descriptor Implementation ---
+
+TensorDescriptor::TensorDescriptor(const hipdnn_data_sdk::data_objects::TensorAttributes* attr)
+    : dims(attr->dims()->begin(), attr->dims()->end())
+    , strides(attr->strides()->begin(), attr->strides()->end())
+    , strideOrder(hipdnn_data_sdk::utilities::extractStrideOrder(strides))
+{
+}
+
+bool TensorDescriptor::isPacked() const
+{
+    return hipdnn_data_sdk::utilities::isTensorPacked(dims, strides);
+}
+
+void IValidator::validateDimensionCount(size_t numDims)
+{
+    constexpr size_t MIN_SUPPORTED_DIMS = 4;
+    constexpr size_t MAX_SUPPORTED_DIMS = 5;
+
+    if(numDims < MIN_SUPPORTED_DIMS || numDims > MAX_SUPPORTED_DIMS)
+    {
+        throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                                                       "Only 4D or 5D tensors supported.");
+    }
+}
+
+void IValidator::validateConsistentDimensions(const std::vector<TensorDescriptor>& tensors)
+{
+    if(tensors.empty())
+    {
+        return;
+    }
+
+    const size_t expectedDims = tensors[0].numDims();
+    validateDimensionCount(expectedDims);
+
+    for(size_t i = 1; i < tensors.size(); ++i)
+    {
+        if(tensors[i].numDims() != expectedDims)
+        {
+            throw hipdnn_plugin_sdk::HipdnnPluginException(
+                HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                "All tensors must have the same number of dimensions.");
+        }
+    }
+}
+
+void IValidator::validatePackedTensors(const std::vector<TensorDescriptor>& tensors)
+{
+    for(const auto& tensor : tensors)
+    {
+        if(!tensor.isPacked())
+        {
+            throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                                                           "Only packed tensors supported.");
+        }
+    }
+}
+
+void IValidator::validateSupportedLayout(const std::vector<int64_t>& strideOrder, size_t numDims)
+{
+    if(numDims == 4)
+    {
+        const auto layoutNchw = hipdnn_data_sdk::utilities::TensorLayout::NCHW;
+        const auto layoutNhwc = hipdnn_data_sdk::utilities::TensorLayout::NHWC;
+
+        if(strideOrder != layoutNchw.strideOrder && strideOrder != layoutNhwc.strideOrder)
+        {
+            throw hipdnn_plugin_sdk::HipdnnPluginException(
+                HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                "Only NCHW and NHWC layouts supported for 4D tensors.");
+        }
+    }
+    else
+    {
+        const auto layoutNcdhw = hipdnn_data_sdk::utilities::TensorLayout::NCDHW;
+        const auto layoutNdhwc = hipdnn_data_sdk::utilities::TensorLayout::NDHWC;
+
+        if(strideOrder != layoutNcdhw.strideOrder && strideOrder != layoutNdhwc.strideOrder)
+        {
+            throw hipdnn_plugin_sdk::HipdnnPluginException(
+                HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                "Only NCDHW and NDHWC layouts supported for 5D tensors.");
+        }
+    }
+}
+
+void IValidator::validateConsistentLayouts(const std::vector<TensorDescriptor>& tensors)
+{
+    if(tensors.empty())
+    {
+        return;
+    }
+
+    // Use first tensor with meaningful layout as reference
+    int64_t referenceIndex = -1;
+    for(size_t i = 0; i < tensors.size(); ++i)
+    {
+        if(hipdnn_data_sdk::utilities::isLayoutAgnostic(tensors[i].dims))
+        {
+            continue;
+        }
+
+        if(referenceIndex == -1)
+        {
+            referenceIndex = static_cast<int64_t>(i);
+            validateSupportedLayout(tensors[static_cast<size_t>(referenceIndex)].strideOrder,
+                                    tensors[static_cast<size_t>(referenceIndex)].numDims());
+        }
+        else
+        {
+            if(tensors[i].strideOrder != tensors[static_cast<size_t>(referenceIndex)].strideOrder)
+            {
+                throw hipdnn_plugin_sdk::HipdnnPluginException(
+                    HIPDNN_PLUGIN_STATUS_BAD_PARAM, "All tensors must have the same layout.");
+            }
+        }
+    }
+}
+
+void IValidator::validateDataTypeIsSupported(
+    hipdnn_data_sdk::data_objects::DataType dataType,
+    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
+    const std::string& errorMessage)
+{
+    if(allowedTypes.count(dataType) > 0)
+    {
+        return;
+    }
+    throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM, errorMessage);
+}
+
+void IValidator::validateConsistentDataTypes(
+    const std::vector<int64_t>& tensorIds,
+    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
+    const std::string& typeErrorMessage,
+    const std::string& consistencyErrorMessage)
+{
+    if(tensorIds.empty())
+    {
+        return;
+    }
+
+    const auto& firstTensor = hip_kernel_utils::findTensorAttributes(_tensorMap, tensorIds[0]);
+    const auto referenceType = firstTensor.data_type();
+
+    validateDataTypeIsSupported(referenceType, allowedTypes, typeErrorMessage);
+
+    for(size_t i = 1; i < tensorIds.size(); ++i)
+    {
+        const auto& tensor = hip_kernel_utils::findTensorAttributes(_tensorMap, tensorIds[i]);
+        if(tensor.data_type() != referenceType)
+        {
+            throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                                                           consistencyErrorMessage);
+        }
+    }
+}
+
+void IValidator::validateConsistentShapes(const std::vector<int64_t>& tensorIds,
+                                          const std::vector<int64_t>& referenceShape,
+                                          const std::string& errorMessage)
+{
+    for(const auto tensorId : tensorIds)
+    {
+        const auto& tensorAttr = hip_kernel_utils::findTensorAttributes(_tensorMap, tensorId);
+        const std::vector<int64_t> dims(tensorAttr.dims()->begin(), tensorAttr.dims()->end());
+        if(dims != referenceShape)
+        {
+            throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                                                           errorMessage);
+        }
+    }
+}
+
+} // namespace hip_kernel_provider

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/ApplicabilityChecks.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/ApplicabilityChecks.cpp
@@ -170,6 +170,21 @@ void IValidator::validateConsistentDataTypes(
     }
 }
 
+void IValidator::validateFixedDataType(const std::vector<int64_t>& tensorIds,
+                                       hipdnn_data_sdk::data_objects::DataType expectedType,
+                                       const std::string& errorMessage)
+{
+    for(const auto tensorId : tensorIds)
+    {
+        const auto& tensor = hip_kernel_utils::findTensorAttributes(_tensorMap, tensorId);
+        if(tensor.data_type() != expectedType)
+        {
+            throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                                                           errorMessage);
+        }
+    }
+}
+
 void IValidator::validateConsistentShapes(const std::vector<int64_t>& tensorIds,
                                           const std::vector<int64_t>& referenceShape,
                                           const std::string& errorMessage)

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/ApplicabilityChecks.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/ApplicabilityChecks.hpp
@@ -1,0 +1,93 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
+
+namespace hip_kernel_provider
+{
+
+// --- Tensor Descriptor Value Object ---
+
+struct TensorDescriptor
+{
+    std::vector<int64_t> dims;
+    std::vector<int64_t> strides;
+    std::vector<int64_t> strideOrder;
+
+    explicit TensorDescriptor(const hipdnn_data_sdk::data_objects::TensorAttributes* attr);
+
+    size_t numDims() const
+    {
+        return dims.size();
+    }
+    bool isPacked() const;
+};
+
+// --- Abstract Base Class For Plan Validation ---
+
+class IValidator
+{
+public:
+    IValidator(
+        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+            tensorMap)
+        : _tensorMap(tensorMap) {};
+
+    virtual ~IValidator() = default;
+
+protected:
+    // --- Validation Utilities ---
+
+    virtual void validateDimensionCount(size_t numDims);
+
+    virtual void validateConsistentDimensions(const std::vector<TensorDescriptor>& tensors);
+
+    virtual void validatePackedTensors(const std::vector<TensorDescriptor>& tensors);
+
+    virtual void validateSupportedLayout(const std::vector<int64_t>& strideOrder, size_t numDims);
+
+    virtual void validateConsistentLayouts(const std::vector<TensorDescriptor>& tensors);
+
+    virtual void validateDataTypeIsSupported(
+        hipdnn_data_sdk::data_objects::DataType dataType,
+        const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
+        const std::string& errorMessage);
+
+    virtual void validateConsistentDataTypes(
+        const std::vector<int64_t>& tensorIds,
+        const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
+        const std::string& typeErrorMessage,
+        const std::string& consistencyErrorMessage);
+
+    virtual void validateConsistentShapes(const std::vector<int64_t>& tensorIds,
+                                          const std::vector<int64_t>& referenceShape,
+                                          const std::string& errorMessage);
+
+    // --- Component Validators ---
+
+    virtual void checkTensorLayoutsAndDimsSupported() = 0;
+
+    virtual void checkTensorDataTypesSupported(const std::vector<int64_t>& ioTensorIds,
+                                               const std::vector<int64_t>& affineTensorIds,
+                                               const std::vector<int64_t>& statTensorIds,
+                                               const std::vector<int64_t>& intermediateTensorIds)
+        = 0;
+
+    virtual void checkTensorShapesSupported(const std::vector<int64_t>& ioTensorIds,
+                                            const std::vector<int64_t>& affineTensorIds,
+                                            const std::vector<int64_t>& statTensorIds,
+                                            bool isTraining)
+        = 0;
+
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        _tensorMap;
+};
+
+} // namespace hip_kernel_provider

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/ApplicabilityChecks.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/ApplicabilityChecks.hpp
@@ -74,18 +74,6 @@ protected:
 
     virtual void checkTensorLayoutsAndDimsSupported() = 0;
 
-    virtual void checkTensorDataTypesSupported(const std::vector<int64_t>& ioTensorIds,
-                                               const std::vector<int64_t>& affineTensorIds,
-                                               const std::vector<int64_t>& statTensorIds,
-                                               const std::vector<int64_t>& intermediateTensorIds)
-        = 0;
-
-    virtual void checkTensorShapesSupported(const std::vector<int64_t>& ioTensorIds,
-                                            const std::vector<int64_t>& affineTensorIds,
-                                            const std::vector<int64_t>& statTensorIds,
-                                            bool isTraining)
-        = 0;
-
     const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
         _tensorMap;
 };

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/ApplicabilityChecks.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/ApplicabilityChecks.hpp
@@ -66,6 +66,10 @@ protected:
         const std::string& typeErrorMessage,
         const std::string& consistencyErrorMessage);
 
+    virtual void validateFixedDataType(const std::vector<int64_t>& tensorIds,
+                                       hipdnn_data_sdk::data_objects::DataType expectedType,
+                                       const std::string& errorMessage);
+
     virtual void validateConsistentShapes(const std::vector<int64_t>& tensorIds,
                                           const std::vector<int64_t>& referenceShape,
                                           const std::string& errorMessage);

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormApplicabilityChecks.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormApplicabilityChecks.cpp
@@ -65,11 +65,9 @@ void RMSnormValidator::checkTensorLayoutsAndDimsSupported()
     validateConsistentLayouts(tensors);
 }
 
-void RMSnormValidator::checkTensorDataTypesSupported(
-    const std::vector<int64_t>& ioTensorIds,
-    const std::vector<int64_t>& affineTensorIds,
-    const std::vector<int64_t>& statTensorIds,
-    [[maybe_unused]] const std::vector<int64_t>& intermediateTensorIds)
+void RMSnormValidator::checkTensorDataTypesSupported(const std::vector<int64_t>& ioTensorIds,
+                                                     const std::vector<int64_t>& affineTensorIds,
+                                                     const std::vector<int64_t>& statTensorIds)
 {
     std::unordered_set<hipdnn_data_sdk::data_objects::DataType> allowedIOTypes{
         hipdnn_data_sdk::data_objects::DataType::FLOAT,
@@ -100,8 +98,7 @@ void RMSnormValidator::checkTensorDataTypesSupported(
 
 void RMSnormValidator::checkTensorShapesSupported(const std::vector<int64_t>& ioTensorIds,
                                                   const std::vector<int64_t>& affineTensorIds,
-                                                  const std::vector<int64_t>& statTensorIds,
-                                                  [[maybe_unused]] bool isTraining)
+                                                  const std::vector<int64_t>& statTensorIds)
 {
     if(ioTensorIds.empty())
     {
@@ -148,8 +145,8 @@ void RMSnormValidator::checkTensorConfigSupported(
     }
 
     checkTensorLayoutsAndDimsSupported();
-    checkTensorDataTypesSupported(ioTensorIds, affineTensorIds, statTensorIds, {});
-    checkTensorShapesSupported(ioTensorIds, affineTensorIds, statTensorIds, false);
+    checkTensorDataTypesSupported(ioTensorIds, affineTensorIds, statTensorIds);
+    checkTensorShapesSupported(ioTensorIds, affineTensorIds, statTensorIds);
 }
 
 void RMSnormValidator::checkBwdTensorConfigSupported(
@@ -177,4 +174,4 @@ void RMSnormValidator::checkBwdTensorConfigSupported(
     checkTensorShapesSupported(ioTensorIds, affineTensorIds, statTensorIds, false);
 }
 
-} // namespace hip_kernel_provider
+} // namespace hip_kernel_provider::rmsnorm

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormApplicabilityChecks.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormApplicabilityChecks.cpp
@@ -150,7 +150,7 @@ void RMSnormValidator::checkTensorConfigSupported(
 }
 
 void RMSnormValidator::checkBwdTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::RMSNormBackwardAttributes& rmsNormBwdAttr
+    const hipdnn_data_sdk::data_objects::RMSNormBackwardAttributes& rmsNormBwdAttr)
 {
     std::vector<int64_t> ioTensorIds = {rmsNormBwdAttr.dy_tensor_uid(),
                                         rmsNormBwdAttr.x_tensor_uid(),
@@ -170,8 +170,8 @@ void RMSnormValidator::checkBwdTensorConfigSupported(
     }
 
     checkTensorLayoutsAndDimsSupported();
-    checkTensorDataTypesSupported(ioTensorIds, affineTensorIds, statTensorIds, {});
-    checkTensorShapesSupported(ioTensorIds, affineTensorIds, statTensorIds, false);
+    checkTensorDataTypesSupported(ioTensorIds, affineTensorIds, statTensorIds);
+    checkTensorShapesSupported(ioTensorIds, affineTensorIds, statTensorIds);
 }
 
 } // namespace hip_kernel_provider::rmsnorm

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormApplicabilityChecks.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormApplicabilityChecks.cpp
@@ -14,73 +14,10 @@
 
 namespace hip_kernel_provider::rmsnorm
 {
-
-// --- Tensor Descriptor Implementation ---
-RMSnormTensorDescriptor::RMSnormTensorDescriptor(
-    const hipdnn_data_sdk::data_objects::TensorAttributes* attr)
-    : dims(attr->dims()->begin(), attr->dims()->end())
-    , strides(attr->strides()->begin(), attr->strides()->end())
-    , strideOrder(hipdnn_data_sdk::utilities::extractStrideOrder(strides))
-{
-}
-
-bool RMSnormTensorDescriptor::isPacked() const
-{
-    return hipdnn_data_sdk::utilities::isTensorPacked(dims, strides);
-}
-
-namespace
-{
-
 // --- Validation Utilities ---
-void validateDimensionCount(size_t numDims)
-{
-    constexpr size_t MIN_SUPPORTED_DIMS = 4;
-    constexpr size_t MAX_SUPPORTED_DIMS = 5;
 
-    if(numDims < MIN_SUPPORTED_DIMS || numDims > MAX_SUPPORTED_DIMS)
-    {
-        throw hipdnn_plugin_sdk::HipdnnPluginException(
-            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
-            "RMSnorm implementation supports only 4D or 5D tensors.");
-    }
-}
-
-void validateConsistentDimensions(const std::vector<RMSnormTensorDescriptor>& tensors)
-{
-    if(tensors.empty())
-    {
-        return;
-    }
-
-    const size_t expectedDims = tensors[0].numDims();
-    validateDimensionCount(expectedDims);
-
-    for(size_t i = 1; i < tensors.size(); ++i)
-    {
-        if(tensors[i].numDims() != expectedDims)
-        {
-            throw hipdnn_plugin_sdk::HipdnnPluginException(
-                HIPDNN_PLUGIN_STATUS_BAD_PARAM,
-                "All tensors for RMSnorm must have the same number of dimensions.");
-        }
-    }
-}
-
-void validatePackedTensors(const std::vector<RMSnormTensorDescriptor>& tensors)
-{
-    for(const auto& tensor : tensors)
-    {
-        if(!tensor.isPacked())
-        {
-            throw hipdnn_plugin_sdk::HipdnnPluginException(
-                HIPDNN_PLUGIN_STATUS_BAD_PARAM,
-                "RMSnorm implementation supports only packed tensors.");
-        }
-    }
-}
-
-void validateSupportedLayout(const std::vector<int64_t>& strideOrder, size_t numDims)
+void RMSnormValidator::validateSupportedLayout(const std::vector<int64_t>& strideOrder,
+                                               size_t numDims)
 {
     if(numDims == 4)
     {
@@ -106,111 +43,15 @@ void validateSupportedLayout(const std::vector<int64_t>& strideOrder, size_t num
     }
 }
 
-void validateConsistentLayouts(const std::vector<RMSnormTensorDescriptor>& tensors)
-{
-    if(tensors.empty())
-    {
-        return;
-    }
-
-    // Use first tensor with meaningful layout as reference
-    int64_t referenceIndex = -1;
-    for(size_t i = 0; i < tensors.size(); ++i)
-    {
-        if(hipdnn_data_sdk::utilities::isLayoutAgnostic(tensors[i].dims))
-        {
-            continue;
-        }
-
-        if(referenceIndex == -1)
-        {
-            referenceIndex = static_cast<int64_t>(i);
-            validateSupportedLayout(tensors[static_cast<size_t>(referenceIndex)].strideOrder,
-                                    tensors[static_cast<size_t>(referenceIndex)].numDims());
-        }
-        else
-        {
-            if(tensors[i].strideOrder != tensors[static_cast<size_t>(referenceIndex)].strideOrder)
-            {
-                throw hipdnn_plugin_sdk::HipdnnPluginException(
-                    HIPDNN_PLUGIN_STATUS_BAD_PARAM,
-                    "All tensors for RMSnorm must have the same layout.");
-            }
-        }
-    }
-}
-
-void validateDataTypeIsSupported(
-    hipdnn_data_sdk::data_objects::DataType dataType,
-    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
-    const std::string& errorMessage)
-{
-    if(allowedTypes.count(dataType) > 0)
-    {
-        return;
-    }
-    throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM, errorMessage);
-}
-
-void validateConsistentDataTypes(
-    const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap,
-    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
-    const std::string& typeErrorMessage,
-    const std::string& consistencyErrorMessage)
-{
-    if(tensorIds.empty())
-    {
-        return;
-    }
-
-    const auto& firstTensor = hip_kernel_utils::findTensorAttributes(tensorMap, tensorIds[0]);
-    const auto referenceType = firstTensor.data_type();
-
-    validateDataTypeIsSupported(referenceType, allowedTypes, typeErrorMessage);
-
-    for(size_t i = 1; i < tensorIds.size(); ++i)
-    {
-        const auto& tensor = hip_kernel_utils::findTensorAttributes(tensorMap, tensorIds[i]);
-        if(tensor.data_type() != referenceType)
-        {
-            throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM,
-                                                           consistencyErrorMessage);
-        }
-    }
-}
-
-void validateConsistentShapes(
-    const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap,
-    const std::vector<int64_t>& referenceShape,
-    const std::string& errorMessage)
-{
-    for(const auto tensorId : tensorIds)
-    {
-        const auto& tensorAttr = hip_kernel_utils::findTensorAttributes(tensorMap, tensorId);
-        const std::vector<int64_t> dims(tensorAttr.dims()->begin(), tensorAttr.dims()->end());
-        if(dims != referenceShape)
-        {
-            throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM,
-                                                           errorMessage);
-        }
-    }
-}
-
 // --- Component Validators ---
 
-void checkTensorLayoutsAndDimsSupported(
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap)
+void RMSnormValidator::checkTensorLayoutsAndDimsSupported()
 {
     // Skip tensors with embedded scalar values (epsilon) - they don't have layouts or dimensions to validate
-    std::vector<RMSnormTensorDescriptor> tensors;
-    tensors.reserve(tensorMap.size());
+    std::vector<TensorDescriptor> tensors;
+    tensors.reserve(_tensorMap.size());
 
-    for(const auto& [id, attr] : tensorMap)
+    for(const auto& [id, attr] : _tensorMap)
     {
         if(attr->value_type() != hipdnn_data_sdk::data_objects::TensorValue::NONE)
         {
@@ -224,12 +65,11 @@ void checkTensorLayoutsAndDimsSupported(
     validateConsistentLayouts(tensors);
 }
 
-void checkTensorDataTypesSupported(
+void RMSnormValidator::checkTensorDataTypesSupported(
     const std::vector<int64_t>& ioTensorIds,
     const std::vector<int64_t>& affineTensorIds,
     const std::vector<int64_t>& statTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap)
+    [[maybe_unused]] const std::vector<int64_t>& intermediateTensorIds)
 {
     std::unordered_set<hipdnn_data_sdk::data_objects::DataType> allowedIOTypes{
         hipdnn_data_sdk::data_objects::DataType::FLOAT,
@@ -237,7 +77,6 @@ void checkTensorDataTypesSupported(
         hipdnn_data_sdk::data_objects::DataType::HALF};
 
     validateConsistentDataTypes(ioTensorIds,
-                                tensorMap,
                                 allowedIOTypes,
                                 "RMSnorm implementation supports only FLOAT, HALF, and BFLOAT16 "
                                 "data types for x & y tensors.",
@@ -249,24 +88,20 @@ void checkTensorDataTypesSupported(
 
     };
     validateConsistentDataTypes(affineTensorIds,
-                                tensorMap,
                                 allowedComputeTypes,
                                 "RMSnorm affine tensors use unsupported data type.",
                                 "All affine tensors for RMSnorm must have the same data type.");
 
     validateConsistentDataTypes(statTensorIds,
-                                tensorMap,
                                 allowedComputeTypes,
                                 "RMSnorm stat tensors use unsupported data type.",
                                 "All stat tensors for RMSnorm must have the same data type.");
 }
 
-void checkTensorShapesSupported(
-    const std::vector<int64_t>& ioTensorIds,
-    const std::vector<int64_t>& affineTensorIds,
-    const std::vector<int64_t>& statTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap)
+void RMSnormValidator::checkTensorShapesSupported(const std::vector<int64_t>& ioTensorIds,
+                                                  const std::vector<int64_t>& affineTensorIds,
+                                                  const std::vector<int64_t>& statTensorIds,
+                                                  [[maybe_unused]] bool isTraining)
 {
     if(ioTensorIds.empty())
     {
@@ -275,15 +110,14 @@ void checkTensorShapesSupported(
             "At least one IO tensor must be provided for RMSnorm.");
     }
 
-    const auto& ioTensorAttr = hip_kernel_utils::findTensorAttributes(tensorMap, ioTensorIds[0]);
+    const auto& ioTensorAttr = hip_kernel_utils::findTensorAttributes(_tensorMap, ioTensorIds[0]);
     const std::vector<int64_t> ioDims(ioTensorAttr.dims()->begin(), ioTensorAttr.dims()->end());
 
     validateConsistentShapes(
-        ioTensorIds, tensorMap, ioDims, "All IO tensors for RMSnorm must have the same shape.");
+        ioTensorIds, ioDims, "All IO tensors for RMSnorm must have the same shape.");
 
     const std::vector<int64_t> affineDims = hipdnn_data_sdk::utilities::getDerivedShape(ioDims);
     validateConsistentShapes(affineTensorIds,
-                             tensorMap,
                              affineDims,
                              "Scale and bias tensors for RMSnorm must have channel-only shape "
                              "derived from IO tensor shape.");
@@ -292,18 +126,13 @@ void checkTensorShapesSupported(
     std::vector<int64_t> invRMSDims = ioDims;
     invRMSDims[1] = 1;
     validateConsistentShapes(statTensorIds,
-                             tensorMap,
                              invRMSDims,
                              "RMS variance tensor for RMSnorm must have single channel shape "
                              "derived from IO tensor shape.");
 }
-} // anonymous namespace
 
-// --- High-Level Configuration Validators ---
-void checkRMSnormTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::RMSNormAttributes& rmsNormAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap)
+void RMSnormValidator::checkTensorConfigSupported(
+    const hipdnn_data_sdk::data_objects::RMSNormAttributes& rmsNormAttr)
 {
     std::vector<int64_t> ioTensorIds = {rmsNormAttr.x_tensor_uid(), rmsNormAttr.y_tensor_uid()};
     std::vector<int64_t> affineTensorIds = {rmsNormAttr.scale_tensor_uid()};
@@ -318,15 +147,13 @@ void checkRMSnormTensorConfigSupported(
         statTensorIds.push_back(rmsNormAttr.inv_rms_tensor_uid().value());
     }
 
-    checkTensorLayoutsAndDimsSupported(tensorMap);
-    checkTensorDataTypesSupported(ioTensorIds, affineTensorIds, statTensorIds, tensorMap);
-    checkTensorShapesSupported(ioTensorIds, affineTensorIds, statTensorIds, tensorMap);
+    checkTensorLayoutsAndDimsSupported();
+    checkTensorDataTypesSupported(ioTensorIds, affineTensorIds, statTensorIds, {});
+    checkTensorShapesSupported(ioTensorIds, affineTensorIds, statTensorIds, false);
 }
 
-void checkRMSNormBwdTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::RMSNormBackwardAttributes& rmsNormBwdAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap)
+void RMSnormValidator::checkBwdTensorConfigSupported(
+    const hipdnn_data_sdk::data_objects::RMSNormBackwardAttributes& rmsNormBwdAttr
 {
     std::vector<int64_t> ioTensorIds = {rmsNormBwdAttr.dy_tensor_uid(),
                                         rmsNormBwdAttr.x_tensor_uid(),
@@ -345,9 +172,9 @@ void checkRMSNormBwdTensorConfigSupported(
         statTensorIds.push_back(rmsNormBwdAttr.inv_rms_tensor_uid().value());
     }
 
-    checkTensorLayoutsAndDimsSupported(tensorMap);
-    checkTensorDataTypesSupported(ioTensorIds, affineTensorIds, statTensorIds, tensorMap);
-    checkTensorShapesSupported(ioTensorIds, affineTensorIds, statTensorIds, tensorMap);
+    checkTensorLayoutsAndDimsSupported();
+    checkTensorDataTypesSupported(ioTensorIds, affineTensorIds, statTensorIds, {});
+    checkTensorShapesSupported(ioTensorIds, affineTensorIds, statTensorIds, false);
 }
 
 } // namespace hip_kernel_provider

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormApplicabilityChecks.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormApplicabilityChecks.hpp
@@ -36,7 +36,7 @@ public:
         const hipdnn_data_sdk::data_objects::RMSNormAttributes& rmsNormAttr);
 
     void checkBwdTensorConfigSupported(
-        const hipdnn_data_sdk::data_objects::RMSNormBackwardAttributes& rmsNormAttr);
+        const hipdnn_data_sdk::data_objects::RMSNormBackwardAttributes& rmsNormBwdAttr);
 };
 
 } // namespace hip_kernel_provider::rmsnorm

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormApplicabilityChecks.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormApplicabilityChecks.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "../ApplicabilityChecks.hpp"
+#include "engines/plans/ApplicabilityChecks.hpp"
 #include <hipdnn_data_sdk/data_objects/rmsnorm_attributes_generated.h>
 #include <hipdnn_data_sdk/data_objects/rmsnorm_backward_attributes_generated.h>
 

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormApplicabilityChecks.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormApplicabilityChecks.hpp
@@ -19,13 +19,11 @@ private:
 
     void checkTensorDataTypesSupported(const std::vector<int64_t>& ioTensorIds,
                                        const std::vector<int64_t>& affineTensorIds,
-                                       const std::vector<int64_t>& statTensorIds,
-                                       const std::vector<int64_t>& intermediateTensorIds) override;
+                                       const std::vector<int64_t>& statTensorIds);
 
     void checkTensorShapesSupported(const std::vector<int64_t>& ioTensorIds,
                                     const std::vector<int64_t>& affineTensorIds,
-                                    const std::vector<int64_t>& statTensorIds,
-                                    bool isTraining) override;
+                                    const std::vector<int64_t>& statTensorIds);
 
 public:
     RMSnormValidator(

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormApplicabilityChecks.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormApplicabilityChecks.hpp
@@ -3,43 +3,42 @@
 
 #pragma once
 
-#include <unordered_map>
-#include <vector>
-
+#include "../ApplicabilityChecks.hpp"
 #include <hipdnn_data_sdk/data_objects/rmsnorm_attributes_generated.h>
 #include <hipdnn_data_sdk/data_objects/rmsnorm_backward_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
 
 namespace hip_kernel_provider::rmsnorm
 {
 
-// --- Tensor Descriptor Value Object ---
-
-struct RMSnormTensorDescriptor
+class RMSnormValidator : public IValidator
 {
-    std::vector<int64_t> dims;
-    std::vector<int64_t> strides;
-    std::vector<int64_t> strideOrder;
+private:
+    void validateSupportedLayout(const std::vector<int64_t>& strideOrder, size_t numDims) override;
 
-    explicit RMSnormTensorDescriptor(const hipdnn_data_sdk::data_objects::TensorAttributes* attr);
+    void checkTensorLayoutsAndDimsSupported() override;
 
-    size_t numDims() const
-    {
-        return dims.size();
-    }
-    bool isPacked() const;
+    void checkTensorDataTypesSupported(const std::vector<int64_t>& ioTensorIds,
+                                       const std::vector<int64_t>& affineTensorIds,
+                                       const std::vector<int64_t>& statTensorIds,
+                                       const std::vector<int64_t>& intermediateTensorIds) override;
+
+    void checkTensorShapesSupported(const std::vector<int64_t>& ioTensorIds,
+                                    const std::vector<int64_t>& affineTensorIds,
+                                    const std::vector<int64_t>& statTensorIds,
+                                    bool isTraining) override;
+
+public:
+    RMSnormValidator(
+        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+            tensorMapLocal)
+        : IValidator(tensorMapLocal) {};
+
+    // --- High-Level Configuration Validators ---
+    void checkTensorConfigSupported(
+        const hipdnn_data_sdk::data_objects::RMSNormAttributes& rmsNormAttr);
+
+    void checkBwdTensorConfigSupported(
+        const hipdnn_data_sdk::data_objects::RMSNormBackwardAttributes& rmsNormAttr);
 };
-
-// --- High-Level Configuration Validators ---
-void checkRMSnormTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::RMSNormAttributes& rmsNormAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap);
-
-// Backward-specific validator
-void checkRMSNormBwdTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::RMSNormBackwardAttributes& rmsNormBwdAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap);
 
 } // namespace hip_kernel_provider::rmsnorm

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormBwdPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormBwdPlanBuilder.cpp
@@ -58,8 +58,9 @@ bool RMSnormBwdPlanBuilder::isApplicable(
 
         try
         {
-            rmsnorm::checkRMSNormBwdTensorConfigSupported(
-                *node.attributes_as_RMSNormBackwardAttributes(), opGraph.getTensorMap());
+            rmsnorm::RMSnormValidator validator(opGraph.getTensorMap());
+            validator.checkBwdTensorConfigSupported(
+                *node.attributes_as_RMSNormBackwardAttributes());
         }
         catch(const std::exception& e)
         {

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormPlanBuilder.cpp
@@ -57,8 +57,8 @@ bool RMSnormPlanBuilder::isApplicable(
 
         try
         {
-            rmsnorm::checkRMSnormTensorConfigSupported(*node.attributes_as_RMSNormAttributes(),
-                                                       opGraph.getTensorMap());
+            rmsnorm::RMSnormValidator validator(opGraph.getTensorMap());
+            validator.checkTensorConfigSupported(*node.attributes_as_RMSNormAttributes());
         }
         catch(const std::exception& e)
         {

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormApplicabilityChecks.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormApplicabilityChecks.cpp
@@ -11,12 +11,12 @@
 #include "BatchnormApplicabilityChecks.hpp"
 #include "HipKernelUtils.hpp"
 
-namespace hip_kernel_provider::batchnorm
+namespace hip_kernel_provider
 {
 
 // --- Type Configuration Helpers ---
 
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType> type_configs::getAllowedIoTypes()
+std::unordered_set<hipdnn_data_sdk::data_objects::DataType> bn_type_configs::getAllowedIoTypes()
 {
     std::unordered_set<hipdnn_data_sdk::data_objects::DataType> types;
     for(const auto& config : VALID)
@@ -26,7 +26,7 @@ std::unordered_set<hipdnn_data_sdk::data_objects::DataType> type_configs::getAll
     return types;
 }
 
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType> type_configs::getAllowedAffineTypes()
+std::unordered_set<hipdnn_data_sdk::data_objects::DataType> bn_type_configs::getAllowedAffineTypes()
 {
     std::unordered_set<hipdnn_data_sdk::data_objects::DataType> types;
     for(const auto& config : VALID)
@@ -36,7 +36,7 @@ std::unordered_set<hipdnn_data_sdk::data_objects::DataType> type_configs::getAll
     return types;
 }
 
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType> type_configs::getAllowedStatTypes()
+std::unordered_set<hipdnn_data_sdk::data_objects::DataType> bn_type_configs::getAllowedStatTypes()
 {
     std::unordered_set<hipdnn_data_sdk::data_objects::DataType> types;
     for(const auto& config : VALID)
@@ -47,7 +47,7 @@ std::unordered_set<hipdnn_data_sdk::data_objects::DataType> type_configs::getAll
 }
 
 std::unordered_set<hipdnn_data_sdk::data_objects::DataType>
-    type_configs::getAllowedIntermediateTypes()
+    bn_type_configs::getAllowedIntermediateTypes()
 {
     std::unordered_set<hipdnn_data_sdk::data_objects::DataType> types;
     for(const auto& config : VALID)
@@ -57,186 +57,13 @@ std::unordered_set<hipdnn_data_sdk::data_objects::DataType>
     return types;
 }
 
-// --- Tensor Descriptor Implementation ---
-
-BatchnormTensorDescriptor::BatchnormTensorDescriptor(
-    const hipdnn_data_sdk::data_objects::TensorAttributes* attr)
-    : dims(attr->dims()->begin(), attr->dims()->end())
-    , strides(attr->strides()->begin(), attr->strides()->end())
-    , strideOrder(hipdnn_data_sdk::utilities::extractStrideOrder(strides))
-{
-}
-
-bool BatchnormTensorDescriptor::isPacked() const
-{
-    return hipdnn_data_sdk::utilities::isTensorPacked(dims, strides);
-}
-
-// --- Validation Utilities ---
-
-namespace validators
-{
-
-void validateDimensionCount(size_t numDims)
-{
-    constexpr size_t MIN_SUPPORTED_DIMS = 4;
-    constexpr size_t MAX_SUPPORTED_DIMS = 5;
-
-    if(numDims < MIN_SUPPORTED_DIMS || numDims > MAX_SUPPORTED_DIMS)
-    {
-        throw hipdnn_plugin_sdk::HipdnnPluginException(
-            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
-            "Batchnorm implementation supports only 4D or 5D tensors.");
-    }
-}
-
-void validateConsistentDimensions(const std::vector<BatchnormTensorDescriptor>& tensors)
-{
-    if(tensors.empty())
-    {
-        return;
-    }
-
-    const size_t expectedDims = tensors[0].numDims();
-    validateDimensionCount(expectedDims);
-
-    for(size_t i = 1; i < tensors.size(); ++i)
-    {
-        if(tensors[i].numDims() != expectedDims)
-        {
-            throw hipdnn_plugin_sdk::HipdnnPluginException(
-                HIPDNN_PLUGIN_STATUS_BAD_PARAM,
-                "All tensors for batchnorm must have the same number of dimensions.");
-        }
-    }
-}
-
-void validatePackedTensors(const std::vector<BatchnormTensorDescriptor>& tensors)
-{
-    for(const auto& tensor : tensors)
-    {
-        if(!tensor.isPacked())
-        {
-            throw hipdnn_plugin_sdk::HipdnnPluginException(
-                HIPDNN_PLUGIN_STATUS_BAD_PARAM,
-                "Batchnorm implementation supports only packed tensors.");
-        }
-    }
-}
-
-void validateSupportedLayout(const std::vector<int64_t>& strideOrder, size_t numDims)
-{
-    if(numDims == 4)
-    {
-        const auto layoutNchw = hipdnn_data_sdk::utilities::TensorLayout::NCHW;
-        const auto layoutNhwc = hipdnn_data_sdk::utilities::TensorLayout::NHWC;
-
-        if(strideOrder != layoutNchw.strideOrder && strideOrder != layoutNhwc.strideOrder)
-        {
-            throw hipdnn_plugin_sdk::HipdnnPluginException(
-                HIPDNN_PLUGIN_STATUS_BAD_PARAM,
-                "Batchnorm implementation supports only NCHW and NHWC layouts for 4D tensors.");
-        }
-    }
-    else
-    {
-        const auto layoutNcdhw = hipdnn_data_sdk::utilities::TensorLayout::NCDHW;
-        const auto layoutNdhwc = hipdnn_data_sdk::utilities::TensorLayout::NDHWC;
-
-        if(strideOrder != layoutNcdhw.strideOrder && strideOrder != layoutNdhwc.strideOrder)
-        {
-            throw hipdnn_plugin_sdk::HipdnnPluginException(
-                HIPDNN_PLUGIN_STATUS_BAD_PARAM,
-                "Batchnorm implementation supports only NCDHW and NDHWC layouts for 5D tensors.");
-        }
-    }
-}
-
-void validateConsistentLayouts(const std::vector<BatchnormTensorDescriptor>& tensors)
-{
-    if(tensors.empty())
-    {
-        return;
-    }
-
-    // Use first tensor with meaningful layout as reference
-    int64_t referenceIndex = -1;
-    for(size_t i = 0; i < tensors.size(); ++i)
-    {
-        if(hipdnn_data_sdk::utilities::isLayoutAgnostic(tensors[i].dims))
-        {
-            continue;
-        }
-
-        if(referenceIndex == -1)
-        {
-            referenceIndex = static_cast<int64_t>(i);
-            validateSupportedLayout(tensors[static_cast<size_t>(referenceIndex)].strideOrder,
-                                    tensors[static_cast<size_t>(referenceIndex)].numDims());
-        }
-        else
-        {
-            if(tensors[i].strideOrder != tensors[static_cast<size_t>(referenceIndex)].strideOrder)
-            {
-                throw hipdnn_plugin_sdk::HipdnnPluginException(
-                    HIPDNN_PLUGIN_STATUS_BAD_PARAM,
-                    "All tensors for batchnorm must have the same layout.");
-            }
-        }
-    }
-}
-
-void validateDataTypeIsSupported(
-    hipdnn_data_sdk::data_objects::DataType dataType,
-    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
-    const std::string& errorMessage)
-{
-    if(allowedTypes.count(dataType) > 0)
-    {
-        return;
-    }
-    throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM, errorMessage);
-}
-
-void validateConsistentDataTypes(
-    const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap,
-    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
-    const std::string& typeErrorMessage,
-    const std::string& consistencyErrorMessage)
-{
-    if(tensorIds.empty())
-    {
-        return;
-    }
-
-    const auto& firstTensor = hip_kernel_utils::findTensorAttributes(tensorMap, tensorIds[0]);
-    const auto referenceType = firstTensor.data_type();
-
-    validateDataTypeIsSupported(referenceType, allowedTypes, typeErrorMessage);
-
-    for(size_t i = 1; i < tensorIds.size(); ++i)
-    {
-        const auto& tensor = hip_kernel_utils::findTensorAttributes(tensorMap, tensorIds[i]);
-        if(tensor.data_type() != referenceType)
-        {
-            throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM,
-                                                           consistencyErrorMessage);
-        }
-    }
-}
-
-void validateFixedDataType(
-    const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap,
-    hipdnn_data_sdk::data_objects::DataType expectedType,
-    const std::string& errorMessage)
+void BatchnormValidator::validateFixedDataType(const std::vector<int64_t>& tensorIds,
+                                               hipdnn_data_sdk::data_objects::DataType expectedType,
+                                               const std::string& errorMessage)
 {
     for(const auto tensorId : tensorIds)
     {
-        const auto& tensor = hip_kernel_utils::findTensorAttributes(tensorMap, tensorId);
+        const auto& tensor = hip_kernel_utils::findTensorAttributes(_tensorMap, tensorId);
         if(tensor.data_type() != expectedType)
         {
             throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM,
@@ -245,26 +72,7 @@ void validateFixedDataType(
     }
 }
 
-void validateConsistentShapes(
-    const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap,
-    const std::vector<int64_t>& referenceShape,
-    const std::string& errorMessage)
-{
-    for(const auto tensorId : tensorIds)
-    {
-        const auto& tensorAttr = hip_kernel_utils::findTensorAttributes(tensorMap, tensorId);
-        const std::vector<int64_t> dims(tensorAttr.dims()->begin(), tensorAttr.dims()->end());
-        if(dims != referenceShape)
-        {
-            throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM,
-                                                           errorMessage);
-        }
-    }
-}
-
-void validateSpatialDimensions(const std::vector<int64_t>& ioDims)
+void BatchnormValidator::validateSpatialDimensions(const std::vector<int64_t>& ioDims)
 {
     if(ioDims.size() < 3)
     {
@@ -285,29 +93,15 @@ void validateSpatialDimensions(const std::vector<int64_t>& ioDims)
     }
 }
 
-void validatePeerStatsNotPopulated(const flatbuffers::Vector<int64_t>* peerStatsTensorUid,
-                                   const std::string& errorMessage)
-{
-    if(peerStatsTensorUid != nullptr && !peerStatsTensorUid->empty())
-    {
-        throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM,
-                                                       errorMessage);
-    }
-}
-
-} // namespace validators
-
 // --- Component Validators ---
 
-void checkTensorLayoutsAndDimsSupported(
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap)
+void BatchnormValidator::checkTensorLayoutsAndDimsSupported()
 {
     // Skip tensors with embedded scalar values (epsilon, momentum) - they don't have layouts or dimensions to validate
-    std::vector<BatchnormTensorDescriptor> tensors;
-    tensors.reserve(tensorMap.size());
+    std::vector<TensorDescriptor> tensors;
+    tensors.reserve(_tensorMap.size());
 
-    for(const auto& [id, attr] : tensorMap)
+    for(const auto& [id, attr] : _tensorMap)
     {
         if(attr->value_type() != hipdnn_data_sdk::data_objects::TensorValue::NONE)
         {
@@ -316,92 +110,80 @@ void checkTensorLayoutsAndDimsSupported(
         tensors.emplace_back(attr);
     }
 
-    validators::validateConsistentDimensions(tensors);
-    validators::validatePackedTensors(tensors);
-    validators::validateConsistentLayouts(tensors);
+    validateConsistentDimensions(tensors);
+    validatePackedTensors(tensors);
+    validateConsistentLayouts(tensors);
 }
 
-void checkTensorDataTypesSupported(
+void BatchnormValidator::checkTensorDataTypesSupported(
     const std::vector<int64_t>& ioTensorIds,
     const std::vector<int64_t>& affineTensorIds,
     const std::vector<int64_t>& statTensorIds,
-    const std::vector<int64_t>& intermediateTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap)
+    const std::vector<int64_t>& intermediateTensorIds)
 {
-    validators::validateConsistentDataTypes(
+    validateConsistentDataTypes(
         ioTensorIds,
-        tensorMap,
-        type_configs::getAllowedIoTypes(),
+        bn_type_configs::getAllowedIoTypes(),
         "Batchnorm implementation supports only FLOAT, HALF, and BFLOAT16 data types for x, y, "
         "dy, and dx tensors.",
         "All IO tensors for batchnorm must have the same data type.");
 
-    const auto allowedAffineTypes = type_configs::getAllowedAffineTypes();
+    const auto allowedAffineTypes = bn_type_configs::getAllowedAffineTypes();
     if(allowedAffineTypes.size() == 1)
     {
-        validators::validateFixedDataType(affineTensorIds,
-                                          tensorMap,
-                                          *allowedAffineTypes.begin(),
-                                          "Batchnorm implementation supports only FLOAT data type "
-                                          "for scale and bias tensors.");
+        validateFixedDataType(affineTensorIds,
+                              *allowedAffineTypes.begin(),
+                              "Batchnorm implementation supports only FLOAT data type "
+                              "for scale and bias tensors.");
     }
     else
     {
-        validators::validateConsistentDataTypes(
+        validateConsistentDataTypes(
             affineTensorIds,
-            tensorMap,
             allowedAffineTypes,
             "Batchnorm affine tensors use unsupported data type.",
             "All affine tensors for batchnorm must have the same data type.");
     }
 
-    const auto allowedStatTypes = type_configs::getAllowedStatTypes();
+    const auto allowedStatTypes = bn_type_configs::getAllowedStatTypes();
     if(allowedStatTypes.size() == 1)
     {
-        validators::validateFixedDataType(statTensorIds,
-                                          tensorMap,
-                                          *allowedStatTypes.begin(),
-                                          "Batchnorm implementation supports only FLOAT data type "
-                                          "for mean and variance tensors.");
+        validateFixedDataType(statTensorIds,
+                              *allowedStatTypes.begin(),
+                              "Batchnorm implementation supports only FLOAT data type "
+                              "for mean and variance tensors.");
     }
     else
     {
-        validators::validateConsistentDataTypes(
-            statTensorIds,
-            tensorMap,
-            allowedStatTypes,
-            "Batchnorm stat tensors use unsupported data type.",
-            "All stat tensors for batchnorm must have the same data type.");
+        validateConsistentDataTypes(statTensorIds,
+                                    allowedStatTypes,
+                                    "Batchnorm stat tensors use unsupported data type.",
+                                    "All stat tensors for batchnorm must have the same data type.");
     }
 
-    const auto allowedIntermediateTypes = type_configs::getAllowedIntermediateTypes();
+    const auto allowedIntermediateTypes = bn_type_configs::getAllowedIntermediateTypes();
     if(allowedIntermediateTypes.size() == 1)
     {
-        validators::validateFixedDataType(
+        validateFixedDataType(
             intermediateTensorIds,
-            tensorMap,
             *allowedIntermediateTypes.begin(),
             "Batchnorm implementation supports only FLOAT data type for intermediate tensors.");
     }
     else
     {
-        validators::validateConsistentDataTypes(
+        validateConsistentDataTypes(
             intermediateTensorIds,
-            tensorMap,
             allowedIntermediateTypes,
             "Batchnorm intermediate tensors use unsupported data type.",
             "All intermediate tensors for batchnorm must have the same data type.");
     }
 }
 
-void checkTensorShapesSupported(
-    const std::vector<int64_t>& ioTensorIds,
-    const std::vector<int64_t>& affineTensorIds,
-    const std::vector<int64_t>& statTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap,
-    bool isTraining)
+void BatchnormValidator::checkTensorShapesSupported(const std::vector<int64_t>& ioTensorIds,
+                                                    const std::vector<int64_t>& affineTensorIds,
+                                                    const std::vector<int64_t>& statTensorIds,
+
+                                                    bool isTraining)
 {
     if(ioTensorIds.empty())
     {
@@ -410,56 +192,45 @@ void checkTensorShapesSupported(
             "At least one IO tensor must be provided for batchnorm.");
     }
 
-    const auto& ioTensorAttr = hip_kernel_utils::findTensorAttributes(tensorMap, ioTensorIds[0]);
+    const auto& ioTensorAttr = hip_kernel_utils::findTensorAttributes(_tensorMap, ioTensorIds[0]);
     const std::vector<int64_t> ioDims(ioTensorAttr.dims()->begin(), ioTensorAttr.dims()->end());
 
-    validators::validateConsistentShapes(
-        ioTensorIds, tensorMap, ioDims, "All IO tensors for batchnorm must have the same shape.");
+    validateConsistentShapes(
+        ioTensorIds, ioDims, "All IO tensors for batchnorm must have the same shape.");
 
     const auto derivedDims = hipdnn_data_sdk::utilities::getDerivedShape(ioDims);
-    validators::validateConsistentShapes(affineTensorIds,
-                                         tensorMap,
-                                         derivedDims,
-                                         "Scale and bias tensors for batchnorm must have shape "
-                                         "derived from IO tensor shape.");
-    validators::validateConsistentShapes(statTensorIds,
-                                         tensorMap,
-                                         derivedDims,
-                                         "Mean and variance tensors for batchnorm must have shape "
-                                         "derived from IO tensor shape.");
+    validateConsistentShapes(affineTensorIds,
+                             derivedDims,
+                             "Scale and bias tensors for batchnorm must have shape "
+                             "derived from IO tensor shape.");
+    validateConsistentShapes(statTensorIds,
+                             derivedDims,
+                             "Mean and variance tensors for batchnorm must have shape "
+                             "derived from IO tensor shape.");
 
     if(isTraining)
     {
-        validators::validateSpatialDimensions(ioDims);
+        validateSpatialDimensions(ioDims);
     }
 }
 
 // --- High-Level Configuration Validators ---
 
-namespace
-{
-
-void checkBatchnormTensorConfigSupported(
+void BatchnormValidator::checkTensorConfigSupported(
     const std::vector<int64_t>& ioTensorIds,
     const std::vector<int64_t>& affineTensorIds,
     const std::vector<int64_t>& statTensorIds,
     const std::vector<int64_t>& intermediateTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap,
     bool isTraining)
 {
-    checkTensorLayoutsAndDimsSupported(tensorMap);
+    checkTensorLayoutsAndDimsSupported();
     checkTensorDataTypesSupported(
-        ioTensorIds, affineTensorIds, statTensorIds, intermediateTensorIds, tensorMap);
-    checkTensorShapesSupported(ioTensorIds, affineTensorIds, statTensorIds, tensorMap, isTraining);
+        ioTensorIds, affineTensorIds, statTensorIds, intermediateTensorIds);
+    checkTensorShapesSupported(ioTensorIds, affineTensorIds, statTensorIds, isTraining);
 }
 
-} // namespace
-
-void checkBatchnormInferenceTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap)
+void BatchnormValidator::checkInferenceTensorConfigSupported(
+    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr)
 {
     std::vector<int64_t> ioTensorIds = {bnInfAttr.x_tensor_uid(), bnInfAttr.y_tensor_uid()};
     std::vector<int64_t> affineTensorIds
@@ -467,14 +238,11 @@ void checkBatchnormInferenceTensorConfigSupported(
     std::vector<int64_t> statTensorIds
         = {bnInfAttr.mean_tensor_uid(), bnInfAttr.inv_variance_tensor_uid()};
 
-    checkBatchnormTensorConfigSupported(
-        ioTensorIds, affineTensorIds, statTensorIds, {}, tensorMap, false);
+    checkTensorConfigSupported(ioTensorIds, affineTensorIds, statTensorIds, {}, false);
 }
 
-void checkBatchnormInferenceVarianceExtTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap)
+void BatchnormValidator::checkInferenceVarianceExtTensorConfigSupported(
+    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr)
 {
     std::vector<int64_t> ioTensorIds = {bnInfAttr.x_tensor_uid(), bnInfAttr.y_tensor_uid()};
     std::vector<int64_t> affineTensorIds
@@ -482,17 +250,14 @@ void checkBatchnormInferenceVarianceExtTensorConfigSupported(
     std::vector<int64_t> statTensorIds
         = {bnInfAttr.mean_tensor_uid(), bnInfAttr.variance_tensor_uid()};
 
-    checkBatchnormTensorConfigSupported(
-        ioTensorIds, affineTensorIds, statTensorIds, {}, tensorMap, false);
+    checkTensorConfigSupported(ioTensorIds, affineTensorIds, statTensorIds, {}, false);
 }
 
-void checkBatchnormInferenceActivationTensorConfigSupported(
+void BatchnormValidator::checkInferenceActivationTensorConfigSupported(
     const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap)
+    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr)
 {
-    checkBatchnormFwdActivationModeSupported(actAttr);
+    checkFwdActivationModeSupported(actAttr);
 
     std::vector<int64_t> ioTensorIds = {bnInfAttr.x_tensor_uid(), actAttr.out_0_tensor_uid()};
     std::vector<int64_t> affineTensorIds
@@ -502,17 +267,15 @@ void checkBatchnormInferenceActivationTensorConfigSupported(
     std::vector<int64_t> intermediateTensorIds
         = {bnInfAttr.y_tensor_uid(), actAttr.in_0_tensor_uid()};
 
-    checkBatchnormTensorConfigSupported(
-        ioTensorIds, affineTensorIds, statTensorIds, intermediateTensorIds, tensorMap, false);
+    checkTensorConfigSupported(
+        ioTensorIds, affineTensorIds, statTensorIds, intermediateTensorIds, false);
 }
 
-void checkBatchnormInferenceVarianceExtActivationTensorConfigSupported(
+void BatchnormValidator::checkInferenceVarianceExtActivationTensorConfigSupported(
     const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap)
+    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr)
 {
-    checkBatchnormFwdActivationModeSupported(actAttr);
+    checkFwdActivationModeSupported(actAttr);
 
     std::vector<int64_t> ioTensorIds = {bnInfAttr.x_tensor_uid(), actAttr.out_0_tensor_uid()};
     std::vector<int64_t> affineTensorIds
@@ -522,8 +285,8 @@ void checkBatchnormInferenceVarianceExtActivationTensorConfigSupported(
     std::vector<int64_t> intermediateTensorIds
         = {bnInfAttr.y_tensor_uid(), actAttr.in_0_tensor_uid()};
 
-    checkBatchnormTensorConfigSupported(
-        ioTensorIds, affineTensorIds, statTensorIds, intermediateTensorIds, tensorMap, false);
+    checkTensorConfigSupported(
+        ioTensorIds, affineTensorIds, statTensorIds, intermediateTensorIds, false);
 }
 
 // --- Activation Mode Validators ---
@@ -531,10 +294,10 @@ void checkBatchnormInferenceVarianceExtActivationTensorConfigSupported(
 namespace
 {
 
-void checkBatchnormActivationModeSupported(
+void checkActivationModeSupported(
     const hipdnn_data_sdk::data_objects::PointwiseAttributes& activAttr, bool isBwd)
 {
-    // hip-kernel-provider batchnorm supports: PASSTHRU, RELU, CLIPPEDREU, CLAMP (no Leaky ReLU)
+    // hip-kernel-provider batchnorm supports: PASSTHRU, RELU, CLIPPEDRELU, CLAMP (no Leaky ReLU)
 
     if(activAttr.operation() == hipdnn_data_sdk::data_objects::PointwiseMode::IDENTITY)
     {
@@ -560,41 +323,16 @@ void checkBatchnormActivationModeSupported(
 
 } // namespace
 
-void checkBatchnormFwdActivationModeSupported(
+void BatchnormValidator::checkFwdActivationModeSupported(
     const hipdnn_data_sdk::data_objects::PointwiseAttributes& activAttr)
 {
-    checkBatchnormActivationModeSupported(activAttr, false);
+    checkActivationModeSupported(activAttr, false);
 }
 
-void checkBatchnormBwdActivationModeSupported(
+void BatchnormValidator::checkBwdActivationModeSupported(
     const hipdnn_data_sdk::data_objects::PointwiseAttributes& activAttr)
 {
-    checkBatchnormActivationModeSupported(activAttr, true);
+    checkActivationModeSupported(activAttr, true);
 }
 
-void checkBatchnormFwdTrainingTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormAttributes& bnAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap)
-{
-    validators::validatePeerStatsNotPopulated(
-        bnAttr.peer_stats_tensor_uid(),
-        "Batchnorm forward training does not support peer statistics");
-
-    std::vector<int64_t> ioTensorIds = {bnAttr.x_tensor_uid(), bnAttr.y_tensor_uid()};
-    std::vector<int64_t> affineTensorIds = {bnAttr.scale_tensor_uid(), bnAttr.bias_tensor_uid()};
-    std::vector<int64_t> statTensorIds;
-    if(bnAttr.mean_tensor_uid().has_value())
-    {
-        statTensorIds.push_back(bnAttr.mean_tensor_uid().value());
-    }
-    if(bnAttr.inv_variance_tensor_uid().has_value())
-    {
-        statTensorIds.push_back(bnAttr.inv_variance_tensor_uid().value());
-    }
-
-    checkBatchnormTensorConfigSupported(
-        ioTensorIds, affineTensorIds, statTensorIds, {}, tensorMap, true);
-}
-
-} // namespace hip_kernel_provider::batchnorm
+} // namespace hip_kernel_provider

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormApplicabilityChecks.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormApplicabilityChecks.cpp
@@ -57,21 +57,6 @@ std::unordered_set<hipdnn_data_sdk::data_objects::DataType>
     return types;
 }
 
-void BatchnormValidator::validateFixedDataType(const std::vector<int64_t>& tensorIds,
-                                               hipdnn_data_sdk::data_objects::DataType expectedType,
-                                               const std::string& errorMessage)
-{
-    for(const auto tensorId : tensorIds)
-    {
-        const auto& tensor = hip_kernel_utils::findTensorAttributes(_tensorMap, tensorId);
-        if(tensor.data_type() != expectedType)
-        {
-            throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM,
-                                                           errorMessage);
-        }
-    }
-}
-
 void BatchnormValidator::validateSpatialDimensions(const std::vector<int64_t>& ioDims)
 {
     if(ioDims.size() < 3)

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormApplicabilityChecks.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormApplicabilityChecks.cpp
@@ -289,6 +289,31 @@ void BatchnormValidator::checkInferenceVarianceExtActivationTensorConfigSupporte
         ioTensorIds, affineTensorIds, statTensorIds, intermediateTensorIds, false);
 }
 
+void BatchnormValidator::checkFwdTrainingTensorConfigSupported(
+    const hipdnn_data_sdk::data_objects::BatchnormAttributes& bnAttr)
+{
+    if(bnAttr.peer_stats_tensor_uid() != nullptr && !bnAttr.peer_stats_tensor_uid()->empty())
+    {
+        throw hipdnn_plugin_sdk::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+            "Batchnorm forward training does not support peer statistics");
+    }
+
+    std::vector<int64_t> ioTensorIds = {bnAttr.x_tensor_uid(), bnAttr.y_tensor_uid()};
+    std::vector<int64_t> affineTensorIds = {bnAttr.scale_tensor_uid(), bnAttr.bias_tensor_uid()};
+    std::vector<int64_t> statTensorIds;
+    if(bnAttr.mean_tensor_uid().has_value())
+    {
+        statTensorIds.push_back(bnAttr.mean_tensor_uid().value());
+    }
+    if(bnAttr.inv_variance_tensor_uid().has_value())
+    {
+        statTensorIds.push_back(bnAttr.inv_variance_tensor_uid().value());
+    }
+
+    checkTensorConfigSupported(ioTensorIds, affineTensorIds, statTensorIds, {}, true);
+}
+
 // --- Activation Mode Validators ---
 
 namespace

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormApplicabilityChecks.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormApplicabilityChecks.hpp
@@ -5,6 +5,7 @@
 
 #include "../ApplicabilityChecks.hpp"
 #include <array>
+#include <hipdnn_data_sdk/data_objects/batchnorm_attributes_generated.h>
 #include <hipdnn_data_sdk/data_objects/batchnorm_inference_attributes_generated.h>
 #include <hipdnn_data_sdk/data_objects/batchnorm_inference_attributes_variance_ext_generated.h>
 #include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
@@ -72,6 +73,9 @@ public:
     void checkInferenceVarianceExtActivationTensorConfigSupported(
         const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
         const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr);
+
+    void checkFwdTrainingTensorConfigSupported(
+        const hipdnn_data_sdk::data_objects::BatchnormAttributes& bnAttr);
 };
 
 // --- Batchnorm Type Configuration ---

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormApplicabilityChecks.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormApplicabilityChecks.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "../ApplicabilityChecks.hpp"
+#include "engines/plans/ApplicabilityChecks.hpp"
 #include <array>
 #include <hipdnn_data_sdk/data_objects/batchnorm_attributes_generated.h>
 #include <hipdnn_data_sdk/data_objects/batchnorm_inference_attributes_generated.h>
@@ -25,10 +25,6 @@ private:
         const hipdnn_data_sdk::data_objects::PointwiseAttributes& activAttr);
 
     // --- Validation Utilities ---
-
-    void validateFixedDataType(const std::vector<int64_t>& tensorIds,
-                               hipdnn_data_sdk::data_objects::DataType expectedType,
-                               const std::string& errorMessage);
 
     static void validateSpatialDimensions(const std::vector<int64_t>& ioDims);
 

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormApplicabilityChecks.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormApplicabilityChecks.hpp
@@ -3,145 +3,83 @@
 
 #pragma once
 
-#include <string>
-#include <unordered_map>
-#include <unordered_set>
-#include <vector>
-
-#include <hipdnn_data_sdk/data_objects/batchnorm_attributes_generated.h>
+#include "../ApplicabilityChecks.hpp"
+#include <array>
 #include <hipdnn_data_sdk/data_objects/batchnorm_inference_attributes_generated.h>
 #include <hipdnn_data_sdk/data_objects/batchnorm_inference_attributes_variance_ext_generated.h>
 #include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
 
-namespace hip_kernel_provider::batchnorm
+namespace hip_kernel_provider
 {
 
-// --- Tensor Descriptor Value Object ---
-
-struct BatchnormTensorDescriptor
+class BatchnormValidator : public IValidator
 {
-    std::vector<int64_t> dims;
-    std::vector<int64_t> strides;
-    std::vector<int64_t> strideOrder;
+private:
+    // --- Activation Mode Validators ---
 
-    explicit BatchnormTensorDescriptor(const hipdnn_data_sdk::data_objects::TensorAttributes* attr);
+    static void checkFwdActivationModeSupported(
+        const hipdnn_data_sdk::data_objects::PointwiseAttributes& activAttr);
 
-    size_t numDims() const
-    {
-        return dims.size();
-    }
-    bool isPacked() const;
+    static void checkBwdActivationModeSupported(
+        const hipdnn_data_sdk::data_objects::PointwiseAttributes& activAttr);
+
+    // --- Validation Utilities ---
+
+    void validateFixedDataType(const std::vector<int64_t>& tensorIds,
+                               hipdnn_data_sdk::data_objects::DataType expectedType,
+                               const std::string& errorMessage);
+
+    static void validateSpatialDimensions(const std::vector<int64_t>& ioDims);
+
+    // --- Component Validators ---
+
+    void checkTensorLayoutsAndDimsSupported() override;
+
+    void checkTensorDataTypesSupported(const std::vector<int64_t>& ioTensorIds,
+                                       const std::vector<int64_t>& affineTensorIds,
+                                       const std::vector<int64_t>& statTensorIds,
+                                       const std::vector<int64_t>& intermediateTensorIds) override;
+
+    void checkTensorShapesSupported(const std::vector<int64_t>& ioTensorIds,
+                                    const std::vector<int64_t>& affineTensorIds,
+                                    const std::vector<int64_t>& statTensorIds,
+                                    bool isTraining) override;
+
+    void checkTensorConfigSupported(const std::vector<int64_t>& ioTensorIds,
+                                    const std::vector<int64_t>& affineTensorIds,
+                                    const std::vector<int64_t>& statTensorIds,
+                                    const std::vector<int64_t>& intermediateTensorIds,
+                                    bool isTraining);
+
+public:
+    BatchnormValidator(
+        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+            tensorMapLocal)
+        : IValidator(tensorMapLocal) {};
+
+    // --- High-Level Configuration Validators ---
+
+    void checkInferenceTensorConfigSupported(
+        const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr);
+
+    void checkInferenceVarianceExtTensorConfigSupported(
+        const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr);
+
+    void checkInferenceActivationTensorConfigSupported(
+        const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
+        const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr);
+
+    void checkInferenceVarianceExtActivationTensorConfigSupported(
+        const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
+        const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr);
 };
-
-// --- Validation Utilities ---
-
-namespace validators
-{
-void validateDimensionCount(size_t numDims);
-
-void validateConsistentDimensions(const std::vector<BatchnormTensorDescriptor>& tensors);
-
-void validatePackedTensors(const std::vector<BatchnormTensorDescriptor>& tensors);
-
-void validateSupportedLayout(const std::vector<int64_t>& strideOrder, size_t numDims);
-
-void validateConsistentLayouts(const std::vector<BatchnormTensorDescriptor>& tensors);
-
-void validateDataTypeIsSupported(
-    hipdnn_data_sdk::data_objects::DataType dataType,
-    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
-    const std::string& errorMessage);
-
-void validateConsistentDataTypes(
-    const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap,
-    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
-    const std::string& typeErrorMessage,
-    const std::string& consistencyErrorMessage);
-
-void validateFixedDataType(
-    const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap,
-    hipdnn_data_sdk::data_objects::DataType expectedType,
-    const std::string& errorMessage);
-
-void validateConsistentShapes(
-    const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap,
-    const std::vector<int64_t>& referenceShape,
-    const std::string& errorMessage);
-
-void validateSpatialDimensions(const std::vector<int64_t>& ioDims);
-
-} // namespace validators
-
-// --- Component Validators ---
-
-void checkTensorLayoutsAndDimsSupported(
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap);
-
-void checkTensorDataTypesSupported(
-    const std::vector<int64_t>& ioTensorIds,
-    const std::vector<int64_t>& affineTensorIds,
-    const std::vector<int64_t>& statTensorIds,
-    const std::vector<int64_t>& intermediateTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap);
-
-void checkTensorShapesSupported(
-    const std::vector<int64_t>& ioTensorIds,
-    const std::vector<int64_t>& affineTensorIds,
-    const std::vector<int64_t>& statTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap,
-    bool isTraining);
-
-// --- High-Level Configuration Validators ---
-
-void checkBatchnormInferenceTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap);
-
-void checkBatchnormInferenceVarianceExtTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap);
-
-void checkBatchnormInferenceActivationTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap);
-
-void checkBatchnormInferenceVarianceExtActivationTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap);
-
-void checkBatchnormFwdActivationModeSupported(
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& activAttr);
-
-void checkBatchnormBwdActivationModeSupported(
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& activAttr);
-
-void checkBatchnormFwdTrainingTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormAttributes& bnAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap);
 
 // --- Batchnorm Type Configuration ---
 
 // hip-kernel-provider batchnorm requirements (based on underlying kernel constraints):
 // - IO tensors: same type (FLOAT, HALF, or BFLOAT16)
 // - Affine/Stat/Intermediate tensors: FLOAT only
-struct TensorTypes
+struct BnTensorTypes
 {
     hipdnn_data_sdk::data_objects::DataType io;
     hipdnn_data_sdk::data_objects::DataType affine;
@@ -149,21 +87,21 @@ struct TensorTypes
     hipdnn_data_sdk::data_objects::DataType intermediate;
 };
 
-namespace type_configs
+namespace bn_type_configs
 {
 using DT = hipdnn_data_sdk::data_objects::DataType;
 
-inline constexpr TensorTypes ALL_FLOAT = {DT::FLOAT, DT::FLOAT, DT::FLOAT, DT::FLOAT};
-inline constexpr TensorTypes HALF_IO = {DT::HALF, DT::FLOAT, DT::FLOAT, DT::FLOAT};
-inline constexpr TensorTypes BFLOAT16_IO = {DT::BFLOAT16, DT::FLOAT, DT::FLOAT, DT::FLOAT};
+inline constexpr BnTensorTypes ALL_FLOAT = {DT::FLOAT, DT::FLOAT, DT::FLOAT, DT::FLOAT};
+inline constexpr BnTensorTypes HALF_IO = {DT::HALF, DT::FLOAT, DT::FLOAT, DT::FLOAT};
+inline constexpr BnTensorTypes BFLOAT16_IO = {DT::BFLOAT16, DT::FLOAT, DT::FLOAT, DT::FLOAT};
 
-inline constexpr std::array<TensorTypes, 3> VALID = {ALL_FLOAT, HALF_IO, BFLOAT16_IO};
+inline constexpr std::array<BnTensorTypes, 3> VALID = {ALL_FLOAT, HALF_IO, BFLOAT16_IO};
 
 std::unordered_set<hipdnn_data_sdk::data_objects::DataType> getAllowedIoTypes();
 std::unordered_set<hipdnn_data_sdk::data_objects::DataType> getAllowedAffineTypes();
 std::unordered_set<hipdnn_data_sdk::data_objects::DataType> getAllowedStatTypes();
 std::unordered_set<hipdnn_data_sdk::data_objects::DataType> getAllowedIntermediateTypes();
 
-} // namespace type_configs
+} // namespace bn_type_configs
 
-} // namespace hip_kernel_provider::batchnorm
+} // namespace hip_kernel_provider

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormApplicabilityChecks.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormApplicabilityChecks.hpp
@@ -38,12 +38,12 @@ private:
     void checkTensorDataTypesSupported(const std::vector<int64_t>& ioTensorIds,
                                        const std::vector<int64_t>& affineTensorIds,
                                        const std::vector<int64_t>& statTensorIds,
-                                       const std::vector<int64_t>& intermediateTensorIds) override;
+                                       const std::vector<int64_t>& intermediateTensorIds);
 
     void checkTensorShapesSupported(const std::vector<int64_t>& ioTensorIds,
                                     const std::vector<int64_t>& affineTensorIds,
                                     const std::vector<int64_t>& statTensorIds,
-                                    bool isTraining) override;
+                                    bool isTraining);
 
     void checkTensorConfigSupported(const std::vector<int64_t>& ioTensorIds,
                                     const std::vector<int64_t>& affineTensorIds,

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormPlanBuilder.cpp
@@ -194,6 +194,7 @@ bool BatchnormPlanBuilder::isApplicable(
 
         try
         {
+            BatchnormValidator validator(opGraph.getTensorMap());
             switch(node.attributes_type())
             {
             case hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes:
@@ -201,14 +202,13 @@ bool BatchnormPlanBuilder::isApplicable(
                     *node.attributes_as_BatchnormAttributes(), opGraph.getTensorMap());
                 break;
             case hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes:
-                checkBatchnormInferenceTensorConfigSupported(
-                    *node.attributes_as_BatchnormInferenceAttributes(), opGraph.getTensorMap());
+                validator.checkInferenceTensorConfigSupported(
+                    *node.attributes_as_BatchnormInferenceAttributes());
                 break;
             case hipdnn_data_sdk::data_objects::NodeAttributes::
                 BatchnormInferenceAttributesVarianceExt:
-                checkBatchnormInferenceVarianceExtTensorConfigSupported(
-                    *node.attributes_as_BatchnormInferenceAttributesVarianceExt(),
-                    opGraph.getTensorMap());
+                validator.checkInferenceVarianceExtTensorConfigSupported(
+                    *node.attributes_as_BatchnormInferenceAttributesVarianceExt());
                 break;
             default:
                 throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_INTERNAL_ERROR,
@@ -265,8 +265,8 @@ bool BatchnormPlanBuilder::isApplicable(
 
             try
             {
-                checkBatchnormInferenceActivationTensorConfigSupported(
-                    bnInfAttr, actAttr, opGraph.getTensorMap());
+                BatchnormValidator validator(opGraph.getTensorMap());
+                validator.checkInferenceActivationTensorConfigSupported(bnInfAttr, actAttr);
             }
             catch(const std::exception& e)
             {
@@ -289,8 +289,9 @@ bool BatchnormPlanBuilder::isApplicable(
 
             try
             {
-                checkBatchnormInferenceVarianceExtActivationTensorConfigSupported(
-                    bnInfAttr, actAttr, opGraph.getTensorMap());
+                BatchnormValidator validator(opGraph.getTensorMap());
+                validator.checkInferenceVarianceExtActivationTensorConfigSupported(bnInfAttr,
+                                                                                   actAttr);
             }
             catch(const std::exception& e)
             {

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormPlanBuilder.cpp
@@ -198,8 +198,8 @@ bool BatchnormPlanBuilder::isApplicable(
             switch(node.attributes_type())
             {
             case hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes:
-                checkBatchnormFwdTrainingTensorConfigSupported(
-                    *node.attributes_as_BatchnormAttributes(), opGraph.getTensorMap());
+                validator.checkFwdTrainingTensorConfigSupported(
+                    *node.attributes_as_BatchnormAttributes());
                 break;
             case hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes:
                 validator.checkInferenceTensorConfigSupported(

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormPlanBuilder.cpp
@@ -252,6 +252,7 @@ bool BatchnormPlanBuilder::isApplicable(
             return false;
         }
 
+        BatchnormValidator validator(opGraph.getTensorMap());
         if(isFwdInferenceFirst)
         {
             const auto& bnInfAttr
@@ -265,7 +266,6 @@ bool BatchnormPlanBuilder::isApplicable(
 
             try
             {
-                BatchnormValidator validator(opGraph.getTensorMap());
                 validator.checkInferenceActivationTensorConfigSupported(bnInfAttr, actAttr);
             }
             catch(const std::exception& e)
@@ -289,7 +289,6 @@ bool BatchnormPlanBuilder::isApplicable(
 
             try
             {
-                BatchnormValidator validator(opGraph.getTensorMap());
                 validator.checkInferenceVarianceExtActivationTensorConfigSupported(bnInfAttr,
                                                                                    actAttr);
             }

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormApplicabilityChecks.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormApplicabilityChecks.cpp
@@ -60,259 +60,11 @@ std::unordered_set<hipdnn_data_sdk::data_objects::DataType> type_configs::getAll
     return types;
 }
 
-// --- Tensor Descriptor Implementation ---
-
-LayernormTensorDescriptor::LayernormTensorDescriptor(
-    const hipdnn_data_sdk::data_objects::TensorAttributes* attr)
-    : dims(attr->dims()->begin(), attr->dims()->end())
-    , strides(attr->strides()->begin(), attr->strides()->end())
-    , strideOrder(hipdnn_data_sdk::utilities::extractStrideOrder(strides))
-{
-}
-
-bool LayernormTensorDescriptor::isPacked() const
-{
-    return hipdnn_data_sdk::utilities::isTensorPacked(dims, strides);
-}
-
 // --- Validation Utilities ---
 
-namespace validators
-{
-
-void validateDimensionCount(size_t numDims)
-{
-    constexpr size_t MIN_SUPPORTED_DIMS = 4;
-    constexpr size_t MAX_SUPPORTED_DIMS = 5;
-
-    if(numDims < MIN_SUPPORTED_DIMS || numDims > MAX_SUPPORTED_DIMS)
-    {
-        throw hipdnn_plugin_sdk::HipdnnPluginException(
-            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
-            "Layernorm implementation supports only 4D or 5D tensors.");
-    }
-}
-
-void validateConsistentDimensions(const std::vector<LayernormTensorDescriptor>& tensors)
-{
-    if(tensors.empty())
-    {
-        return;
-    }
-
-    const size_t expectedDims = tensors[0].numDims();
-    validateDimensionCount(expectedDims);
-
-    for(size_t i = 1; i < tensors.size(); ++i)
-    {
-        if(tensors[i].numDims() != expectedDims)
-        {
-            throw hipdnn_plugin_sdk::HipdnnPluginException(
-                HIPDNN_PLUGIN_STATUS_BAD_PARAM,
-                "All tensors for layernorm must have the same number of dimensions.");
-        }
-    }
-}
-
-void validatePackedTensors(const std::vector<LayernormTensorDescriptor>& tensors)
-{
-    for(const auto& tensor : tensors)
-    {
-        if(!tensor.isPacked())
-        {
-            throw hipdnn_plugin_sdk::HipdnnPluginException(
-                HIPDNN_PLUGIN_STATUS_BAD_PARAM,
-                "Layernorm implementation only supports all packed tensors.");
-        }
-    }
-}
-
-void validateSupportedLayout(const std::vector<int64_t>& strideOrder, size_t numDims)
-{
-    if(numDims == 4)
-    {
-        const auto layoutNCHW = hipdnn_data_sdk::utilities::TensorLayout::NCHW;
-        const auto layoutNHWC = hipdnn_data_sdk::utilities::TensorLayout::NHWC;
-
-        if(strideOrder != layoutNCHW.strideOrder && strideOrder != layoutNHWC.strideOrder)
-        {
-            throw hipdnn_plugin_sdk::HipdnnPluginException(
-                HIPDNN_PLUGIN_STATUS_BAD_PARAM,
-                "Layernorm implementation only supports NCHW and NHWC layouts for 4D tensors.");
-        }
-    }
-    else if(numDims == 5)
-    {
-        const auto layoutNCDHW = hipdnn_data_sdk::utilities::TensorLayout::NCDHW;
-        const auto layoutNDHWC = hipdnn_data_sdk::utilities::TensorLayout::NDHWC;
-
-        if(strideOrder != layoutNCDHW.strideOrder && strideOrder != layoutNDHWC.strideOrder)
-        {
-            throw hipdnn_plugin_sdk::HipdnnPluginException(
-                HIPDNN_PLUGIN_STATUS_BAD_PARAM,
-                "Layernorm implementation only supports NCDHW and NDHWC layouts for 5D tensors.");
-        }
-    }
-}
-
-void validateConsistentLayouts(const std::vector<LayernormTensorDescriptor>& tensors)
-{
-    if(tensors.empty())
-    {
-        return;
-    }
-
-    // Use first tensor with meaningful layout as reference
-    int64_t referenceIndex = -1;
-    for(size_t i = 0; i < tensors.size(); ++i)
-    {
-        if(hipdnn_data_sdk::utilities::isLayoutAgnostic(tensors[i].dims))
-        {
-            continue;
-        }
-
-        if(referenceIndex == -1)
-        {
-            referenceIndex = static_cast<int64_t>(i);
-            validateSupportedLayout(tensors[static_cast<size_t>(referenceIndex)].strideOrder,
-                                    tensors[static_cast<size_t>(referenceIndex)].numDims());
-        }
-        else
-        {
-            if(tensors[i].strideOrder != tensors[static_cast<size_t>(referenceIndex)].strideOrder)
-            {
-                throw hipdnn_plugin_sdk::HipdnnPluginException(
-                    HIPDNN_PLUGIN_STATUS_BAD_PARAM,
-                    "All tensors for layernorm must have the same layout.");
-            }
-        }
-    }
-}
-
-void validateDataTypeIsSupported(
-    hipdnn_data_sdk::data_objects::DataType dataType,
-    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
-    const std::string& errorMessage)
-{
-    if(allowedTypes.count(dataType) > 0)
-    {
-        return;
-    }
-    throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM, errorMessage);
-}
-
-void validateConsistentDataTypes(
-    const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap,
-    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
-    const std::string& typeErrorMessage,
-    const std::string& consistencyErrorMessage)
-{
-    if(tensorIds.empty())
-    {
-        return;
-    }
-
-    const auto& firstTensor = hip_kernel_utils::findTensorAttributes(tensorMap, tensorIds[0]);
-    const auto referenceType = firstTensor.data_type();
-
-    validateDataTypeIsSupported(referenceType, allowedTypes, typeErrorMessage);
-
-    for(size_t i = 1; i < tensorIds.size(); ++i)
-    {
-        const auto& tensor = hip_kernel_utils::findTensorAttributes(tensorMap, tensorIds[i]);
-        if(tensor.data_type() != referenceType)
-        {
-            throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM,
-                                                           consistencyErrorMessage);
-        }
-    }
-}
-
-void validateConsistentDataTypes(
-    const std::vector<std::optional<int64_t>>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap,
-    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
-    const std::string& typeErrorMessage,
-    const std::string& consistencyErrorMessage)
-{
-    std::vector<int64_t> actualTensorIds;
-    for(auto i : tensorIds)
-    {
-        if(i.has_value())
-        {
-            actualTensorIds.emplace_back(i.value());
-        }
-    }
-
-    validateConsistentDataTypes(
-        actualTensorIds, tensorMap, allowedTypes, typeErrorMessage, consistencyErrorMessage);
-}
-
-void validateFixedDataType(
-    const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap,
-    hipdnn_data_sdk::data_objects::DataType expectedType,
-    const std::string& errorMessage)
-{
-    for(const auto tensorId : tensorIds)
-    {
-        const auto& tensor = hip_kernel_utils::findTensorAttributes(tensorMap, tensorId);
-        if(tensor.data_type() != expectedType)
-        {
-            throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM,
-                                                           errorMessage);
-        }
-    }
-}
-
-void validateConsistentShapes(
-    const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap,
-    const std::vector<int64_t>& referenceShape,
-    const std::string& errorMessage)
-{
-    for(const auto tensorId : tensorIds)
-    {
-        const auto& tensorAttr = hip_kernel_utils::findTensorAttributes(tensorMap, tensorId);
-        const std::vector<int64_t> dims(tensorAttr.dims()->begin(), tensorAttr.dims()->end());
-        if(dims != referenceShape)
-        {
-            throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM,
-                                                           errorMessage);
-        }
-    }
-}
-
-void validateConsistentShapes(
-    const std::vector<std::optional<int64_t>>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap,
-    const std::vector<int64_t>& referenceShape,
-    const std::string& errorMessage)
-{
-    std::vector<int64_t> actualTensorIds;
-    for(auto i : tensorIds)
-    {
-        if(i.has_value())
-        {
-            actualTensorIds.emplace_back(i.value());
-        }
-    }
-
-    validateConsistentShapes(actualTensorIds, tensorMap, referenceShape, errorMessage);
-}
-
-void validateNormalizedDim(
-    const std::vector<int64_t>& ioTensorIds,
-    const std::vector<int64_t>& affineTensorIds,
-    const std::vector<std::optional<int64_t>>& statTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap)
+void LayernormValidator::validateNormalizedDim(const std::vector<int64_t>& ioTensorIds,
+                                               const std::vector<int64_t>& affineTensorIds,
+                                               const std::vector<int64_t>& statTensorIds)
 {
     if(ioTensorIds.empty())
     {
@@ -329,27 +81,22 @@ void validateNormalizedDim(
             "one stat tensor.");
     }
 
-    const auto& ioAttr = hip_kernel_utils::findTensorAttributes(tensorMap, ioTensorIds[0]);
+    const auto& ioAttr = hip_kernel_utils::findTensorAttributes(_tensorMap, ioTensorIds[0]);
     const std::vector<int64_t> ioDims(ioAttr.dims()->begin(), ioAttr.dims()->end());
 
     size_t affineNormalizedDimMin
-        = getMinNormalizedDimFromAffine(ioTensorIds[0], affineTensorIds[0], tensorMap);
+        = getMinNormalizedDimFromAffine(ioTensorIds[0], affineTensorIds[0], _tensorMap);
     size_t affineNormalizedDimMax
-        = getMaxNormalizedDimFromAffine(ioTensorIds[0], affineTensorIds[0], tensorMap);
+        = getMaxNormalizedDimFromAffine(ioTensorIds[0], affineTensorIds[0], _tensorMap);
 
-    size_t statNormalizedDimMin = 0;
-    size_t statNormalizedDimMax = ioDims.size();
-    for(auto statTensorId : statTensorIds)
-    {
-        if(statTensorId.has_value())
-        {
-            statNormalizedDimMin
-                = getMinNormalizedDimFromStat(ioTensorIds[0], statTensorId.value(), tensorMap);
-            statNormalizedDimMax
-                = getMaxNormalizedDimFromStat(ioTensorIds[0], statTensorId.value(), tensorMap);
-            break;
-        }
-    }
+    size_t statNormalizedDimMin
+        = statTensorIds.empty()
+              ? 0
+              : getMinNormalizedDimFromStat(ioTensorIds[0], statTensorIds[0], _tensorMap);
+    size_t statNormalizedDimMax
+        = statTensorIds.empty()
+              ? ioDims.size()
+              : getMaxNormalizedDimFromStat(ioTensorIds[0], statTensorIds[0], _tensorMap);
 
     if(std::max(affineNormalizedDimMin, statNormalizedDimMin)
        > std::min(affineNormalizedDimMax, statNormalizedDimMax))
@@ -361,81 +108,68 @@ void validateNormalizedDim(
     }
 }
 
-} // namespace validators
-
 // --- Component Validators
 
-void checkTensorLayoutsAndDimsSupported(
-    const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap)
+void LayernormValidator::checkTensorIDLayoutsAndDimsSupported(const std::vector<int64_t>& tensorIds)
 {
-    std::vector<LayernormTensorDescriptor> tensors;
+    // Skip tensors with embedded scalar values (epsilon, momentum) - they don't have layouts or dimensions to validate
+    std::vector<TensorDescriptor> tensors;
     tensors.reserve(tensorIds.size());
 
     for(const auto& id : tensorIds)
     {
-        auto attr = tensorMap.at(id);
+        auto attr = _tensorMap.at(id);
         if(attr->value_type() == hipdnn_data_sdk::data_objects::TensorValue::NONE)
         {
             tensors.emplace_back(attr);
         }
     }
 
-    validators::validateConsistentDimensions(tensors);
-    validators::validatePackedTensors(tensors);
-    validators::validateConsistentLayouts(tensors);
+    validateConsistentDimensions(tensors);
+    validatePackedTensors(tensors);
+    validateConsistentLayouts(tensors);
 }
 
-void checkTensorLayoutsAndDimsSupported(
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap)
+void LayernormValidator::checkTensorLayoutsAndDimsSupported()
 {
     // Skip tensors with embedded scalar values (epsilon, momentum) - they don't have layouts or dimensions to validate
     std::vector<int64_t> tensorIds;
-    tensorIds.reserve(tensorMap.size());
-    for(const auto& [id, attr] : tensorMap)
+    tensorIds.reserve(_tensorMap.size());
+    for(const auto& [id, attr] : _tensorMap)
     {
-        if(attr->value_type() != hipdnn_data_sdk::data_objects::TensorValue::NONE)
+        if(attr->value_type() == hipdnn_data_sdk::data_objects::TensorValue::NONE)
         {
-            continue;
+            tensorIds.emplace_back(id);
         }
-        tensorIds.emplace_back(id);
     }
 
-    checkTensorLayoutsAndDimsSupported(tensorIds, tensorMap);
+    checkTensorIDLayoutsAndDimsSupported(tensorIds);
 }
 
-void checkTensorDataTypesSupported(
-    const std::vector<int64_t>& ioTensorIds,
-    const std::vector<int64_t>& affineTensorIds,
-    const std::vector<std::optional<int64_t>>& statTensorIds,
-    const std::vector<int64_t>& epsilonTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap)
+void LayernormValidator::checkTensorDataTypesSupported(const std::vector<int64_t>& ioTensorIds,
+                                                       const std::vector<int64_t>& affineTensorIds,
+                                                       const std::vector<int64_t>& statTensorIds,
+                                                       const std::vector<int64_t>& epsilonTensorIds)
 {
     const auto allowedIoTypes = type_configs::getAllowedIoTypes();
-    validators::validateConsistentDataTypes(
+    validateConsistentDataTypes(
         ioTensorIds,
-        tensorMap,
         allowedIoTypes,
         "Layernorm implementation supports only FLOAT, HALF and BFLOAT16 data types for x and y "
         "tensors.",
         "All IO tensors for layernorm must have the same data type.");
 
     const auto allowedAffineTypes = type_configs::getAllowedAffineTypes();
-    validators::validateConsistentDataTypes(
+    validateConsistentDataTypes(
         affineTensorIds,
-        tensorMap,
         allowedAffineTypes,
         "Layernorm implementation supports only FLOAT, HALF and BFLOAT16 data types for scale and "
         "bias tensors.",
         "All affine tensors for layernorm must have the same data type.");
 
     const auto allowedStatTypes = type_configs::getAllowedStatTypes();
-    validators::validateConsistentDataTypes(
+    validateConsistentDataTypes(
         statTensorIds,
-        tensorMap,
         allowedStatTypes,
         "Layernorm implementation supports only FLOAT, HALF and BFLOAT16 data types for mean and "
         "inverse variance tensors.",
@@ -444,20 +178,14 @@ void checkTensorDataTypesSupported(
     std::vector<int64_t> allTensorIds;
     allTensorIds.insert(allTensorIds.end(), ioTensorIds.begin(), ioTensorIds.end());
     allTensorIds.insert(allTensorIds.end(), affineTensorIds.begin(), affineTensorIds.end());
-    for(auto tensorId : statTensorIds)
-    {
-        if(tensorId.has_value())
-        {
-            allTensorIds.emplace_back(tensorId.value());
-        }
-    }
+    allTensorIds.insert(allTensorIds.end(), statTensorIds.begin(), statTensorIds.end());
+
     std::unordered_set<hipdnn_data_sdk::data_objects::DataType> allAllowedTypes;
     allAllowedTypes.insert(allowedIoTypes.begin(), allowedIoTypes.end());
     allAllowedTypes.insert(allowedAffineTypes.begin(), allowedAffineTypes.end());
     allAllowedTypes.insert(allowedStatTypes.begin(), allowedStatTypes.end());
-    validators::validateConsistentDataTypes(
+    validateConsistentDataTypes(
         allTensorIds,
-        tensorMap,
         allAllowedTypes,
         "Layernorm implementation only supports FLOAT, HALF and BFLOAT16 data types.",
         "All IO, affine and stat tensors for layernorm must have the same data type.");
@@ -465,29 +193,24 @@ void checkTensorDataTypesSupported(
     const auto allowedEpsilonTypes = type_configs::getAllowedEpsilonTypes();
     if(allowedEpsilonTypes.size() == 1)
     {
-        validators::validateFixedDataType(
+        validateFixedDataType(
             epsilonTensorIds,
-            tensorMap,
             *allowedEpsilonTypes.begin(),
             "Layernorm implementation supports only FLOAT data type for epsilon tensors.");
     }
     else
     {
-        validators::validateConsistentDataTypes(
+        validateConsistentDataTypes(
             epsilonTensorIds,
-            tensorMap,
             allowedEpsilonTypes,
             "Layernorm epsilon tensors use unsupported data type.",
             "All epsilon tensors for layernorm must have the same data type.");
     }
 }
 
-void checkTensorShapesSupported(
-    const std::vector<int64_t>& ioTensorIds,
-    const std::vector<int64_t>& affineTensorIds,
-    const std::vector<std::optional<int64_t>>& statTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap)
+void LayernormValidator::checkTensorShapesSupported(const std::vector<int64_t>& ioTensorIds,
+                                                    const std::vector<int64_t>& affineTensorIds,
+                                                    const std::vector<int64_t>& statTensorIds)
 {
     if(ioTensorIds.empty())
     {
@@ -496,70 +219,58 @@ void checkTensorShapesSupported(
             "At least one IO tensor must be provided for layernorm.");
     }
 
-    const auto& ioTensorAttr = hip_kernel_utils::findTensorAttributes(tensorMap, ioTensorIds[0]);
+    const auto& ioTensorAttr = hip_kernel_utils::findTensorAttributes(_tensorMap, ioTensorIds[0]);
     const std::vector<int64_t> ioDims(ioTensorAttr.dims()->begin(), ioTensorAttr.dims()->end());
 
-    validators::validateConsistentShapes(
-        ioTensorIds, tensorMap, ioDims, "All IO tensors for layernorm must have the same shape.");
+    validateConsistentShapes(
+        ioTensorIds, ioDims, "All IO tensors for layernorm must have the same shape.");
 
     const auto& affineTensorAttr
-        = hip_kernel_utils::findTensorAttributes(tensorMap, affineTensorIds[0]);
+        = hip_kernel_utils::findTensorAttributes(_tensorMap, affineTensorIds[0]);
     const std::vector<int64_t> affineDims(affineTensorAttr.dims()->begin(),
                                           affineTensorAttr.dims()->end());
-    validators::validateConsistentShapes(
-        affineTensorIds,
-        tensorMap,
-        affineDims,
-        "All affine tensors for layernorm must have the same shape.");
+    validateConsistentShapes(
+        affineTensorIds, affineDims, "All affine tensors for layernorm must have the same shape.");
 
     if(!statTensorIds.empty())
     {
-        for(const auto& statTensorId : statTensorIds)
-        {
-            if(statTensorId.has_value())
-            {
-                const auto& statTensorAttr
-                    = hip_kernel_utils::findTensorAttributes(tensorMap, statTensorId.value());
-                const std::vector<int64_t> statDims(statTensorAttr.dims()->begin(),
-                                                    statTensorAttr.dims()->end());
-                validators::validateConsistentShapes(
-                    statTensorIds,
-                    tensorMap,
-                    statDims,
-                    "All stat tensors for layernorm must have the same shape.");
-                break;
-            }
-        }
+        const auto& statTensorAttr
+            = hip_kernel_utils::findTensorAttributes(_tensorMap, statTensorIds[0]);
+        const std::vector<int64_t> statDims(statTensorAttr.dims()->begin(),
+                                            statTensorAttr.dims()->end());
+        validateConsistentShapes(statTensorIds,
+                                 statDims,
+                                 "Mean and variance tensors for batchnorm must have shape "
+                                 "derived from IO tensor shape.");
     }
 }
 
 // --- High-level Configuration Validators ---
 
-void checkLayernormTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::LayernormAttributes& lnAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap)
+void LayernormValidator::checkTensorConfigSupported(
+    const hipdnn_data_sdk::data_objects::LayernormAttributes& lnAttr)
 {
     std::vector<int64_t> ioTensorIds = {lnAttr.x_tensor_uid(), lnAttr.y_tensor_uid()};
     std::vector<int64_t> affineTensorIds = {lnAttr.scale_tensor_uid(), lnAttr.bias_tensor_uid()};
-    std::vector<std::optional<int64_t>> statTensorIds
-        = {lnAttr.mean_tensor_uid(), lnAttr.inv_variance_tensor_uid()};
+    std::vector<int64_t> statTensorIds;
+    if(lnAttr.mean_tensor_uid().has_value())
+    {
+        statTensorIds.push_back(lnAttr.mean_tensor_uid().value());
+    }
+    if(lnAttr.inv_variance_tensor_uid().has_value())
+    {
+        statTensorIds.push_back(lnAttr.inv_variance_tensor_uid().value());
+    }
     std::vector<int64_t> epsilonTensorIds = {lnAttr.epsilon_tensor_uid()};
+
     std::vector<int64_t> ioAndStatTensorIds
         = std::vector<int64_t>(ioTensorIds.begin(), ioTensorIds.end());
-    for(auto statTensorId : statTensorIds)
-    {
-        if(statTensorId.has_value())
-        {
-            ioAndStatTensorIds.emplace_back(statTensorId.value());
-        }
-    }
+    ioAndStatTensorIds.insert(ioAndStatTensorIds.end(), statTensorIds.begin(), statTensorIds.end());
 
-    checkTensorLayoutsAndDimsSupported(ioAndStatTensorIds, tensorMap);
-    checkTensorDataTypesSupported(
-        ioTensorIds, affineTensorIds, statTensorIds, epsilonTensorIds, tensorMap);
-    validators::validateNormalizedDim(ioTensorIds, affineTensorIds, statTensorIds, tensorMap);
-    checkTensorShapesSupported(ioTensorIds, affineTensorIds, statTensorIds, tensorMap);
+    checkTensorIDLayoutsAndDimsSupported(ioAndStatTensorIds);
+    checkTensorDataTypesSupported(ioTensorIds, affineTensorIds, statTensorIds, epsilonTensorIds);
+    validateNormalizedDim(ioTensorIds, affineTensorIds, statTensorIds);
+    checkTensorShapesSupported(ioTensorIds, affineTensorIds, statTensorIds);
 }
 
 } // namespace hip_kernel_provider::layernorm

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormApplicabilityChecks.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormApplicabilityChecks.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "engines/plans/ApplicabilityChecks.hpp"
+
 #include <array>
 #include <optional>
 #include <string>
@@ -17,121 +19,41 @@
 namespace hip_kernel_provider::layernorm
 {
 
-// --- Tensor Descriptor Value Object ---
-
-struct LayernormTensorDescriptor
+class LayernormValidator : public IValidator
 {
-    std::vector<int64_t> dims;
-    std::vector<int64_t> strides;
-    std::vector<int64_t> strideOrder;
+private:
+public:
+    LayernormValidator(
+        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+            tensorMapLocal)
+        : IValidator(tensorMapLocal) {};
 
-    explicit LayernormTensorDescriptor(const hipdnn_data_sdk::data_objects::TensorAttributes* attr);
+    // --- Validation Utilities ---
 
-    size_t numDims() const
-    {
-        return dims.size();
-    }
-    bool isPacked() const;
+    void validateNormalizedDim(const std::vector<int64_t>& ioTensorIds,
+                               const std::vector<int64_t>& affineTensorIds,
+                               const std::vector<int64_t>& statTensorIds);
+
+    // --- Component Validators ---
+
+    void checkTensorLayoutsAndDimsSupported() override;
+
+    void checkTensorIDLayoutsAndDimsSupported(const std::vector<int64_t>& tensorIds);
+
+    void checkTensorDataTypesSupported(const std::vector<int64_t>& ioTensorIds,
+                                       const std::vector<int64_t>& affineTensorIds,
+                                       const std::vector<int64_t>& statTensorIds,
+                                       const std::vector<int64_t>& epsilonTensorIds);
+
+    void checkTensorShapesSupported(const std::vector<int64_t>& ioTensorIds,
+                                    const std::vector<int64_t>& affineTensorIds,
+                                    const std::vector<int64_t>& statTensorIds);
+
+    // --- High-level Configuration Validators ---
+
+    void checkTensorConfigSupported(
+        const hipdnn_data_sdk::data_objects::LayernormAttributes& lnAttr);
 };
-
-// --- Validation Utilities ---
-
-namespace validators
-{
-
-void validateDimensionCount(size_t numDims);
-
-void validateConsistentDimensions(const std::vector<LayernormTensorDescriptor>& tensors);
-
-void validatePackedTensors(const std::vector<LayernormTensorDescriptor>& tensors);
-
-void validateSupportedLayout(const std::vector<int64_t>& strideOrder, size_t numDims);
-
-void validateConsistentLayouts(const std::vector<LayernormTensorDescriptor>& tensors);
-
-void validateDataTypeIsSupported(
-    hipdnn_data_sdk::data_objects::DataType dataType,
-    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
-    const std::string& errorMessage);
-
-void validateConsistentDataTypes(
-    const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap,
-    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
-    const std::string& typeErrorMessage,
-    const std::string& consistencyErrorMessage);
-
-void validateConsistentDataTypes(
-    const std::vector<std::optional<int64_t>>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap,
-    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
-    const std::string& typeErrorMessage,
-    const std::string& consistencyErrorMessage);
-
-void validateFixedDataType(
-    const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap,
-    hipdnn_data_sdk::data_objects::DataType expectedType,
-    const std::string& errorMessage);
-
-void validateConsistentShapes(
-    const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap,
-    const std::vector<int64_t>& referenceShape,
-    const std::string& errorMessage);
-
-void validateConsistentShapes(
-    const std::vector<std::optional<int64_t>>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap,
-    const std::vector<int64_t>& referenceShape,
-    const std::string& errorMessage);
-
-void validateNormalizedDim(
-    const std::vector<int64_t>& ioTensorIds,
-    const std::vector<int64_t>& affineTensorIds,
-    const std::vector<std::optional<int64_t>>& statTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap);
-
-} // namespace validators
-
-// --- Component Validators ---
-
-void checkTensorLayoutsAndDimsSupported(
-    const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap);
-
-void checkTensorLayoutsAndDimsSupported(
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap);
-
-void checkTensorDataTypesSupported(
-    const std::vector<int64_t>& ioTensorIds,
-    const std::vector<int64_t>& affineTensorIds,
-    const std::vector<std::optional<int64_t>>& statTensorIds,
-    const std::vector<int64_t>& epsilonTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap);
-
-void checkTensorShapesSupported(
-    const std::vector<int64_t>& ioTensorIds,
-    const std::vector<int64_t>& affineTensorIds,
-    const std::vector<std::optional<int64_t>>& statTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap);
-
-// --- High-level Configuration Validators ---
-
-void checkLayernormTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::LayernormAttributes& lnAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
-        tensorMap);
 
 // Layernorm Type Configuration ---
 

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormPlanBuilder.cpp
@@ -57,11 +57,11 @@ bool LayernormPlanBuilder::isApplicable(
 
         try
         {
+            LayernormValidator validator(opGraph.getTensorMap());
             switch(node.attributes_type())
             {
             case hipdnn_data_sdk::data_objects::NodeAttributes::LayernormAttributes:
-                checkLayernormTensorConfigSupported(*node.attributes_as_LayernormAttributes(),
-                                                    opGraph.getTensorMap());
+                validator.checkTensorConfigSupported(*node.attributes_as_LayernormAttributes());
                 break;
             default:
                 throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_INTERNAL_ERROR,

--- a/dnn-providers/hip-kernel-provider/src/tests/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/src/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(
     engines/plans/Batchnorm/TestBatchnormApplicabilityChecks.cpp
     engines/plans/Layernorm/TestLayernormPlanBuilder.cpp
     engines/plans/Layernorm/TestLayernormFwdPlan.cpp
+    engines/plans/Layernorm/TestLayernormApplicabilityChecks.cpp
     engines/plans/TestPlanUtils.cpp
     engines/plans/RMSnorm/TestRMSnormPlanBuilder.cpp
     engines/plans/RMSnorm/TestRMSnormFwdPlan.cpp

--- a/dnn-providers/hip-kernel-provider/src/tests/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/src/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(
     engines/plans/Batchnorm/TestBatchnormFwdInferenceWithVariancePlan.cpp
     engines/plans/Batchnorm/TestBatchnormFwdTrainingPlan.cpp
     engines/plans/Batchnorm/TestBatchnormCommon.cpp
+    engines/plans/Batchnorm/TestBatchnormApplicabilityChecks.cpp
     engines/plans/Layernorm/TestLayernormPlanBuilder.cpp
     engines/plans/Layernorm/TestLayernormFwdPlan.cpp
     engines/plans/TestPlanUtils.cpp
@@ -29,6 +30,7 @@ add_executable(
     engines/plans/RMSnorm/TestRMSnormFwdPlan.cpp
     engines/plans/RMSnorm/TestRMSnormBwdPlanBuilder.cpp
     engines/plans/RMSnorm/TestRMSnormBwdPlan.cpp
+    engines/plans/RMSnorm/TestRMSnormApplicabilityChecks.cpp
     hip/TestHipProgramAndKernel.cpp
 )
 

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Batchnorm/TestBatchnormApplicabilityChecks.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Batchnorm/TestBatchnormApplicabilityChecks.cpp
@@ -1,0 +1,570 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <gtest/gtest.h>
+
+#include "engines/plans/Batchnorm/BatchnormApplicabilityChecks.hpp"
+#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_plugin_sdk/PluginException.hpp>
+#include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
+
+using namespace hip_kernel_provider;
+
+TEST(TestBatchnormValidator, ValidInference)
+{
+    auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+    const auto& node = graph.getNode(0);
+    const auto& attr = *node.attributes_as_BatchnormInferenceAttributes();
+
+    BatchnormValidator validator(graph.getTensorMap());
+    EXPECT_NO_THROW(validator.checkInferenceTensorConfigSupported(attr));
+}
+
+TEST(TestBatchnormValidator, ValidInferenceActiv)
+{
+    auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdInferActGraph();
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    const auto& attr = *node.attributes_as_BatchnormInferenceAttributes();
+
+    const auto& activNode = graph.getNode(1);
+    const auto& activAttrs = *activNode.attributes_as_PointwiseAttributes();
+
+    BatchnormValidator validator(graph.getTensorMap());
+    EXPECT_NO_THROW(validator.checkInferenceActivationTensorConfigSupported(attr, activAttrs));
+}
+
+TEST(TestBatchnormValidator, ValidVarianceExtInference)
+{
+    auto builder = hipdnn_test_sdk::utilities::createValidBatchnormWithVarianceInferenceGraph();
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+    const auto& node = graph.getNode(0);
+    const auto& attr = *node.attributes_as_BatchnormInferenceAttributesVarianceExt();
+
+    BatchnormValidator validator(graph.getTensorMap());
+    EXPECT_NO_THROW(validator.checkInferenceVarianceExtTensorConfigSupported(attr));
+}
+
+TEST(TestBatchnormValidator, ValidVarianceExtInferenceActiv)
+{
+    auto builder
+        = hipdnn_test_sdk::utilities::createValidBatchnormWithVarianceInferenceActivGraph();
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    const auto& attr = *node.attributes_as_BatchnormInferenceAttributesVarianceExt();
+
+    const auto& activNode = graph.getNode(1);
+    const auto& activAttrs = *activNode.attributes_as_PointwiseAttributes();
+
+    BatchnormValidator validator(graph.getTensorMap());
+    EXPECT_NO_THROW(
+        validator.checkInferenceVarianceExtActivationTensorConfigSupported(attr, activAttrs));
+}
+
+TEST(TestBatchnormValidator, MismatchShapes)
+{
+    auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+    const auto& node = graph.getNode(0);
+    const auto& attr = *node.attributes_as_BatchnormInferenceAttributes();
+
+    BatchnormValidator validator(graph.getTensorMap());
+    EXPECT_NO_THROW(validator.checkInferenceTensorConfigSupported(attr));
+}
+
+namespace
+{
+
+flatbuffers::FlatBufferBuilder
+    createInvalidTypeBatchnormActivGraph(hipdnn_data_sdk::data_objects::DataType xType,
+                                         hipdnn_data_sdk::data_objects::DataType scaleType,
+                                         hipdnn_data_sdk::data_objects::DataType biasType,
+                                         hipdnn_data_sdk::data_objects::DataType meanType,
+                                         hipdnn_data_sdk::data_objects::DataType invVarianceType,
+                                         hipdnn_data_sdk::data_objects::DataType yType,
+                                         hipdnn_data_sdk::data_objects::DataType dyType,
+                                         hipdnn_data_sdk::data_objects::DataType computeDataType,
+                                         hipdnn_data_sdk::data_objects::PointwiseMode activ
+                                         = hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    std::vector<int64_t> strides{150528, 50176, 224, 1};
+    std::vector<int64_t> dims{1, 3, 224, 224};
+
+    const std::vector<int64_t> derivedDims = hipdnn_data_sdk::utilities::getDerivedShape(dims);
+    const std::vector<int64_t> derivedStrides = hipdnn_data_sdk::utilities::generateStrides(
+        derivedDims, hipdnn_data_sdk::utilities::extractStrideOrder(strides));
+
+    // inputs
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "x", xType, &strides, &dims));
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 2, "scale", scaleType, &derivedStrides, &derivedDims));
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 3, "bias", biasType, &derivedStrides, &derivedDims));
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 4, "mean", meanType, &derivedStrides, &derivedDims));
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 5, "inv_variance", invVarianceType, &derivedStrides, &derivedDims));
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 6, "y", yType, &strides, &dims, true));
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 7, "Dy", dyType, &strides, &dims, false)); // is_virtual = true
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // Node 0: Batchnorm Inference
+    auto bnInfAttributes = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+        builder,
+        1, // x_tensor_uid
+        4, // mean_tensor_uid
+        5, // inv_variance_tensor_uid
+        2, // scale_tensor_uid
+        3, // bias_tensor_uid
+        6 // y_tensor_uid (BN_Y - virtual)
+    );
+
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "batchnorm_inference",
+        computeDataType,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        bnInfAttributes.Union()));
+
+    // Node 1: Pointwise
+    auto pointwiseAttributes = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        activ,
+        std::nullopt, // relu_lower_clip
+        std::nullopt, // relu_upper_clip
+        std::nullopt, // relu_lower_clip_slope
+        flatbuffers::nullopt, // axis_tensor_uid
+        6, // in_0_tensor_uid (BN_Y)
+        flatbuffers::nullopt, // in_1_tensor_uid
+        flatbuffers::nullopt, // in_2_tensor_uid
+        7 // out_0_tensor_uid (Dy - not virtual)
+    );
+
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "relu_fwd",
+        computeDataType,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        pointwiseAttributes.Union()));
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+    return builder;
+}
+} // anonymous namespace
+
+TEST(TestBatchnormValidator, MismatchIOTypes)
+{
+    auto builder
+        = createInvalidTypeBatchnormActivGraph(hipdnn_data_sdk::data_objects::DataType::HALF,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    const auto& attr = *node.attributes_as_BatchnormInferenceAttributes();
+
+    const auto& activNode = graph.getNode(1);
+    const auto& activAttrs = *activNode.attributes_as_PointwiseAttributes();
+
+    // Data type of io tensors should match, expect exception when this isn't the case
+    BatchnormValidator validator(graph.getTensorMap());
+    EXPECT_THROW(validator.checkInferenceActivationTensorConfigSupported(attr, activAttrs),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+TEST(TestBatchnormValidator, MismatchAffineTypes)
+{
+    auto builder
+        = createInvalidTypeBatchnormActivGraph(hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::HALF,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    const auto& attr = *node.attributes_as_BatchnormInferenceAttributes();
+
+    const auto& activNode = graph.getNode(1);
+    const auto& activAttrs = *activNode.attributes_as_PointwiseAttributes();
+
+    // Data type of affine tensors should match, expect exception when this isn't the case
+    BatchnormValidator validator(graph.getTensorMap());
+    EXPECT_THROW(validator.checkInferenceActivationTensorConfigSupported(attr, activAttrs),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+TEST(TestBatchnormValidator, MismatchStatTypes)
+{
+    auto builder
+        = createInvalidTypeBatchnormActivGraph(hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::HALF,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    const auto& attr = *node.attributes_as_BatchnormInferenceAttributes();
+
+    const auto& activNode = graph.getNode(1);
+    const auto& activAttrs = *activNode.attributes_as_PointwiseAttributes();
+
+    // Data type of stat tensors should match, expect exception when this isn't the case
+    BatchnormValidator validator(graph.getTensorMap());
+    EXPECT_THROW(validator.checkInferenceActivationTensorConfigSupported(attr, activAttrs),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+TEST(TestBatchnormValidator, MismatchIntermediateTypes)
+{
+    auto builder
+        = createInvalidTypeBatchnormActivGraph(hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::HALF,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    const auto& attr = *node.attributes_as_BatchnormInferenceAttributes();
+
+    const auto& activNode = graph.getNode(1);
+    const auto& activAttrs = *activNode.attributes_as_PointwiseAttributes();
+
+    // Data type of intermediate tensors should match, expect exception when this isn't the case
+    BatchnormValidator validator(graph.getTensorMap());
+    EXPECT_THROW(validator.checkInferenceActivationTensorConfigSupported(attr, activAttrs),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+TEST(TestBatchnormValidator, InvalidActivation)
+{
+    auto builder = createInvalidTypeBatchnormActivGraph(
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::PointwiseMode::RECIPROCAL);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    const auto& attr = *node.attributes_as_BatchnormInferenceAttributes();
+
+    const auto& activNode = graph.getNode(1);
+    const auto& activAttrs = *activNode.attributes_as_PointwiseAttributes();
+
+    // Plan doesn't change to reciprocal activation mode yet
+    BatchnormValidator validator(graph.getTensorMap());
+    EXPECT_THROW(validator.checkInferenceActivationTensorConfigSupported(attr, activAttrs),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+namespace
+{
+
+flatbuffers::FlatBufferBuilder
+    createInvalidShapeBatchnormActivGraph(const std::vector<int64_t>& xDims,
+                                          const std::vector<int64_t>& xStrides,
+                                          const std::vector<int64_t>& scaleDims,
+                                          const std::vector<int64_t>& scaleStrides,
+                                          const std::vector<int64_t>& biasDims,
+                                          const std::vector<int64_t>& biasStrides,
+                                          const std::vector<int64_t>& meanDims,
+                                          const std::vector<int64_t>& meansStrides,
+                                          const std::vector<int64_t>& invVarianceDims,
+                                          const std::vector<int64_t>& invVarianceStrides,
+                                          const std::vector<int64_t>& yDims,
+                                          const std::vector<int64_t>& yStrides,
+                                          const std::vector<int64_t>& dyDims,
+                                          const std::vector<int64_t>& dyStrides)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    // inputs
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "x", hipdnn_data_sdk::data_objects::DataType::FLOAT, &xStrides, &xDims));
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        2,
+        "scale",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &scaleStrides,
+        &scaleDims));
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        3,
+        "bias",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &biasStrides,
+        &biasDims));
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        4,
+        "mean",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &meansStrides,
+        &meanDims));
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        5,
+        "inv_variance",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &invVarianceStrides,
+        &invVarianceDims));
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 6, "y", hipdnn_data_sdk::data_objects::DataType::FLOAT, &yStrides, &yDims, true));
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        7,
+        "Dy",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &dyStrides,
+        &dyDims,
+        false)); // is_virtual = true
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // Node 0: Batchnorm Inference
+    auto bnInfAttributes = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+        builder,
+        1, // x_tensor_uid
+        4, // mean_tensor_uid
+        5, // inv_variance_tensor_uid
+        2, // scale_tensor_uid
+        3, // bias_tensor_uid
+        6 // y_tensor_uid (BN_Y - virtual)
+    );
+
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "batchnorm_inference",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        bnInfAttributes.Union()));
+
+    // Node 1: Pointwise
+    auto pointwiseAttributes = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        std::nullopt, // relu_lower_clip
+        std::nullopt, // relu_upper_clip
+        std::nullopt, // relu_lower_clip_slope
+        flatbuffers::nullopt, // axis_tensor_uid
+        6, // in_0_tensor_uid (BN_Y)
+        flatbuffers::nullopt, // in_1_tensor_uid
+        flatbuffers::nullopt, // in_2_tensor_uid
+        7 // out_0_tensor_uid (Dy - not virtual)
+    );
+
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "relu_fwd",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        pointwiseAttributes.Union()));
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+    return builder;
+}
+} // anonymous namespace
+
+TEST(TestBatchnormValidator, MismatchIOShapes)
+{
+    std::vector<int64_t> xDims{1, 3, 4, 4};
+    std::vector<int64_t> xStrides{48, 16, 4, 1};
+
+    std::vector<int64_t> dims{1, 3, 224, 224};
+    std::vector<int64_t> strides{150528, 50176, 224, 1};
+
+    const std::vector<int64_t> derivedDims = hipdnn_data_sdk::utilities::getDerivedShape(dims);
+    const std::vector<int64_t> derivedStrides = hipdnn_data_sdk::utilities::generateStrides(
+        derivedDims, hipdnn_data_sdk::utilities::extractStrideOrder(strides));
+
+    auto builder = createInvalidShapeBatchnormActivGraph(xDims,
+                                                         xStrides,
+                                                         derivedDims,
+                                                         derivedStrides,
+                                                         derivedDims,
+                                                         derivedStrides,
+                                                         derivedDims,
+                                                         derivedStrides,
+                                                         derivedDims,
+                                                         derivedStrides,
+                                                         dims,
+                                                         strides,
+                                                         dims,
+                                                         strides);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    const auto& attr = *node.attributes_as_BatchnormInferenceAttributes();
+
+    const auto& activNode = graph.getNode(1);
+    const auto& activAttrs = *activNode.attributes_as_PointwiseAttributes();
+
+    // Data type of io tensors should match, expect exception when this isn't the case
+    BatchnormValidator validator(graph.getTensorMap());
+    EXPECT_THROW(validator.checkInferenceActivationTensorConfigSupported(attr, activAttrs),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+TEST(TestBatchnormValidator, MismatchAffineShapes)
+{
+    std::vector<int64_t> dims{1, 3, 224, 224};
+    std::vector<int64_t> strides{150528, 50176, 224, 1};
+
+    std::vector<int64_t> scaleDims{1, 3, 4, 4};
+    std::vector<int64_t> scaleStrides{48, 16, 4, 1};
+
+    const std::vector<int64_t> derivedDims = hipdnn_data_sdk::utilities::getDerivedShape(dims);
+    const std::vector<int64_t> derivedStrides = hipdnn_data_sdk::utilities::generateStrides(
+        derivedDims, hipdnn_data_sdk::utilities::extractStrideOrder(strides));
+
+    auto builder = createInvalidShapeBatchnormActivGraph(dims,
+                                                         strides,
+                                                         scaleDims,
+                                                         scaleStrides,
+                                                         derivedDims,
+                                                         derivedStrides,
+                                                         derivedDims,
+                                                         derivedStrides,
+                                                         derivedDims,
+                                                         derivedStrides,
+                                                         dims,
+                                                         strides,
+                                                         dims,
+                                                         strides);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    const auto& attr = *node.attributes_as_BatchnormInferenceAttributes();
+
+    const auto& activNode = graph.getNode(1);
+    const auto& activAttrs = *activNode.attributes_as_PointwiseAttributes();
+
+    // Data type of io tensors should match, expect exception when this isn't the case
+    BatchnormValidator validator(graph.getTensorMap());
+    EXPECT_THROW(validator.checkInferenceActivationTensorConfigSupported(attr, activAttrs),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+TEST(TestBatchnormValidator, MismatchStatShapes)
+{
+    std::vector<int64_t> meanDims{1, 3, 4, 4};
+    std::vector<int64_t> meanStrides{48, 16, 4, 1};
+
+    std::vector<int64_t> dims{1, 3, 224, 224};
+    std::vector<int64_t> strides{150528, 50176, 224, 1};
+
+    const std::vector<int64_t> derivedDims = hipdnn_data_sdk::utilities::getDerivedShape(dims);
+    const std::vector<int64_t> derivedStrides = hipdnn_data_sdk::utilities::generateStrides(
+        derivedDims, hipdnn_data_sdk::utilities::extractStrideOrder(strides));
+
+    auto builder = createInvalidShapeBatchnormActivGraph(dims,
+                                                         strides,
+                                                         derivedDims,
+                                                         derivedStrides,
+                                                         derivedDims,
+                                                         derivedStrides,
+                                                         meanDims,
+                                                         meanStrides,
+                                                         derivedDims,
+                                                         derivedStrides,
+                                                         dims,
+                                                         strides,
+                                                         dims,
+                                                         strides);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    const auto& attr = *node.attributes_as_BatchnormInferenceAttributes();
+
+    const auto& activNode = graph.getNode(1);
+    const auto& activAttrs = *activNode.attributes_as_PointwiseAttributes();
+
+    // Data type of io tensors should match, expect exception when this isn't the case
+    BatchnormValidator validator(graph.getTensorMap());
+    EXPECT_THROW(validator.checkInferenceActivationTensorConfigSupported(attr, activAttrs),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Batchnorm/TestBatchnormApplicabilityChecks.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Batchnorm/TestBatchnormApplicabilityChecks.cpp
@@ -3,7 +3,7 @@
 
 #include <gtest/gtest.h>
 
-#include "engines/plans/Batchnorm/BatchnormApplicabilityChecks.hpp"
+#include "engines/plans/batchnorm/BatchnormApplicabilityChecks.hpp"
 #include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
@@ -66,6 +66,19 @@ TEST(TestBatchnormValidator, ValidVarianceExtInferenceActiv)
     BatchnormValidator validator(graph.getTensorMap());
     EXPECT_NO_THROW(
         validator.checkInferenceVarianceExtActivationTensorConfigSupported(attr, activAttrs));
+}
+
+TEST(TestBatchnormValidator, ValidFwdTraining)
+{
+    auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph();
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    const auto& attr = *node.attributes_as_BatchnormAttributes();
+
+    BatchnormValidator validator(graph.getTensorMap());
+    EXPECT_NO_THROW(validator.checkFwdTrainingTensorConfigSupported(attr));
 }
 
 TEST(TestBatchnormValidator, MismatchShapes)

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Layernorm/TestLayernormApplicabilityChecks.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Layernorm/TestLayernormApplicabilityChecks.cpp
@@ -1,0 +1,548 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <gtest/gtest.h>
+
+#include "engines/plans/layernorm/LayernormApplicabilityChecks.hpp"
+#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_plugin_sdk/PluginException.hpp>
+#include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
+
+using namespace hip_kernel_provider::layernorm;
+
+TEST(TestLayernormValidator, ValidFprop)
+{
+    auto builder = hipdnn_test_sdk::utilities::createValidLayernormFpropGraph();
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+    const auto& node = graph.getNode(0);
+    const auto& attr = *node.attributes_as_LayernormAttributes();
+
+    LayernormValidator validator(graph.getTensorMap());
+    EXPECT_NO_THROW(validator.checkTensorConfigSupported(attr));
+}
+
+TEST(TestLayernormValidator, UnsupportedDim)
+{
+    auto builder
+        = hipdnn_test_sdk::utilities::createValidLayernormFpropGraph({12, 4, 1}, {1, 3, 4});
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+    const auto& node = graph.getNode(0);
+    const auto& attr = *node.attributes_as_LayernormAttributes();
+
+    LayernormValidator validator(graph.getTensorMap());
+    EXPECT_THROW(validator.checkTensorConfigSupported(attr),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+namespace
+{
+
+flatbuffers::FlatBufferBuilder
+    createInvalidTypeLayernormFpropGraph(hipdnn_data_sdk::data_objects::DataType xType,
+                                         hipdnn_data_sdk::data_objects::DataType yType,
+                                         hipdnn_data_sdk::data_objects::DataType scaleType,
+                                         hipdnn_data_sdk::data_objects::DataType biasType,
+                                         hipdnn_data_sdk::data_objects::DataType epsilonType,
+                                         hipdnn_data_sdk::data_objects::DataType meanType,
+                                         hipdnn_data_sdk::data_objects::DataType invVarianceType)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    const std::vector<int64_t> ioStrides = {588, 196, 14, 1};
+    const std::vector<int64_t> ioDims = {1, 3, 14, 14};
+
+    const std::vector<int64_t> affineDims(ioDims.begin() + 1, ioDims.end());
+    const std::vector<int64_t> affineStrides
+        = hipdnn_data_sdk::utilities::generateStrides(affineDims);
+
+    std::vector<int64_t> statsDims = {ioDims[0], 1, 1, 1};
+    std::vector<int64_t> statsStrides = hipdnn_data_sdk::utilities::generateStrides(statsDims);
+
+    // Required tensors
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "x", xType, &ioStrides, &ioDims));
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 2, "y", yType, &ioStrides, &ioDims));
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 3, "scale", scaleType, &affineStrides, &affineDims));
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 4, "bias", biasType, &affineStrides, &affineDims));
+
+    // Epsilon (pass-by-value)
+    const std::vector<int64_t> epsilonDims = {1};
+    const hipdnn_data_sdk::data_objects::Float32Value epsilonVal(1e-5f);
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        5,
+        "epsilon",
+        epsilonType,
+        &epsilonDims,
+        &epsilonDims,
+        false,
+        hipdnn_data_sdk::data_objects::TensorValue::Float32Value,
+        builder.CreateStruct(epsilonVal).Union()));
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 6, "mean", meanType, &statsDims, &statsDims));
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 7, "inv_variance", invVarianceType, &statsDims, &statsDims));
+
+    auto layernormAttributes
+        = hipdnn_data_sdk::data_objects::CreateLayernormAttributes(builder,
+                                                                   1, // x tensor uid
+                                                                   3, // scale tensor uid
+                                                                   4, // bias tensor uid
+                                                                   5, // epsilon tensor uid
+                                                                   2, // y tensor uid
+                                                                   0, // normalized dim count
+                                                                   6, // mean tensor uid
+                                                                   7 // inv variance tensor uid
+        );
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "layernorm",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::LayernormAttributes,
+        layernormAttributes.Union());
+    nodes.push_back(node);
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+    return builder;
+}
+} // anonymous namespace
+
+TEST(TestLayernormValidator, MismatchIOTypes)
+{
+    auto builder
+        = createInvalidTypeLayernormFpropGraph(hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::HALF,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    const auto& attr = *node.attributes_as_LayernormAttributes();
+
+    LayernormValidator validator(graph.getTensorMap());
+    EXPECT_THROW(validator.checkTensorConfigSupported(attr),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+TEST(TestLayernormValidator, InvalidEpsilonType)
+{
+    auto builder
+        = createInvalidTypeLayernormFpropGraph(hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::HALF,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                               hipdnn_data_sdk::data_objects::DataType::FLOAT);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    const auto& attr = *node.attributes_as_LayernormAttributes();
+
+    LayernormValidator validator(graph.getTensorMap());
+    EXPECT_THROW(validator.checkTensorConfigSupported(attr),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+namespace
+{
+
+flatbuffers::FlatBufferBuilder
+    createInvalidShapeLayernormActivGraph(const std::vector<int64_t>& xDims,
+                                          const std::vector<int64_t>& xStrides,
+                                          const std::vector<int64_t>& yDims,
+                                          const std::vector<int64_t>& yStrides,
+                                          const std::vector<int64_t>& scaleDims,
+                                          const std::vector<int64_t>& scaleStrides,
+                                          const std::vector<int64_t>& biasDims,
+                                          const std::vector<int64_t>& biasStrides,
+                                          const std::vector<int64_t>& epsilonDims,
+                                          const std::vector<int64_t>& epsilonStrides,
+                                          const std::vector<int64_t>& meanDims,
+                                          const std::vector<int64_t>& meanStrides,
+                                          const std::vector<int64_t>& invVarianceDims,
+                                          const std::vector<int64_t>& invVarianceStrides)
+{
+
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    // Required tensors
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "x", hipdnn_data_sdk::data_objects::DataType::FLOAT, &xStrides, &xDims));
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 2, "y", hipdnn_data_sdk::data_objects::DataType::FLOAT, &yStrides, &yDims));
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        3,
+        "scale",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &scaleStrides,
+        &scaleDims));
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        4,
+        "bias",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &biasStrides,
+        &biasDims));
+
+    // Epsilon (pass-by-value)
+    const hipdnn_data_sdk::data_objects::Float32Value epsilonVal(1e-5f);
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        5,
+        "epsilon",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &epsilonStrides,
+        &epsilonDims,
+        false,
+        hipdnn_data_sdk::data_objects::TensorValue::Float32Value,
+        builder.CreateStruct(epsilonVal).Union()));
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        6,
+        "mean",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &meanStrides,
+        &meanDims));
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        7,
+        "inv_variance",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &invVarianceStrides,
+        &invVarianceDims));
+
+    auto layernormAttributes
+        = hipdnn_data_sdk::data_objects::CreateLayernormAttributes(builder,
+                                                                   1, // x tensor uid
+                                                                   3, // scale tensor uid
+                                                                   4, // bias tensor uid
+                                                                   5, // epsilon tensor uid
+                                                                   2, // y tensor uid
+                                                                   0, // normalized dim count
+                                                                   6, // mean tensor uid
+                                                                   7 // inv variance tensor uid
+        );
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "layernorm",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::LayernormAttributes,
+        layernormAttributes.Union());
+    nodes.push_back(node);
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+    return builder;
+}
+} // anonymous namespace
+
+TEST(TestLayernormValidator, MismatchIOShapes)
+{
+
+    const std::vector<int64_t> xDims{1, 3, 224, 224};
+    const std::vector<int64_t> xStrides{150528, 50176, 224, 1};
+
+    const std::vector<int64_t> ioDims{1, 3, 4, 4};
+    const std::vector<int64_t> ioStrides{48, 16, 4, 1};
+
+    // For LayerNorm, scale and bias match the normalized dimensions (all dims except batch).
+    // E.g., for input [N, C, H, W], normalized dims are [C, H, W].
+    const std::vector<int64_t> affineDims(ioDims.begin() + 1, ioDims.end());
+    const std::vector<int64_t> affineStrides
+        = hipdnn_data_sdk::utilities::generateStrides(affineDims);
+
+    const std::vector<int64_t> epsilonDims = {1};
+
+    const std::vector<int64_t> statsDims = {1, 1, 1, 1};
+    const std::vector<int64_t> statsStrides
+        = hipdnn_data_sdk::utilities::generateStrides(statsDims);
+
+    // NOLINTBEGIN(readability-suspicious-call-argument)
+    auto builder = createInvalidShapeLayernormActivGraph(xDims,
+                                                         xStrides,
+                                                         ioDims,
+                                                         ioStrides,
+                                                         affineDims,
+                                                         affineStrides,
+                                                         affineDims,
+                                                         affineStrides,
+                                                         epsilonDims,
+                                                         epsilonDims,
+                                                         statsDims,
+                                                         statsStrides,
+                                                         statsDims,
+                                                         statsStrides);
+    // NOLINTEND(readability-suspicious-call-argument)
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    const auto& attr = *node.attributes_as_LayernormAttributes();
+
+    LayernormValidator validator(graph.getTensorMap());
+    EXPECT_THROW(validator.checkTensorConfigSupported(attr),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+TEST(TestLayernormValidator, MismatchAffineShapes)
+{
+    const std::vector<int64_t> ioDims{1, 3, 4, 4};
+    const std::vector<int64_t> ioStrides{48, 16, 4, 1};
+
+    const std::vector<int64_t> affineDims(ioDims.begin() + 1, ioDims.end());
+    const std::vector<int64_t> affineStrides
+        = hipdnn_data_sdk::utilities::generateStrides(affineDims);
+
+    const std::vector<int64_t> biasDims{1, 3, 224, 224};
+    const std::vector<int64_t> biasStrides{150528, 50176, 224, 1};
+
+    const std::vector<int64_t> epsilonDims = {1};
+
+    const std::vector<int64_t> statsDims = {1, 1, 1, 1};
+    const std::vector<int64_t> statsStrides
+        = hipdnn_data_sdk::utilities::generateStrides(statsDims);
+
+    // NOLINTBEGIN(readability-suspicious-call-argument)
+    auto builder = createInvalidShapeLayernormActivGraph(ioDims,
+                                                         ioStrides,
+                                                         ioDims,
+                                                         ioStrides,
+                                                         affineDims,
+                                                         affineStrides,
+                                                         biasDims,
+                                                         biasStrides,
+                                                         epsilonDims,
+                                                         epsilonDims,
+                                                         statsDims,
+                                                         statsStrides,
+                                                         statsDims,
+                                                         statsStrides);
+    // NOLINTEND(readability-suspicious-call-argument)
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    const auto& attr = *node.attributes_as_LayernormAttributes();
+
+    LayernormValidator validator(graph.getTensorMap());
+    EXPECT_THROW(validator.checkTensorConfigSupported(attr),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+TEST(TestLayernormValidator, MismatchStatsShapes)
+{
+    const std::vector<int64_t> ioDims{1, 3, 4, 4};
+    const std::vector<int64_t> ioStrides{48, 16, 4, 1};
+
+    const std::vector<int64_t> affineDims(ioDims.begin() + 1, ioDims.end());
+    const std::vector<int64_t> affineStrides
+        = hipdnn_data_sdk::utilities::generateStrides(affineDims);
+
+    const std::vector<int64_t> epsilonDims = {1};
+
+    const std::vector<int64_t> statsDims = {1, 1, 1, 1};
+    const std::vector<int64_t> statsStrides
+        = hipdnn_data_sdk::utilities::generateStrides(statsDims);
+
+    const std::vector<int64_t> invVarDims{1, 3, 224, 224};
+    const std::vector<int64_t> invVarStrides{150528, 50176, 224, 1};
+
+    // NOLINTBEGIN(readability-suspicious-call-argument)
+    auto builder = createInvalidShapeLayernormActivGraph(ioDims,
+                                                         ioStrides,
+                                                         ioDims,
+                                                         ioStrides,
+                                                         affineDims,
+                                                         affineStrides,
+                                                         affineDims,
+                                                         affineStrides,
+                                                         epsilonDims,
+                                                         epsilonDims,
+                                                         statsDims,
+                                                         statsStrides,
+                                                         invVarDims,
+                                                         invVarStrides);
+    // NOLINTEND(readability-suspicious-call-argument)
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    const auto& attr = *node.attributes_as_LayernormAttributes();
+
+    LayernormValidator validator(graph.getTensorMap());
+    EXPECT_THROW(validator.checkTensorConfigSupported(attr),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+TEST(TestLayernormValidator, InvalidNormalization)
+{
+    const std::vector<int64_t> ioDims{2, 3, 4, 4};
+    const std::vector<int64_t> ioStrides{48, 16, 4, 1};
+
+    const std::vector<int64_t> affineDims(ioDims.begin() + 1, ioDims.end());
+    const std::vector<int64_t> affineStrides
+        = hipdnn_data_sdk::utilities::generateStrides(affineDims);
+    const std::vector<int64_t> epsilonDims = {1};
+
+    const std::vector<int64_t> statsDims = {2, 1, 1, 1};
+    const std::vector<int64_t> statsStrides
+        = hipdnn_data_sdk::utilities::generateStrides(statsDims);
+
+    // NOLINTBEGIN(readability-suspicious-call-argument)
+    auto builder = createInvalidShapeLayernormActivGraph(ioDims,
+                                                         ioStrides,
+                                                         ioDims,
+                                                         ioStrides,
+                                                         affineDims,
+                                                         affineStrides,
+                                                         affineDims,
+                                                         affineStrides,
+                                                         epsilonDims,
+                                                         epsilonDims,
+                                                         statsDims,
+                                                         statsStrides,
+                                                         statsDims,
+                                                         statsStrides);
+    // NOLINTEND(readability-suspicious-call-argument)
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    const auto& attr = *node.attributes_as_LayernormAttributes();
+
+    LayernormValidator validator(graph.getTensorMap());
+    EXPECT_THROW(validator.checkTensorConfigSupported(attr),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+/*
+TEST(TestBatchnormValidator, MismatchAffineShapes)
+{
+    std::vector<int64_t> dims{1, 3, 224, 224};
+    std::vector<int64_t> strides{150528, 50176, 224, 1};
+
+    std::vector<int64_t> scaleDims{1, 3, 4, 4};
+    std::vector<int64_t> scaleStrides{48, 16, 4, 1};
+
+    const std::vector<int64_t> derivedDims = hipdnn_data_sdk::utilities::getDerivedShape(dims);
+    const std::vector<int64_t> derivedStrides = hipdnn_data_sdk::utilities::generateStrides(
+        derivedDims, hipdnn_data_sdk::utilities::extractStrideOrder(strides));
+
+    auto builder = createInvalidShapeBatchnormActivGraph(dims,
+                                                         strides,
+                                                         scaleDims,
+                                                         scaleStrides,
+                                                         derivedDims,
+                                                         derivedStrides,
+                                                         derivedDims,
+                                                         derivedStrides,
+                                                         derivedDims,
+                                                         derivedStrides,
+                                                         dims,
+                                                         strides,
+                                                         dims,
+                                                         strides);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    const auto& attr = *node.attributes_as_BatchnormInferenceAttributes();
+
+    const auto& activNode = graph.getNode(1);
+    const auto& activAttrs = *activNode.attributes_as_PointwiseAttributes();
+
+    // Data type of io tensors should match, expect exception when this isn't the case
+    BatchnormValidator validator(graph.getTensorMap());
+    EXPECT_THROW(validator.checkInferenceActivationTensorConfigSupported(attr, activAttrs),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+TEST(TestBatchnormValidator, MismatchStatShapes)
+{
+    std::vector<int64_t> meanDims{1, 3, 4, 4};
+    std::vector<int64_t> meanStrides{48, 16, 4, 1};
+
+    std::vector<int64_t> dims{1, 3, 224, 224};
+    std::vector<int64_t> strides{150528, 50176, 224, 1};
+
+    const std::vector<int64_t> derivedDims = hipdnn_data_sdk::utilities::getDerivedShape(dims);
+    const std::vector<int64_t> derivedStrides = hipdnn_data_sdk::utilities::generateStrides(
+        derivedDims, hipdnn_data_sdk::utilities::extractStrideOrder(strides));
+
+    auto builder = createInvalidShapeBatchnormActivGraph(dims,
+                                                         strides,
+                                                         derivedDims,
+                                                         derivedStrides,
+                                                         derivedDims,
+                                                         derivedStrides,
+                                                         meanDims,
+                                                         meanStrides,
+                                                         derivedDims,
+                                                         derivedStrides,
+                                                         dims,
+                                                         strides,
+                                                         dims,
+                                                         strides);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    const auto& attr = *node.attributes_as_BatchnormInferenceAttributes();
+
+    const auto& activNode = graph.getNode(1);
+    const auto& activAttrs = *activNode.attributes_as_PointwiseAttributes();
+
+    // Data type of io tensors should match, expect exception when this isn't the case
+    BatchnormValidator validator(graph.getTensorMap());
+    EXPECT_THROW(validator.checkInferenceActivationTensorConfigSupported(attr, activAttrs),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}*/

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/plans/RMSnorm/TestRMSnormApplicabilityChecks.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/plans/RMSnorm/TestRMSnormApplicabilityChecks.cpp
@@ -1,0 +1,388 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <cstdint>
+#include <gtest/gtest.h>
+
+#include "engines/plans/RMSnorm/RMSnormApplicabilityChecks.hpp"
+#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_plugin_sdk/PluginException.hpp>
+#include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
+
+using namespace hip_kernel_provider::rmsnorm;
+
+TEST(TestRMSnormValidator, Valid)
+{
+    auto builder = hipdnn_test_sdk::utilities::createValidRMSNormGraph();
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+    const auto& node = graph.getNode(0);
+    const auto& attr = *node.attributes_as_RMSNormAttributes();
+
+    RMSnormValidator validator(graph.getTensorMap());
+    EXPECT_NO_THROW(validator.checkTensorConfigSupported(attr));
+}
+
+TEST(TestRMSnormValidator, UnsupportedDim)
+{
+    auto builder = hipdnn_test_sdk::utilities::createValidRMSNormGraph(
+        {12, 4, 1}, {1, 3, 4}, hipdnn_data_sdk::data_objects::DataType::FLOAT);
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    const auto& attr = *node.attributes_as_RMSNormAttributes();
+
+    // 3D tensor is not supported
+    RMSnormValidator validator(graph.getTensorMap());
+    EXPECT_THROW(validator.checkTensorConfigSupported(attr),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+namespace
+{
+flatbuffers::FlatBufferBuilder
+    createInvalidTypeRMSNormGraph(hipdnn_data_sdk::data_objects::DataType xType,
+                                  hipdnn_data_sdk::data_objects::DataType yType,
+                                  hipdnn_data_sdk::data_objects::DataType scaleType,
+                                  hipdnn_data_sdk::data_objects::DataType biasType,
+                                  hipdnn_data_sdk::data_objects::DataType invRMSType)
+{
+    std::vector<int64_t> strides{48, 16, 4, 1};
+    std::vector<int64_t> dims{1, 3, 4, 4};
+
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    const std::vector<int64_t> derivedDims = hipdnn_data_sdk::utilities::getDerivedShape(dims);
+    const std::vector<int64_t> derivedStrides = hipdnn_data_sdk::utilities::generateStrides(
+        derivedDims, hipdnn_data_sdk::utilities::extractStrideOrder(strides));
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "x", xType, &strides, &dims));
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 2, "y", yType, &strides, &dims));
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 3, "scale", scaleType, &derivedStrides, &derivedDims));
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 4, "bias", biasType, &derivedStrides, &derivedDims));
+
+    // inv_rms should get norm stats shape [N, 1, H, W]
+    std::vector<int64_t> invRMSDims = dims;
+    invRMSDims[1] = 1;
+    std::vector<int64_t> invRMSStrides = strides;
+    invRMSStrides[0] = invRMSStrides[1];
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 5, "inv_rms", invRMSType, &invRMSStrides, &invRMSDims));
+
+    // Epsilon (pass-by-value)
+    const std::vector<int64_t> passByValueDims = {1};
+    const hipdnn_data_sdk::data_objects::Float32Value epsilonVal(1e-5f);
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        6,
+        "epsilon",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &passByValueDims,
+        &passByValueDims,
+        false,
+        hipdnn_data_sdk::data_objects::TensorValue::Float32Value,
+        builder.CreateStruct(epsilonVal).Union()));
+
+    auto rmsnormAttributes
+        = hipdnn_data_sdk::data_objects::CreateRMSNormAttributes(builder,
+                                                                 1, // x uid
+                                                                 3, // scale uid
+                                                                 6, // epsilon uid
+                                                                 2, // y uid
+                                                                 4, // bias uid
+                                                                 5 // invRMS
+        );
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "rmsnorm",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::RMSNormAttributes,
+        rmsnormAttributes.Union());
+    nodes.push_back(node);
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+    return builder;
+}
+} // anonymous namespace
+
+TEST(TestRMSnormValidator, MismatchIOTypes)
+{
+    auto builder = createInvalidTypeRMSNormGraph(hipdnn_data_sdk::data_objects::DataType::HALF,
+                                                 hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                                 hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                                 hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                                 hipdnn_data_sdk::data_objects::DataType::FLOAT);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& graphNode = graph.getNode(0);
+    const auto& attr = *graphNode.attributes_as_RMSNormAttributes();
+
+    // Data type of x and y tensors should match, expect exception when this isn't the case
+    RMSnormValidator validator(graph.getTensorMap());
+    EXPECT_THROW(validator.checkTensorConfigSupported(attr),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+TEST(TestRMSnormValidator, UnsupportedScaleType)
+{
+    auto builder = createInvalidTypeRMSNormGraph(hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                                 hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                                 hipdnn_data_sdk::data_objects::DataType::HALF,
+                                                 hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                                 hipdnn_data_sdk::data_objects::DataType::FLOAT);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& graphNode = graph.getNode(0);
+    const auto& attr = *graphNode.attributes_as_RMSNormAttributes();
+
+    // Data type of scale should be the same as bias, expect exception when this isn't the case
+    RMSnormValidator validator(graph.getTensorMap());
+    EXPECT_THROW(validator.checkTensorConfigSupported(attr),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+TEST(TestRMSnormValidator, UnsupportedInvRMSType)
+{
+    auto builder = createInvalidTypeRMSNormGraph(hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                                 hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                                 hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                                 hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                                                 hipdnn_data_sdk::data_objects::DataType::HALF);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& graphNode = graph.getNode(0);
+    const auto& attr = *graphNode.attributes_as_RMSNormAttributes();
+
+    // only FLOAT inv_rms type is supported at the moment, expect exception when this isn't the case
+    RMSnormValidator validator(graph.getTensorMap());
+    EXPECT_THROW(validator.checkTensorConfigSupported(attr),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+namespace
+{
+flatbuffers::FlatBufferBuilder
+    createInvalidShapeRMSNormGraph(const std::vector<int64_t>& xDims,
+                                   const std::vector<int64_t>& xStrides,
+                                   const std::vector<int64_t>& yDims,
+                                   const std::vector<int64_t>& yStrides,
+                                   const std::vector<int64_t>& scaleDims,
+                                   const std::vector<int64_t>& scaleStrides,
+                                   const std::vector<int64_t>& biasDims,
+                                   const std::vector<int64_t>& biasStrides,
+                                   const std::vector<int64_t>& invRMSDims,
+                                   const std::vector<int64_t>& invRMSStrides)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "x", hipdnn_data_sdk::data_objects::DataType::FLOAT, &xStrides, &xDims));
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 2, "y", hipdnn_data_sdk::data_objects::DataType::FLOAT, &yStrides, &yDims));
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        3,
+        "scale",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &scaleStrides,
+        &scaleDims));
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        4,
+        "bias",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &biasStrides,
+        &biasDims));
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        5,
+        "inv_rms",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &invRMSStrides,
+        &invRMSDims));
+
+    // Epsilon (pass-by-value)
+    const std::vector<int64_t> passByValueDims = {1};
+    const hipdnn_data_sdk::data_objects::Float32Value epsilonVal(1e-5f);
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        6,
+        "epsilon",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &passByValueDims,
+        &passByValueDims,
+        false,
+        hipdnn_data_sdk::data_objects::TensorValue::Float32Value,
+        builder.CreateStruct(epsilonVal).Union()));
+
+    auto rmsnormAttributes
+        = hipdnn_data_sdk::data_objects::CreateRMSNormAttributes(builder,
+                                                                 1, // x uid
+                                                                 3, // scale uid
+                                                                 6, // epsilon uid
+                                                                 2, // y uid
+                                                                 4, // bias uid
+                                                                 5 // invRMS
+        );
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "rmsnorm",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::RMSNormAttributes,
+        rmsnormAttributes.Union());
+    nodes.push_back(node);
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+    return builder;
+}
+} // anonymous namespace
+
+TEST(TestRMSnormValidator, MismatchIOShapes)
+{
+    std::vector<int64_t> xDims{1, 3, 4, 4};
+    std::vector<int64_t> xStrides{48, 16, 4, 1};
+
+    std::vector<int64_t> yDims{1, 3, 2, 2};
+    std::vector<int64_t> yStrides{12, 4, 2, 1};
+
+    // inv_rms should get norm stats shape [N, 1, H, W]
+    std::vector<int64_t> invRMSDims = xDims;
+    invRMSDims[1] = 1;
+    std::vector<int64_t> invRMSStrides = xStrides;
+    invRMSStrides[0] = invRMSStrides[1];
+
+    const std::vector<int64_t> derivedDims = hipdnn_data_sdk::utilities::getDerivedShape(xDims);
+    const std::vector<int64_t> derivedStrides = hipdnn_data_sdk::utilities::generateStrides(
+        derivedDims, hipdnn_data_sdk::utilities::extractStrideOrder(xStrides));
+
+    auto builder = createInvalidShapeRMSNormGraph(xDims,
+                                                  xStrides,
+                                                  yDims,
+                                                  yStrides,
+                                                  derivedDims,
+                                                  derivedStrides,
+                                                  derivedDims,
+                                                  derivedStrides,
+                                                  invRMSDims,
+                                                  invRMSStrides);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& graphNode = graph.getNode(0);
+    const auto& attr = *graphNode.attributes_as_RMSNormAttributes();
+
+    // Shape of x and y tensors should match, expect exception when this isn't the case
+    RMSnormValidator validator(graph.getTensorMap());
+    EXPECT_THROW(validator.checkTensorConfigSupported(attr),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+TEST(TestRMSnormValidator, UnsupportedScaleShape)
+{
+    std::vector<int64_t> ioDims{1, 3, 4, 4};
+    std::vector<int64_t> ioStrides{48, 16, 4, 1};
+
+    // inv_rms should get norm stats shape [N, 1, H, W]
+    std::vector<int64_t> invRMSDims = ioDims;
+    invRMSDims[1] = 1;
+    std::vector<int64_t> invRMSStrides = ioStrides;
+    invRMSStrides[0] = invRMSStrides[1];
+
+    auto builder = createInvalidShapeRMSNormGraph(ioDims,
+                                                  ioStrides,
+                                                  ioDims,
+                                                  ioStrides,
+                                                  invRMSDims,
+                                                  invRMSDims,
+                                                  invRMSDims,
+                                                  invRMSDims,
+                                                  invRMSDims,
+                                                  invRMSStrides);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& graphNode = graph.getNode(0);
+    const auto& attr = *graphNode.attributes_as_RMSNormAttributes();
+
+    // Shape of scale and bias should be channel-only, expect exception when this isn't the case
+    RMSnormValidator validator(graph.getTensorMap());
+    EXPECT_THROW(validator.checkTensorConfigSupported(attr),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+TEST(TestRMSnormValidator, UnsupportedInvRMShape)
+{
+    std::vector<int64_t> ioDims{1, 3, 4, 4};
+    std::vector<int64_t> ioStrides{48, 16, 4, 1};
+
+    const std::vector<int64_t> derivedDims = hipdnn_data_sdk::utilities::getDerivedShape(ioDims);
+    const std::vector<int64_t> derivedStrides = hipdnn_data_sdk::utilities::generateStrides(
+        derivedDims, hipdnn_data_sdk::utilities::extractStrideOrder(ioStrides));
+
+    // Shape of x and y tensors should match
+    auto builder = createInvalidShapeRMSNormGraph(ioDims,
+                                                  ioStrides,
+                                                  ioDims,
+                                                  ioStrides,
+                                                  derivedDims,
+                                                  derivedStrides,
+                                                  derivedDims,
+                                                  derivedStrides,
+                                                  derivedDims,
+                                                  derivedStrides);
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& graphNode = graph.getNode(0);
+    const auto& attr = *graphNode.attributes_as_RMSNormAttributes();
+
+    // inv_rms should get norm stats shape [N, 1, H, W], expect exception when this isn't the case
+    RMSnormValidator validator(graph.getTensorMap());
+    EXPECT_THROW(validator.checkTensorConfigSupported(attr),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/plans/RMSnorm/TestRMSnormApplicabilityChecks.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/plans/RMSnorm/TestRMSnormApplicabilityChecks.cpp
@@ -23,6 +23,18 @@ TEST(TestRMSnormValidator, Valid)
     EXPECT_NO_THROW(validator.checkTensorConfigSupported(attr));
 }
 
+TEST(TestRMSnormValidator, ValidBwd)
+{
+    auto builder = hipdnn_test_sdk::utilities::createValidRMSNormBwdGraph();
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+    const auto& node = graph.getNode(0);
+    const auto& attr = *node.attributes_as_RMSNormBackwardAttributes();
+
+    RMSnormValidator validator(graph.getTensorMap());
+    EXPECT_NO_THROW(validator.checkBwdTensorConfigSupported(attr));
+}
+
 TEST(TestRMSnormValidator, UnsupportedDim)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidRMSNormGraph(


### PR DESCRIPTION
To reduce code duplication across hip-kernel-provider plans when implementing similar checks for applicability create common infrastructure. This PR introduces an abstract base class with common virtual methods that each plan can instantiate and override for their specific applicability check needs.