### PR TITLE
Fix FinInterface CI breakage 

### DIFF
--- a/projects/miopen/src/CMakeLists.txt
+++ b/projects/miopen/src/CMakeLists.txt
@@ -1044,9 +1044,6 @@ if(NOT WIN32 AND NOT APPLE)
     target_link_libraries(MIOpen PRIVATE "-Wl,--exclude-libs,ALL")
     set_target_properties(MIOpen PROPERTIES CXX_VISIBILITY_PRESET hidden)
     set_target_properties(MIOpen PROPERTIES VISIBILITY_INLINES_HIDDEN 1)
-    # fin_interface.cpp uses explicit template instantiation with MIOPEN_INTERNALS_EXPORT,
-    # which requires -fno-visibility-inlines-hidden to actually export the symbols.
-    set_source_files_properties(fin/fin_interface.cpp PROPERTIES COMPILE_FLAGS "-fno-visibility-inlines-hidden")
 endif()
 #######################################
 if(MIOPEN_ENABLE_SQLITE)

--- a/projects/miopen/src/CMakeLists.txt
+++ b/projects/miopen/src/CMakeLists.txt
@@ -1044,6 +1044,9 @@ if(NOT WIN32 AND NOT APPLE)
     target_link_libraries(MIOpen PRIVATE "-Wl,--exclude-libs,ALL")
     set_target_properties(MIOpen PROPERTIES CXX_VISIBILITY_PRESET hidden)
     set_target_properties(MIOpen PROPERTIES VISIBILITY_INLINES_HIDDEN 1)
+    # fin_interface.cpp uses explicit template instantiation with MIOPEN_INTERNALS_EXPORT,
+    # which requires -fno-visibility-inlines-hidden to actually export the symbols.
+    set_source_files_properties(fin/fin_interface.cpp PROPERTIES COMPILE_FLAGS "-fno-visibility-inlines-hidden")
 endif()
 #######################################
 if(MIOPEN_ENABLE_SQLITE)

--- a/projects/miopen/src/fin/fin_interface.cpp
+++ b/projects/miopen/src/fin/fin_interface.cpp
@@ -335,6 +335,7 @@ AnySolver<miopen::ExecutionContext, miopen::conv::ProblemDescription>::AnySolver
     case 141: SetObject<miopen::solver::conv::ConvHipImplicitGemm3DGroupBwdXdlops>(); break;
     case 155: SetObject<miopen::solver::conv::ConvHipImplicitGemmGroupBwdXdlops>(); break;
     case 156: SetObject<miopen::solver::conv::ConvHipImplicitGemmGroupWrwXdlops>(); break;
+    case 185: SetObject<miopen::solver::conv::ConvDepthwiseFwd2D>(); break;
     // New tunable solver should be added here
     default:
         MIOPEN_THROW(miopenStatusInternalError, "Unknown solver ID (" + std::to_string(id) + ")");

--- a/projects/miopen/src/include/miopen/binary_cache.hpp
+++ b/projects/miopen/src/include/miopen/binary_cache.hpp
@@ -59,11 +59,11 @@ MIOPEN_INTERNALS_EXPORT std::vector<char> LoadBinary(const TargetProperties& tar
                                                      const fs::path& name,
                                                      const std::string& args);
 
-void SaveBinary(const std::vector<char>& hsaco,
-                const TargetProperties& target,
-                std::size_t num_cu,
-                const fs::path& name,
-                const std::string& args);
+MIOPEN_INTERNALS_EXPORT void SaveBinary(const std::vector<char>& hsaco,
+                                        const TargetProperties& target,
+                                        std::size_t num_cu,
+                                        const fs::path& name,
+                                        const std::string& args);
 #endif
 
 #ifdef MIOPEN_BUILD_TESTING

--- a/projects/miopen/src/include/miopen/fin/fin_interface.hpp
+++ b/projects/miopen/src/include/miopen/fin/fin_interface.hpp
@@ -121,8 +121,10 @@ protected:
     friend Solver GetSolver(const std::string&);
 };
 
-extern template class MIOPEN_INTERNALS_EXPORT SolverMixin<miopen::ExecutionContext, miopen::conv::ProblemDescription>;
-extern template class MIOPEN_INTERNALS_EXPORT SolverMixin<miopen::ExecutionContext, miopen::batchnorm::ProblemDescription>;
+extern template class MIOPEN_INTERNALS_EXPORT
+    SolverMixin<miopen::ExecutionContext, miopen::conv::ProblemDescription>;
+extern template class MIOPEN_INTERNALS_EXPORT
+    SolverMixin<miopen::ExecutionContext, miopen::batchnorm::ProblemDescription>;
 
 // Convolution solver
 class ConvSolver final
@@ -164,12 +166,14 @@ protected:
 
 // Convolution
 MIOPEN_INTERNALS_EXPORT const std::vector<ConvSolver>& GetAllConvSolvers();
-MIOPEN_INTERNALS_EXPORT std::vector<ConvSolver> GetConvSolvers(const std::vector<std::string>& names);
+MIOPEN_INTERNALS_EXPORT std::vector<ConvSolver>
+GetConvSolvers(const std::vector<std::string>& names);
 MIOPEN_INTERNALS_EXPORT ConvSolver GetConvSolver(const std::string& name);
 
 // Batch normalization
 MIOPEN_INTERNALS_EXPORT const std::vector<BatchNormSolver>& GetAllBatchNormSolvers();
-MIOPEN_INTERNALS_EXPORT std::vector<BatchNormSolver> GetBatchNormSolvers(const std::vector<std::string>& names);
+MIOPEN_INTERNALS_EXPORT std::vector<BatchNormSolver>
+GetBatchNormSolvers(const std::vector<std::string>& names);
 MIOPEN_INTERNALS_EXPORT BatchNormSolver GetBatchNormSolver(const std::string& name);
 
 // Examples:

--- a/projects/miopen/src/include/miopen/fin/fin_interface.hpp
+++ b/projects/miopen/src/include/miopen/fin/fin_interface.hpp
@@ -33,6 +33,7 @@
 
 #include <miopen/conv_algo_name.hpp>
 #include <miopen/conv_solution.hpp>
+#include <miopen/export_internals.h>
 #include <miopen/miopen.h>
 #include <miopen/mlo_internal.hpp>
 
@@ -65,14 +66,14 @@ public:
     // valid.
 
     // Returns false if the solver could not be found by its name.
-    bool IsValid() const;
+    MIOPEN_INTERNALS_EXPORT bool IsValid() const;
 
-    uint64_t GetId() const;
+    MIOPEN_INTERNALS_EXPORT uint64_t GetId() const;
     // Returns the name even if the solver is not valid (returns the requested name).
-    const std::string& GetName() const;
+    MIOPEN_INTERNALS_EXPORT const std::string& GetName() const;
 
-    bool IsTunable() const;
-    bool IsDynamic() const;
+    MIOPEN_INTERNALS_EXPORT bool IsTunable() const;
+    MIOPEN_INTERNALS_EXPORT bool IsDynamic() const;
 
 protected:
     Solver(const miopen::solver::SolverBase* solver_base, uint64_t solver_id);
@@ -120,8 +121,8 @@ protected:
     friend Solver GetSolver(const std::string&);
 };
 
-extern template class SolverMixin<miopen::ExecutionContext, miopen::conv::ProblemDescription>;
-extern template class SolverMixin<miopen::ExecutionContext, miopen::batchnorm::ProblemDescription>;
+extern template class MIOPEN_INTERNALS_EXPORT SolverMixin<miopen::ExecutionContext, miopen::conv::ProblemDescription>;
+extern template class MIOPEN_INTERNALS_EXPORT SolverMixin<miopen::ExecutionContext, miopen::batchnorm::ProblemDescription>;
 
 // Convolution solver
 class ConvSolver final
@@ -129,7 +130,7 @@ class ConvSolver final
 {
 public:
     ConvSolver(const miopen::solver::SolverBase* solver_base, uint64_t solver_id) = delete;
-    std::string GetAlgo(miopen::conv::Direction dir) const;
+    MIOPEN_INTERNALS_EXPORT std::string GetAlgo(miopen::conv::Direction dir) const;
 
 protected:
     ConvSolver(const miopen::solver::SolverBase* solver_base,
@@ -162,14 +163,14 @@ protected:
 // dummy if a solver with specified name does not exist.
 
 // Convolution
-const std::vector<ConvSolver>& GetAllConvSolvers();
-std::vector<ConvSolver> GetConvSolvers(const std::vector<std::string>& names);
-ConvSolver GetConvSolver(const std::string& name);
+MIOPEN_INTERNALS_EXPORT const std::vector<ConvSolver>& GetAllConvSolvers();
+MIOPEN_INTERNALS_EXPORT std::vector<ConvSolver> GetConvSolvers(const std::vector<std::string>& names);
+MIOPEN_INTERNALS_EXPORT ConvSolver GetConvSolver(const std::string& name);
 
 // Batch normalization
-const std::vector<BatchNormSolver>& GetAllBatchNormSolvers();
-std::vector<BatchNormSolver> GetBatchNormSolvers(const std::vector<std::string>& names);
-BatchNormSolver GetBatchNormSolver(const std::string& name);
+MIOPEN_INTERNALS_EXPORT const std::vector<BatchNormSolver>& GetAllBatchNormSolvers();
+MIOPEN_INTERNALS_EXPORT std::vector<BatchNormSolver> GetBatchNormSolvers(const std::vector<std::string>& names);
+MIOPEN_INTERNALS_EXPORT BatchNormSolver GetBatchNormSolver(const std::string& name);
 
 // Examples:
 //


### PR DESCRIPTION
Export fin_interface and SaveBinary symbols; add ConvDepthwiseFwd2D to AnySolver

  fin_interface.hpp/cpp: Add MIOPEN_INTERNALS_EXPORT to all public Solver methods,
  ConvSolver::GetAlgo, the SolverMixin extern template declarations, and the free
  functions (GetAllConvSolvers, GetConvSolvers, etc.) so they are visible in
  libMIOpen.so when built with -fvisibility=hidden.

  The SolverMixin explicit instantiations require -fno-visibility-inlines-hidden
  to be emitted with default visibility despite the target-level
  VISIBILITY_INLINES_HIDDEN property; this is set via set_source_files_properties
  for fin_interface.cpp in src/CMakeLists.txt.

  binary_cache.hpp: Add MIOPEN_INTERNALS_EXPORT to SaveBinary (SQLite kern-cache
  path), which is called by fin but was not exported from the shared library.

  fin_interface.cpp: Add case 185 (ConvDepthwiseFwd2D) to the AnySolver conv
  switch; this tunable solver was added to MIOpen after the switch was last updated,
  causing GetAllConvSolvers() to throw at runtime.

  Fixes test_unit_FinInterface (110/110 pass).

Tracker:
https://amd-hub.atlassian.net/browse/ALMIOPEN-1707