### PR TITLE
[CI] Fix pre-commit workflow failing on push events

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,6 +22,10 @@ concurrency:
 jobs:
   pre-commit:
     runs-on: ubuntu-24.04
+    env:
+      # For PRs, diff against the base branch. For pushes, diff against the
+      # commit that existed before the push (github.event.before).
+      FROM_REF: ${{ github.event.pull_request.base.ref && format('origin/{0}', github.event.pull_request.base.ref) || github.event.before }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -36,7 +40,7 @@ jobs:
           PROJECTS_WITH_OPTIONAL_DEPS: >-
             hipdnn
         run: |
-          CHANGED_FILES=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD)
+          CHANGED_FILES=$(git diff --name-only ${FROM_REF}...HEAD)
 
           # Check each project for changes
           for project in $PROJECTS_WITH_OPTIONAL_DEPS; do
@@ -63,5 +67,5 @@ jobs:
 
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
-          # Only check changed files in the PR
-          extra_args: --from-ref origin/${{ github.event.pull_request.base.ref }} --to-ref HEAD
+          # Only check changed files in the PR/push
+          extra_args: --from-ref ${{ env.FROM_REF }} --to-ref HEAD

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - develop
       - release/therock-*
-      - users/sareeder/pre-commit-push-fix # temporary: testing push event fix
   pull_request:
     branches: [develop]
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - release/therock-*
+      - users/sareeder/pre-commit-push-fix # temporary: testing push event fix
   pull_request:
     branches: [develop]
 


### PR DESCRIPTION
## Summary
- `github.event.pull_request.base.ref` is only set for `pull_request` events — on `push` events it's empty, making the git diff command `origin/...HEAD` which is invalid
- Use `github.event.before` (the SHA before the push) as the diff base for push events, keep `origin/<base-branch>` for PRs
- Hoist the ref expression to a job-level env var to avoid duplication

Closes #6035

## Test plan
- [x] Verify PR-triggered runs still diff against the base branch correctly
- [x] Verify push-triggered runs use `github.event.before` and no longer fail (action via temporary commit adding this branch to the push inclusions: https://github.com/ROCm/rocm-libraries/actions/runs/23762945704/job/69235004575)