### PR TITLE
delete GPU_LSTM_FP64

### DIFF
--- a/projects/miopen/test/gtest/lstm.cpp
+++ b/projects/miopen/test/gtest/lstm.cpp
@@ -131,9 +131,3 @@ using GPU_LSTM_FP32 = GPU_LSTM_test<float>;
 TEST_P(GPU_LSTM_FP32, FloatTest) { RunTest(); }
 
 INSTANTIATE_TEST_SUITE_P(Full, GPU_LSTM_FP32, testing::ValuesIn(GetTestCases()));
-
-using GPU_LSTM_FP64 = GPU_LSTM_test<double>;
-
-TEST_P(GPU_LSTM_FP64, DoubleTest) { RunTest(); }
-
-INSTANTIATE_TEST_SUITE_P(Full, GPU_LSTM_FP64, testing::ValuesIn(GetTestCases()));


### PR DESCRIPTION
## Motivation

RNN does not support fp64. This one was missed in the first PR:
https://github.com/ROCm/rocm-libraries/pull/5750

## Technical Details

There is no requirement to support this. I was told the 64-bit tests were added by mistake.

## Test Plan

Pass CI.

## Test Result

Pending.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
