### PR TITLE
Unknown solution fix

### DIFF
--- a/projects/miopen/driver/conv_driver.hpp
+++ b/projects/miopen/driver/conv_driver.hpp
@@ -2011,8 +2011,7 @@ void ConvDriver<Tgpu, Tref>::GetSolutionAfterFind(
     }
     if(rc != miopenStatusSuccess           // (formatting)
        || immed_count < 1                  // It should not be so if Find succeeded.
-       || found_algo != solution.algorithm // These must match.
-       || solution.time < 0)               // Fallback mode (no entry in find-db -- disabled?)
+       || found_algo != solution.algorithm) // These must match.
     {
         // Ignore errors, just skip printing the solver information.
         solution.solution_id = 0;


### PR DESCRIPTION
Print the solver name even when the solution came from the fallback path (heuristic/WTI estimated time). A negative time in the find-db is an internal bookkeeping convention that has no bearing on whether the solver actually ran and can be identified.
