### PR TITLE
feat(rocprim): add support for graph captures in device segmented radix sort 

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/detail/various.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/detail/various.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -679,6 +679,18 @@ public:
         return ret;
     }
 };
+
+ROCPRIM_INLINE
+hipError_t is_graph_capture(hipStream_t stream, bool& is_capturing)
+{
+    hipStreamCaptureStatus status;
+    unsigned long long     id;
+    ROCPRIM_RETURN_ON_ERROR(hipStreamGetCaptureInfo(stream, &status, &id));
+
+    is_capturing = status != hipStreamCaptureStatus::hipStreamCaptureStatusNone;
+
+    return hipSuccess;
+}
 
 } // end namespace detail
 END_ROCPRIM_NAMESPACE

--- a/projects/rocprim/rocprim/include/rocprim/device/device_segmented_radix_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_segmented_radix_sort.hpp
@@ -161,8 +161,9 @@ inline hipError_t segmented_radix_sort_impl(
     const auto params = get_config<Selector>(Config{}, current_target);
 
     static constexpr bool with_values = !std::is_same<value_type, ::rocprim::empty_type>::value;
-    const bool            partitioning_allowed     = params.warp_sort_config.partitioning_allowed;
-    const unsigned int    max_small_segment_length = params.warp_sort_config.items_per_thread_small
+
+    const bool         config_allows_partitioning = params.warp_sort_config.partitioning_allowed;
+    const unsigned int max_small_segment_length   = params.warp_sort_config.items_per_thread_small
                                                   * params.warp_sort_config.logical_warp_size_small;
     const unsigned int small_segments_per_block = params.warp_sort_config.block_size_small
                                                   / params.warp_sort_config.logical_warp_size_small;
@@ -194,8 +195,22 @@ inline hipError_t segmented_radix_sort_impl(
     const unsigned int iterations         = ::rocprim::detail::ceiling_div(bits, params.radix_bits);
     const bool         to_output          = with_double_buffer || (iterations - 1) % 2 == 0;
     is_result_in_output                   = (iterations % 2 == 0) != to_output;
-    const bool do_partitioning
-        = partitioning_allowed && segments >= params.warp_sort_config.partitioning_threshold;
+
+    // Check if the stream is a graph capture. Partitioning is not allowed under graph
+    // capture since the number, since the launch parameters are dependend on the results
+    // of partioning.
+    //
+    // This has implications on performance under graph capture and should be investigated
+    // in the future.
+    bool is_graph_capture;
+    ROCPRIM_RETURN_ON_ERROR(::rocprim::detail::is_graph_capture(stream, is_graph_capture));
+
+    // We only allow partitioning if:
+    //   - The config allows it,
+    //   - The number of segments is significant enough, and
+    //   - We are not a graph capture.
+    const bool do_partitioning = config_allows_partitioning && !is_graph_capture
+                                 && segments >= params.warp_sort_config.partitioning_threshold;
 
     const size_t medium_segment_indices_size = three_way_partitioning ? segments : 0;
     const size_t segment_count_output_size   = three_way_partitioning ? 2 : 1;

--- a/projects/rocprim/test/rocprim/test_device_segmented_radix_sort.cpp.in
+++ b/projects/rocprim/test/rocprim/test_device_segmented_radix_sort.cpp.in
@@ -36,36 +36,36 @@
 #cmakedefine ROCPRIM_TEST_TYPE_SLICE  @ROCPRIM_TEST_TYPE_SLICE@
 
 #if   ROCPRIM_TEST_SUITE_SLICE == 0
-    TYPED_TEST_P(SUITE, SortKeys                ) { sort_keys<TestFixture>(); } 
+    TYPED_TEST_P(SUITE, SortKeys                ) { sort_keys<TestFixture>(); }
     REGISTER_TYPED_TEST_SUITE_P(SUITE, SortKeys);
 #elif ROCPRIM_TEST_SUITE_SLICE == 1
-    TYPED_TEST_P(SUITE, SortPairs               ) { sort_pairs<TestFixture>(); } 
+    TYPED_TEST_P(SUITE, SortPairs               ) { sort_pairs<TestFixture>(); }
     REGISTER_TYPED_TEST_SUITE_P(SUITE, SortPairs);
 #elif ROCPRIM_TEST_SUITE_SLICE == 2
-    TYPED_TEST_P(SUITE, SortKeysDoubleBuffer    ) { sort_keys_double_buffer<TestFixture>(); } 
+    TYPED_TEST_P(SUITE, SortKeysDoubleBuffer    ) { sort_keys_double_buffer<TestFixture>(); }
     REGISTER_TYPED_TEST_SUITE_P(SUITE, SortKeysDoubleBuffer);
 #elif ROCPRIM_TEST_SUITE_SLICE == 3
-    TYPED_TEST_P(SUITE, SortPairsDoubleBuffer   ) { sort_pairs_double_buffer<TestFixture>(); } 
+    TYPED_TEST_P(SUITE, SortPairsDoubleBuffer   ) { sort_pairs_double_buffer<TestFixture>(); }
     REGISTER_TYPED_TEST_SUITE_P(SUITE, SortPairsDoubleBuffer);
 #elif ROCPRIM_TEST_SUITE_SLICE == 4
-    TYPED_TEST_P(SUITE, SortKeysEmptyData       ) { sort_keys_empty_data<TestFixture>(); } 
+    TYPED_TEST_P(SUITE, SortKeysEmptyData       ) { sort_keys_empty_data<TestFixture>(); }
     REGISTER_TYPED_TEST_SUITE_P(SUITE, SortKeysEmptyData);
 #elif ROCPRIM_TEST_SUITE_SLICE == 5
-    TYPED_TEST_P(SUITE, SortKeysLargeSegments   ) { sort_keys_large_segments<TestFixture>(); } 
+    TYPED_TEST_P(SUITE, SortKeysLargeSegments   ) { sort_keys_large_segments<TestFixture>(); }
     REGISTER_TYPED_TEST_SUITE_P(SUITE, SortKeysLargeSegments);
 #elif ROCPRIM_TEST_SUITE_SLICE == 6
-    TYPED_TEST_P(SUITE, SortKeysUnspecifiedRanges   ) { sort_keys_unspecified_ranges<TestFixture>(); } 
+    TYPED_TEST_P(SUITE, SortKeysUnspecifiedRanges   ) { sort_keys_unspecified_ranges<TestFixture>(); }
     REGISTER_TYPED_TEST_SUITE_P(SUITE, SortKeysUnspecifiedRanges);
 #elif ROCPRIM_TEST_SUITE_SLICE == 7
-    TYPED_TEST_P(SUITE, SortPairsUnspecifiedRanges   ) { sort_pairs_unspecified_ranges<TestFixture>(); } 
+    TYPED_TEST_P(SUITE, SortPairsUnspecifiedRanges   ) { sort_pairs_unspecified_ranges<TestFixture>(); }
     REGISTER_TYPED_TEST_SUITE_P(SUITE, SortPairsUnspecifiedRanges);
 #endif
 
 #if ROCPRIM_TEST_TYPE_SLICE == 0
-    INSTANTIATE(params<signed char,         double,                             true,   0, 8,   0,      1000,  config_default>)
-    INSTANTIATE(params<int,                 short,                              false,  0, 32,  0,      100,   config_semi_custom>)
-    INSTANTIATE(params<short,               int,                                true,   0, 16,  0,      10000, config_semi_custom_warp_config>)
-    INSTANTIATE(params<long long,           common::custom_type<char, char, true>, false,  0, 64,  4000,   8000,  config_custom>)
+    INSTANTIATE(params<signed char,         double,                             true,   0, 8,   0,      1000,  false, config_default>)
+    INSTANTIATE(params<int,                 short,                              false,  0, 32,  0,      100,   false, config_semi_custom>)
+    INSTANTIATE(params<short,               int,                                true,   0, 16,  0,      10000, false, config_semi_custom_warp_config>)
+    INSTANTIATE(params<long long,           common::custom_type<char, char, true>, false,  0, 64,  4000,   8000,  false, config_custom>)
 #elif ROCPRIM_TEST_TYPE_SLICE == 1
     INSTANTIATE(params<double,              unsigned int,                       false,  0, 64,  2,      10>)
     INSTANTIATE(params<int8_t,              int8_t,                             true,   0, 8,   2000,   10000>)
@@ -97,4 +97,6 @@
 #elif ROCPRIM_TEST_TYPE_SLICE == 6
     INSTANTIATE(params<unsigned long long,  char,                                   false,  8, 20,  0,      1000>)
     INSTANTIATE(params<unsigned short,      common::custom_type<double, double, true>,   false,  8, 11,  50,     200>)
+    INSTANTIATE(params<unsigned short,      int,                                    true,   4, 10,  0,      10000, true>)
+    INSTANTIATE(params<unsigned int,        double,                                 true,   4, 21,  100,    100000, true>)
 #endif

--- a/projects/rocprim/test/rocprim/test_device_segmented_radix_sort.hpp
+++ b/projects/rocprim/test/rocprim/test_device_segmented_radix_sort.hpp
@@ -183,63 +183,40 @@ inline void sort_keys()
 
             common::device_ptr<offset_type> d_offsets(offsets);
 
-            size_t temporary_storage_bytes = 0;
-            HIP_CHECK(rocprim::segmented_radix_sort_keys<config>(nullptr,
-                                                                 temporary_storage_bytes,
-                                                                 d_keys_input.get(),
-                                                                 d_keys_output.get(),
-                                                                 size,
-                                                                 segments_count,
-                                                                 d_offsets.get(),
-                                                                 d_offsets.get() + 1,
-                                                                 start_bit,
-                                                                 end_bit));
-
-            ASSERT_GT(temporary_storage_bytes, 0U);
-
-            common::device_ptr<void> d_temporary_storage(temporary_storage_bytes);
-
-            test_utils::GraphHelper gHelper;
-            if(use_graphs)
-            {
-                gHelper.startStreamCapture(stream);
-            }
-
-            if(descending)
-            {
-                HIP_CHECK(rocprim::segmented_radix_sort_keys_desc<config>(d_temporary_storage.get(),
-                                                                          temporary_storage_bytes,
-                                                                          d_keys_input.get(),
-                                                                          d_keys_output.get(),
-                                                                          size,
-                                                                          segments_count,
-                                                                          d_offsets.get(),
-                                                                          d_offsets.get() + 1,
-                                                                          start_bit,
-                                                                          end_bit,
-                                                                          stream,
-                                                                          debug_synchronous));
-            }
-            else
-            {
-                HIP_CHECK(rocprim::segmented_radix_sort_keys<config>(d_temporary_storage.get(),
-                                                                     temporary_storage_bytes,
-                                                                     d_keys_input.get(),
-                                                                     d_keys_output.get(),
-                                                                     size,
-                                                                     segments_count,
-                                                                     d_offsets.get(),
-                                                                     d_offsets.get() + 1,
-                                                                     start_bit,
-                                                                     end_bit,
-                                                                     stream,
-                                                                     debug_synchronous));
-            }
-
-            if(use_graphs)
-            {
-                gHelper.createAndLaunchGraph(stream);
-            }
+            test_utils::test_kernel_wrapper(
+                [&](void* d_temporary_storage, auto& temporary_storage_bytes)
+                {
+                    if(descending)
+                    {
+                        return rocprim::segmented_radix_sort_keys_desc<config>(
+                            d_temporary_storage,
+                            temporary_storage_bytes,
+                            d_keys_input.get(),
+                            d_keys_output.get(),
+                            size,
+                            segments_count,
+                            d_offsets.get(),
+                            d_offsets.get() + 1,
+                            start_bit,
+                            end_bit,
+                            stream,
+                            debug_synchronous);
+                    }
+                    return rocprim::segmented_radix_sort_keys<config>(d_temporary_storage,
+                                                                      temporary_storage_bytes,
+                                                                      d_keys_input.get(),
+                                                                      d_keys_output.get(),
+                                                                      size,
+                                                                      segments_count,
+                                                                      d_offsets.get(),
+                                                                      d_offsets.get() + 1,
+                                                                      start_bit,
+                                                                      end_bit,
+                                                                      stream,
+                                                                      debug_synchronous);
+                },
+                stream,
+                use_graphs);
 
             // Calculate expected results on host
             std::vector<key_type> expected(keys_input);
@@ -254,11 +231,6 @@ inline void sort_keys()
             const auto keys_output = d_keys_output.load();
 
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(keys_output, expected));
-
-            if(use_graphs)
-            {
-                gHelper.cleanupGraphHelper();
-            }
         }
     }
 }
@@ -310,30 +282,27 @@ inline void sort_keys_empty_data()
 
             common::device_ptr<offset_type> d_offsets(offsets);
 
-            size_t temporary_storage_bytes = 0;
-            HIP_CHECK(rocprim::segmented_radix_sort_keys<config>(nullptr,
-                                                                 temporary_storage_bytes,
-                                                                 d_keys.get(),
-                                                                 d_keys.get(),
-                                                                 size,
-                                                                 segments_count,
-                                                                 d_offsets.get(),
-                                                                 d_offsets.get() + 1,
-                                                                 start_bit,
-                                                                 end_bit));
-
-            ASSERT_GT(temporary_storage_bytes, 0U);
-
-            common::device_ptr<void> d_temporary_storage(temporary_storage_bytes);
-
-            test_utils::GraphHelper gHelper;
-            if(use_graphs)
-            {
-                gHelper.startStreamCapture(stream);
-            }
-            if(descending)
-            {
-                HIP_CHECK(rocprim::segmented_radix_sort_keys_desc<config>(d_temporary_storage.get(),
+            test_utils::test_kernel_wrapper(
+                [&](void* d_temporary_storage, auto& temporary_storage_bytes)
+                {
+                    if constexpr(descending)
+                    {
+                        return rocprim::segmented_radix_sort_keys_desc<config>(
+                            d_temporary_storage,
+                            temporary_storage_bytes,
+                            d_keys.get(),
+                            d_keys.get(),
+                            size,
+                            segments_count,
+                            d_offsets.get(),
+                            d_offsets.get() + 1,
+                            start_bit,
+                            end_bit,
+                            stream);
+                    }
+                    else
+                    {
+                        return rocprim::segmented_radix_sort_keys<config>(d_temporary_storage,
                                                                           temporary_storage_bytes,
                                                                           d_keys.get(),
                                                                           d_keys.get(),
@@ -343,37 +312,16 @@ inline void sort_keys_empty_data()
                                                                           d_offsets.get() + 1,
                                                                           start_bit,
                                                                           end_bit,
-                                                                          stream));
-            }
-            else
-            {
-                HIP_CHECK(rocprim::segmented_radix_sort_keys<config>(d_temporary_storage.get(),
-                                                                     temporary_storage_bytes,
-                                                                     d_keys.get(),
-                                                                     d_keys.get(),
-                                                                     size,
-                                                                     segments_count,
-                                                                     d_offsets.get(),
-                                                                     d_offsets.get() + 1,
-                                                                     start_bit,
-                                                                     end_bit,
-                                                                     stream));
-            }
-
-            if(use_graphs)
-            {
-                gHelper.createAndLaunchGraph(stream);
-            }
+                                                                          stream);
+                    }
+                },
+                stream,
+                use_graphs);
 
             const auto keys_output = d_keys.load();
 
             // Output should not have changed
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(keys_output, keys_input));
-
-            if(use_graphs)
-            {
-                gHelper.cleanupGraphHelper();
-            }
         }
     }
 }
@@ -426,30 +374,26 @@ inline void sort_keys_large_segments()
 
         common::device_ptr<offset_type> d_offsets(offsets);
 
-        size_t temporary_storage_bytes = 0;
-        HIP_CHECK(rocprim::segmented_radix_sort_keys<config>(nullptr,
-                                                             temporary_storage_bytes,
-                                                             d_keys_input.get(),
-                                                             d_keys_output.get(),
-                                                             size,
-                                                             segments_count,
-                                                             d_offsets.get(),
-                                                             d_offsets.get() + 1,
-                                                             start_bit,
-                                                             end_bit));
-
-        ASSERT_GT(temporary_storage_bytes, 0U);
-
-        common::device_ptr<void> d_temporary_storage(temporary_storage_bytes);
-
-        test_utils::GraphHelper gHelper;
-        if(use_graphs)
-        {
-            gHelper.startStreamCapture(stream);
-        }
-        if(descending)
-        {
-            HIP_CHECK(rocprim::segmented_radix_sort_keys_desc<config>(d_temporary_storage.get(),
+        test_utils::test_kernel_wrapper(
+            [&](void* d_temporary_storage, auto& temporary_storage_bytes)
+            {
+                if constexpr(descending)
+                {
+                    return rocprim::segmented_radix_sort_keys_desc<config>(d_temporary_storage,
+                                                                           temporary_storage_bytes,
+                                                                           d_keys_input.get(),
+                                                                           d_keys_output.get(),
+                                                                           size,
+                                                                           segments_count,
+                                                                           d_offsets.get(),
+                                                                           d_offsets.get() + 1,
+                                                                           start_bit,
+                                                                           end_bit,
+                                                                           stream);
+                }
+                else
+                {
+                    return rocprim::segmented_radix_sort_keys<config>(d_temporary_storage,
                                                                       temporary_storage_bytes,
                                                                       d_keys_input.get(),
                                                                       d_keys_output.get(),
@@ -459,26 +403,11 @@ inline void sort_keys_large_segments()
                                                                       d_offsets.get() + 1,
                                                                       start_bit,
                                                                       end_bit,
-                                                                      stream));
-        }
-        else
-        {
-            HIP_CHECK(rocprim::segmented_radix_sort_keys<config>(d_temporary_storage.get(),
-                                                                 temporary_storage_bytes,
-                                                                 d_keys_input.get(),
-                                                                 d_keys_output.get(),
-                                                                 size,
-                                                                 segments_count,
-                                                                 d_offsets.get(),
-                                                                 d_offsets.get() + 1,
-                                                                 start_bit,
-                                                                 end_bit,
-                                                                 stream));
-        }
-        if(use_graphs)
-        {
-            gHelper.createAndLaunchGraph(stream);
-        }
+                                                                      stream);
+                }
+            },
+            stream,
+            use_graphs);
 
         bool all_blocks_sorted = true;
         for(size_t s = 0; s < segments_count; ++s)
@@ -489,10 +418,6 @@ inline void sort_keys_large_segments()
                 test_utils::key_comparator<key_type, descending, start_bit, end_bit>());
         }
         ASSERT_TRUE(all_blocks_sorted);
-        if(use_graphs)
-        {
-            gHelper.cleanupGraphHelper();
-        }
     }
 }
 
@@ -589,18 +514,27 @@ inline void sort_keys_unspecified_ranges()
                                                                  start_bit,
                                                                  end_bit));
 
-            ASSERT_GT(temporary_storage_bytes, 0U);
-
-            common::device_ptr<void> d_temporary_storage(temporary_storage_bytes);
-
-            test_utils::GraphHelper gHelper;
-            if(use_graphs)
-            {
-                gHelper.startStreamCapture(stream);
-            }
-            if(descending)
-            {
-                HIP_CHECK(rocprim::segmented_radix_sort_keys_desc<config>(d_temporary_storage.get(),
+            test_utils::test_kernel_wrapper(
+                [&](void* d_temporary_storage, auto& temporary_storage_bytes)
+                {
+                    if constexpr(descending)
+                    {
+                        return rocprim::segmented_radix_sort_keys_desc<config>(
+                            d_temporary_storage,
+                            temporary_storage_bytes,
+                            d_keys_input.get(),
+                            d_keys_output.get(),
+                            size,
+                            segments_count,
+                            d_offsets_begin.get(),
+                            d_offsets_end.get(),
+                            start_bit,
+                            end_bit,
+                            stream);
+                    }
+                    else
+                    {
+                        return rocprim::segmented_radix_sort_keys<config>(d_temporary_storage,
                                                                           temporary_storage_bytes,
                                                                           d_keys_input.get(),
                                                                           d_keys_output.get(),
@@ -610,26 +544,11 @@ inline void sort_keys_unspecified_ranges()
                                                                           d_offsets_end.get(),
                                                                           start_bit,
                                                                           end_bit,
-                                                                          stream));
-            }
-            else
-            {
-                HIP_CHECK(rocprim::segmented_radix_sort_keys<config>(d_temporary_storage.get(),
-                                                                     temporary_storage_bytes,
-                                                                     d_keys_input.get(),
-                                                                     d_keys_output.get(),
-                                                                     size,
-                                                                     segments_count,
-                                                                     d_offsets_begin.get(),
-                                                                     d_offsets_end.get(),
-                                                                     start_bit,
-                                                                     end_bit,
-                                                                     stream));
-            }
-            if(use_graphs)
-            {
-                gHelper.createAndLaunchGraph(stream);
-            }
+                                                                          stream);
+                    }
+                },
+                stream,
+                use_graphs);
 
             // Calculate expected results on host
             std::vector<key_type> expected(keys_input);
@@ -644,10 +563,6 @@ inline void sort_keys_unspecified_ranges()
             const auto keys_output = d_keys_output.load();
 
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(keys_output, expected));
-            if(use_graphs)
-            {
-                gHelper.cleanupGraphHelper();
-            }
         }
     }
 }
@@ -726,68 +641,47 @@ inline void sort_pairs()
 
             using key_value = std::pair<key_type, value_type>;
 
-            size_t temporary_storage_bytes = 0;
-            HIP_CHECK(rocprim::segmented_radix_sort_pairs<config>(nullptr,
-                                                                  temporary_storage_bytes,
-                                                                  d_keys_input.get(),
-                                                                  d_keys_output.get(),
-                                                                  d_values_input.get(),
-                                                                  d_values_output.get(),
-                                                                  size,
-                                                                  segments_count,
-                                                                  d_offsets.get(),
-                                                                  d_offsets.get() + 1,
-                                                                  start_bit,
-                                                                  end_bit));
-
-            ASSERT_GT(temporary_storage_bytes, 0U);
-
-            common::device_ptr<void> d_temporary_storage(temporary_storage_bytes);
-
-            test_utils::GraphHelper gHelper;
-            if(use_graphs)
-            {
-                gHelper.startStreamCapture(stream);
-            }
-            if(descending)
-            {
-                HIP_CHECK(
-                    rocprim::segmented_radix_sort_pairs_desc<config>(d_temporary_storage.get(),
-                                                                     temporary_storage_bytes,
-                                                                     d_keys_input.get(),
-                                                                     d_keys_output.get(),
-                                                                     d_values_input.get(),
-                                                                     d_values_output.get(),
-                                                                     size,
-                                                                     segments_count,
-                                                                     d_offsets.get(),
-                                                                     d_offsets.get() + 1,
-                                                                     start_bit,
-                                                                     end_bit,
-                                                                     stream,
-                                                                     debug_synchronous));
-            }
-            else
-            {
-                HIP_CHECK(rocprim::segmented_radix_sort_pairs<config>(d_temporary_storage.get(),
-                                                                      temporary_storage_bytes,
-                                                                      d_keys_input.get(),
-                                                                      d_keys_output.get(),
-                                                                      d_values_input.get(),
-                                                                      d_values_output.get(),
-                                                                      size,
-                                                                      segments_count,
-                                                                      d_offsets.get(),
-                                                                      d_offsets.get() + 1,
-                                                                      start_bit,
-                                                                      end_bit,
-                                                                      stream,
-                                                                      debug_synchronous));
-            }
-            if(use_graphs)
-            {
-                gHelper.createAndLaunchGraph(stream);
-            }
+            test_utils::test_kernel_wrapper(
+                [&](void* d_temporary_storage, auto& temporary_storage_bytes)
+                {
+                    if constexpr(descending)
+                    {
+                        return rocprim::segmented_radix_sort_pairs_desc<config>(
+                            d_temporary_storage,
+                            temporary_storage_bytes,
+                            d_keys_input.get(),
+                            d_keys_output.get(),
+                            d_values_input.get(),
+                            d_values_output.get(),
+                            size,
+                            segments_count,
+                            d_offsets.get(),
+                            d_offsets.get() + 1,
+                            start_bit,
+                            end_bit,
+                            stream,
+                            debug_synchronous);
+                    }
+                    else
+                    {
+                        return rocprim::segmented_radix_sort_pairs<config>(d_temporary_storage,
+                                                                           temporary_storage_bytes,
+                                                                           d_keys_input.get(),
+                                                                           d_keys_output.get(),
+                                                                           d_values_input.get(),
+                                                                           d_values_output.get(),
+                                                                           size,
+                                                                           segments_count,
+                                                                           d_offsets.get(),
+                                                                           d_offsets.get() + 1,
+                                                                           start_bit,
+                                                                           end_bit,
+                                                                           stream,
+                                                                           debug_synchronous);
+                    }
+                },
+                stream,
+                use_graphs);
 
             // Calculate expected results on host
             std::vector<key_value> expected(size);
@@ -818,10 +712,6 @@ inline void sort_pairs()
 
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(keys_output, keys_expected));
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(values_output, values_expected));
-            if(use_graphs)
-            {
-                gHelper.cleanupGraphHelper();
-            }
         }
     }
 }
@@ -916,66 +806,45 @@ inline void sort_pairs_unspecified_ranges()
 
             using key_value = std::pair<key_type, value_type>;
 
-            size_t temporary_storage_bytes = 0;
-            HIP_CHECK(rocprim::segmented_radix_sort_pairs<config>(nullptr,
-                                                                  temporary_storage_bytes,
-                                                                  d_keys_input.get(),
-                                                                  d_keys_output.get(),
-                                                                  d_values_input.get(),
-                                                                  d_values_output.get(),
-                                                                  size,
-                                                                  segments_count,
-                                                                  d_offsets_begin.get(),
-                                                                  d_offsets_end.get(),
-                                                                  start_bit,
-                                                                  end_bit));
-
-            ASSERT_GT(temporary_storage_bytes, 0U);
-
-            common::device_ptr<void> d_temporary_storage(temporary_storage_bytes);
-
-            test_utils::GraphHelper gHelper;
-            if(use_graphs)
-            {
-                gHelper.startStreamCapture(stream);
-            }
-            if(descending)
-            {
-                HIP_CHECK(
-                    rocprim::segmented_radix_sort_pairs_desc<config>(d_temporary_storage.get(),
-                                                                     temporary_storage_bytes,
-                                                                     d_keys_input.get(),
-                                                                     d_keys_output.get(),
-                                                                     d_values_input.get(),
-                                                                     d_values_output.get(),
-                                                                     size,
-                                                                     segments_count,
-                                                                     d_offsets_begin.get(),
-                                                                     d_offsets_end.get(),
-                                                                     start_bit,
-                                                                     end_bit,
-                                                                     stream));
-            }
-            else
-            {
-                HIP_CHECK(rocprim::segmented_radix_sort_pairs<config>(d_temporary_storage.get(),
-                                                                      temporary_storage_bytes,
-                                                                      d_keys_input.get(),
-                                                                      d_keys_output.get(),
-                                                                      d_values_input.get(),
-                                                                      d_values_output.get(),
-                                                                      size,
-                                                                      segments_count,
-                                                                      d_offsets_begin.get(),
-                                                                      d_offsets_end.get(),
-                                                                      start_bit,
-                                                                      end_bit,
-                                                                      stream));
-            }
-            if(use_graphs)
-            {
-                gHelper.createAndLaunchGraph(stream);
-            }
+            test_utils::test_kernel_wrapper(
+                [&](void* d_temporary_storage, auto& temporary_storage_bytes)
+                {
+                    if constexpr(descending)
+                    {
+                        return rocprim::segmented_radix_sort_pairs_desc<config>(
+                            d_temporary_storage,
+                            temporary_storage_bytes,
+                            d_keys_input.get(),
+                            d_keys_output.get(),
+                            d_values_input.get(),
+                            d_values_output.get(),
+                            size,
+                            segments_count,
+                            d_offsets_begin.get(),
+                            d_offsets_end.get(),
+                            start_bit,
+                            end_bit,
+                            stream);
+                    }
+                    else
+                    {
+                        return rocprim::segmented_radix_sort_pairs<config>(d_temporary_storage,
+                                                                           temporary_storage_bytes,
+                                                                           d_keys_input.get(),
+                                                                           d_keys_output.get(),
+                                                                           d_values_input.get(),
+                                                                           d_values_output.get(),
+                                                                           size,
+                                                                           segments_count,
+                                                                           d_offsets_begin.get(),
+                                                                           d_offsets_end.get(),
+                                                                           start_bit,
+                                                                           end_bit,
+                                                                           stream);
+                    }
+                },
+                stream,
+                use_graphs);
 
             // Calculate expected results on host
             std::vector<key_value> expected(size);
@@ -1001,10 +870,6 @@ inline void sort_pairs_unspecified_ranges()
             {
                 ASSERT_EQ(keys_output[i], expected[i].first);
                 ASSERT_EQ(values_output[i], expected[i].second);
-            }
-            if(use_graphs)
-            {
-                gHelper.cleanupGraphHelper();
             }
         }
     }
@@ -1077,29 +942,27 @@ inline void sort_keys_double_buffer()
 
             rocprim::double_buffer<key_type> d_keys(d_keys_input.get(), d_keys_output.get());
 
-            size_t temporary_storage_bytes = 0;
-            HIP_CHECK(rocprim::segmented_radix_sort_keys<config>(nullptr,
-                                                                 temporary_storage_bytes,
-                                                                 d_keys,
-                                                                 size,
-                                                                 segments_count,
-                                                                 d_offsets.get(),
-                                                                 d_offsets.get() + 1,
-                                                                 start_bit,
-                                                                 end_bit));
-
-            ASSERT_GT(temporary_storage_bytes, 0U);
-
-            common::device_ptr<void> d_temporary_storage(temporary_storage_bytes);
-
-            test_utils::GraphHelper gHelper;
-            if(use_graphs)
-            {
-                gHelper.startStreamCapture(stream);
-            }
-            if(descending)
-            {
-                HIP_CHECK(rocprim::segmented_radix_sort_keys_desc<config>(d_temporary_storage.get(),
+            test_utils::test_kernel_wrapper(
+                [&](void* d_temporary_storage, auto& temporary_storage_bytes)
+                {
+                    if constexpr(descending)
+                    {
+                        return rocprim::segmented_radix_sort_keys_desc<config>(
+                            d_temporary_storage,
+                            temporary_storage_bytes,
+                            d_keys,
+                            size,
+                            segments_count,
+                            d_offsets.get(),
+                            d_offsets.get() + 1,
+                            start_bit,
+                            end_bit,
+                            stream,
+                            debug_synchronous);
+                    }
+                    else
+                    {
+                        return rocprim::segmented_radix_sort_keys<config>(d_temporary_storage,
                                                                           temporary_storage_bytes,
                                                                           d_keys,
                                                                           size,
@@ -1109,26 +972,11 @@ inline void sort_keys_double_buffer()
                                                                           start_bit,
                                                                           end_bit,
                                                                           stream,
-                                                                          debug_synchronous));
-            }
-            else
-            {
-                HIP_CHECK(rocprim::segmented_radix_sort_keys<config>(d_temporary_storage.get(),
-                                                                     temporary_storage_bytes,
-                                                                     d_keys,
-                                                                     size,
-                                                                     segments_count,
-                                                                     d_offsets.get(),
-                                                                     d_offsets.get() + 1,
-                                                                     start_bit,
-                                                                     end_bit,
-                                                                     stream,
-                                                                     debug_synchronous));
-            }
-            if(use_graphs)
-            {
-                gHelper.createAndLaunchGraph(stream);
-            }
+                                                                          debug_synchronous);
+                    }
+                },
+                stream,
+                use_graphs);
 
             // Calculate expected results on host
             std::vector<key_type> expected(keys_input);
@@ -1147,10 +995,6 @@ inline void sort_keys_double_buffer()
                                 hipMemcpyDeviceToHost));
 
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(keys_output, expected));
-            if(use_graphs)
-            {
-                gHelper.cleanupGraphHelper();
-            }
         }
     }
 }
@@ -1245,50 +1089,43 @@ inline void sort_pairs_double_buffer()
                                                                   start_bit,
                                                                   end_bit));
 
-            ASSERT_GT(temporary_storage_bytes, 0U);
-
-            common::device_ptr<void> d_temporary_storage(temporary_storage_bytes);
-
-            test_utils::GraphHelper gHelper;
-            if(use_graphs)
-            {
-                gHelper.startStreamCapture(stream);
-            }
-            if(descending)
-            {
-                HIP_CHECK(
-                    rocprim::segmented_radix_sort_pairs_desc<config>(d_temporary_storage.get(),
-                                                                     temporary_storage_bytes,
-                                                                     d_keys,
-                                                                     d_values,
-                                                                     size,
-                                                                     segments_count,
-                                                                     d_offsets.get(),
-                                                                     d_offsets.get() + 1,
-                                                                     start_bit,
-                                                                     end_bit,
-                                                                     stream,
-                                                                     debug_synchronous));
-            }
-            else
-            {
-                HIP_CHECK(rocprim::segmented_radix_sort_pairs<config>(d_temporary_storage.get(),
-                                                                      temporary_storage_bytes,
-                                                                      d_keys,
-                                                                      d_values,
-                                                                      size,
-                                                                      segments_count,
-                                                                      d_offsets.get(),
-                                                                      d_offsets.get() + 1,
-                                                                      start_bit,
-                                                                      end_bit,
-                                                                      stream,
-                                                                      debug_synchronous));
-            }
-            if(use_graphs)
-            {
-                gHelper.createAndLaunchGraph(stream);
-            }
+            test_utils::test_kernel_wrapper(
+                [&](void* d_temporary_storage, auto& temporary_storage_bytes)
+                {
+                    if constexpr(descending)
+                    {
+                        return rocprim::segmented_radix_sort_pairs_desc<config>(
+                            d_temporary_storage,
+                            temporary_storage_bytes,
+                            d_keys,
+                            d_values,
+                            size,
+                            segments_count,
+                            d_offsets.get(),
+                            d_offsets.get() + 1,
+                            start_bit,
+                            end_bit,
+                            stream,
+                            debug_synchronous);
+                    }
+                    else
+                    {
+                        return rocprim::segmented_radix_sort_pairs<config>(d_temporary_storage,
+                                                                           temporary_storage_bytes,
+                                                                           d_keys,
+                                                                           d_values,
+                                                                           size,
+                                                                           segments_count,
+                                                                           d_offsets.get(),
+                                                                           d_offsets.get() + 1,
+                                                                           start_bit,
+                                                                           end_bit,
+                                                                           stream,
+                                                                           debug_synchronous);
+                    }
+                },
+                stream,
+                use_graphs);
 
             // Calculate expected results on host
             std::vector<key_value> expected(size);
@@ -1328,10 +1165,6 @@ inline void sort_pairs_double_buffer()
 
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(keys_output, keys_expected));
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(values_output, values_expected));
-            if(use_graphs)
-            {
-                gHelper.cleanupGraphHelper();
-            }
         }
     }
 }

--- a/projects/rocprim/test/rocprim/test_device_segmented_radix_sort.hpp
+++ b/projects/rocprim/test/rocprim/test_device_segmented_radix_sort.hpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -57,7 +57,8 @@ template<class Key,
          unsigned int EndBit,
          unsigned int MinSegmentLength,
          unsigned int MaxSegmentLength,
-         class Config = rocprim::default_config>
+         bool         UseGraph = false,
+         class Config          = rocprim::default_config>
 struct params
 {
     using key_type                                   = Key;
@@ -67,6 +68,7 @@ struct params
     static constexpr unsigned int end_bit            = EndBit;
     static constexpr unsigned int min_segment_length = MinSegmentLength;
     static constexpr unsigned int max_segment_length = MaxSegmentLength;
+    static constexpr bool         use_graph          = UseGraph;
     using config                                     = Config;
 };
 
@@ -125,6 +127,7 @@ inline void sort_keys()
     using key_type                           = typename TestFixture::params::key_type;
     using config                             = typename TestFixture::params::config;
     static constexpr bool         descending = TestFixture::params::descending;
+    static constexpr bool         use_graphs = TestFixture::params::use_graph;
     static constexpr unsigned int start_bit  = TestFixture::params::start_bit;
     static constexpr unsigned int end_bit    = TestFixture::params::end_bit;
 
@@ -140,6 +143,11 @@ inline void sort_keys()
     common::uniform_int_distribution<size_t> segment_length_dis(
         TestFixture::params::min_segment_length,
         TestFixture::params::max_segment_length);
+
+    if(use_graphs)
+    {
+        HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
+    }
 
     for(size_t seed_index = 0; seed_index < number_of_runs; seed_index++)
     {
@@ -191,6 +199,12 @@ inline void sort_keys()
 
             common::device_ptr<void> d_temporary_storage(temporary_storage_bytes);
 
+            test_utils::GraphHelper gHelper;
+            if(use_graphs)
+            {
+                gHelper.startStreamCapture(stream);
+            }
+
             if(descending)
             {
                 HIP_CHECK(rocprim::segmented_radix_sort_keys_desc<config>(d_temporary_storage.get(),
@@ -222,6 +236,11 @@ inline void sort_keys()
                                                                      debug_synchronous));
             }
 
+            if(use_graphs)
+            {
+                gHelper.createAndLaunchGraph(stream);
+            }
+
             // Calculate expected results on host
             std::vector<key_type> expected(keys_input);
             for(size_t i = 0; i < segments_count; i++)
@@ -235,6 +254,11 @@ inline void sort_keys()
             const auto keys_output = d_keys_output.load();
 
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(keys_output, expected));
+
+            if(use_graphs)
+            {
+                gHelper.cleanupGraphHelper();
+            }
         }
     }
 }
@@ -251,10 +275,15 @@ inline void sort_keys_empty_data()
     static constexpr bool         descending = TestFixture::params::descending;
     static constexpr unsigned int start_bit  = TestFixture::params::start_bit;
     static constexpr unsigned int end_bit    = TestFixture::params::end_bit;
+    static constexpr bool         use_graphs = TestFixture::params::use_graph;
 
     using offset_type = unsigned int;
 
     hipStream_t stream = 0;
+    if(use_graphs)
+    {
+        HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
+    }
 
     const std::vector<size_t> sizes = {0, 1024};
     for(size_t size : sizes)
@@ -297,6 +326,11 @@ inline void sort_keys_empty_data()
 
             common::device_ptr<void> d_temporary_storage(temporary_storage_bytes);
 
+            test_utils::GraphHelper gHelper;
+            if(use_graphs)
+            {
+                gHelper.startStreamCapture(stream);
+            }
             if(descending)
             {
                 HIP_CHECK(rocprim::segmented_radix_sort_keys_desc<config>(d_temporary_storage.get(),
@@ -326,10 +360,20 @@ inline void sort_keys_empty_data()
                                                                      stream));
             }
 
+            if(use_graphs)
+            {
+                gHelper.createAndLaunchGraph(stream);
+            }
+
             const auto keys_output = d_keys.load();
 
             // Output should not have changed
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(keys_output, keys_input));
+
+            if(use_graphs)
+            {
+                gHelper.cleanupGraphHelper();
+            }
         }
     }
 }
@@ -346,10 +390,15 @@ inline void sort_keys_large_segments()
     constexpr bool         descending = TestFixture::params::descending;
     constexpr unsigned int start_bit  = TestFixture::params::start_bit;
     constexpr unsigned int end_bit    = TestFixture::params::end_bit;
+    static constexpr bool  use_graphs = TestFixture::params::use_graph;
 
     using offset_type = unsigned int;
 
     hipStream_t stream = 0;
+    if(use_graphs)
+    {
+        HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
+    }
 
     size_t size           = 1 << 20;
     size_t segments_count = 2;
@@ -393,6 +442,11 @@ inline void sort_keys_large_segments()
 
         common::device_ptr<void> d_temporary_storage(temporary_storage_bytes);
 
+        test_utils::GraphHelper gHelper;
+        if(use_graphs)
+        {
+            gHelper.startStreamCapture(stream);
+        }
         if(descending)
         {
             HIP_CHECK(rocprim::segmented_radix_sort_keys_desc<config>(d_temporary_storage.get(),
@@ -421,6 +475,10 @@ inline void sort_keys_large_segments()
                                                                  end_bit,
                                                                  stream));
         }
+        if(use_graphs)
+        {
+            gHelper.createAndLaunchGraph(stream);
+        }
 
         bool all_blocks_sorted = true;
         for(size_t s = 0; s < segments_count; ++s)
@@ -431,6 +489,10 @@ inline void sort_keys_large_segments()
                 test_utils::key_comparator<key_type, descending, start_bit, end_bit>());
         }
         ASSERT_TRUE(all_blocks_sorted);
+        if(use_graphs)
+        {
+            gHelper.cleanupGraphHelper();
+        }
     }
 }
 
@@ -446,10 +508,15 @@ inline void sort_keys_unspecified_ranges()
     constexpr bool         descending = TestFixture::params::descending;
     constexpr unsigned int start_bit  = TestFixture::params::start_bit;
     constexpr unsigned int end_bit    = TestFixture::params::end_bit;
+    static constexpr bool  use_graphs = TestFixture::params::use_graph;
 
     using offset_type = unsigned int;
 
     hipStream_t stream = 0;
+    if(use_graphs)
+    {
+        HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
+    }
 
     std::random_device         rd;
     std::default_random_engine gen(rd());
@@ -526,6 +593,11 @@ inline void sort_keys_unspecified_ranges()
 
             common::device_ptr<void> d_temporary_storage(temporary_storage_bytes);
 
+            test_utils::GraphHelper gHelper;
+            if(use_graphs)
+            {
+                gHelper.startStreamCapture(stream);
+            }
             if(descending)
             {
                 HIP_CHECK(rocprim::segmented_radix_sort_keys_desc<config>(d_temporary_storage.get(),
@@ -554,6 +626,10 @@ inline void sort_keys_unspecified_ranges()
                                                                      end_bit,
                                                                      stream));
             }
+            if(use_graphs)
+            {
+                gHelper.createAndLaunchGraph(stream);
+            }
 
             // Calculate expected results on host
             std::vector<key_type> expected(keys_input);
@@ -568,6 +644,10 @@ inline void sort_keys_unspecified_ranges()
             const auto keys_output = d_keys_output.load();
 
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(keys_output, expected));
+            if(use_graphs)
+            {
+                gHelper.cleanupGraphHelper();
+            }
         }
     }
 }
@@ -585,10 +665,15 @@ inline void sort_pairs()
     constexpr bool         descending = TestFixture::params::descending;
     constexpr unsigned int start_bit  = TestFixture::params::start_bit;
     constexpr unsigned int end_bit    = TestFixture::params::end_bit;
+    static constexpr bool  use_graphs = TestFixture::params::use_graph;
 
     using offset_type = unsigned int;
 
     hipStream_t stream = 0;
+    if(use_graphs)
+    {
+        HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
+    }
 
     const bool debug_synchronous = false;
 
@@ -659,6 +744,11 @@ inline void sort_pairs()
 
             common::device_ptr<void> d_temporary_storage(temporary_storage_bytes);
 
+            test_utils::GraphHelper gHelper;
+            if(use_graphs)
+            {
+                gHelper.startStreamCapture(stream);
+            }
             if(descending)
             {
                 HIP_CHECK(
@@ -694,6 +784,10 @@ inline void sort_pairs()
                                                                       stream,
                                                                       debug_synchronous));
             }
+            if(use_graphs)
+            {
+                gHelper.createAndLaunchGraph(stream);
+            }
 
             // Calculate expected results on host
             std::vector<key_value> expected(size);
@@ -724,6 +818,10 @@ inline void sort_pairs()
 
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(keys_output, keys_expected));
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(values_output, values_expected));
+            if(use_graphs)
+            {
+                gHelper.cleanupGraphHelper();
+            }
         }
     }
 }
@@ -741,10 +839,15 @@ inline void sort_pairs_unspecified_ranges()
     constexpr bool         descending = TestFixture::params::descending;
     constexpr unsigned int start_bit  = TestFixture::params::start_bit;
     constexpr unsigned int end_bit    = TestFixture::params::end_bit;
+    static constexpr bool  use_graphs = TestFixture::params::use_graph;
 
     using offset_type = unsigned int;
 
     hipStream_t stream = 0;
+    if(use_graphs)
+    {
+        HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
+    }
 
     std::random_device         rd;
     std::default_random_engine gen(rd());
@@ -831,6 +934,11 @@ inline void sort_pairs_unspecified_ranges()
 
             common::device_ptr<void> d_temporary_storage(temporary_storage_bytes);
 
+            test_utils::GraphHelper gHelper;
+            if(use_graphs)
+            {
+                gHelper.startStreamCapture(stream);
+            }
             if(descending)
             {
                 HIP_CHECK(
@@ -864,6 +972,10 @@ inline void sort_pairs_unspecified_ranges()
                                                                       end_bit,
                                                                       stream));
             }
+            if(use_graphs)
+            {
+                gHelper.createAndLaunchGraph(stream);
+            }
 
             // Calculate expected results on host
             std::vector<key_value> expected(size);
@@ -890,6 +1002,10 @@ inline void sort_pairs_unspecified_ranges()
                 ASSERT_EQ(keys_output[i], expected[i].first);
                 ASSERT_EQ(values_output[i], expected[i].second);
             }
+            if(use_graphs)
+            {
+                gHelper.cleanupGraphHelper();
+            }
         }
     }
 }
@@ -906,10 +1022,15 @@ inline void sort_keys_double_buffer()
     constexpr bool         descending = TestFixture::params::descending;
     constexpr unsigned int start_bit  = TestFixture::params::start_bit;
     constexpr unsigned int end_bit    = TestFixture::params::end_bit;
+    static constexpr bool  use_graphs = TestFixture::params::use_graph;
 
     using offset_type = unsigned int;
 
     hipStream_t stream = 0;
+    if(use_graphs)
+    {
+        HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
+    }
 
     const bool debug_synchronous = false;
 
@@ -971,6 +1092,11 @@ inline void sort_keys_double_buffer()
 
             common::device_ptr<void> d_temporary_storage(temporary_storage_bytes);
 
+            test_utils::GraphHelper gHelper;
+            if(use_graphs)
+            {
+                gHelper.startStreamCapture(stream);
+            }
             if(descending)
             {
                 HIP_CHECK(rocprim::segmented_radix_sort_keys_desc<config>(d_temporary_storage.get(),
@@ -999,6 +1125,10 @@ inline void sort_keys_double_buffer()
                                                                      stream,
                                                                      debug_synchronous));
             }
+            if(use_graphs)
+            {
+                gHelper.createAndLaunchGraph(stream);
+            }
 
             // Calculate expected results on host
             std::vector<key_type> expected(keys_input);
@@ -1017,6 +1147,10 @@ inline void sort_keys_double_buffer()
                                 hipMemcpyDeviceToHost));
 
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(keys_output, expected));
+            if(use_graphs)
+            {
+                gHelper.cleanupGraphHelper();
+            }
         }
     }
 }
@@ -1034,10 +1168,15 @@ inline void sort_pairs_double_buffer()
     constexpr bool         descending = TestFixture::params::descending;
     constexpr unsigned int start_bit  = TestFixture::params::start_bit;
     constexpr unsigned int end_bit    = TestFixture::params::end_bit;
+    static constexpr bool  use_graphs = TestFixture::params::use_graph;
 
     using offset_type = unsigned int;
 
     hipStream_t stream = 0;
+    if(use_graphs)
+    {
+        HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
+    }
 
     const bool debug_synchronous = false;
 
@@ -1110,6 +1249,11 @@ inline void sort_pairs_double_buffer()
 
             common::device_ptr<void> d_temporary_storage(temporary_storage_bytes);
 
+            test_utils::GraphHelper gHelper;
+            if(use_graphs)
+            {
+                gHelper.startStreamCapture(stream);
+            }
             if(descending)
             {
                 HIP_CHECK(
@@ -1140,6 +1284,10 @@ inline void sort_pairs_double_buffer()
                                                                       end_bit,
                                                                       stream,
                                                                       debug_synchronous));
+            }
+            if(use_graphs)
+            {
+                gHelper.createAndLaunchGraph(stream);
             }
 
             // Calculate expected results on host
@@ -1180,6 +1328,10 @@ inline void sort_pairs_double_buffer()
 
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(keys_output, keys_expected));
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(values_output, values_expected));
+            if(use_graphs)
+            {
+                gHelper.cleanupGraphHelper();
+            }
         }
     }
 }


### PR DESCRIPTION
## Motivation

This is a different approach to https://github.com/ROCm/rocm-libraries/pull/4416.
* Adds graph tests to device segmented radix sort.
* Disables partitioning in device segmented radix sort if a graph capture is detected.

## Technical Details

This PR introduces a check in `rocprim/device/device_segmented_radix_sort.hpp` and force disables the partioning whenever a graph capture is detected. This means performance under graph capture may be different compared to standard launches. See the code comments in that file.

## Test Plan

Tests has been added.

## Test Result

Tests pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
