### PR TITLE
Separated warning options for clang-23

### DIFF
--- a/projects/miopen/cmake/EnableCompilerWarnings.cmake
+++ b/projects/miopen/cmake/EnableCompilerWarnings.cmake
@@ -23,10 +23,6 @@
 # SOFTWARE.
 #
 ################################################################################
-# - Enable warning all for gcc/clang or use /W4 for visual studio
-
-## Strict warning level
-set(__msvc_cxx_compile_options /W4)
 
 set(__default_cxx_compile_options
     -Wall
@@ -103,35 +99,33 @@ set(__clang_cxx_compile_options
     -Wno-deprecated-builtins
     -Wno-enum-constexpr-conversion
     -Wno-unused-parameter
-    -Wmissing-noreturn
-    -Wno-nrvo
-    -Wno-lifetime-safety
-    -Wno-lifetime-safety-suggestion
-    -Wno-lifetime-safety-intra-tu-suggestions
-    -Wno-lifetime-safety-cross-tu-suggestions)
+    -Wmissing-noreturn)
+
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "19")
     list(APPEND __clang_cxx_compile_options
         -Wno-unique-object-duplication
         -Wno-switch-default
         -Wno-nontrivial-memcall)
 endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "23")
+    list(APPEND __clang_cxx_compile_options
+        -Wno-nrvo
+        -Wno-lifetime-safety
+        -Wno-lifetime-safety-suggestions
+        -Wno-lifetime-safety-intra-tu-suggestions
+        -Wno-lifetime-safety-cross-tu-suggestions)
+endif()
+
 if(WIN32)
     list(APPEND __clang_cxx_compile_options
         -fms-extensions
         -fms-compatibility)
 endif()
 
-set(__gnu_cxx_compile_options
-    -Wno-missing-field-initializers
-)
-
 add_compile_options(
-    "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:MSVC>>:${__msvc_cxx_compile_options}>"
     "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:Clang>>:${__default_cxx_compile_options};${__clang_cxx_compile_options}>"
-    "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:GNU>>:${__default_cxx_compile_options};${__gnu_cxx_compile_options}>"
 )
 
-unset(__msvc_cxx_compile_options)
 unset(__default_cxx_compile_options)
-unset(__gnu_cxx_compile_options)
 unset(__clang_cxx_compile_options)


### PR DESCRIPTION
## Motivation
At adding warning options should check the compiler version