### PR TITLE
[Origami] Update README.md to properly reflect supported GPUs

### DIFF
--- a/shared/origami/README.md
+++ b/shared/origami/README.md
@@ -144,7 +144,7 @@ int main() {
 |-------------|------|------------|-----------|
 | gfx942 | MI325X, MI300X, MI300A | ✔️ | ✔️ |
 | gfx950 | MI355X, MI350X | ✔️ | ✔️ |
-| gfx1100 | RX 7900 XTX/XT/GRE, Radeon PRO W7900 (Dual Slot), Radeon PRO W7800 (48GB) | ✔️ | |
+| gfx1100 | Radeon RX 7900 XTX/XT/GRE, Radeon PRO W7900 (Dual Slot), Radeon PRO W7800 (48GB) | ✔️ | |
 | gfx1150 | Radeon 890M/880M iGPU | ✔️ | |
 | gfx1151 | Radeon 8060S/8050S/8040S iGPU | ✔️ | |
 | gfx1152 | Radeon 860M/840M iGPU | ✔️ | |

--- a/shared/origami/README.md
+++ b/shared/origami/README.md
@@ -144,12 +144,12 @@ int main() {
 |-------------|------|------------|-----------|
 | gfx942 | MI325X, MI300X, MI300A | ✔️ | ✔️ |
 | gfx950 | MI355X, MI350X | ✔️ | ✔️ |
-| gfx1100 | Radeon RX 7900 XTX, Radeon RX 7900 XT, Radeon RX 7900 GRE, Radeon RX 7900 | ✔️ | |
-| gfx1150 | AMD Strix Point iGPU | ✔️ | |
-| gfx1151 | Radeon RX 8000 series | ✔️ | |
-| gfx1152 | AMD Radeon 840M iGPU | ✔️ | |
-| gfx1153 | AMD Radeon 820M iGPU | ✔️ | |
-| gfx1201 | Radeon RX 8900 XTX, Radeon RX 8900 XT, Radeon RX 8800 XT, Radeon RX 8800, Radeon RX 8700 XT, Radeon RX 8700, Radeon RX 8600 XT, Radeon RX 8600 | ✔️ | |
+| gfx1100 | RX 7900 XTX/XT/GRE, Radeon PRO W7900 (Dual Slot), Radeon PRO W7800 (48GB) | ✔️ | |
+| gfx1150 | Radeon 890M/880M iGPU | ✔️ | |
+| gfx1151 | Radeon 8060S/8050S/8040S iGPU | ✔️ | |
+| gfx1152 | Radeon 860M/840M iGPU | ✔️ | |
+| gfx1153 | TBA | ✔️ | |
+| gfx1201 | Radeon RX 9070 (XT/GRE), Radeon AI PRO R9700 (D/S) | ✔️ | |
 
 For more information on GPU hardware specifications, check out [ROCm documentation](https://rocm.docs.amd.com/en/latest/reference/gpu-arch-specs.html).
 


### PR DESCRIPTION
## Motivation

Current GPU support table in `README.md` lists non-existing GPU names for `gfx1201` and is missing some GPUs for other architectures. Additionally fixed some inconsistent naming convention for some iGPUs.

## Technical Details

Added the following mappings:

| LLVM Target | GPUs
|-------------|------|
| gfx1100 | Radeon PRO W7900 (Dual Slot), Radeon PRO W7800 (48GB) |
| gfx1150 | Radeon 890M/880M iGPU | 
| gfx1151 | Radeon 8060S/8050S/8040S iGPU |
| gfx1152 | Radeon 860M iGPU |
| gfx1153 | TBA |
| gfx1201 | Radeon RX 9070 (XT/GRE), Radeon AI PRO R9700 (D/S) |


## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
