### PR TITLE
fix(tensilelite): Reduce unaccounted overhead of ScopedTimer and timing_context

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Common/TimingInstrumentation.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Common/TimingInstrumentation.py
@@ -37,16 +37,37 @@ if not _timing_logger.handlers:
     _timing_logger.setLevel(logging.INFO)
     _timing_logger.propagate = False
 
+# Accumulated overhead of the timing instrumentation itself (in nanoseconds).
+# Tracks f-string formatting and logger.info calls — excludes time.time_ns().
+_timing_overhead_ns = 0
+
 
 @contextmanager
 def timing_context(category_name):
     """Context manager for timing instrumentation."""
     if globalParameters.get("TimingInstrumentation", False):
+        global _timing_overhead_ns
+        overhead_snapshot = _timing_overhead_ns
         start = time.time_ns()
         try:
             yield
         finally:
-            elapsed_ms = (time.time_ns() - start) / 1_000_000
-            _timing_logger.info(f"TIMING:{category_name}:{elapsed_ms:.3f}")
+            elapsed_ns = time.time_ns() - start
+            # Subtract overhead accumulated by child timers during our span
+            child_overhead_ns = _timing_overhead_ns - overhead_snapshot
+            adjusted_ms = (elapsed_ns - child_overhead_ns) / 1_000_000
+            t0 = time.time_ns()
+            _timing_logger.info(f"TIMING:{category_name}:{adjusted_ms:.3f}")
+            t1 = time.time_ns()
+            _timing_overhead_ns += t1 - t0
     else:
         yield
+
+
+def emit_timing_overhead():
+    """Emit accumulated Python timing overhead as a TIMING line and reset."""
+    global _timing_overhead_ns
+    if _timing_overhead_ns > 0:
+        ms = _timing_overhead_ns / 1_000_000
+        _timing_logger.info(f"TIMING:python_timing_overhead:{ms:.3f}")
+        _timing_overhead_ns = 0

--- a/projects/hipblaslt/tensilelite/Tensile/Common/TimingInstrumentation.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Common/TimingInstrumentation.py
@@ -39,65 +39,35 @@ if not _timing_logger.handlers:
 
 # Deferred I/O buffer: list of (category, duration_ms) tuples.
 # All formatting and I/O happens in flush_timing_buffer().
+# Raw timings are stored without overhead adjustment; the analysis script
+# (analyze_timing.py) handles overhead subtraction using the hierarchy and
+# the timing_overhead record emitted by the C++ client.
 _timing_buffer = []
-
-# Calibrated per-invocation overhead of timing_context (nanoseconds).
-# Covers context-manager protocol, clock calls, buffer append.
-_per_call_overhead_ns = 0
-
-# Total number of timing_context completions. Used to count child invocations
-# within a parent scope for overhead subtraction.
-_invocation_count = 0
-
-
-def calibrate_timing(iterations=10000):
-    """Measure the full per-invocation cost of timing_context.
-
-    Must be called after globalParameters["TimingInstrumentation"] is set to True.
-    """
-    global _per_call_overhead_ns, _invocation_count
-    if not globalParameters.get("TimingInstrumentation", False):
-        return
-    # Warmup — let CPython's adaptive specialization settle
-    for _ in range(100):
-        with timing_context("calibrate_python_timing_overhead"):
-            pass
-    buf_before = len(_timing_buffer)
-    count_before = _invocation_count
-    start = time.time_ns()
-    for _ in range(iterations):
-        with timing_context("calibrate_python_timing_overhead"):
-            pass
-    total = time.time_ns() - start
-    # Remove calibration entries from buffer and counter
-    del _timing_buffer[buf_before:]
-    _invocation_count = count_before
-    _per_call_overhead_ns = total // iterations
 
 
 @contextmanager
 def timing_context(category_name):
-    """Context manager for timing instrumentation."""
+    """Context manager for timing instrumentation.
+
+    Records raw wall-clock time with no overhead subtraction.  Python-side
+    overhead (context-manager protocol, time.time_ns, dict lookup) is not
+    tracked because there are only ~a dozen calls per run — the overhead
+    is negligible relative to the seconds-scale measurements.  C++ overhead
+    is tracked separately via a calibrated timing_overhead record.
+    """
     if globalParameters.get("TimingInstrumentation", False):
-        global _invocation_count
-        count_snapshot = _invocation_count
         start = time.time_ns()
         try:
             yield
         finally:
             elapsed_ns = time.time_ns() - start
-            child_invocations = _invocation_count - count_snapshot
-            adjusted_ns = elapsed_ns - child_invocations * _per_call_overhead_ns
-            _timing_buffer.append((category_name, adjusted_ns / 1_000_000))
-            _invocation_count += 1
+            _timing_buffer.append((category_name, elapsed_ns / 1_000_000))
     else:
         yield
 
 
 def flush_timing_buffer():
     """Write all buffered timing records and reset."""
-    global _invocation_count
     for category, duration_ms in _timing_buffer:
         _timing_logger.info(f"TIMING:{category}:{duration_ms:.3f}")
     _timing_buffer.clear()
-    _invocation_count = 0

--- a/projects/hipblaslt/tensilelite/Tensile/Common/TimingInstrumentation.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Common/TimingInstrumentation.py
@@ -60,13 +60,13 @@ def calibrate_timing(iterations=10000):
         return
     # Warmup — let CPython's adaptive specialization settle
     for _ in range(100):
-        with timing_context("__calibrate__"):
+        with timing_context("calibrate_python_timing_overhead"):
             pass
     buf_before = len(_timing_buffer)
     count_before = _invocation_count
     start = time.time_ns()
     for _ in range(iterations):
-        with timing_context("__calibrate__"):
+        with timing_context("calibrate_python_timing_overhead"):
             pass
     total = time.time_ns() - start
     # Remove calibration entries from buffer and counter

--- a/projects/hipblaslt/tensilelite/Tensile/Common/TimingInstrumentation.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Common/TimingInstrumentation.py
@@ -37,37 +37,67 @@ if not _timing_logger.handlers:
     _timing_logger.setLevel(logging.INFO)
     _timing_logger.propagate = False
 
-# Accumulated overhead of the timing instrumentation itself (in nanoseconds).
-# Tracks f-string formatting and logger.info calls — excludes time.time_ns().
-_timing_overhead_ns = 0
+# Deferred I/O buffer: list of (category, duration_ms) tuples.
+# All formatting and I/O happens in flush_timing_buffer().
+_timing_buffer = []
+
+# Calibrated per-invocation overhead of timing_context (nanoseconds).
+# Covers context-manager protocol, clock calls, buffer append.
+_per_call_overhead_ns = 0
+
+# Total number of timing_context completions. Used to count child invocations
+# within a parent scope for overhead subtraction.
+_invocation_count = 0
+
+
+def calibrate_timing(iterations=10000):
+    """Measure the full per-invocation cost of timing_context.
+
+    Must be called after globalParameters["TimingInstrumentation"] is set to True.
+    """
+    global _per_call_overhead_ns, _invocation_count
+    if not globalParameters.get("TimingInstrumentation", False):
+        return
+    # Warmup — let CPython's adaptive specialization settle
+    for _ in range(100):
+        with timing_context("__calibrate__"):
+            pass
+    buf_before = len(_timing_buffer)
+    count_before = _invocation_count
+    start = time.time_ns()
+    for _ in range(iterations):
+        with timing_context("__calibrate__"):
+            pass
+    total = time.time_ns() - start
+    # Remove calibration entries from buffer and counter
+    del _timing_buffer[buf_before:]
+    _invocation_count = count_before
+    _per_call_overhead_ns = total // iterations
 
 
 @contextmanager
 def timing_context(category_name):
     """Context manager for timing instrumentation."""
     if globalParameters.get("TimingInstrumentation", False):
-        global _timing_overhead_ns
-        overhead_snapshot = _timing_overhead_ns
+        global _invocation_count
+        count_snapshot = _invocation_count
         start = time.time_ns()
         try:
             yield
         finally:
             elapsed_ns = time.time_ns() - start
-            # Subtract overhead accumulated by child timers during our span
-            child_overhead_ns = _timing_overhead_ns - overhead_snapshot
-            adjusted_ms = (elapsed_ns - child_overhead_ns) / 1_000_000
-            t0 = time.time_ns()
-            _timing_logger.info(f"TIMING:{category_name}:{adjusted_ms:.3f}")
-            t1 = time.time_ns()
-            _timing_overhead_ns += t1 - t0
+            child_invocations = _invocation_count - count_snapshot
+            adjusted_ns = elapsed_ns - child_invocations * _per_call_overhead_ns
+            _timing_buffer.append((category_name, adjusted_ns / 1_000_000))
+            _invocation_count += 1
     else:
         yield
 
 
-def emit_timing_overhead():
-    """Emit accumulated Python timing overhead as a TIMING line and reset."""
-    global _timing_overhead_ns
-    if _timing_overhead_ns > 0:
-        ms = _timing_overhead_ns / 1_000_000
-        _timing_logger.info(f"TIMING:python_timing_overhead:{ms:.3f}")
-        _timing_overhead_ns = 0
+def flush_timing_buffer():
+    """Write all buffered timing records and reset."""
+    global _invocation_count
+    for category, duration_ms in _timing_buffer:
+        _timing_logger.info(f"TIMING:{category}:{duration_ms:.3f}")
+    _timing_buffer.clear()
+    _invocation_count = 0

--- a/projects/hipblaslt/tensilelite/Tensile/Tensile.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tensile.py
@@ -151,6 +151,7 @@ def executeStepsInConfig(
                     debugConfig.printIndexAssignmentInfo,
                     isaInfoMap,
                 )
+            flush_timing_buffer()
             print1("")
         else:
             print1("# LibraryLogic already done.")
@@ -174,6 +175,7 @@ def executeStepsInConfig(
                 deviceId,
                 gfxName,
             )
+        flush_timing_buffer()
         print1("")
 
 

--- a/projects/hipblaslt/tensilelite/Tensile/Tensile.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tensile.py
@@ -43,7 +43,7 @@ from Tensile.Common.Architectures import detectGlobalCurrentISA, isaToGfx
 from Tensile.Common.Capabilities import makeIsaInfoMap
 from Tensile.Common.GlobalParameters import globalParameters, assignGlobalParameters, \
                                             restoreDefaultGlobalParameters
-from Tensile.Common.TimingInstrumentation import timing_context, emit_timing_overhead
+from Tensile.Common.TimingInstrumentation import timing_context, calibrate_timing, flush_timing_buffer
 from Tensile.Toolchain.Assembly import AssemblyToolchain, makeAssemblyToolchain
 from Tensile.Toolchain.Source import SourceToolchain, makeSourceToolchain
 from Tensile.Toolchain.Validators import validateToolchain, ToolchainDefaults
@@ -120,7 +120,7 @@ def executeStepsInConfig(
                 probSolDict,
                 buildOnly,
             )
-        emit_timing_overhead()
+        flush_timing_buffer()
         print1("")
 
     if buildOnly:
@@ -621,6 +621,8 @@ def Tensile(userArgs):
     for key, value in overrideParameters.items():
         print("Overriding {0}={1}".format(key, value))
         globalParameters[key] = value
+
+    calibrate_timing()
 
     if "MaxFileName" in globalParameters or "MaxFileName" in config:
         printWarning("MaxFileName is no longer configurable, it will be automatically set to 64")

--- a/projects/hipblaslt/tensilelite/Tensile/Tensile.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tensile.py
@@ -43,7 +43,7 @@ from Tensile.Common.Architectures import detectGlobalCurrentISA, isaToGfx
 from Tensile.Common.Capabilities import makeIsaInfoMap
 from Tensile.Common.GlobalParameters import globalParameters, assignGlobalParameters, \
                                             restoreDefaultGlobalParameters
-from Tensile.Common.TimingInstrumentation import timing_context, calibrate_timing, flush_timing_buffer
+from Tensile.Common.TimingInstrumentation import timing_context, flush_timing_buffer
 from Tensile.Toolchain.Assembly import AssemblyToolchain, makeAssemblyToolchain
 from Tensile.Toolchain.Source import SourceToolchain, makeSourceToolchain
 from Tensile.Toolchain.Validators import validateToolchain, ToolchainDefaults
@@ -621,8 +621,6 @@ def Tensile(userArgs):
     for key, value in overrideParameters.items():
         print("Overriding {0}={1}".format(key, value))
         globalParameters[key] = value
-
-    calibrate_timing()
 
     if "MaxFileName" in globalParameters or "MaxFileName" in config:
         printWarning("MaxFileName is no longer configurable, it will be automatically set to 64")

--- a/projects/hipblaslt/tensilelite/Tensile/Tensile.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tensile.py
@@ -43,7 +43,7 @@ from Tensile.Common.Architectures import detectGlobalCurrentISA, isaToGfx
 from Tensile.Common.Capabilities import makeIsaInfoMap
 from Tensile.Common.GlobalParameters import globalParameters, assignGlobalParameters, \
                                             restoreDefaultGlobalParameters
-from Tensile.Common.TimingInstrumentation import timing_context
+from Tensile.Common.TimingInstrumentation import timing_context, emit_timing_overhead
 from Tensile.Toolchain.Assembly import AssemblyToolchain, makeAssemblyToolchain
 from Tensile.Toolchain.Source import SourceToolchain, makeSourceToolchain
 from Tensile.Toolchain.Validators import validateToolchain, ToolchainDefaults
@@ -120,6 +120,7 @@ def executeStepsInConfig(
                 probSolDict,
                 buildOnly,
             )
+        emit_timing_overhead()
         print1("")
 
     if buildOnly:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/characterization/TimingInstrumentation/test_timing_instrumentation_char.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/characterization/TimingInstrumentation/test_timing_instrumentation_char.py
@@ -12,7 +12,7 @@ import contextlib
 import pytest
 
 from Tensile.Common.GlobalParameters import globalParameters
-from Tensile.Common.TimingInstrumentation import timing_context
+from Tensile.Common.TimingInstrumentation import flush_timing_buffer, timing_context
 
 pytestmark = pytest.mark.unit
 
@@ -40,9 +40,10 @@ def test_timing_context_disabled_yields():
 
 
 def test_timing_context_enabled_times_and_logs():
-    # Flag on -> the timing path; body runs and a TIMING line is emitted. The
-    # "tensile.timing" logger has propagate=False, so attach a capture handler
-    # directly to it (caplog/capsys can't see it).
+    # Flag on -> the timing path; body runs and a TIMING line is buffered until
+    # flush_timing_buffer() emits it. The "tensile.timing" logger has
+    # propagate=False, so attach a capture handler directly to it (caplog/capsys
+    # can't see it).
     import logging
 
     messages = []
@@ -53,6 +54,7 @@ def test_timing_context_enabled_times_and_logs():
 
     logger = logging.getLogger("tensile.timing")
     handler = _Capture()
+    flush_timing_buffer()
     logger.addHandler(handler)
     try:
         with _timing_flag(True):
@@ -60,6 +62,9 @@ def test_timing_context_enabled_times_and_logs():
             with timing_context("mycat"):
                 ran.append(1)
             assert ran == [1]
+            assert not any("TIMING:mycat:" in m for m in messages)
+            flush_timing_buffer()
     finally:
         logger.removeHandler(handler)
+        flush_timing_buffer()
     assert any("TIMING:mycat:" in m for m in messages)

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_analyze_timing.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_analyze_timing.py
@@ -250,7 +250,6 @@ TIMING:python_benchmark_problems:5000.0
             + timings["code_object_loading"][0]
             + timings["cpu_data_init"][0]
             + timings["cpu_reference_gemm"][0]
-            + timings["gpu_kernel_execution"][0]
         )
         assert cpp_sum <= timings["python_client_execution"][0]
 

--- a/projects/hipblaslt/tensilelite/client/include/TimingInstrumentation.hpp
+++ b/projects/hipblaslt/tensilelite/client/include/TimingInstrumentation.hpp
@@ -3,12 +3,13 @@
 
 #pragma once
 
-#include <atomic>
 #include <charconv>
 #include <chrono>
 #include <cstring>
 #include <iostream>
 #include <string>
+#include <variant>
+#include <vector>
 
 namespace TensileLite
 {
@@ -18,14 +19,46 @@ namespace TensileLite
         // Set via command line: --timing-instrumentation
         inline bool g_timingInstrumentationEnabled = false;
 
-        // Accumulated overhead of the timing instrumentation itself (in nanoseconds).
-        // Tracks string copies, formatting, and I/O — excludes clock::now() calls.
-        inline std::atomic<int64_t> g_timingOverheadNs{0};
+        // ---- Deferred I/O buffer ------------------------------------------------
+        //
+        // During measurement, timing data is captured as raw structs with no string
+        // formatting or I/O. All formatting and writing happens in flushTimingBuffer().
+        //
+        // Note: single-threaded. The benchmark loop in main.cpp is sequential.
 
-        // Fast formatters — to_chars into a caller-supplied buffer
+        struct TimingRec
+        {
+            const char* category;
+            double      durationMs;
+        };
+
+        struct ContextRec
+        {
+            size_t      M, N, K, batchCount;
+            std::string typeA, typeD;
+        };
+
+        struct GroupedContextRec
+        {
+            size_t      index, totalGemms;
+            size_t      M, N, K, batchCount;
+            std::string typeA, typeD;
+        };
+
+        using TimingRecord = std::variant<TimingRec, ContextRec, GroupedContextRec>;
+        inline std::vector<TimingRecord> g_timingBuffer;
+
+        // Reserve buffer capacity upfront. Real workloads produce ~2M+ records.
+        inline void initTimingBuffer(size_t capacity = 2'500'000)
+        {
+            g_timingBuffer.reserve(capacity);
+        }
+
+        // ---- Formatting helpers (used only during flush) ------------------------
+
         inline char* fmtOne(char* p, char* end, const char* s)
         {
-            auto len = std::strlen(s);
+            auto len   = std::strlen(s);
             auto avail = static_cast<size_t>(end - p);
             if(len > avail)
                 len = avail;
@@ -54,7 +87,7 @@ namespace TensileLite
         template<typename... Args>
         inline void writeLine(Args&&... args)
         {
-            char buf[256];
+            char        buf[256];
             char*       p   = buf;
             char* const end = buf + sizeof(buf) - 1;
             ((p = fmtOne(p, end, args)), ...);
@@ -62,67 +95,63 @@ namespace TensileLite
             std::clog.write(buf, p - buf);
         }
 
+        // Format and write all buffered records, then clear the buffer.
         inline void flushTimingBuffer()
         {
-            if(g_timingInstrumentationEnabled)
+            for(auto& rec : g_timingBuffer)
             {
-                double overheadMs
-                    = g_timingOverheadNs.load(std::memory_order_relaxed) / 1'000'000.0;
-                writeLine("TIMING:timing_overhead:", overheadMs);
+                std::visit(
+                    [](auto& r)
+                    {
+                        using T = std::decay_t<decltype(r)>;
+                        if constexpr(std::is_same_v<T, TimingRec>)
+                            writeLine("TIMING:", r.category, ":", r.durationMs);
+                        else if constexpr(std::is_same_v<T, ContextRec>)
+                            writeLine("TIMING_CONTEXT:M=", r.M, ",N=", r.N, ",K=", r.K,
+                                      ",batch=", r.batchCount,
+                                      ",typeA=", r.typeA, ",typeD=", r.typeD);
+                        else
+                            writeLine("TIMING_CONTEXT_GROUPED:index=", r.index,
+                                      ",total=", r.totalGemms,
+                                      ",M=", r.M, ",N=", r.N, ",K=", r.K,
+                                      ",batch=", r.batchCount,
+                                      ",typeA=", r.typeA, ",typeD=", r.typeD);
+                    },
+                    rec);
             }
+            g_timingBuffer.clear();
             std::clog.flush();
         }
 
         using TimingClock = std::chrono::high_resolution_clock;
 
-        // Helper to accumulate overhead (time around non-clock work)
-        inline void accumulateOverhead(TimingClock::time_point t0, TimingClock::time_point t1)
-        {
-            g_timingOverheadNs.fetch_add(
-                std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count(),
-                std::memory_order_relaxed);
-        }
-
-        // Simple RAII timer that records timing on destruction
+        // Simple RAII timer that records timing on destruction.
         // Output format: TIMING:<category>:<duration_ms>
-        // This format is easily parseable by post-processing scripts
         //
-        // Timing records are written to std::clog (buffered stderr).
-        // Call flushTimingBuffer() to ensure all records are flushed.
+        // Timing records are buffered in g_timingBuffer during measurement.
+        // Call flushTimingBuffer() to format and write all records to std::clog.
         class ScopedTimer
         {
         public:
             using clock = TimingClock;
 
-            ScopedTimer(const std::string& category)
+            ScopedTimer(const char* category)
             {
                 if(g_timingInstrumentationEnabled)
                 {
-                    auto t0    = clock::now();
                     m_category = category;
-                    auto t1    = clock::now();
-                    accumulateOverhead(t0, t1);
+                    m_start    = clock::now();
                 }
-                m_startOverhead = g_timingOverheadNs.load(std::memory_order_relaxed);
-                m_start         = clock::now();
             }
 
             ~ScopedTimer()
             {
                 if(g_timingInstrumentationEnabled)
                 {
-                    auto end = clock::now();
-                    // Subtract overhead accumulated by child timers during our span
-                    auto childOverheadNs
-                        = g_timingOverheadNs.load(std::memory_order_relaxed) - m_startOverhead;
-                    auto rawNs = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                                     end - m_start)
-                                     .count();
-                    double durationMs = (rawNs - childOverheadNs) / 1'000'000.0;
-                    auto   t0         = clock::now();
-                    writeLine("TIMING:", m_category, ":", durationMs);
-                    auto t1 = clock::now();
-                    accumulateOverhead(t0, t1);
+                    auto   end        = clock::now();
+                    double durationMs
+                        = std::chrono::duration<double, std::milli>(end - m_start).count();
+                    g_timingBuffer.push_back(TimingRec{m_category, durationMs});
                 }
             }
 
@@ -135,20 +164,16 @@ namespace TensileLite
             }
 
         private:
-            std::string                    m_category;
+            const char*                    m_category = nullptr;
             std::chrono::time_point<clock> m_start;
-            int64_t                        m_startOverhead = 0;
         };
 
         // Report a timing value directly (for GPU timings already measured)
-        inline void reportTiming(const std::string& category, double ms)
+        inline void reportTiming(const char* category, double ms)
         {
             if(g_timingInstrumentationEnabled)
             {
-                auto t0 = TimingClock::now();
-                writeLine("TIMING:", category, ":", ms);
-                auto t1 = TimingClock::now();
-                accumulateOverhead(t0, t1);
+                g_timingBuffer.push_back(TimingRec{category, ms});
             }
         }
 
@@ -158,11 +183,7 @@ namespace TensileLite
         {
             if(g_timingInstrumentationEnabled)
             {
-                auto t0 = TimingClock::now();
-                writeLine("TIMING_CONTEXT:M=", M, ",N=", N, ",K=", K,
-                          ",batch=", batchCount, ",typeA=", typeA, ",typeD=", typeD);
-                auto t1 = TimingClock::now();
-                accumulateOverhead(t0, t1);
+                g_timingBuffer.push_back(ContextRec{M, N, K, batchCount, typeA, typeD});
             }
         }
 
@@ -173,12 +194,8 @@ namespace TensileLite
         {
             if(g_timingInstrumentationEnabled)
             {
-                auto t0 = TimingClock::now();
-                writeLine("TIMING_CONTEXT_GROUPED:index=", index, ",total=", totalGemms,
-                          ",M=", M, ",N=", N, ",K=", K,
-                          ",batch=", batchCount, ",typeA=", typeA, ",typeD=", typeD);
-                auto t1 = TimingClock::now();
-                accumulateOverhead(t0, t1);
+                g_timingBuffer.push_back(
+                    GroupedContextRec{index, totalGemms, M, N, K, batchCount, typeA, typeD});
             }
         }
 

--- a/projects/hipblaslt/tensilelite/client/include/TimingInstrumentation.hpp
+++ b/projects/hipblaslt/tensilelite/client/include/TimingInstrumentation.hpp
@@ -19,11 +19,9 @@ namespace TensileLite
         // Set via command line: --timing-instrumentation
         inline bool g_timingInstrumentationEnabled = false;
 
-        // Accumulated instrumentation overhead in nanoseconds.
-        // Tracks time spent in ScopedTimer construction/destruction bookkeeping
-        // (clock::now calls, push_back, etc.) that falls OUTSIDE measured intervals.
+        // Per-call overhead measured once at startup via calibrateTimingOverhead().
         // Single-threaded — no atomic needed.
-        inline int64_t g_timingOverheadNs = 0;
+        inline double g_calibratedPerCallOverheadMs = 0;
 
         // ---- Deferred I/O buffer ------------------------------------------------
         //
@@ -55,9 +53,11 @@ namespace TensileLite
         inline std::vector<TimingRecord> g_timingBuffer;
 
         // Reserve buffer capacity upfront. Real workloads produce ~2M+ records.
+        // Only allocates when timing is enabled to avoid penalizing normal runs.
         inline void initTimingBuffer(size_t capacity = 2'500'000)
         {
-            g_timingBuffer.reserve(capacity);
+            if(g_timingInstrumentationEnabled)
+                g_timingBuffer.reserve(capacity);
         }
 
         // ---- Formatting helpers (used only during flush) ------------------------
@@ -104,12 +104,11 @@ namespace TensileLite
         // Format and write all buffered records, then clear the buffer.
         inline void flushTimingBuffer()
         {
-            // Emit accumulated instrumentation overhead as a timing record.
-            if(g_timingInstrumentationEnabled)
+            // Emit calibrated instrumentation overhead as a timing record.
+            if(g_timingInstrumentationEnabled && g_calibratedPerCallOverheadMs > 0)
             {
-                double overheadMs = g_timingOverheadNs / 1'000'000.0;
+                double overheadMs = g_calibratedPerCallOverheadMs * g_timingBuffer.size();
                 g_timingBuffer.push_back(TimingRec{"timing_overhead", overheadMs});
-                g_timingOverheadNs = 0;
             }
 
             for(auto& rec : g_timingBuffer)
@@ -149,18 +148,13 @@ namespace TensileLite
         public:
             using clock = TimingClock;
 
+            // category must be a string literal or have static storage duration
             ScopedTimer(const char* category)
             {
                 if(g_timingInstrumentationEnabled)
                 {
-                    auto t0    = clock::now();
                     m_category = category;
                     m_start    = clock::now();
-                    // Overhead = time between first clock::now and measurement start.
-                    g_timingOverheadNs
-                        += std::chrono::duration_cast<std::chrono::nanoseconds>(
-                               m_start - t0)
-                               .count();
                 }
             }
 
@@ -172,11 +166,6 @@ namespace TensileLite
                     double durationMs
                         = std::chrono::duration<double, std::milli>(end - m_start).count();
                     g_timingBuffer.push_back(TimingRec{m_category, durationMs});
-                    auto t1 = clock::now();
-                    // Overhead = time between measurement end and destructor finish.
-                    g_timingOverheadNs
-                        += std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - end)
-                               .count();
                 }
             }
 
@@ -193,16 +182,32 @@ namespace TensileLite
             std::chrono::time_point<clock> m_start;
         };
 
+        // Measure per-call ScopedTimer overhead once at startup.
+        // Must be called after initTimingBuffer().
+        inline void calibrateTimingOverhead()
+        {
+            if(!g_timingInstrumentationEnabled)
+                return;
+            constexpr int kWarmup = 1000;
+            constexpr int kIter   = 100000;
+            for(int i = 0; i < kWarmup; i++)
+            { ScopedTimer t("_calibrate"); }
+            g_timingBuffer.clear();
+            auto t0 = TimingClock::now();
+            for(int i = 0; i < kIter; i++)
+            { ScopedTimer t("_calibrate"); }
+            auto t1 = TimingClock::now();
+            g_calibratedPerCallOverheadMs
+                = std::chrono::duration<double, std::milli>(t1 - t0).count() / kIter;
+            g_timingBuffer.clear();
+        }
+
         // Report a timing value directly (for GPU timings already measured)
         inline void reportTiming(const char* category, double ms)
         {
             if(g_timingInstrumentationEnabled)
             {
-                auto t0 = TimingClock::now();
                 g_timingBuffer.push_back(TimingRec{category, ms});
-                auto t1 = TimingClock::now();
-                g_timingOverheadNs
-                    += std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
             }
         }
 
@@ -212,11 +217,7 @@ namespace TensileLite
         {
             if(g_timingInstrumentationEnabled)
             {
-                auto t0 = TimingClock::now();
                 g_timingBuffer.push_back(ContextRec{M, N, K, batchCount, typeA, typeD});
-                auto t1 = TimingClock::now();
-                g_timingOverheadNs
-                    += std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
             }
         }
 
@@ -227,12 +228,8 @@ namespace TensileLite
         {
             if(g_timingInstrumentationEnabled)
             {
-                auto t0 = TimingClock::now();
                 g_timingBuffer.push_back(
                     GroupedContextRec{index, totalGemms, M, N, K, batchCount, typeA, typeD});
-                auto t1 = TimingClock::now();
-                g_timingOverheadNs
-                    += std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
             }
         }
 

--- a/projects/hipblaslt/tensilelite/client/include/TimingInstrumentation.hpp
+++ b/projects/hipblaslt/tensilelite/client/include/TimingInstrumentation.hpp
@@ -8,7 +8,6 @@
 #include <cstring>
 #include <iostream>
 #include <string>
-#include <variant>
 #include <vector>
 
 namespace TensileLite
@@ -36,21 +35,30 @@ namespace TensileLite
             double      durationMs;
         };
 
-        struct ContextRec
+        // Context buffers: separate from the main timing buffer.
+        // posInTimingBuffer records g_timingBuffer.size() at push time so that
+        // flushTimingBuffer() can merge context lines into the correct position.
+        struct ContextEntry
         {
+            size_t      posInTimingBuffer;
             size_t      M, N, K, batchCount;
             std::string typeA, typeD;
         };
 
-        struct GroupedContextRec
+        struct GroupedContextEntry
         {
+            size_t      posInTimingBuffer;
             size_t      index, totalGemms;
             size_t      M, N, K, batchCount;
             std::string typeA, typeD;
         };
 
-        using TimingRecord = std::variant<TimingRec, ContextRec, GroupedContextRec>;
-        inline std::vector<TimingRecord> g_timingBuffer;
+        // Main buffer: timing records only (hot path, ~2.5M entries, 16 bytes each).
+        inline std::vector<TimingRec> g_timingBuffer;
+
+        // Context buffers: cold path, few thousand entries each.
+        inline std::vector<ContextEntry>        g_contextBuffer;
+        inline std::vector<GroupedContextEntry>  g_groupedContextBuffer;
 
         // Reserve buffer capacity upfront. Real workloads produce ~2M+ records.
         // Only allocates when timing is enabled to avoid penalizing normal runs.
@@ -101,38 +109,66 @@ namespace TensileLite
             std::clog.write(buf, p - buf);
         }
 
-        // Format and write all buffered records, then clear the buffer.
+        // Format and write all buffered records, then clear the buffers.
+        // Context entries are merged into the output at their recorded positions
+        // to preserve the interleaving expected by analyze_timing.py.
         inline void flushTimingBuffer()
         {
             // Emit calibrated instrumentation overhead as a timing record.
+            // g_timingBuffer.size() now correctly counts only TimingRec entries.
             if(g_timingInstrumentationEnabled && g_calibratedPerCallOverheadMs > 0)
             {
                 double overheadMs = g_calibratedPerCallOverheadMs * g_timingBuffer.size();
                 g_timingBuffer.push_back(TimingRec{"timing_overhead", overheadMs});
             }
 
-            for(auto& rec : g_timingBuffer)
+            // Two-pointer merge: emit context lines at their recorded positions.
+            size_t ctxIdx = 0;
+            size_t grpIdx = 0;
+            for(size_t i = 0; i < g_timingBuffer.size(); i++)
             {
-                std::visit(
-                    [](auto& r)
-                    {
-                        using T = std::decay_t<decltype(r)>;
-                        if constexpr(std::is_same_v<T, TimingRec>)
-                            writeLine("TIMING:", r.category, ":", r.durationMs);
-                        else if constexpr(std::is_same_v<T, ContextRec>)
-                            writeLine("TIMING_CONTEXT:M=", r.M, ",N=", r.N, ",K=", r.K,
-                                      ",batch=", r.batchCount,
-                                      ",typeA=", r.typeA, ",typeD=", r.typeD);
-                        else
-                            writeLine("TIMING_CONTEXT_GROUPED:index=", r.index,
-                                      ",total=", r.totalGemms,
-                                      ",M=", r.M, ",N=", r.N, ",K=", r.K,
-                                      ",batch=", r.batchCount,
-                                      ",typeA=", r.typeA, ",typeD=", r.typeD);
-                    },
-                    rec);
+                while(ctxIdx < g_contextBuffer.size()
+                      && g_contextBuffer[ctxIdx].posInTimingBuffer <= i)
+                {
+                    auto& c = g_contextBuffer[ctxIdx++];
+                    writeLine("TIMING_CONTEXT:M=", c.M, ",N=", c.N, ",K=", c.K,
+                              ",batch=", c.batchCount,
+                              ",typeA=", c.typeA, ",typeD=", c.typeD);
+                }
+                while(grpIdx < g_groupedContextBuffer.size()
+                      && g_groupedContextBuffer[grpIdx].posInTimingBuffer <= i)
+                {
+                    auto& g = g_groupedContextBuffer[grpIdx++];
+                    writeLine("TIMING_CONTEXT_GROUPED:index=", g.index,
+                              ",total=", g.totalGemms,
+                              ",M=", g.M, ",N=", g.N, ",K=", g.K,
+                              ",batch=", g.batchCount,
+                              ",typeA=", g.typeA, ",typeD=", g.typeD);
+                }
+                writeLine("TIMING:", g_timingBuffer[i].category, ":",
+                          g_timingBuffer[i].durationMs);
             }
+            // Emit any trailing context entries (after all timing records).
+            while(ctxIdx < g_contextBuffer.size())
+            {
+                auto& c = g_contextBuffer[ctxIdx++];
+                writeLine("TIMING_CONTEXT:M=", c.M, ",N=", c.N, ",K=", c.K,
+                          ",batch=", c.batchCount,
+                          ",typeA=", c.typeA, ",typeD=", c.typeD);
+            }
+            while(grpIdx < g_groupedContextBuffer.size())
+            {
+                auto& g = g_groupedContextBuffer[grpIdx++];
+                writeLine("TIMING_CONTEXT_GROUPED:index=", g.index,
+                          ",total=", g.totalGemms,
+                          ",M=", g.M, ",N=", g.N, ",K=", g.K,
+                          ",batch=", g.batchCount,
+                          ",typeA=", g.typeA, ",typeD=", g.typeD);
+            }
+
             g_timingBuffer.clear();
+            g_contextBuffer.clear();
+            g_groupedContextBuffer.clear();
             std::clog.flush();
         }
 
@@ -188,6 +224,14 @@ namespace TensileLite
         {
             if(!g_timingInstrumentationEnabled)
                 return;
+
+            // Pre-touch all reserved pages so calibration runs on faulted memory,
+            // matching the conditions of real workloads.
+            size_t cap = g_timingBuffer.capacity();
+            for(size_t i = 0; i < cap; i++)
+                g_timingBuffer.push_back(TimingRec{"_warmup", 0});
+            g_timingBuffer.clear();
+
             constexpr int kWarmup = 1000;
             constexpr int kIter   = 100000;
             for(int i = 0; i < kWarmup; i++)
@@ -211,25 +255,28 @@ namespace TensileLite
             }
         }
 
-        // Report problem context for correlation (single GEMM)
+        // Report problem context for correlation (single GEMM).
+        // Buffered separately from timing records; merged during flush.
         inline void reportProblemContext(size_t M, size_t N, size_t K, size_t batchCount,
                                          const std::string& typeA, const std::string& typeD)
         {
             if(g_timingInstrumentationEnabled)
             {
-                g_timingBuffer.push_back(ContextRec{M, N, K, batchCount, typeA, typeD});
+                g_contextBuffer.push_back(
+                    ContextEntry{g_timingBuffer.size(), M, N, K, batchCount, typeA, typeD});
             }
         }
 
-        // Report problem context for grouped GEMM (multiple GEMMs batched together)
+        // Report problem context for grouped GEMM (multiple GEMMs batched together).
+        // Buffered separately from timing records; merged during flush.
         inline void reportGroupedProblemContext(size_t index, size_t totalGemms,
                                                 size_t M, size_t N, size_t K, size_t batchCount,
                                                 const std::string& typeA, const std::string& typeD)
         {
             if(g_timingInstrumentationEnabled)
             {
-                g_timingBuffer.push_back(
-                    GroupedContextRec{index, totalGemms, M, N, K, batchCount, typeA, typeD});
+                g_groupedContextBuffer.push_back(GroupedContextEntry{
+                    g_timingBuffer.size(), index, totalGemms, M, N, K, batchCount, typeA, typeD});
             }
         }
 

--- a/projects/hipblaslt/tensilelite/client/include/TimingInstrumentation.hpp
+++ b/projects/hipblaslt/tensilelite/client/include/TimingInstrumentation.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <charconv>
 #include <chrono>
 #include <cstring>
@@ -16,6 +17,10 @@ namespace TensileLite
         // Global flag to enable/disable timing instrumentation output
         // Set via command line: --timing-instrumentation
         inline bool g_timingInstrumentationEnabled = false;
+
+        // Accumulated overhead of the timing instrumentation itself (in nanoseconds).
+        // Tracks string copies, formatting, and I/O — excludes clock::now() calls.
+        inline std::atomic<int64_t> g_timingOverheadNs{0};
 
         // Fast formatters — to_chars into a caller-supplied buffer
         inline char* fmtOne(char* p, char* end, const char* s)
@@ -59,7 +64,23 @@ namespace TensileLite
 
         inline void flushTimingBuffer()
         {
+            if(g_timingInstrumentationEnabled)
+            {
+                double overheadMs
+                    = g_timingOverheadNs.load(std::memory_order_relaxed) / 1'000'000.0;
+                writeLine("TIMING:timing_overhead:", overheadMs);
+            }
             std::clog.flush();
+        }
+
+        using TimingClock = std::chrono::high_resolution_clock;
+
+        // Helper to accumulate overhead (time around non-clock work)
+        inline void accumulateOverhead(TimingClock::time_point t0, TimingClock::time_point t1)
+        {
+            g_timingOverheadNs.fetch_add(
+                std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count(),
+                std::memory_order_relaxed);
         }
 
         // Simple RAII timer that records timing on destruction
@@ -71,21 +92,37 @@ namespace TensileLite
         class ScopedTimer
         {
         public:
-            using clock = std::chrono::high_resolution_clock;
+            using clock = TimingClock;
 
             ScopedTimer(const std::string& category)
-                : m_category(category)
-                , m_start(clock::now())
             {
+                if(g_timingInstrumentationEnabled)
+                {
+                    auto t0    = clock::now();
+                    m_category = category;
+                    auto t1    = clock::now();
+                    accumulateOverhead(t0, t1);
+                }
+                m_startOverhead = g_timingOverheadNs.load(std::memory_order_relaxed);
+                m_start         = clock::now();
             }
 
             ~ScopedTimer()
             {
                 if(g_timingInstrumentationEnabled)
                 {
-                    auto end      = clock::now();
-                    auto duration = std::chrono::duration<double, std::milli>(end - m_start);
-                    writeLine("TIMING:", m_category, ":", duration.count());
+                    auto end = clock::now();
+                    // Subtract overhead accumulated by child timers during our span
+                    auto childOverheadNs
+                        = g_timingOverheadNs.load(std::memory_order_relaxed) - m_startOverhead;
+                    auto rawNs = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                     end - m_start)
+                                     .count();
+                    double durationMs = (rawNs - childOverheadNs) / 1'000'000.0;
+                    auto   t0         = clock::now();
+                    writeLine("TIMING:", m_category, ":", durationMs);
+                    auto t1 = clock::now();
+                    accumulateOverhead(t0, t1);
                 }
             }
 
@@ -100,6 +137,7 @@ namespace TensileLite
         private:
             std::string                    m_category;
             std::chrono::time_point<clock> m_start;
+            int64_t                        m_startOverhead = 0;
         };
 
         // Report a timing value directly (for GPU timings already measured)
@@ -107,7 +145,10 @@ namespace TensileLite
         {
             if(g_timingInstrumentationEnabled)
             {
+                auto t0 = TimingClock::now();
                 writeLine("TIMING:", category, ":", ms);
+                auto t1 = TimingClock::now();
+                accumulateOverhead(t0, t1);
             }
         }
 
@@ -117,8 +158,11 @@ namespace TensileLite
         {
             if(g_timingInstrumentationEnabled)
             {
+                auto t0 = TimingClock::now();
                 writeLine("TIMING_CONTEXT:M=", M, ",N=", N, ",K=", K,
                           ",batch=", batchCount, ",typeA=", typeA, ",typeD=", typeD);
+                auto t1 = TimingClock::now();
+                accumulateOverhead(t0, t1);
             }
         }
 
@@ -129,9 +173,12 @@ namespace TensileLite
         {
             if(g_timingInstrumentationEnabled)
             {
+                auto t0 = TimingClock::now();
                 writeLine("TIMING_CONTEXT_GROUPED:index=", index, ",total=", totalGemms,
                           ",M=", M, ",N=", N, ",K=", K,
                           ",batch=", batchCount, ",typeA=", typeA, ",typeD=", typeD);
+                auto t1 = TimingClock::now();
+                accumulateOverhead(t0, t1);
             }
         }
 

--- a/projects/hipblaslt/tensilelite/client/include/TimingInstrumentation.hpp
+++ b/projects/hipblaslt/tensilelite/client/include/TimingInstrumentation.hpp
@@ -19,6 +19,12 @@ namespace TensileLite
         // Set via command line: --timing-instrumentation
         inline bool g_timingInstrumentationEnabled = false;
 
+        // Accumulated instrumentation overhead in nanoseconds.
+        // Tracks time spent in ScopedTimer construction/destruction bookkeeping
+        // (clock::now calls, push_back, etc.) that falls OUTSIDE measured intervals.
+        // Single-threaded — no atomic needed.
+        inline int64_t g_timingOverheadNs = 0;
+
         // ---- Deferred I/O buffer ------------------------------------------------
         //
         // During measurement, timing data is captured as raw structs with no string
@@ -98,6 +104,14 @@ namespace TensileLite
         // Format and write all buffered records, then clear the buffer.
         inline void flushTimingBuffer()
         {
+            // Emit accumulated instrumentation overhead as a timing record.
+            if(g_timingInstrumentationEnabled)
+            {
+                double overheadMs = g_timingOverheadNs / 1'000'000.0;
+                g_timingBuffer.push_back(TimingRec{"timing_overhead", overheadMs});
+                g_timingOverheadNs = 0;
+            }
+
             for(auto& rec : g_timingBuffer)
             {
                 std::visit(
@@ -139,8 +153,14 @@ namespace TensileLite
             {
                 if(g_timingInstrumentationEnabled)
                 {
+                    auto t0    = clock::now();
                     m_category = category;
                     m_start    = clock::now();
+                    // Overhead = time between first clock::now and measurement start.
+                    g_timingOverheadNs
+                        += std::chrono::duration_cast<std::chrono::nanoseconds>(
+                               m_start - t0)
+                               .count();
                 }
             }
 
@@ -152,6 +172,11 @@ namespace TensileLite
                     double durationMs
                         = std::chrono::duration<double, std::milli>(end - m_start).count();
                     g_timingBuffer.push_back(TimingRec{m_category, durationMs});
+                    auto t1 = clock::now();
+                    // Overhead = time between measurement end and destructor finish.
+                    g_timingOverheadNs
+                        += std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - end)
+                               .count();
                 }
             }
 
@@ -173,7 +198,11 @@ namespace TensileLite
         {
             if(g_timingInstrumentationEnabled)
             {
+                auto t0 = TimingClock::now();
                 g_timingBuffer.push_back(TimingRec{category, ms});
+                auto t1 = TimingClock::now();
+                g_timingOverheadNs
+                    += std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
             }
         }
 
@@ -183,7 +212,11 @@ namespace TensileLite
         {
             if(g_timingInstrumentationEnabled)
             {
+                auto t0 = TimingClock::now();
                 g_timingBuffer.push_back(ContextRec{M, N, K, batchCount, typeA, typeD});
+                auto t1 = TimingClock::now();
+                g_timingOverheadNs
+                    += std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
             }
         }
 
@@ -194,8 +227,12 @@ namespace TensileLite
         {
             if(g_timingInstrumentationEnabled)
             {
+                auto t0 = TimingClock::now();
                 g_timingBuffer.push_back(
                     GroupedContextRec{index, totalGemms, M, N, K, batchCount, typeA, typeD});
+                auto t1 = TimingClock::now();
+                g_timingOverheadNs
+                    += std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
             }
         }
 

--- a/projects/hipblaslt/tensilelite/client/main.cpp
+++ b/projects/hipblaslt/tensilelite/client/main.cpp
@@ -886,6 +886,7 @@ int main(int argc, const char* argv[])
     ClientProblemFactory problemFactory(args);
 
     initTimingBuffer();
+    calibrateTimingOverhead();
 
     std::shared_ptr<Hardware> hardware;
     hipStream_t              stream;
@@ -1239,9 +1240,6 @@ int main(int argc, const char* argv[])
 
                     if(exitOnError && listeners.error() > 0)
                     {
-                        // Note: active ScopedTimers on the stack will push records
-                        // after this flush during stack unwinding, but those are lost.
-                        // Acceptable on an error-exit path.
                         flushTimingBuffer();
                         // error range in shell is [0-255]
                         return std::min(listeners.error(), 255);

--- a/projects/hipblaslt/tensilelite/client/main.cpp
+++ b/projects/hipblaslt/tensilelite/client/main.cpp
@@ -885,6 +885,8 @@ int main(int argc, const char* argv[])
 
     ClientProblemFactory problemFactory(args);
 
+    initTimingBuffer();
+
     std::shared_ptr<Hardware> hardware;
     hipStream_t              stream;
     {
@@ -1237,6 +1239,9 @@ int main(int argc, const char* argv[])
 
                     if(exitOnError && listeners.error() > 0)
                     {
+                        // Note: active ScopedTimers on the stack will push records
+                        // after this flush during stack unwinding, but those are lost.
+                        // Acceptable on an error-exit path.
                         flushTimingBuffer();
                         // error range in shell is [0-255]
                         return std::min(listeners.error(), 255);

--- a/projects/hipblaslt/tensilelite/client/main.cpp
+++ b/projects/hipblaslt/tensilelite/client/main.cpp
@@ -1197,22 +1197,25 @@ int main(int argc, const char* argv[])
                                             TimingEvents startEvents(enq, eventCount);
                                             TimingEvents stopEvents(enq, eventCount);
 
-                                            listeners.preEnqueues(stream);
-
-                                            for(int j = 0; j < enq; j++)
                                             {
-                                                size_t kIdx = ((i * enq) + j) % kernels.size();
-                                                HIP_CHECK_EXC(adapter.launchKernels(
-                                                    kernels[kIdx], stream, nullptr, nullptr));
+                                                ScopedTimer kernelTimer("gpu_kernel_execution");
+                                                listeners.preEnqueues(stream);
 
-                                                if(icacheFlush)
+                                                for(int j = 0; j < enq; j++)
                                                 {
-                                                    hipLaunchKernelGGL(
-                                                        flush_icache, flushGridSize, 64, 0, stream);
-                                                }
-                                            }
+                                                    size_t kIdx = ((i * enq) + j) % kernels.size();
+                                                    HIP_CHECK_EXC(adapter.launchKernels(
+                                                        kernels[kIdx], stream, nullptr, nullptr));
 
-                                            listeners.postEnqueues(startEvents, stopEvents, stream);
+                                                    if(icacheFlush)
+                                                    {
+                                                        hipLaunchKernelGGL(
+                                                            flush_icache, flushGridSize, 64, 0, stream);
+                                                    }
+                                                }
+
+                                                listeners.postEnqueues(startEvents, stopEvents, stream);
+                                            }
                                             listeners.validateEnqueues(inputs, startEvents, stopEvents);
                                         }
 

--- a/projects/hipblaslt/tensilelite/client/main.cpp
+++ b/projects/hipblaslt/tensilelite/client/main.cpp
@@ -1263,8 +1263,17 @@ int main(int argc, const char* argv[])
         listeners.finalizeReport();
     }
 
-    // Flush all buffered timing records to stderr
-    flushTimingBuffer();
+    // Flush all buffered timing records to stderr.
+    // Timed with raw chrono instead of ScopedTimer because ScopedTimer pushes
+    // its record into the buffer on destruction — after flushTimingBuffer()
+    // has already drained and cleared it, so the record would be lost.
+    {
+        auto flushStart = TimingClock::now();
+        flushTimingBuffer();
+        auto flushMs = std::chrono::duration<double, std::milli>(
+            TimingClock::now() - flushStart).count();
+        std::clog << "TIMING:flush_timing_buffer:" << flushMs << "\n";
+    }
 
     // error range in shell is [0-255]
     return std::min(listeners.error(), 255);

--- a/projects/hipblaslt/tensilelite/client/src/BenchmarkTimer.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/BenchmarkTimer.cpp
@@ -400,9 +400,6 @@ namespace TensileLite
             m_totalGPUTime += totalTime;
             m_numEnqueuesInSolution += startEvents->size();
 
-            // Report GPU execution time for timing instrumentation
-            reportTiming("gpu_kernel_execution", totalTime.count());
-
             if(m_sleepPercent > 0)
             {
                 auto sleepTime = totalTime * (m_sleepPercent / 100.0);

--- a/projects/hipblaslt/tensilelite/scripts/analyze_timing.py
+++ b/projects/hipblaslt/tensilelite/scripts/analyze_timing.py
@@ -97,8 +97,9 @@ TIMING_HIERARCHY = {
             "pre_solution": {},
             "kernel_solving": {},
             "warmup_runs": {},
-            "benchmark_runs": {},
-            "gpu_kernel_execution": {},
+            "benchmark_runs": {
+                "gpu_kernel_execution": {},
+            },
             "post_solution": {
                 "post_solution_perf_calc": {},
                 "post_solution_reporting": {},
@@ -152,7 +153,6 @@ CPP_PHASE_GROUPS = {
         "kernel_solving",
         "warmup_runs",
         "benchmark_runs",
-        "gpu_kernel_execution",
         "post_solution",
         "post_problem",
         "finalize_report",

--- a/projects/hipblaslt/tensilelite/scripts/analyze_timing.py
+++ b/projects/hipblaslt/tensilelite/scripts/analyze_timing.py
@@ -111,7 +111,11 @@ TIMING_HIERARCHY = {
             },
             "post_problem": {},
             "finalize_report": {},
+            "timing_overhead": {},
+            "flush_timing_buffer": {},
         },
+        "python_timing_overhead": {},
+        "calibrate_python_timing_overhead": {},
     },
     "python_library_logic": {
         "python_logic_parse_solutions": {},
@@ -156,6 +160,10 @@ CPP_PHASE_GROUPS = {
         "post_solution",
         "post_problem",
         "finalize_report",
+    ],
+    "Timing Overhead": [
+        "timing_overhead",
+        "flush_timing_buffer",
     ],
 }
 

--- a/projects/hipblaslt/tensilelite/scripts/analyze_timing.py
+++ b/projects/hipblaslt/tensilelite/scripts/analyze_timing.py
@@ -81,9 +81,10 @@ TIMING_HIERARCHY = {
             "solution_iterator_setup": {},
             "listener_setup": {},
             "reporter_setup": {},
-            "pre_problem": {},
-            "cpu_data_init": {},
-            "cpu_reference_gemm": {},
+            "pre_problem": {
+                "cpu_data_init": {},
+                "cpu_reference_gemm": {},
+            },
             "validate_warmups": {
                 "validate_gpu_sync": {},
                 "validate_gpu_readback": {},
@@ -138,13 +139,11 @@ CPP_PHASE_GROUPS = {
     ],
     "Data Preparation": [
         "pre_problem",
-        "cpu_data_init",
         "gpu_input_preparation",
         "gpu_input_reset",
         "rotating_buffer_preparation",
     ],
     "Reference Computation": [
-        "cpu_reference_gemm",
         "validate_warmups",
     ],
     "Kernel Execution": [

--- a/projects/hipblaslt/tensilelite/scripts/analyze_timing.py
+++ b/projects/hipblaslt/tensilelite/scripts/analyze_timing.py
@@ -107,15 +107,12 @@ TIMING_HIERARCHY = {
                 "post_solution_lib_update": {},
                 "post_solution_perf_reset": {},
                 "post_solution_sol_advance": {},
-                "post_solution_profiler": {},
             },
             "post_problem": {},
             "finalize_report": {},
             "timing_overhead": {},
             "flush_timing_buffer": {},
         },
-        "python_timing_overhead": {},
-        "calibrate_python_timing_overhead": {},
     },
     "python_library_logic": {
         "python_logic_parse_solutions": {},
@@ -227,26 +224,71 @@ class PhaseNode:
     children: List['PhaseNode']
 
 
-def _build_node(name: str, children_dict: Dict, timings: Dict[str, List[float]]) -> Optional['PhaseNode']:
+# Categories that represent instrumentation overhead measurements, not actual work.
+OVERHEAD_CATEGORIES = {'timing_overhead'}
+
+
+def _count_descendant_invocations(children_dict: Dict, timings: Dict[str, List[float]]) -> int:
+    """Count total timer invocations across all descendants in the hierarchy."""
+    count = 0
+    for child_name, grandchildren in children_dict.items():
+        count += len(timings.get(child_name, []))
+        count += _count_descendant_invocations(grandchildren, timings)
+    return count
+
+
+def _compute_per_call_overhead(timings: Dict[str, List[float]]) -> float:
+    """Compute per-call instrumentation overhead from the C++ timing_overhead record.
+
+    The C++ client emits a timing_overhead record containing the total estimated
+    overhead across all ScopedTimer invocations (calibrated at startup).  Dividing
+    by total invocations gives the average overhead each timer call adds to its
+    parent's measurement.
+
+    Note: Python-side timing_context overhead is not tracked or adjusted here.
+    Python has only ~a dozen calls per run, so the overhead is negligible.
+    """
+    total_overhead_ms = sum(timings.get('timing_overhead', []))
+    if total_overhead_ms <= 0:
+        return 0.0
+    total_invocations = sum(
+        len(vals) for cat, vals in timings.items()
+        if cat not in OVERHEAD_CATEGORIES
+    )
+    if total_invocations == 0:
+        return 0.0
+    return total_overhead_ms / total_invocations
+
+
+def _build_node(name: str, children_dict: Dict, timings: Dict[str, List[float]],
+                per_call_overhead_ms: float = 0) -> Optional['PhaseNode']:
     """Build a PhaseNode recursively from the hierarchy dict.
 
     Args:
         name: The timing category name.
         children_dict: Dict of {child_name: grandchildren_dict} from TIMING_HIERARCHY.
         timings: Raw timing data from analyze_timing_file.
+        per_call_overhead_ms: Per-invocation overhead to subtract from parent totals
+            based on descendant invocation count.
     """
     if name not in timings:
         return None
     values = timings[name]
     count = len(values)
-    total_ms = sum(values)
+    raw_total_ms = sum(values)
+
+    # Subtract estimated overhead from descendant timer invocations.
+    # Each descendant invocation adds ~per_call_overhead_ms to this node's
+    # raw measurement via context-manager / RAII bookkeeping.
+    desc_invocations = _count_descendant_invocations(children_dict, timings)
+    total_ms = max(0, raw_total_ms - desc_invocations * per_call_overhead_ms)
     mean_ms = total_ms / count if count > 0 else 0
 
     children = []
     if children_dict:
         child_sum = 0.0
         for child_name, grandchildren in children_dict.items():
-            child_node = _build_node(child_name, grandchildren, timings)
+            child_node = _build_node(child_name, grandchildren, timings, per_call_overhead_ms)
             if child_node:
                 children.append(child_node)
                 child_sum += child_node.total_ms
@@ -291,10 +333,15 @@ def _get_display_children(node: PhaseNode) -> List[PhaseNode]:
 
 
 def build_hierarchy(timings: Dict[str, List[float]]) -> List[PhaseNode]:
-    """Build the phase hierarchy from raw timings, sorted by total time descending."""
+    """Build the phase hierarchy from raw timings, sorted by total time descending.
+
+    Automatically adjusts parent totals by subtracting estimated per-call
+    instrumentation overhead based on descendant invocation counts.
+    """
+    per_call_overhead_ms = _compute_per_call_overhead(timings)
     top_nodes = []
     for phase, children_dict in TIMING_HIERARCHY.items():
-        node = _build_node(phase, children_dict, timings)
+        node = _build_node(phase, children_dict, timings, per_call_overhead_ms)
         if node:
             top_nodes.append(node)
     top_nodes.sort(key=lambda n: n.total_ms, reverse=True)

--- a/projects/hipblaslt/tensilelite/scripts/analyze_timing.py
+++ b/projects/hipblaslt/tensilelite/scripts/analyze_timing.py
@@ -107,6 +107,7 @@ TIMING_HIERARCHY = {
                 "post_solution_lib_update": {},
                 "post_solution_perf_reset": {},
                 "post_solution_sol_advance": {},
+                "post_solution_profiler": {},
             },
             "post_problem": {},
             "finalize_report": {},


### PR DESCRIPTION
## Motivation
Each `ScopedTimer` / `timing_context` call performed string formatting and I/O inline, adding significant overhead that inflated parent timers, especially for bad for high call count but low execution time operations.

Additionally, `gpu_kernel_execution` and `cpu_reference_gemm` were placed at the wrong hierarchy level, making the analysis output misleading.

Follow-up to #6259.

## Technical Details

Overhead reduction
- **Deferred I/O** (`TimingInstrumentation.hpp`, `TimingInstrumentation.py`): Replaced inline `writeLine`/`_timing_logger.info` calls with lightweight buffer appends during measurement. All formatting and I/O now happens in a single `flushTimingBuffer()` call after measurement is complete.
- **Overhead calibration** (`TimingInstrumentation.hpp`, `main.cpp`): Added `calibrateTimingOverhead()` which measures per-call `ScopedTimer` overhead at startup (warmup + 100k iterations). The calibrated value is emitted as a `timing_overhead` record and used by `analyze_timing.py` to subtract instrumentation overhead from parent totals.
- **Buffer pre-allocation** (`TimingInstrumentation.hpp`): `initTimingBuffer()` reserves 2.5M entries upfront to avoid reallocation stalls during benchmarking.
- **Analysis improvements** (`analyze_timing.py`): Added per-call overhead subtraction based on descendant invocation counts, and a new "Timing Overhead" phase group for `timing_overhead` and `flush_timing_buffer`.

Fixes
- **Hierarchy fixes** (`main.cpp`, `BenchmarkTimer.cpp`, `analyze_timing.py`):
  - Moved `gpu_kernel_execution` under `benchmark_runs` (was a sibling, incorrectly double-counted).
  - Moved `cpu_data_init` and `cpu_reference_gemm` under `pre_problem` (where they actually execute).

## Test Plan
Run timing instrumentation end-to-end and verify that parent totals are consistent with child sums after overhead adjustment.

## Test Result
Timing output shows correct parent-child relationships and overhead-adjusted totals.
