### PR TITLE
[MIOpen] PyJWT Docker fix

### DIFF
--- a/projects/miopen/Dockerfile
+++ b/projects/miopen/Dockerfile
@@ -76,13 +76,13 @@ RUN wget -O /tmp/ccache.tar.gz https://github.com/ccache/ccache/archive/${CCACHE
     cd / 
 
 # Purge packages conflicting with doc-requirements
-RUN apt-get remove --purge -y python3-pyparsing python3-cryptography 
+RUN apt-get remove --purge -y python3-pyparsing python3-cryptography python3-jwt
 
 # Add requirements files
 ADD miopen/docs/sphinx/requirements.txt /doc-requirements.txt
 
 # Install doc requirements
-RUN pip3 install --break-system-packages --ignore-installed -r /doc-requirements.txt && \
+RUN pip3 install --break-system-packages -r /doc-requirements.txt && \
 # Install an init system
     wget https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
     dpkg -i dumb-init_*.deb && rm dumb-init_*.deb && \

--- a/projects/miopen/Dockerfile
+++ b/projects/miopen/Dockerfile
@@ -82,7 +82,7 @@ RUN apt-get remove --purge -y python3-pyparsing python3-cryptography
 ADD miopen/docs/sphinx/requirements.txt /doc-requirements.txt
 
 # Install doc requirements
-RUN pip3 install --break-system-packages -r /doc-requirements.txt && \
+RUN pip3 install --break-system-packages --ignore-installed -r /doc-requirements.txt && \
 # Install an init system
     wget https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb && \
     dpkg -i dumb-init_*.deb && rm dumb-init_*.deb && \


### PR DESCRIPTION
## Motivation

Added python3-jwt to the purge list to avoid version mismatch                                                                                                   

This removes the system-managed Python JWT 2.7.0 the packages and just installs the requested version over it.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
