### PR TITLE
[CK] Replace inline asm tile loads with intrinsics in FMHA forward qr_async pipeline

### DIFF
--- a/projects/composablekernel/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs_async.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs_async.hpp
@@ -260,15 +260,8 @@ struct BlockFmhaPipelineQRKSVSAsync
                                               q_dram_block_window_tmp.get_window_lengths(),
                                               q_dram_block_window_tmp.get_window_origin(),
                                               Policy::template MakeQRegTileDistribution<Problem>());
-        q_dram_window.init_raw();
-
-        // TODO: we use async Copy for K, which is inline asm
-        // a side effect is we have to use inline asm for q as well
-        auto q = decltype(load_tile(q_dram_window)){};
-        // TODO: start from rocm-6.2, compiler will have problem if manually set clear of q.
-        // however, q would be cleared in the constructor of static distributed tensor
-        // set_tile(q, number<0>{}); // use per-dword clear to avoid scratch
-        load_tile_raw(q, q_dram_window);
+        auto q             = decltype(load_tile(q_dram_window)){};
+        load_tile(q, q_dram_window);
         __builtin_amdgcn_sched_barrier(0);
 
         using SaccBlockTileType = decltype(gemm_0.MakeCBlockTile());


### PR DESCRIPTION
## Summary

Replace `load_tile_raw(q, q_dram_window)` with `load_tile(q, q_dram_window)` in the qr_async FMHA forward pipeline. This makes the Q DRAM load visible to the compiler's instruction scheduler, enabling proper `s_waitcnt` insertion for RAW hazard protection when VGPR spills occur.

K/V loads remain as `_raw` variants.

## Motivation

The `_raw` load variants use inline `asm volatile` which is opaque to the compiler. When VGPR spills occur (common in M0=128 tile kernels — 44/96 qr_async kernels already spill on baseline), the compiler cannot insert `s_waitcnt vmcnt()` instructions to guard spill/reload operations, leading to potential RAW data hazards.

Specifically, `load_tile_raw()` issues Q `buffer_load` instructions inside `asm volatile` blocks. If the compiler later spills the destination VGPRs to scratch memory, it must insert `s_waitcnt vmcnt(0)` before the `scratch_store` to ensure the `buffer_load` has completed — otherwise the spill reads stale VGPR values. But because the `buffer_load` is inside `asm volatile`, the compiler cannot see the pending memory operation and may omit the necessary `vmcnt` wait. This creates a silent RAW hazard: the scratch spill captures the old register value before the load writes the new one.

This is particularly critical for small seqlen cases (e.g., seqlen=512, batch=32) where the Q tile is loaded once in the prologue and reloaded from scratch every iteration of the inner loop. With fewer iterations, the corrupted Q values affect a larger fraction of the output. At larger seqlens the impact is diluted across more K/V tiles, but the hazard is still present.

The intrinsic-based `load_tile()` makes Q loads visible to the compiler, enabling correct `s_waitcnt vmcnt()` insertion around spill/reload operations.

## Design Decisions

**Q-only, not Q+K+V:** Switching K/V to intrinsic-based `async_load_tile()` causes +13-14 bf16 VGPR spills (18→32) and 7-10% regression. The K `async_load_tile()` makes DRAM→LDS async copies visible to the register allocator, expanding live ranges. Since K/V async copies go DRAM→LDS (not to VGPRs), spill RAW hazards are less critical for them. Q loads go DRAM→VGPRs where spill hazards matter most.

**Branching OOB serializes Q loads in the prologue (known cost):** With the default `oob_conditional_check=true`, the compiler wraps each Q chunk's `buffer_load_dwordx4` in its own basic block (`s_and_saveexec` + `s_cbranch_execz`). When the register allocator cannot assign contiguous VGPRs for the load destination, it inserts `v_mov_b32` instructions to copy the results into the target registers. These `v_mov` instructions read the `buffer_load` result, which forces an `s_waitcnt vmcnt(0)` before each copy — serializing all 8 Q loads. `load_tile_raw()` also issues each `buffer_load` in a separate `asm volatile` block (8 blocks, one per chunk), but because the loads are opaque to the compiler, no `vmcnt` is inserted between them — all 8 can be in-flight simultaneously, with only a single deferred `buffer_load_fence()` after all 8. This serialization lengthens the prologue, which is why bf16 at small seqlen (s=512) shows ~3-5% regression — the prologue cost is a larger fraction of total kernel time. At larger seqlens the inner loop dominates and the prologue overhead is negligible.

**No OOB offset trick:** The `CK_TILE_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK` branchless address-shift mechanism avoids the above serialization, but causes a worse 5-7% regression across all seqlens due to increased register pressure from the address-shift computation (`v_bfrev + v_cndmask + v_add` per chunk). The branching OOB path is the lesser cost — regression is limited to small seqlens where the prologue dominates.

**No policy/descriptor changes:** The Q-only change requires no new policy classes, no LDS descriptor changes, and no fence/waitcnt mapping changes. It is a single-line functional change in the pipeline file.

## Performance (d=128, bhsd layout, qr_async pipeline, gfx950)

3-way interleaved benchmark on idle GPUs. Pre-built binaries, run order: NoTrick(6) → Baseline(6) → Trick(6) → NoTrick(6) → Baseline(6) → Trick(6). Discard run 1 warmup, average runs 2-6, merge both rounds.

- **Baseline**: develop (`load_tile_raw`)
- **NoTrick**: `load_tile(q, q_dram_window)` with default OOB check (this PR)
- **Trick**: `load_tile` with `oob_use_offset_trick=true` (evaluated, not shipped)

| dtype | batch | seqlen | Baseline TFlops | NoTrick TFlops | Trick TFlops | NoTrick vs Baseline | Trick vs Baseline |
|-------|-------|--------|-----------------|----------------|--------------|---------------------|-------------------|
| fp16 | 32 | 512 | 450.79 | 460.19 | 436.61 | +2.1% | -3.1% |
| fp16 | 16 | 1024 | 535.28 | 544.83 | 512.73 | +1.8% | -4.2% |
| fp16 | 8 | 2048 | 616.52 | 641.89 | 593.52 | +4.1% | -3.7% |
| fp16 | 4 | 4096 | 715.91 | 735.63 | 689.45 | +2.8% | -3.7% |
| fp16 | 2 | 8192 | 795.75 | 813.38 | 757.83 | +2.2% | -4.8% |
| fp16 | 1 | 16384 | 835.00 | 849.59 | 799.19 | +1.7% | -4.3% |
| bf16 | 32 | 512 | 488.10 | 470.92 | 458.12 | -3.5% | -6.1% |
| bf16 | 16 | 1024 | 570.36 | 563.38 | 536.00 | -1.2% | -6.0% |
| bf16 | 8 | 2048 | 663.43 | 656.90 | 619.32 | -1.0% | -6.6% |
| bf16 | 4 | 4096 | 758.53 | 754.84 | 710.49 | -0.5% | -6.3% |
| bf16 | 2 | 8192 | 842.95 | 837.79 | 780.59 | -0.6% | -7.4% |
| bf16 | 1 | 16384 | 875.81 | 866.47 | 828.37 | -1.1% | -5.4% |

**NoTrick (this PR) vs Baseline:** bf16 within 1% for seqlen >= 2048, ~3-5% regression at s=512 due to prologue Q load serialization. fp16 within noise (+2-4%). The prologue cost is a one-time overhead that diminishes at larger seqlens.
**Trick vs Baseline:** 5-7% regression across all seqlens — the OOB offset trick is not used.

## Regression Tests

0 failures across all 5 dtype test targets (6335 total tests), matching develop baseline exactly.

| dtype | Total | Passed | Failed | Skipped |
|-------|-------|--------|--------|---------|
| fp16 | 2491 | 2491 | 0 | 0 |
| bf16 | 2491 | 2491 | 0 | 0 |
| fp8bf16 | 707 | 43 | 0 | 664 |
| mxfp8 | 323 | 83 | 0 | 240 |
| mxfp4 | 323 | 83 | 0 | 240 |

## Test Plan

- [x] All FMHA forward regression tests pass (5 dtypes, 6335 tests)
- [x] Performance benchmarked with interleaved methodology on idle GPUs
- [x] Padded hdim cases verified (hdim 24, 40, 96 — previously caught a bug)