### PR TITLE
refactor(ck_tile): extract calculateRtolAtol into shared host header

### DIFF
--- a/projects/composablekernel/example/ck_tile/03_gemm/gemm_basic.cpp
+++ b/projects/composablekernel/example/ck_tile/03_gemm/gemm_basic.cpp
@@ -15,7 +15,7 @@ int run_gemm_example(ck_tile::ArgParser& arg_parser)
     std::string c_layout  = arg_parser.get_str("c_layout");
 
     std::tuple<ck_tile::index_t, ck_tile::index_t, ck_tile::index_t> gemm_sizes =
-        parse_gemm_size(arg_parser);
+        parseGemmSize(arg_parser);
 
     int m = std::get<0>(gemm_sizes);
     int n = std::get<1>(gemm_sizes);

--- a/projects/composablekernel/example/ck_tile/03_gemm/gemm_basic_invoker.hpp
+++ b/projects/composablekernel/example/ck_tile/03_gemm/gemm_basic_invoker.hpp
@@ -148,9 +148,9 @@ struct BasicInvoker
             std::cout << "Flushing cache..." << std::endl;
 
             ck_tile::HostTensor<ADataTypeBuf> a_m(ck_tile::host_tensor_descriptor(
-                args.M, args.K, args.stride_A, is_row_major(ALayout{})));
+                args.M, args.K, args.stride_A, ck_tile::is_row_major(ALayout{})));
             ck_tile::HostTensor<BDataTypeBuf> b_n(ck_tile::host_tensor_descriptor(
-                args.K, args.N, args.stride_B, is_row_major(BLayout{})));
+                args.K, args.N, args.stride_B, ck_tile::is_row_major(BLayout{})));
 
             auto size_a_buffer = a_m.get_element_space_size_in_bytes();
             auto size_b_buffer = b_n.get_element_space_size_in_bytes();

--- a/projects/composablekernel/example/ck_tile/03_gemm/gemm_splitk_two_stage_invoker.hpp
+++ b/projects/composablekernel/example/ck_tile/03_gemm/gemm_splitk_two_stage_invoker.hpp
@@ -171,9 +171,9 @@ struct SplitKTwoStageInvoker
             std::cout << "Flushing cache..." << std::endl;
 
             ck_tile::HostTensor<ADataType> a_m(ck_tile::host_tensor_descriptor(
-                args.M, args.K, args.stride_A, is_row_major(ALayout{})));
+                args.M, args.K, args.stride_A, ck_tile::is_row_major(ALayout{})));
             ck_tile::HostTensor<BDataType> b_n(ck_tile::host_tensor_descriptor(
-                args.K, args.N, args.stride_B, is_row_major(BLayout{})));
+                args.K, args.N, args.stride_B, ck_tile::is_row_major(BLayout{})));
 
             auto size_a_buffer = a_m.get_element_space_size_in_bytes();
             auto size_b_buffer = b_n.get_element_space_size_in_bytes();

--- a/projects/composablekernel/example/ck_tile/03_gemm/gemm_splitk_two_stage_reduce.cpp
+++ b/projects/composablekernel/example/ck_tile/03_gemm/gemm_splitk_two_stage_reduce.cpp
@@ -717,8 +717,9 @@ int run_gemm_example_with_layouts_two_stage(ck_tile::ArgParser& arg_parser,
             a_m_k, b_k_n, c_m_n_host_ref);
         const float max_accumulated_value =
             *std::max_element(c_m_n_host_ref.mData.begin(), c_m_n_host_ref.mData.end());
-        const auto rtol_atol = ck_tile::calculateRtolAtol<ADataType, BDataType, AccDataType, CDataType>(
-            K, kbatch, max_accumulated_value);
+        const auto rtol_atol =
+            ck_tile::calculateRtolAtol<ADataType, BDataType, AccDataType, CDataType>(
+                K, kbatch, max_accumulated_value);
         pass = ck_tile::check_err(c_m_n_dev_result,
                                   c_m_n_host_ref,
                                   "Error: Incorrect results!",
@@ -767,8 +768,9 @@ int run_gemm_example_with_layouts_two_stage(ck_tile::ArgParser& arg_parser,
 
         const float max_accumulated_value =
             *std::max_element(c_m_n_gpu_ref.mData.begin(), c_m_n_gpu_ref.mData.end());
-        const auto rtol_atol = ck_tile::calculateRtolAtol<ADataType, BDataType, AccDataType, CDataType>(
-            K, kbatch, max_accumulated_value);
+        const auto rtol_atol =
+            ck_tile::calculateRtolAtol<ADataType, BDataType, AccDataType, CDataType>(
+                K, kbatch, max_accumulated_value);
         pass = ck_tile::check_err(c_m_n_dev_result,
                                   c_m_n_gpu_ref,
                                   "Error: Incorrect results!",

--- a/projects/composablekernel/example/ck_tile/03_gemm/gemm_splitk_two_stage_reduce.cpp
+++ b/projects/composablekernel/example/ck_tile/03_gemm/gemm_splitk_two_stage_reduce.cpp
@@ -717,7 +717,7 @@ int run_gemm_example_with_layouts_two_stage(ck_tile::ArgParser& arg_parser,
             a_m_k, b_k_n, c_m_n_host_ref);
         const float max_accumulated_value =
             *std::max_element(c_m_n_host_ref.mData.begin(), c_m_n_host_ref.mData.end());
-        const auto rtol_atol = calculate_rtol_atol<ADataType, BDataType, AccDataType, CDataType>(
+        const auto rtol_atol = ck_tile::calculateRtolAtol<ADataType, BDataType, AccDataType, CDataType>(
             K, kbatch, max_accumulated_value);
         pass = ck_tile::check_err(c_m_n_dev_result,
                                   c_m_n_host_ref,
@@ -767,7 +767,7 @@ int run_gemm_example_with_layouts_two_stage(ck_tile::ArgParser& arg_parser,
 
         const float max_accumulated_value =
             *std::max_element(c_m_n_gpu_ref.mData.begin(), c_m_n_gpu_ref.mData.end());
-        const auto rtol_atol = calculate_rtol_atol<ADataType, BDataType, AccDataType, CDataType>(
+        const auto rtol_atol = ck_tile::calculateRtolAtol<ADataType, BDataType, AccDataType, CDataType>(
             K, kbatch, max_accumulated_value);
         pass = ck_tile::check_err(c_m_n_dev_result,
                                   c_m_n_gpu_ref,

--- a/projects/composablekernel/example/ck_tile/03_gemm/gemm_splitk_two_stage_reduce.cpp
+++ b/projects/composablekernel/example/ck_tile/03_gemm/gemm_splitk_two_stage_reduce.cpp
@@ -224,9 +224,9 @@ float gemm_stage1(const GemmSplitKHostArgs& args, const ck_tile::stream_config& 
         std::cout << "Flushing cache..." << std::endl;
 
         ck_tile::HostTensor<ADataType> a_m(ck_tile::host_tensor_descriptor(
-            args.M, args.K, args.stride_A, is_row_major(ALayout{})));
+            args.M, args.K, args.stride_A, ck_tile::is_row_major(ALayout{})));
         ck_tile::HostTensor<BDataType> b_n(ck_tile::host_tensor_descriptor(
-            args.K, args.N, args.stride_B, is_row_major(BLayout{})));
+            args.K, args.N, args.stride_B, ck_tile::is_row_major(BLayout{})));
 
         auto size_a_buffer = a_m.get_element_space_size_in_bytes();
         auto size_b_buffer = b_n.get_element_space_size_in_bytes();
@@ -586,16 +586,16 @@ int run_gemm_example_with_layouts_two_stage(ck_tile::ArgParser& arg_parser,
 
     const bool preshuffle = GemmConfig::Preshuffle;
 
-    stride_A = ck_tile::get_default_stride(M, K, stride_A, is_row_major(a_layout));
-    stride_B = ck_tile::get_default_stride(K, N, stride_B, is_row_major(b_layout));
-    stride_C = ck_tile::get_default_stride(M, N, stride_C, is_row_major(CLayout{}));
+    stride_A = ck_tile::get_default_stride(M, K, stride_A, ck_tile::is_row_major(a_layout));
+    stride_B = ck_tile::get_default_stride(K, N, stride_B, ck_tile::is_row_major(b_layout));
+    stride_C = ck_tile::get_default_stride(M, N, stride_C, ck_tile::is_row_major(CLayout{}));
 
     ck_tile::HostTensor<ADataType> a_m_k(
-        ck_tile::host_tensor_descriptor(M, K, stride_A, is_row_major(a_layout)));
+        ck_tile::host_tensor_descriptor(M, K, stride_A, ck_tile::is_row_major(a_layout)));
     ck_tile::HostTensor<BDataType> b_k_n(
-        ck_tile::host_tensor_descriptor(K, N, stride_B, is_row_major(b_layout)));
+        ck_tile::host_tensor_descriptor(K, N, stride_B, ck_tile::is_row_major(b_layout)));
     ck_tile::HostTensor<CDataType> c_m_n_dev_result(
-        ck_tile::host_tensor_descriptor(M, N, stride_C, is_row_major(CLayout{})));
+        ck_tile::host_tensor_descriptor(M, N, stride_C, ck_tile::is_row_major(CLayout{})));
 
     if(init_method == 0)
     {
@@ -710,7 +710,7 @@ int run_gemm_example_with_layouts_two_stage(ck_tile::ArgParser& arg_parser,
     if(arg_parser.get_int("v") == 1)
     {
         ck_tile::HostTensor<CDataType> c_m_n_host_ref(
-            ck_tile::host_tensor_descriptor(M, N, stride_C, is_row_major(CLayout{})));
+            ck_tile::host_tensor_descriptor(M, N, stride_C, ck_tile::is_row_major(CLayout{})));
         c_m_n_host_ref.SetZero();
 
         ck_tile::reference_gemm<ADataType, BDataType, AccDataType, CDataType>(
@@ -745,7 +745,7 @@ int run_gemm_example_with_layouts_two_stage(ck_tile::ArgParser& arg_parser,
 
         // memory on host to store gpu reference result
         ck_tile::HostTensor<CDataType> c_m_n_gpu_ref(
-            ck_tile::host_tensor_descriptor(M, N, stride_C, is_row_major(CLayout{})));
+            ck_tile::host_tensor_descriptor(M, N, stride_C, ck_tile::is_row_major(CLayout{})));
         // memory on device to store gpu reference result
         ck_tile::DeviceMem c_m_n_gpu_buf_ref(c_m_n_gpu_ref.get_element_space_size_in_bytes());
 

--- a/projects/composablekernel/example/ck_tile/03_gemm/gemm_weight_preshuffle_invoker.hpp
+++ b/projects/composablekernel/example/ck_tile/03_gemm/gemm_weight_preshuffle_invoker.hpp
@@ -114,9 +114,9 @@ struct WeightPreshuffleInvoker
             std::cout << "Flushing cache..." << std::endl;
 
             ck_tile::HostTensor<ADataType> a_m(ck_tile::host_tensor_descriptor(
-                args.M, args.K, args.stride_A, is_row_major(ALayout{})));
+                args.M, args.K, args.stride_A, ck_tile::is_row_major(ALayout{})));
             ck_tile::HostTensor<BDataType> b_n(ck_tile::host_tensor_descriptor(
-                args.K, args.N, args.stride_B, is_row_major(BLayout{})));
+                args.K, args.N, args.stride_B, ck_tile::is_row_major(BLayout{})));
 
             auto size_a_buffer = a_m.get_element_space_size_in_bytes();
             auto size_b_buffer = b_n.get_element_space_size_in_bytes();

--- a/projects/composablekernel/example/ck_tile/03_gemm/run_gemm_example.inc
+++ b/projects/composablekernel/example/ck_tile/03_gemm/run_gemm_example.inc
@@ -7,13 +7,6 @@
 #include "ck_tile/host/tensor_shuffle_utils.hpp"
 #include "ck_tile/ops/common/utils.hpp"
 
-template <typename Layout>
-static constexpr inline auto is_row_major(Layout layout_)
-{
-    return ck_tile::bool_constant<std::is_same_v<ck_tile::remove_cvref_t<decltype(layout_)>,
-                                                 ck_tile::tensor_layout::gemm::RowMajor>>{};
-}
-
 template <typename GemmConfig,
           typename Tensor,
           typename ADataType,
@@ -232,16 +225,16 @@ int run_gemm_example_with_layouts(ck_tile::ArgParser& arg_parser,
 
     const bool preshuffle = GemmConfig::Preshuffle;
 
-    stride_A = ck_tile::get_default_stride(M, K, stride_A, is_row_major(a_layout));
-    stride_B = ck_tile::get_default_stride(K, N, stride_B, is_row_major(b_layout));
-    stride_C = ck_tile::get_default_stride(M, N, stride_C, is_row_major(CLayout{}));
+    stride_A = ck_tile::get_default_stride(M, K, stride_A, ck_tile::is_row_major(a_layout));
+    stride_B = ck_tile::get_default_stride(K, N, stride_B, ck_tile::is_row_major(b_layout));
+    stride_C = ck_tile::get_default_stride(M, N, stride_C, ck_tile::is_row_major(CLayout{}));
 
     ck_tile::HostTensor<ADataTypeBuf> a_m_k(
-        ck_tile::host_tensor_descriptor(M, K, stride_A, is_row_major(a_layout)));
+        ck_tile::host_tensor_descriptor(M, K, stride_A, ck_tile::is_row_major(a_layout)));
     ck_tile::HostTensor<BDataTypeBuf> b_k_n(
-        ck_tile::host_tensor_descriptor(K, N, stride_B, is_row_major(b_layout)));
+        ck_tile::host_tensor_descriptor(K, N, stride_B, ck_tile::is_row_major(b_layout)));
     ck_tile::HostTensor<CDataType> c_m_n_dev_result(
-        ck_tile::host_tensor_descriptor(M, N, stride_C, is_row_major(CLayout{})));
+        ck_tile::host_tensor_descriptor(M, N, stride_C, ck_tile::is_row_major(CLayout{})));
 
     if(init_method == 0)
     {
@@ -383,7 +376,7 @@ int run_gemm_example_with_layouts(ck_tile::ArgParser& arg_parser,
 
     // memory on host to store gpu reference result
     ck_tile::HostTensor<CDataType> c_m_n_ref(
-        ck_tile::host_tensor_descriptor(M, N, stride_C, is_row_major(CLayout{})));
+        ck_tile::host_tensor_descriptor(M, N, stride_C, ck_tile::is_row_major(CLayout{})));
     c_m_n_ref.SetZero();
 
     if(arg_parser.get_int("v") == 1)

--- a/projects/composablekernel/example/ck_tile/03_gemm/run_gemm_example.inc
+++ b/projects/composablekernel/example/ck_tile/03_gemm/run_gemm_example.inc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
+#include "ck_tile/host/gemm_rtol_atol.hpp"
 #include "ck_tile/host/permute_pk_int4.hpp"
 #include "ck_tile/host/tensor_shuffle_utils.hpp"
 #include "ck_tile/ops/common/utils.hpp"
@@ -11,27 +12,6 @@ static constexpr inline auto is_row_major(Layout layout_)
 {
     return ck_tile::bool_constant<std::is_same_v<ck_tile::remove_cvref_t<decltype(layout_)>,
                                                  ck_tile::tensor_layout::gemm::RowMajor>>{};
-}
-
-template <typename ADataType, typename BDataType, typename AccDataType, typename CDataType>
-auto calculate_rtol_atol(const ck_tile::index_t K,
-                         const ck_tile::index_t kbatch,
-                         const float max_accumulated_value)
-{
-    using ComputeType =
-        std::conditional_t<sizeof(ADataType) < sizeof(BDataType), ADataType, BDataType>;
-    // Calculate thresholds
-    const auto rtol = ck_tile::get_relative_threshold<ComputeType, CDataType, AccDataType>(
-        ck_tile::integer_divide_ceil(K, kbatch));
-    const auto atol = ck_tile::get_absolute_threshold<ComputeType, CDataType, AccDataType>(
-        max_accumulated_value / kbatch, ck_tile::integer_divide_ceil(K, kbatch));
-    // Calculate error due to split_k accumulation
-    const auto rtol_split_k =
-        ck_tile::get_relative_threshold<CDataType, CDataType, CDataType>(kbatch);
-    const auto atol_split_k = ck_tile::get_absolute_threshold<CDataType, CDataType, CDataType>(
-        max_accumulated_value, kbatch);
-    // Use higher threshold
-    return ck_tile::make_tuple(std::max(rtol, rtol_split_k), std::max(atol, atol_split_k));
 }
 
 template <typename GemmConfig,
@@ -413,7 +393,7 @@ int run_gemm_example_with_layouts(ck_tile::ArgParser& arg_parser,
         const float max_accumulated_value =
             *std::max_element(c_m_n_ref.mData.begin(), c_m_n_ref.mData.end());
         const auto rtol_atol =
-            calculate_rtol_atol<ADataTypeCompute, BDataTypeCompute, AccDataType, CDataType>(
+            ck_tile::calculateRtolAtol<ADataTypeCompute, BDataTypeCompute, AccDataType, CDataType>(
                 K, kbatch, max_accumulated_value);
         pass = do_verify(c_m_n_dev_result, c_m_n_ref, rtol_atol, "CPU");
     }
@@ -450,7 +430,7 @@ int run_gemm_example_with_layouts(ck_tile::ArgParser& arg_parser,
         const float max_accumulated_value =
             *std::max_element(c_m_n_ref.mData.begin(), c_m_n_ref.mData.end());
         const auto rtol_atol =
-            calculate_rtol_atol<ADataTypeCompute, BDataTypeCompute, AccDataType, CDataType>(
+            ck_tile::calculateRtolAtol<ADataTypeCompute, BDataTypeCompute, AccDataType, CDataType>(
                 K, kbatch, max_accumulated_value);
         pass = do_verify(c_m_n_dev_result, c_m_n_ref, rtol_atol, "GPU");
     }

--- a/projects/composablekernel/example/ck_tile/03_gemm/run_gemm_example.inc
+++ b/projects/composablekernel/example/ck_tile/03_gemm/run_gemm_example.inc
@@ -153,9 +153,9 @@ float invoke_gemm(ck_tile::DeviceMem& a_m_k_dev_buf,
 
 template <typename CDataType>
 bool doVerify(const ck_tile::HostTensor<CDataType>& c_m_n_dev_result,
-               const ck_tile::HostTensor<CDataType>& c_m_n_ref,
-               const ck_tile::tuple<double, double>& rtol_atol,
-               const char* variant)
+              const ck_tile::HostTensor<CDataType>& c_m_n_ref,
+              const ck_tile::tuple<double, double>& rtol_atol,
+              const char* variant)
 {
     bool pass = ck_tile::check_err(c_m_n_dev_result,
                                    c_m_n_ref,

--- a/projects/composablekernel/example/ck_tile/03_gemm/run_gemm_example.inc
+++ b/projects/composablekernel/example/ck_tile/03_gemm/run_gemm_example.inc
@@ -159,7 +159,7 @@ float invoke_gemm(ck_tile::DeviceMem& a_m_k_dev_buf,
 }
 
 template <typename CDataType>
-bool do_verify(const ck_tile::HostTensor<CDataType>& c_m_n_dev_result,
+bool doVerify(const ck_tile::HostTensor<CDataType>& c_m_n_dev_result,
                const ck_tile::HostTensor<CDataType>& c_m_n_ref,
                const ck_tile::tuple<double, double>& rtol_atol,
                const char* variant)
@@ -177,7 +177,7 @@ bool do_verify(const ck_tile::HostTensor<CDataType>& c_m_n_dev_result,
     return pass;
 }
 
-std::tuple<ck_tile::index_t, ck_tile::index_t, ck_tile::index_t> inline parse_gemm_size(
+std::tuple<ck_tile::index_t, ck_tile::index_t, ck_tile::index_t> inline parseGemmSize(
     ck_tile::ArgParser& arg_parser)
 {
     ck_tile::index_t M = arg_parser.get_int("m");
@@ -395,7 +395,7 @@ int run_gemm_example_with_layouts(ck_tile::ArgParser& arg_parser,
         const auto rtol_atol =
             ck_tile::calculateRtolAtol<ADataTypeCompute, BDataTypeCompute, AccDataType, CDataType>(
                 K, kbatch, max_accumulated_value);
-        pass = do_verify(c_m_n_dev_result, c_m_n_ref, rtol_atol, "CPU");
+        pass = doVerify(c_m_n_dev_result, c_m_n_ref, rtol_atol, "CPU");
     }
     else if(arg_parser.get_int("v") == 2)
     {
@@ -432,7 +432,7 @@ int run_gemm_example_with_layouts(ck_tile::ArgParser& arg_parser,
         const auto rtol_atol =
             ck_tile::calculateRtolAtol<ADataTypeCompute, BDataTypeCompute, AccDataType, CDataType>(
                 K, kbatch, max_accumulated_value);
-        pass = do_verify(c_m_n_dev_result, c_m_n_ref, rtol_atol, "GPU");
+        pass = doVerify(c_m_n_dev_result, c_m_n_ref, rtol_atol, "GPU");
     }
 
     if(arg_parser.get_int("json") == 1)

--- a/projects/composablekernel/example/ck_tile/03_gemm/universal_gemm.cpp
+++ b/projects/composablekernel/example/ck_tile/03_gemm/universal_gemm.cpp
@@ -107,7 +107,7 @@ int run_gemm_example_with_layouts_universal(ck_tile::ArgParser& arg_parser,
         const auto rtol_atol =
             ck_tile::calculateRtolAtol<ADataType, BDataType, AccDataType, CDataType>(
                 K, kbatch, max_accumulated_value);
-        bool pass = do_verify(c_m_n_dev_result, c_m_n_ref, rtol_atol, "CPU");
+        bool pass = doVerify(c_m_n_dev_result, c_m_n_ref, rtol_atol, "CPU");
 
         std::cout << "Async input scheduler test: " << (pass ? "PASS" : "FAIL") << std::endl;
         return pass;

--- a/projects/composablekernel/example/ck_tile/03_gemm/universal_gemm.cpp
+++ b/projects/composablekernel/example/ck_tile/03_gemm/universal_gemm.cpp
@@ -104,7 +104,7 @@ int run_gemm_example_with_layouts_universal(ck_tile::ArgParser& arg_parser,
         // Verify results
         const float max_accumulated_value =
             *std::max_element(c_m_n_ref.mData.begin(), c_m_n_ref.mData.end());
-        const auto rtol_atol = calculate_rtol_atol<ADataType, BDataType, AccDataType, CDataType>(
+        const auto rtol_atol = ck_tile::calculateRtolAtol<ADataType, BDataType, AccDataType, CDataType>(
             K, kbatch, max_accumulated_value);
         bool pass = do_verify(c_m_n_dev_result, c_m_n_ref, rtol_atol, "CPU");
 

--- a/projects/composablekernel/example/ck_tile/03_gemm/universal_gemm.cpp
+++ b/projects/composablekernel/example/ck_tile/03_gemm/universal_gemm.cpp
@@ -104,8 +104,9 @@ int run_gemm_example_with_layouts_universal(ck_tile::ArgParser& arg_parser,
         // Verify results
         const float max_accumulated_value =
             *std::max_element(c_m_n_ref.mData.begin(), c_m_n_ref.mData.end());
-        const auto rtol_atol = ck_tile::calculateRtolAtol<ADataType, BDataType, AccDataType, CDataType>(
-            K, kbatch, max_accumulated_value);
+        const auto rtol_atol =
+            ck_tile::calculateRtolAtol<ADataType, BDataType, AccDataType, CDataType>(
+                K, kbatch, max_accumulated_value);
         bool pass = do_verify(c_m_n_dev_result, c_m_n_ref, rtol_atol, "CPU");
 
         std::cout << "Async input scheduler test: " << (pass ? "PASS" : "FAIL") << std::endl;

--- a/projects/composablekernel/example/ck_tile/03_gemm/universal_gemm_invoker.hpp
+++ b/projects/composablekernel/example/ck_tile/03_gemm/universal_gemm_invoker.hpp
@@ -127,9 +127,9 @@ struct UniversalInvoker
             std::cout << "Flushing cache..." << std::endl;
 
             ck_tile::HostTensor<ADataType> a_m(ck_tile::host_tensor_descriptor(
-                args.M, args.K, args.stride_A, is_row_major(ALayout{})));
+                args.M, args.K, args.stride_A, ck_tile::is_row_major(ALayout{})));
             ck_tile::HostTensor<BDataType> b_n(ck_tile::host_tensor_descriptor(
-                args.K, args.N, args.stride_B, is_row_major(BLayout{})));
+                args.K, args.N, args.stride_B, ck_tile::is_row_major(BLayout{})));
 
             auto size_a_buffer = a_m.get_element_space_size_in_bytes();
             auto size_b_buffer = b_n.get_element_space_size_in_bytes();

--- a/projects/composablekernel/example/ck_tile/16_batched_gemm/run_batched_gemm_example.inc
+++ b/projects/composablekernel/example/ck_tile/16_batched_gemm/run_batched_gemm_example.inc
@@ -2,25 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
-auto calculate_rtol_atol(const ck_tile::index_t K,
-                         const ck_tile::index_t kbatch,
-                         const float max_accumulated_value)
-{
-    using ComputeType =
-        std::conditional_t<sizeof(ADataType) < sizeof(BDataType), ADataType, BDataType>;
-    // Calculate thresholds
-    const auto rtol = ck_tile::get_relative_threshold<ComputeType, CDataType, AccDataType>(
-        ck_tile::integer_divide_ceil(K, kbatch));
-    const auto atol = ck_tile::get_absolute_threshold<ComputeType, CDataType, AccDataType>(
-        max_accumulated_value / kbatch, ck_tile::integer_divide_ceil(K, kbatch));
-    // Calculate error due to split_k accumulation
-    const auto rtol_split_k =
-        ck_tile::get_relative_threshold<CDataType, CDataType, CDataType>(kbatch);
-    const auto atol_split_k = ck_tile::get_absolute_threshold<CDataType, CDataType, CDataType>(
-        max_accumulated_value, kbatch);
-    // Use higher threshold
-    return ck_tile::make_tuple(std::max(rtol, rtol_split_k), std::max(atol, atol_split_k));
-}
+#include "ck_tile/host/gemm_rtol_atol.hpp"
 
 template <typename GemmConfig,
           typename ADataType,
@@ -228,8 +210,10 @@ int run_batched_gemm_example_with_layouts(int argc,
             a_m_k, b_n_k, c_m_n_host_ref);
         const float max_accumulated_value =
             *std::max_element(c_m_n_host_ref.mData.begin(), c_m_n_host_ref.mData.end());
-        const auto rtol_atol = calculate_rtol_atol(K, kbatch, max_accumulated_value);
-        pass                 = ck_tile::check_err(c_m_n_dev_result,
+        const auto rtol_atol =
+            ck_tile::calculateRtolAtol<ADataType, BDataType, AccDataType, CDataType>(
+                K, kbatch, max_accumulated_value);
+        pass = ck_tile::check_err(c_m_n_dev_result,
                                   c_m_n_host_ref,
                                   "Error: Incorrect results!",
                                   rtol_atol.at(ck_tile::number<0>{}),
@@ -276,8 +260,10 @@ int run_batched_gemm_example_with_layouts(int argc,
         c_m_n_gpu_buf_ref.FromDevice(c_m_n_gpu_ref.data());
         const float max_accumulated_value =
             *std::max_element(c_m_n_gpu_ref.mData.begin(), c_m_n_gpu_ref.mData.end());
-        const auto rtol_atol = calculate_rtol_atol(K, kbatch, max_accumulated_value);
-        pass                 = ck_tile::check_err(c_m_n_dev_result,
+        const auto rtol_atol =
+            ck_tile::calculateRtolAtol<ADataType, BDataType, AccDataType, CDataType>(
+                K, kbatch, max_accumulated_value);
+        pass = ck_tile::check_err(c_m_n_dev_result,
                                   c_m_n_gpu_ref,
                                   "Error: Incorrect results!",
                                   rtol_atol.at(ck_tile::number<0>{}),

--- a/projects/composablekernel/example/ck_tile/17_grouped_gemm/quant_run_grouped_gemm_example.hpp
+++ b/projects/composablekernel/example/ck_tile/17_grouped_gemm/quant_run_grouped_gemm_example.hpp
@@ -22,13 +22,6 @@
 #include "quant_grouped_gemm_config.hpp"
 #include "quant_invoke_grouped_gemm_kernel.hpp"
 
-template <typename Layout>
-static constexpr inline auto is_row_major(Layout layout_)
-{
-    return ck_tile::bool_constant<std::is_same_v<ck_tile::remove_cvref_t<decltype(layout_)>,
-                                                 ck_tile::tensor_layout::gemm::RowMajor>>{};
-}
-
 template <typename GemmConfig,
           typename ADataType,
           typename AQDataType,
@@ -297,15 +290,15 @@ int run_grouped_gemm_example_with_layouts(const ck_tile::ArgParser& arg_parser,
             }
         }
 
-        stride_As[i] = ck_tile::get_default_stride(M, K, stride_As[i], is_row_major(a_layout));
-        stride_Bs[i] = ck_tile::get_default_stride(K, N, stride_Bs[i], is_row_major(b_layout));
-        stride_Cs[i] = ck_tile::get_default_stride(M, N, stride_Cs[i], is_row_major(CLayout{}));
+        stride_As[i] = ck_tile::get_default_stride(M, K, stride_As[i], ck_tile::is_row_major(a_layout));
+        stride_Bs[i] = ck_tile::get_default_stride(K, N, stride_Bs[i], ck_tile::is_row_major(b_layout));
+        stride_Cs[i] = ck_tile::get_default_stride(M, N, stride_Cs[i], ck_tile::is_row_major(CLayout{}));
         if constexpr(QuantMode == ck_tile::QuantType::RowColQuant)
         {
             stride_AQs[i] =
-                ck_tile::get_default_stride(M, 1, stride_AQs[i], is_row_major(aq_layout));
+                ck_tile::get_default_stride(M, 1, stride_AQs[i], ck_tile::is_row_major(aq_layout));
             stride_BQs[i] =
-                ck_tile::get_default_stride(1, N, stride_BQs[i], is_row_major(bq_layout));
+                ck_tile::get_default_stride(1, N, stride_BQs[i], ck_tile::is_row_major(bq_layout));
         }
         else if constexpr(QuantMode == ck_tile::QuantType::TensorQuant)
         {
@@ -315,49 +308,49 @@ int run_grouped_gemm_example_with_layouts(const ck_tile::ArgParser& arg_parser,
         else if constexpr(QuantMode == ck_tile::QuantType::AQuantGrouped)
         {
             stride_AQs[i] =
-                ck_tile::get_default_stride(M, AQK, stride_AQs[i], is_row_major(aq_layout));
+                ck_tile::get_default_stride(M, AQK, stride_AQs[i], ck_tile::is_row_major(aq_layout));
             stride_BQs[i] = 0; // No B quantization
         }
         else if constexpr(QuantMode == ck_tile::QuantType::BQuantGrouped)
         {
             stride_AQs[i] = 0; // No A quantization
             stride_BQs[i] =
-                ck_tile::get_default_stride(BQK, N, stride_BQs[i], is_row_major(bq_layout));
+                ck_tile::get_default_stride(BQK, N, stride_BQs[i], ck_tile::is_row_major(bq_layout));
         }
 
         a_m_k_tensors.push_back(ck_tile::HostTensor<ADataType>(
-            ck_tile::host_tensor_descriptor(M, K, stride_As[i], is_row_major(a_layout))));
+            ck_tile::host_tensor_descriptor(M, K, stride_As[i], ck_tile::is_row_major(a_layout))));
         b_k_n_tensors.push_back(ck_tile::HostTensor<BDataType>(
-            ck_tile::host_tensor_descriptor(K, N, stride_Bs[i], is_row_major(b_layout))));
+            ck_tile::host_tensor_descriptor(K, N, stride_Bs[i], ck_tile::is_row_major(b_layout))));
         c_m_n_tensors.push_back(ck_tile::HostTensor<CDataType>(
-            ck_tile::host_tensor_descriptor(M, N, stride_Cs[i], is_row_major(CLayout{}))));
+            ck_tile::host_tensor_descriptor(M, N, stride_Cs[i], ck_tile::is_row_major(CLayout{}))));
         if constexpr(QuantMode == ck_tile::QuantType::RowColQuant)
         {
             aq_tensors.push_back(ck_tile::HostTensor<AQDataType>(
-                ck_tile::host_tensor_descriptor(M, AQK, stride_AQs[i], is_row_major(aq_layout))));
+                ck_tile::host_tensor_descriptor(M, AQK, stride_AQs[i], ck_tile::is_row_major(aq_layout))));
             bq_tensors.push_back(ck_tile::HostTensor<BQDataType>(
-                ck_tile::host_tensor_descriptor(BQK, N, stride_BQs[i], is_row_major(bq_layout))));
+                ck_tile::host_tensor_descriptor(BQK, N, stride_BQs[i], ck_tile::is_row_major(bq_layout))));
         }
         else if constexpr(QuantMode == ck_tile::QuantType::TensorQuant)
         {
             aq_tensors.push_back(ck_tile::HostTensor<AQDataType>(
-                ck_tile::host_tensor_descriptor(1, 1, stride_AQs[i], is_row_major(aq_layout))));
+                ck_tile::host_tensor_descriptor(1, 1, stride_AQs[i], ck_tile::is_row_major(aq_layout))));
             bq_tensors.push_back(ck_tile::HostTensor<BQDataType>(
-                ck_tile::host_tensor_descriptor(1, 1, stride_BQs[i], is_row_major(bq_layout))));
+                ck_tile::host_tensor_descriptor(1, 1, stride_BQs[i], ck_tile::is_row_major(bq_layout))));
         }
         else if constexpr(QuantMode == ck_tile::QuantType::AQuantGrouped)
         {
             aq_tensors.push_back(ck_tile::HostTensor<AQDataType>(
-                ck_tile::host_tensor_descriptor(M, AQK, stride_AQs[i], is_row_major(aq_layout))));
+                ck_tile::host_tensor_descriptor(M, AQK, stride_AQs[i], ck_tile::is_row_major(aq_layout))));
             bq_tensors.push_back(ck_tile::HostTensor<BQDataType>(
-                ck_tile::host_tensor_descriptor(0, 0, stride_BQs[i], is_row_major(bq_layout))));
+                ck_tile::host_tensor_descriptor(0, 0, stride_BQs[i], ck_tile::is_row_major(bq_layout))));
         }
         else if constexpr(QuantMode == ck_tile::QuantType::BQuantGrouped)
         {
             aq_tensors.push_back(ck_tile::HostTensor<AQDataType>(
-                ck_tile::host_tensor_descriptor(0, 0, stride_AQs[i], is_row_major(aq_layout))));
+                ck_tile::host_tensor_descriptor(0, 0, stride_AQs[i], ck_tile::is_row_major(aq_layout))));
             bq_tensors.push_back(ck_tile::HostTensor<BQDataType>(
-                ck_tile::host_tensor_descriptor(BQK, N, stride_BQs[i], is_row_major(bq_layout))));
+                ck_tile::host_tensor_descriptor(BQK, N, stride_BQs[i], ck_tile::is_row_major(bq_layout))));
         }
 
         std::cout << "gemm[" << i << "]" << " a_m_k: " << a_m_k_tensors[i].mDesc
@@ -457,7 +450,7 @@ int run_grouped_gemm_example_with_layouts(const ck_tile::ArgParser& arg_parser,
         for(int i = 0; i < group_count; ++i)
         {
             ck_tile::HostTensor<CDataType> c_m_n_host_ref(ck_tile::host_tensor_descriptor(
-                Ms[i], Ns[i], stride_Cs[i], is_row_major(CLayout{})));
+                Ms[i], Ns[i], stride_Cs[i], ck_tile::is_row_major(CLayout{})));
             c_m_n_host_ref.SetZero();
             if constexpr(QuantMode == ck_tile::QuantType::RowColQuant)
             {

--- a/projects/composablekernel/example/ck_tile/17_grouped_gemm/quant_run_grouped_gemm_example.hpp
+++ b/projects/composablekernel/example/ck_tile/17_grouped_gemm/quant_run_grouped_gemm_example.hpp
@@ -28,26 +28,7 @@ static constexpr inline auto is_row_major(Layout layout_)
                                                  ck_tile::tensor_layout::gemm::RowMajor>>{};
 }
 
-template <typename ADataType, typename BDataType, typename AccDataType, typename CDataType>
-static auto calculate_rtol_atol(const ck_tile::index_t K,
-                                const ck_tile::index_t kbatch,
-                                const float max_accumulated_value)
-{
-    using ComputeType =
-        std::conditional_t<sizeof(ADataType) < sizeof(BDataType), ADataType, BDataType>;
-    // Calculate thresholds
-    const auto rtol = ck_tile::get_relative_threshold<ComputeType, CDataType, AccDataType>(
-        ck_tile::integer_divide_ceil(K, kbatch));
-    const auto atol = ck_tile::get_absolute_threshold<ComputeType, CDataType, AccDataType>(
-        max_accumulated_value / kbatch, ck_tile::integer_divide_ceil(K, kbatch));
-    // Calculate error due to split_k accumulation
-    const auto rtol_split_k =
-        ck_tile::get_relative_threshold<CDataType, CDataType, CDataType>(kbatch);
-    const auto atol_split_k = ck_tile::get_absolute_threshold<CDataType, CDataType, CDataType>(
-        max_accumulated_value, kbatch);
-    // Use higher threshold
-    return ck_tile::make_tuple(std::max(rtol, rtol_split_k), std::max(atol, atol_split_k));
-}
+#include "ck_tile/host/gemm_rtol_atol.hpp"
 
 template <typename GemmConfig,
           typename ADataType,
@@ -531,7 +512,7 @@ int run_grouped_gemm_example_with_layouts(const ck_tile::ArgParser& arg_parser,
             const float max_accumulated_value =
                 *std::max_element(c_m_n_host_ref.mData.begin(), c_m_n_host_ref.mData.end());
             const auto rtol_atol =
-                calculate_rtol_atol<ADataType, BDataType, AccDataType, CDataType>(
+                ck_tile::calculateRtolAtol<ADataType, BDataType, AccDataType, CDataType>(
                     Ks[i], kbatch, max_accumulated_value);
             pass &= ck_tile::check_err(c_m_n_tensors[i],
                                        c_m_n_host_ref,

--- a/projects/composablekernel/example/ck_tile/17_grouped_gemm/quant_run_grouped_gemm_example.hpp
+++ b/projects/composablekernel/example/ck_tile/17_grouped_gemm/quant_run_grouped_gemm_example.hpp
@@ -290,9 +290,12 @@ int run_grouped_gemm_example_with_layouts(const ck_tile::ArgParser& arg_parser,
             }
         }
 
-        stride_As[i] = ck_tile::get_default_stride(M, K, stride_As[i], ck_tile::is_row_major(a_layout));
-        stride_Bs[i] = ck_tile::get_default_stride(K, N, stride_Bs[i], ck_tile::is_row_major(b_layout));
-        stride_Cs[i] = ck_tile::get_default_stride(M, N, stride_Cs[i], ck_tile::is_row_major(CLayout{}));
+        stride_As[i] =
+            ck_tile::get_default_stride(M, K, stride_As[i], ck_tile::is_row_major(a_layout));
+        stride_Bs[i] =
+            ck_tile::get_default_stride(K, N, stride_Bs[i], ck_tile::is_row_major(b_layout));
+        stride_Cs[i] =
+            ck_tile::get_default_stride(M, N, stride_Cs[i], ck_tile::is_row_major(CLayout{}));
         if constexpr(QuantMode == ck_tile::QuantType::RowColQuant)
         {
             stride_AQs[i] =
@@ -307,15 +310,15 @@ int run_grouped_gemm_example_with_layouts(const ck_tile::ArgParser& arg_parser,
         }
         else if constexpr(QuantMode == ck_tile::QuantType::AQuantGrouped)
         {
-            stride_AQs[i] =
-                ck_tile::get_default_stride(M, AQK, stride_AQs[i], ck_tile::is_row_major(aq_layout));
+            stride_AQs[i] = ck_tile::get_default_stride(
+                M, AQK, stride_AQs[i], ck_tile::is_row_major(aq_layout));
             stride_BQs[i] = 0; // No B quantization
         }
         else if constexpr(QuantMode == ck_tile::QuantType::BQuantGrouped)
         {
             stride_AQs[i] = 0; // No A quantization
-            stride_BQs[i] =
-                ck_tile::get_default_stride(BQK, N, stride_BQs[i], ck_tile::is_row_major(bq_layout));
+            stride_BQs[i] = ck_tile::get_default_stride(
+                BQK, N, stride_BQs[i], ck_tile::is_row_major(bq_layout));
         }
 
         a_m_k_tensors.push_back(ck_tile::HostTensor<ADataType>(
@@ -326,31 +329,31 @@ int run_grouped_gemm_example_with_layouts(const ck_tile::ArgParser& arg_parser,
             ck_tile::host_tensor_descriptor(M, N, stride_Cs[i], ck_tile::is_row_major(CLayout{}))));
         if constexpr(QuantMode == ck_tile::QuantType::RowColQuant)
         {
-            aq_tensors.push_back(ck_tile::HostTensor<AQDataType>(
-                ck_tile::host_tensor_descriptor(M, AQK, stride_AQs[i], ck_tile::is_row_major(aq_layout))));
-            bq_tensors.push_back(ck_tile::HostTensor<BQDataType>(
-                ck_tile::host_tensor_descriptor(BQK, N, stride_BQs[i], ck_tile::is_row_major(bq_layout))));
+            aq_tensors.push_back(ck_tile::HostTensor<AQDataType>(ck_tile::host_tensor_descriptor(
+                M, AQK, stride_AQs[i], ck_tile::is_row_major(aq_layout))));
+            bq_tensors.push_back(ck_tile::HostTensor<BQDataType>(ck_tile::host_tensor_descriptor(
+                BQK, N, stride_BQs[i], ck_tile::is_row_major(bq_layout))));
         }
         else if constexpr(QuantMode == ck_tile::QuantType::TensorQuant)
         {
-            aq_tensors.push_back(ck_tile::HostTensor<AQDataType>(
-                ck_tile::host_tensor_descriptor(1, 1, stride_AQs[i], ck_tile::is_row_major(aq_layout))));
-            bq_tensors.push_back(ck_tile::HostTensor<BQDataType>(
-                ck_tile::host_tensor_descriptor(1, 1, stride_BQs[i], ck_tile::is_row_major(bq_layout))));
+            aq_tensors.push_back(ck_tile::HostTensor<AQDataType>(ck_tile::host_tensor_descriptor(
+                1, 1, stride_AQs[i], ck_tile::is_row_major(aq_layout))));
+            bq_tensors.push_back(ck_tile::HostTensor<BQDataType>(ck_tile::host_tensor_descriptor(
+                1, 1, stride_BQs[i], ck_tile::is_row_major(bq_layout))));
         }
         else if constexpr(QuantMode == ck_tile::QuantType::AQuantGrouped)
         {
-            aq_tensors.push_back(ck_tile::HostTensor<AQDataType>(
-                ck_tile::host_tensor_descriptor(M, AQK, stride_AQs[i], ck_tile::is_row_major(aq_layout))));
-            bq_tensors.push_back(ck_tile::HostTensor<BQDataType>(
-                ck_tile::host_tensor_descriptor(0, 0, stride_BQs[i], ck_tile::is_row_major(bq_layout))));
+            aq_tensors.push_back(ck_tile::HostTensor<AQDataType>(ck_tile::host_tensor_descriptor(
+                M, AQK, stride_AQs[i], ck_tile::is_row_major(aq_layout))));
+            bq_tensors.push_back(ck_tile::HostTensor<BQDataType>(ck_tile::host_tensor_descriptor(
+                0, 0, stride_BQs[i], ck_tile::is_row_major(bq_layout))));
         }
         else if constexpr(QuantMode == ck_tile::QuantType::BQuantGrouped)
         {
-            aq_tensors.push_back(ck_tile::HostTensor<AQDataType>(
-                ck_tile::host_tensor_descriptor(0, 0, stride_AQs[i], ck_tile::is_row_major(aq_layout))));
-            bq_tensors.push_back(ck_tile::HostTensor<BQDataType>(
-                ck_tile::host_tensor_descriptor(BQK, N, stride_BQs[i], ck_tile::is_row_major(bq_layout))));
+            aq_tensors.push_back(ck_tile::HostTensor<AQDataType>(ck_tile::host_tensor_descriptor(
+                0, 0, stride_AQs[i], ck_tile::is_row_major(aq_layout))));
+            bq_tensors.push_back(ck_tile::HostTensor<BQDataType>(ck_tile::host_tensor_descriptor(
+                BQK, N, stride_BQs[i], ck_tile::is_row_major(bq_layout))));
         }
 
         std::cout << "gemm[" << i << "]" << " a_m_k: " << a_m_k_tensors[i].mDesc

--- a/projects/composablekernel/example/ck_tile/17_grouped_gemm/quant_run_grouped_gemm_example.hpp
+++ b/projects/composablekernel/example/ck_tile/17_grouped_gemm/quant_run_grouped_gemm_example.hpp
@@ -17,6 +17,7 @@
 #include "ck_tile/ops/gemm/pipeline/tile_gemm_traits.hpp"
 #include "ck_tile/ops/gemm_quant.hpp"
 #include "ck_tile/host.hpp"
+#include "ck_tile/host/gemm_rtol_atol.hpp"
 
 #include "quant_grouped_gemm_config.hpp"
 #include "quant_invoke_grouped_gemm_kernel.hpp"
@@ -27,8 +28,6 @@ static constexpr inline auto is_row_major(Layout layout_)
     return ck_tile::bool_constant<std::is_same_v<ck_tile::remove_cvref_t<decltype(layout_)>,
                                                  ck_tile::tensor_layout::gemm::RowMajor>>{};
 }
-
-#include "ck_tile/host/gemm_rtol_atol.hpp"
 
 template <typename GemmConfig,
           typename ADataType,

--- a/projects/composablekernel/example/ck_tile/17_grouped_gemm/run_grouped_gemm_abquant_example.inc
+++ b/projects/composablekernel/example/ck_tile/17_grouped_gemm/run_grouped_gemm_abquant_example.inc
@@ -2,33 +2,13 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
+#include "ck_tile/host/gemm_rtol_atol.hpp"
 
 template <typename Layout>
 static constexpr inline auto is_row_major(Layout layout_)
 {
     return ck_tile::bool_constant<std::is_same_v<ck_tile::remove_cvref_t<decltype(layout_)>,
                                                  ck_tile::tensor_layout::gemm::RowMajor>>{};
-}
-
-template <typename ADataType, typename BDataType, typename AccDataType, typename CDataType>
-auto calculate_rtol_atol(const ck_tile::index_t K,
-                         const ck_tile::index_t kbatch,
-                         const float max_accumulated_value)
-{
-    using ComputeType =
-        std::conditional_t<sizeof(ADataType) < sizeof(BDataType), ADataType, BDataType>;
-    // Calculate thresholds
-    const auto rtol = ck_tile::get_relative_threshold<ComputeType, CDataType, AccDataType>(
-        ck_tile::integer_divide_ceil(K, kbatch));
-    const auto atol = ck_tile::get_absolute_threshold<ComputeType, CDataType, AccDataType>(
-        max_accumulated_value / kbatch, ck_tile::integer_divide_ceil(K, kbatch));
-    // Calculate error due to split_k accumulation
-    const auto rtol_split_k =
-        ck_tile::get_relative_threshold<CDataType, CDataType, CDataType>(kbatch);
-    const auto atol_split_k = ck_tile::get_absolute_threshold<CDataType, CDataType, CDataType>(
-        max_accumulated_value, kbatch);
-    // Use higher threshold
-    return ck_tile::make_tuple(std::max(rtol, rtol_split_k), std::max(atol, atol_split_k));
 }
 
 template <typename GemmConfig,
@@ -421,7 +401,7 @@ int run_abquant_grouped_gemm_example_with_layouts(
             const float max_accumulated_value =
                 *std::max_element(c_m_n_host_ref.mData.begin(), c_m_n_host_ref.mData.end());
             const auto rtol_atol =
-                calculate_rtol_atol<ADataType, BDataType, AccDataType, CDataType>(
+                ck_tile::calculateRtolAtol<ADataType, BDataType, AccDataType, CDataType>(
                     Ks[i], kbatch, max_accumulated_value);
             pass &=
                 ck_tile::check_err(c_m_n_tensors[i],

--- a/projects/composablekernel/example/ck_tile/17_grouped_gemm/run_grouped_gemm_abquant_example.inc
+++ b/projects/composablekernel/example/ck_tile/17_grouped_gemm/run_grouped_gemm_abquant_example.inc
@@ -4,13 +4,6 @@
 #pragma once
 #include "ck_tile/host/gemm_rtol_atol.hpp"
 
-template <typename Layout>
-static constexpr inline auto is_row_major(Layout layout_)
-{
-    return ck_tile::bool_constant<std::is_same_v<ck_tile::remove_cvref_t<decltype(layout_)>,
-                                                 ck_tile::tensor_layout::gemm::RowMajor>>{};
-}
-
 template <typename GemmConfig,
           typename ADataType,
           typename AQDataType,
@@ -261,22 +254,22 @@ int run_abquant_grouped_gemm_example_with_layouts(
                 "K must be divisible by BQuantGroupSize::kK for ABQuantGrouped mode");
         }
 
-        stride_As[i]  = ck_tile::get_default_stride(M, K, stride_As[i], is_row_major(a_layout));
-        stride_Bs[i]  = ck_tile::get_default_stride(K, N, stride_Bs[i], is_row_major(b_layout));
-        stride_Cs[i]  = ck_tile::get_default_stride(M, N, stride_Cs[i], is_row_major(CLayout{}));
-        stride_AQs[i] = ck_tile::get_default_stride(M, AQK, stride_AQs[i], is_row_major(aq_layout));
-        stride_BQs[i] = ck_tile::get_default_stride(BQK, N, stride_BQs[i], is_row_major(bq_layout));
+        stride_As[i]  = ck_tile::get_default_stride(M, K, stride_As[i], ck_tile::is_row_major(a_layout));
+        stride_Bs[i]  = ck_tile::get_default_stride(K, N, stride_Bs[i], ck_tile::is_row_major(b_layout));
+        stride_Cs[i]  = ck_tile::get_default_stride(M, N, stride_Cs[i], ck_tile::is_row_major(CLayout{}));
+        stride_AQs[i] = ck_tile::get_default_stride(M, AQK, stride_AQs[i], ck_tile::is_row_major(aq_layout));
+        stride_BQs[i] = ck_tile::get_default_stride(BQK, N, stride_BQs[i], ck_tile::is_row_major(bq_layout));
 
         a_m_k_tensors.push_back(ck_tile::HostTensor<ADataType>(
-            ck_tile::host_tensor_descriptor(M, K, stride_As[i], is_row_major(a_layout))));
+            ck_tile::host_tensor_descriptor(M, K, stride_As[i], ck_tile::is_row_major(a_layout))));
         b_k_n_tensors.push_back(ck_tile::HostTensor<BDataType>(
-            ck_tile::host_tensor_descriptor(K, N, stride_Bs[i], is_row_major(b_layout))));
+            ck_tile::host_tensor_descriptor(K, N, stride_Bs[i], ck_tile::is_row_major(b_layout))));
         c_m_n_tensors.push_back(ck_tile::HostTensor<CDataType>(
-            ck_tile::host_tensor_descriptor(M, N, stride_Cs[i], is_row_major(CLayout{}))));
+            ck_tile::host_tensor_descriptor(M, N, stride_Cs[i], ck_tile::is_row_major(CLayout{}))));
         aq_tensors.push_back(ck_tile::HostTensor<AQDataType>(
-            ck_tile::host_tensor_descriptor(M, AQK, stride_AQs[i], is_row_major(aq_layout))));
+            ck_tile::host_tensor_descriptor(M, AQK, stride_AQs[i], ck_tile::is_row_major(aq_layout))));
         bq_tensors.push_back(ck_tile::HostTensor<BQDataType>(
-            ck_tile::host_tensor_descriptor(BQK, N, stride_BQs[i], is_row_major(bq_layout))));
+            ck_tile::host_tensor_descriptor(BQK, N, stride_BQs[i], ck_tile::is_row_major(bq_layout))));
 
         std::cout << "gemm[" << i << "]" << " a_m_k: " << a_m_k_tensors[i].mDesc
                   << " b_k_n: " << b_k_n_tensors[i].mDesc << " c_m_n: " << c_m_n_tensors[i].mDesc
@@ -384,7 +377,7 @@ int run_abquant_grouped_gemm_example_with_layouts(
         for(int i = 0; i < group_count; ++i)
         {
             ck_tile::HostTensor<CDataType> c_m_n_host_ref(ck_tile::host_tensor_descriptor(
-                Ms[i], Ns[i], stride_Cs[i], is_row_major(CLayout{})));
+                Ms[i], Ns[i], stride_Cs[i], ck_tile::is_row_major(CLayout{})));
             c_m_n_host_ref.SetZero();
 
             // Reference implementation for ABQuantGrouped

--- a/projects/composablekernel/example/ck_tile/17_grouped_gemm/run_grouped_gemm_abquant_example.inc
+++ b/projects/composablekernel/example/ck_tile/17_grouped_gemm/run_grouped_gemm_abquant_example.inc
@@ -254,11 +254,16 @@ int run_abquant_grouped_gemm_example_with_layouts(
                 "K must be divisible by BQuantGroupSize::kK for ABQuantGrouped mode");
         }
 
-        stride_As[i]  = ck_tile::get_default_stride(M, K, stride_As[i], ck_tile::is_row_major(a_layout));
-        stride_Bs[i]  = ck_tile::get_default_stride(K, N, stride_Bs[i], ck_tile::is_row_major(b_layout));
-        stride_Cs[i]  = ck_tile::get_default_stride(M, N, stride_Cs[i], ck_tile::is_row_major(CLayout{}));
-        stride_AQs[i] = ck_tile::get_default_stride(M, AQK, stride_AQs[i], ck_tile::is_row_major(aq_layout));
-        stride_BQs[i] = ck_tile::get_default_stride(BQK, N, stride_BQs[i], ck_tile::is_row_major(bq_layout));
+        stride_As[i] =
+            ck_tile::get_default_stride(M, K, stride_As[i], ck_tile::is_row_major(a_layout));
+        stride_Bs[i] =
+            ck_tile::get_default_stride(K, N, stride_Bs[i], ck_tile::is_row_major(b_layout));
+        stride_Cs[i] =
+            ck_tile::get_default_stride(M, N, stride_Cs[i], ck_tile::is_row_major(CLayout{}));
+        stride_AQs[i] =
+            ck_tile::get_default_stride(M, AQK, stride_AQs[i], ck_tile::is_row_major(aq_layout));
+        stride_BQs[i] =
+            ck_tile::get_default_stride(BQK, N, stride_BQs[i], ck_tile::is_row_major(bq_layout));
 
         a_m_k_tensors.push_back(ck_tile::HostTensor<ADataType>(
             ck_tile::host_tensor_descriptor(M, K, stride_As[i], ck_tile::is_row_major(a_layout))));
@@ -266,10 +271,10 @@ int run_abquant_grouped_gemm_example_with_layouts(
             ck_tile::host_tensor_descriptor(K, N, stride_Bs[i], ck_tile::is_row_major(b_layout))));
         c_m_n_tensors.push_back(ck_tile::HostTensor<CDataType>(
             ck_tile::host_tensor_descriptor(M, N, stride_Cs[i], ck_tile::is_row_major(CLayout{}))));
-        aq_tensors.push_back(ck_tile::HostTensor<AQDataType>(
-            ck_tile::host_tensor_descriptor(M, AQK, stride_AQs[i], ck_tile::is_row_major(aq_layout))));
-        bq_tensors.push_back(ck_tile::HostTensor<BQDataType>(
-            ck_tile::host_tensor_descriptor(BQK, N, stride_BQs[i], ck_tile::is_row_major(bq_layout))));
+        aq_tensors.push_back(ck_tile::HostTensor<AQDataType>(ck_tile::host_tensor_descriptor(
+            M, AQK, stride_AQs[i], ck_tile::is_row_major(aq_layout))));
+        bq_tensors.push_back(ck_tile::HostTensor<BQDataType>(ck_tile::host_tensor_descriptor(
+            BQK, N, stride_BQs[i], ck_tile::is_row_major(bq_layout))));
 
         std::cout << "gemm[" << i << "]" << " a_m_k: " << a_m_k_tensors[i].mDesc
                   << " b_k_n: " << b_k_n_tensors[i].mDesc << " c_m_n: " << c_m_n_tensors[i].mDesc

--- a/projects/composablekernel/example/ck_tile/17_grouped_gemm/run_grouped_gemm_example.inc
+++ b/projects/composablekernel/example/ck_tile/17_grouped_gemm/run_grouped_gemm_example.inc
@@ -182,9 +182,12 @@ int run_grouped_gemm_example_with_layouts(int argc,
         const ck_tile::index_t N = Ns[i];
         const ck_tile::index_t K = Ks[i];
 
-        stride_As[i] = ck_tile::get_default_stride(M, K, stride_As[i], ck_tile::is_row_major(a_layout));
-        stride_Bs[i] = ck_tile::get_default_stride(K, N, stride_Bs[i], ck_tile::is_row_major(b_layout));
-        stride_Cs[i] = ck_tile::get_default_stride(M, N, stride_Cs[i], ck_tile::is_row_major(CLayout{}));
+        stride_As[i] =
+            ck_tile::get_default_stride(M, K, stride_As[i], ck_tile::is_row_major(a_layout));
+        stride_Bs[i] =
+            ck_tile::get_default_stride(K, N, stride_Bs[i], ck_tile::is_row_major(b_layout));
+        stride_Cs[i] =
+            ck_tile::get_default_stride(M, N, stride_Cs[i], ck_tile::is_row_major(CLayout{}));
 
         a_m_k_tensors.push_back(ck_tile::HostTensor<ADataType>(
             ck_tile::host_tensor_descriptor(M, K, stride_As[i], ck_tile::is_row_major(a_layout))));

--- a/projects/composablekernel/example/ck_tile/17_grouped_gemm/run_grouped_gemm_example.inc
+++ b/projects/composablekernel/example/ck_tile/17_grouped_gemm/run_grouped_gemm_example.inc
@@ -2,32 +2,12 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
+#include "ck_tile/host/gemm_rtol_atol.hpp"
 template <typename Layout>
 static constexpr inline auto is_row_major(Layout layout_)
 {
     return ck_tile::bool_constant<std::is_same_v<ck_tile::remove_cvref_t<decltype(layout_)>,
                                                  ck_tile::tensor_layout::gemm::RowMajor>>{};
-}
-
-template <typename ADataType, typename BDataType, typename AccDataType, typename CDataType>
-auto calculate_rtol_atol(const ck_tile::index_t K,
-                         const ck_tile::index_t kbatch,
-                         const float max_accumulated_value)
-{
-    using ComputeType =
-        std::conditional_t<sizeof(ADataType) < sizeof(BDataType), ADataType, BDataType>;
-    // Calculate thresholds
-    const auto rtol = ck_tile::get_relative_threshold<ComputeType, CDataType, AccDataType>(
-        ck_tile::integer_divide_ceil(K, kbatch));
-    const auto atol = ck_tile::get_absolute_threshold<ComputeType, CDataType, AccDataType>(
-        max_accumulated_value / kbatch, ck_tile::integer_divide_ceil(K, kbatch));
-    // Calculate error due to split_k accumulation
-    const auto rtol_split_k =
-        ck_tile::get_relative_threshold<CDataType, CDataType, CDataType>(kbatch);
-    const auto atol_split_k = ck_tile::get_absolute_threshold<CDataType, CDataType, CDataType>(
-        max_accumulated_value, kbatch);
-    // Use higher threshold
-    return ck_tile::make_tuple(std::max(rtol, rtol_split_k), std::max(atol, atol_split_k));
 }
 
 template <typename GemmConfig,
@@ -311,7 +291,7 @@ int run_grouped_gemm_example_with_layouts(int argc,
             const float max_accumulated_value =
                 *std::max_element(c_m_n_host_ref.mData.begin(), c_m_n_host_ref.mData.end());
             const auto rtol_atol =
-                calculate_rtol_atol<ADataType, BDataType, AccDataType, CDataType>(
+                ck_tile::calculateRtolAtol<ADataType, BDataType, AccDataType, CDataType>(
                     Ks[i], kbatch, max_accumulated_value);
             pass &=
                 ck_tile::check_err(c_m_n_tensors[i],

--- a/projects/composablekernel/example/ck_tile/17_grouped_gemm/run_grouped_gemm_example.inc
+++ b/projects/composablekernel/example/ck_tile/17_grouped_gemm/run_grouped_gemm_example.inc
@@ -3,13 +3,6 @@
 
 #pragma once
 #include "ck_tile/host/gemm_rtol_atol.hpp"
-template <typename Layout>
-static constexpr inline auto is_row_major(Layout layout_)
-{
-    return ck_tile::bool_constant<std::is_same_v<ck_tile::remove_cvref_t<decltype(layout_)>,
-                                                 ck_tile::tensor_layout::gemm::RowMajor>>{};
-}
-
 template <typename GemmConfig,
           typename ADataType,
           typename BDataType,
@@ -189,16 +182,16 @@ int run_grouped_gemm_example_with_layouts(int argc,
         const ck_tile::index_t N = Ns[i];
         const ck_tile::index_t K = Ks[i];
 
-        stride_As[i] = ck_tile::get_default_stride(M, K, stride_As[i], is_row_major(a_layout));
-        stride_Bs[i] = ck_tile::get_default_stride(K, N, stride_Bs[i], is_row_major(b_layout));
-        stride_Cs[i] = ck_tile::get_default_stride(M, N, stride_Cs[i], is_row_major(CLayout{}));
+        stride_As[i] = ck_tile::get_default_stride(M, K, stride_As[i], ck_tile::is_row_major(a_layout));
+        stride_Bs[i] = ck_tile::get_default_stride(K, N, stride_Bs[i], ck_tile::is_row_major(b_layout));
+        stride_Cs[i] = ck_tile::get_default_stride(M, N, stride_Cs[i], ck_tile::is_row_major(CLayout{}));
 
         a_m_k_tensors.push_back(ck_tile::HostTensor<ADataType>(
-            ck_tile::host_tensor_descriptor(M, K, stride_As[i], is_row_major(a_layout))));
+            ck_tile::host_tensor_descriptor(M, K, stride_As[i], ck_tile::is_row_major(a_layout))));
         b_k_n_tensors.push_back(ck_tile::HostTensor<BDataType>(
-            ck_tile::host_tensor_descriptor(K, N, stride_Bs[i], is_row_major(b_layout))));
+            ck_tile::host_tensor_descriptor(K, N, stride_Bs[i], ck_tile::is_row_major(b_layout))));
         c_m_n_tensors.push_back(ck_tile::HostTensor<CDataType>(
-            ck_tile::host_tensor_descriptor(M, N, stride_Cs[i], is_row_major(CLayout{}))));
+            ck_tile::host_tensor_descriptor(M, N, stride_Cs[i], ck_tile::is_row_major(CLayout{}))));
 
         std::cout << "gemm[" << i << "]" << " a_m_k: " << a_m_k_tensors[i].mDesc
                   << " b_k_n: " << b_k_n_tensors[i].mDesc << " c_m_n: " << c_m_n_tensors[i].mDesc
@@ -284,7 +277,7 @@ int run_grouped_gemm_example_with_layouts(int argc,
         for(int i = 0; i < group_count; ++i)
         {
             ck_tile::HostTensor<CDataType> c_m_n_host_ref(ck_tile::host_tensor_descriptor(
-                Ms[i], Ns[i], stride_Cs[i], is_row_major(CLayout{})));
+                Ms[i], Ns[i], stride_Cs[i], ck_tile::is_row_major(CLayout{})));
             c_m_n_host_ref.SetZero();
             ck_tile::reference_gemm<ADataType, BDataType, AccDataType, CDataType>(
                 a_m_k_tensors[i], b_k_n_tensors[i], c_m_n_host_ref);

--- a/projects/composablekernel/example/ck_tile/17_grouped_gemm/run_grouped_gemm_multi_d_example.inc
+++ b/projects/composablekernel/example/ck_tile/17_grouped_gemm/run_grouped_gemm_multi_d_example.inc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
+#include "ck_tile/host/gemm_rtol_atol.hpp"
 
 struct MultiplyMultiply
 {
@@ -20,38 +21,6 @@ static constexpr inline auto is_row_major(Layout layout_)
 {
     return ck_tile::bool_constant<std::is_same_v<ck_tile::remove_cvref_t<decltype(layout_)>,
                                                  ck_tile::tensor_layout::gemm::RowMajor>>{};
-}
-
-template <typename ADataType,
-          typename BDataType,
-          typename D0DataType,
-          typename EDataType,
-          typename AccDataType>
-auto calculate_rtol_atol(const ck_tile::index_t K,
-                         const ck_tile::index_t kbatch,
-                         const float max_accumulated_value)
-{
-    using ComputeTypeAB =
-        std::conditional_t<sizeof(ADataType) < sizeof(BDataType), ADataType, BDataType>;
-
-    using ComputeType =
-        std::conditional_t<sizeof(ComputeTypeAB) < sizeof(D0DataType), ComputeTypeAB, D0DataType>;
-    // Calculate thresholds
-    const auto rtol = ck_tile::get_relative_threshold<ComputeType, EDataType, AccDataType>(
-        ck_tile::integer_divide_ceil(K, kbatch));
-
-    const auto atol = ck_tile::get_absolute_threshold<ComputeType, EDataType, AccDataType>(
-        max_accumulated_value / kbatch, ck_tile::integer_divide_ceil(K, kbatch));
-
-    // Calculate error due to split_k accumulation
-    const auto rtol_split_k =
-        ck_tile::get_relative_threshold<EDataType, EDataType, EDataType>(kbatch);
-
-    const auto atol_split_k = ck_tile::get_absolute_threshold<EDataType, EDataType, EDataType>(
-        max_accumulated_value, kbatch);
-
-    // Use higher threshold
-    return ck_tile::make_tuple(std::max(rtol, rtol_split_k), std::max(atol, atol_split_k));
 }
 
 template <typename GemmConfig,
@@ -374,7 +343,7 @@ int run_grouped_gemm_multi_d_example_with_layouts(int argc,
                 *std::max_element(e_m_n_host_refs[i].mData.begin(), e_m_n_host_refs[i].mData.end());
 
             const auto rtol_atol =
-                calculate_rtol_atol<ADataType, BDataType, D0DataType, EDataType, AccDataType>(
+                ck_tile::calculateRtolAtol<ADataType, BDataType, D0DataType, EDataType, AccDataType>(
                     Ks[i], 1, max_accumulated_value);
 
             pass &=

--- a/projects/composablekernel/example/ck_tile/17_grouped_gemm/run_grouped_gemm_multi_d_example.inc
+++ b/projects/composablekernel/example/ck_tile/17_grouped_gemm/run_grouped_gemm_multi_d_example.inc
@@ -203,13 +203,18 @@ int run_grouped_gemm_multi_d_example_with_layouts(int argc,
         const ck_tile::index_t N = Ns[i];
         const ck_tile::index_t K = Ks[i];
 
-        stride_As[i] = ck_tile::get_default_stride(M, K, stride_As[i], ck_tile::is_row_major(a_layout));
-        stride_Bs[i] = ck_tile::get_default_stride(K, N, stride_Bs[i], ck_tile::is_row_major(b_layout));
+        stride_As[i] =
+            ck_tile::get_default_stride(M, K, stride_As[i], ck_tile::is_row_major(a_layout));
+        stride_Bs[i] =
+            ck_tile::get_default_stride(K, N, stride_Bs[i], ck_tile::is_row_major(b_layout));
 
-        stride_D0[i] = ck_tile::get_default_stride(M, N, stride_D0[i], ck_tile::is_row_major(d0_layout));
-        stride_D1[i] = ck_tile::get_default_stride(M, N, stride_D1[i], ck_tile::is_row_major(d1_layout));
+        stride_D0[i] =
+            ck_tile::get_default_stride(M, N, stride_D0[i], ck_tile::is_row_major(d0_layout));
+        stride_D1[i] =
+            ck_tile::get_default_stride(M, N, stride_D1[i], ck_tile::is_row_major(d1_layout));
 
-        stride_Es[i] = ck_tile::get_default_stride(M, N, stride_Es[i], ck_tile::is_row_major(e_layout));
+        stride_Es[i] =
+            ck_tile::get_default_stride(M, N, stride_Es[i], ck_tile::is_row_major(e_layout));
 
         a_m_k_tensors.push_back(ck_tile::HostTensor<ADataType>(
             ck_tile::host_tensor_descriptor(M, K, stride_As[i], ck_tile::is_row_major(a_layout))));
@@ -316,8 +321,8 @@ int run_grouped_gemm_multi_d_example_with_layouts(int argc,
     {
         for(int i = 0; i < group_count; ++i)
         {
-            e_m_n_host_refs.push_back(ck_tile::HostTensor<EDataType>(
-                host_tensor_descriptor(Ms[i], Ns[i], stride_Es[i], ck_tile::is_row_major(e_layout))));
+            e_m_n_host_refs.push_back(ck_tile::HostTensor<EDataType>(host_tensor_descriptor(
+                Ms[i], Ns[i], stride_Es[i], ck_tile::is_row_major(e_layout))));
 
             e_m_n_host_refs[i].SetZero();
 

--- a/projects/composablekernel/example/ck_tile/17_grouped_gemm/run_grouped_gemm_multi_d_example.inc
+++ b/projects/composablekernel/example/ck_tile/17_grouped_gemm/run_grouped_gemm_multi_d_example.inc
@@ -16,13 +16,6 @@ struct MultiplyMultiply
     }
 };
 
-template <typename Layout>
-static constexpr inline auto is_row_major(Layout layout_)
-{
-    return ck_tile::bool_constant<std::is_same_v<ck_tile::remove_cvref_t<decltype(layout_)>,
-                                                 ck_tile::tensor_layout::gemm::RowMajor>>{};
-}
-
 template <typename GemmConfig,
           typename ADataType,
           typename BDataType,
@@ -210,26 +203,26 @@ int run_grouped_gemm_multi_d_example_with_layouts(int argc,
         const ck_tile::index_t N = Ns[i];
         const ck_tile::index_t K = Ks[i];
 
-        stride_As[i] = ck_tile::get_default_stride(M, K, stride_As[i], is_row_major(a_layout));
-        stride_Bs[i] = ck_tile::get_default_stride(K, N, stride_Bs[i], is_row_major(b_layout));
+        stride_As[i] = ck_tile::get_default_stride(M, K, stride_As[i], ck_tile::is_row_major(a_layout));
+        stride_Bs[i] = ck_tile::get_default_stride(K, N, stride_Bs[i], ck_tile::is_row_major(b_layout));
 
-        stride_D0[i] = ck_tile::get_default_stride(M, N, stride_D0[i], is_row_major(d0_layout));
-        stride_D1[i] = ck_tile::get_default_stride(M, N, stride_D1[i], is_row_major(d1_layout));
+        stride_D0[i] = ck_tile::get_default_stride(M, N, stride_D0[i], ck_tile::is_row_major(d0_layout));
+        stride_D1[i] = ck_tile::get_default_stride(M, N, stride_D1[i], ck_tile::is_row_major(d1_layout));
 
-        stride_Es[i] = ck_tile::get_default_stride(M, N, stride_Es[i], is_row_major(e_layout));
+        stride_Es[i] = ck_tile::get_default_stride(M, N, stride_Es[i], ck_tile::is_row_major(e_layout));
 
         a_m_k_tensors.push_back(ck_tile::HostTensor<ADataType>(
-            ck_tile::host_tensor_descriptor(M, K, stride_As[i], is_row_major(a_layout))));
+            ck_tile::host_tensor_descriptor(M, K, stride_As[i], ck_tile::is_row_major(a_layout))));
         b_k_n_tensors.push_back(ck_tile::HostTensor<BDataType>(
-            ck_tile::host_tensor_descriptor(K, N, stride_Bs[i], is_row_major(b_layout))));
+            ck_tile::host_tensor_descriptor(K, N, stride_Bs[i], ck_tile::is_row_major(b_layout))));
 
         d0_m_n_tensors.push_back(ck_tile::HostTensor<D0DataType>(
-            ck_tile::host_tensor_descriptor(M, N, stride_D0[i], is_row_major(d0_layout))));
+            ck_tile::host_tensor_descriptor(M, N, stride_D0[i], ck_tile::is_row_major(d0_layout))));
         d1_m_n_tensors.push_back(ck_tile::HostTensor<D1DataType>(
-            ck_tile::host_tensor_descriptor(M, N, stride_D1[i], is_row_major(d1_layout))));
+            ck_tile::host_tensor_descriptor(M, N, stride_D1[i], ck_tile::is_row_major(d1_layout))));
 
         e_m_n_tensors.push_back(ck_tile::HostTensor<EDataType>(
-            ck_tile::host_tensor_descriptor(M, N, stride_Es[i], is_row_major(e_layout))));
+            ck_tile::host_tensor_descriptor(M, N, stride_Es[i], ck_tile::is_row_major(e_layout))));
 
         std::cout << "gemm[" << i << "]" << " a_m_k: " << a_m_k_tensors[i].mDesc
                   << " b_k_n: " << b_k_n_tensors[i].mDesc << " d0_m_n: " << d0_m_n_tensors[i].mDesc
@@ -324,7 +317,7 @@ int run_grouped_gemm_multi_d_example_with_layouts(int argc,
         for(int i = 0; i < group_count; ++i)
         {
             e_m_n_host_refs.push_back(ck_tile::HostTensor<EDataType>(
-                host_tensor_descriptor(Ms[i], Ns[i], stride_Es[i], is_row_major(e_layout))));
+                host_tensor_descriptor(Ms[i], Ns[i], stride_Es[i], ck_tile::is_row_major(e_layout))));
 
             e_m_n_host_refs[i].SetZero();
 

--- a/projects/composablekernel/example/ck_tile/17_grouped_gemm/run_grouped_gemm_multi_d_example.inc
+++ b/projects/composablekernel/example/ck_tile/17_grouped_gemm/run_grouped_gemm_multi_d_example.inc
@@ -342,8 +342,8 @@ int run_grouped_gemm_multi_d_example_with_layouts(int argc,
             const float max_accumulated_value =
                 *std::max_element(e_m_n_host_refs[i].mData.begin(), e_m_n_host_refs[i].mData.end());
 
-            const auto rtol_atol =
-                ck_tile::calculateRtolAtol<ADataType, BDataType, D0DataType, EDataType, AccDataType>(
+            const auto rtol_atol = ck_tile::
+                calculateRtolAtol<ADataType, BDataType, D0DataType, EDataType, AccDataType>(
                     Ks[i], 1, max_accumulated_value);
 
             pass &=

--- a/projects/composablekernel/example/ck_tile/18_flatmm/flatmm_basic.cpp
+++ b/projects/composablekernel/example/ck_tile/18_flatmm/flatmm_basic.cpp
@@ -40,13 +40,6 @@ constexpr const char* DataTypeToString()
     }
 }
 
-template <typename Layout>
-static constexpr inline auto is_row_major(Layout layout_)
-{
-    return ck_tile::bool_constant<std::is_same_v<ck_tile::remove_cvref_t<decltype(layout_)>,
-                                                 ck_tile::tensor_layout::gemm::RowMajor>>{};
-}
-
 // mfma_type, 0:32x32, 1:16x16
 template <typename FlatmmConfig, typename T>
 auto shuffle_b_v0(const ck_tile::HostTensor<T>& t)
@@ -224,9 +217,9 @@ float flatmm_calc(const ck_tile::ScaleFlatmmHostArgs<ScaleM, ScaleN>& args,
                 std::is_same_v<BDataType, ck_tile::pk_int4_t> ? 2 : 1;
 
             ck_tile::HostTensor<ADataType> a_m(ck_tile::host_tensor_descriptor(
-                args.M, args.K, args.stride_A, is_row_major(ALayout{})));
+                args.M, args.K, args.stride_A, ck_tile::is_row_major(ALayout{})));
             ck_tile::HostTensor<BDataType> b_n(ck_tile::host_tensor_descriptor(
-                args.K, args.N, args.stride_B, is_row_major(BLayout{})));
+                args.K, args.N, args.stride_B, ck_tile::is_row_major(BLayout{})));
 
             auto size_a_buffer = a_m.get_element_space_size_in_bytes() / APackedSize;
             auto size_b_buffer = b_n.get_element_space_size_in_bytes() / BPackedSize;

--- a/projects/composablekernel/example/ck_tile/18_flatmm/flatmm_basic.cpp
+++ b/projects/composablekernel/example/ck_tile/18_flatmm/flatmm_basic.cpp
@@ -11,6 +11,7 @@
 #include <numeric>
 
 #include "ck_tile/host.hpp"
+#include "ck_tile/host/gemm_rtol_atol.hpp"
 #include "flatmm_basic.hpp"
 #include <type_traits>
 
@@ -86,27 +87,6 @@ auto shuffle_b_v1(const ck_tile::HostTensor<T>& t)
                                    ItemsPerAccess});
     std::copy(t.begin(), t.end(), t_view.begin());
     return ck_tile::reference_permute(t_view, {0, 3, 1, 4, 2, 5});
-}
-
-template <typename ADataType, typename BDataType, typename AccDataType, typename CDataType>
-auto calculate_rtol_atol(const ck_tile::index_t K,
-                         const ck_tile::index_t kbatch,
-                         const float max_accumulated_value)
-{
-    using ComputeType =
-        std::conditional_t<sizeof(ADataType) < sizeof(BDataType), ADataType, BDataType>;
-    // Calculate thresholds
-    const auto rtol = ck_tile::get_relative_threshold<ComputeType, CDataType, AccDataType>(
-        ck_tile::integer_divide_ceil(K, kbatch));
-    const auto atol = ck_tile::get_absolute_threshold<ComputeType, CDataType, AccDataType>(
-        max_accumulated_value / kbatch, ck_tile::integer_divide_ceil(K, kbatch));
-    // Calculate error due to split_k accumulation
-    const auto rtol_split_k =
-        ck_tile::get_relative_threshold<CDataType, CDataType, CDataType>(kbatch);
-    const auto atol_split_k = ck_tile::get_absolute_threshold<CDataType, CDataType, CDataType>(
-        max_accumulated_value, kbatch);
-    // Use higher threshold
-    return ck_tile::make_tuple(std::max(rtol, rtol_split_k), std::max(atol, atol_split_k));
 }
 
 template <typename FlatmmConfig,

--- a/projects/composablekernel/example/ck_tile/18_flatmm/grouped_flatmm.cpp
+++ b/projects/composablekernel/example/ck_tile/18_flatmm/grouped_flatmm.cpp
@@ -166,10 +166,16 @@ float grouped_flatmm(const KernelArguments& args, const ck_tile::stream_config& 
             static constexpr ck_tile::index_t BPackedSize =
                 std::is_same_v<BDataType, ck_tile::pk_int4_t> ? 2 : 1;
 
-            ck_tile::HostTensor<ADataType> a_m(ck_tile::host_tensor_descriptor(
-                args.group_count * args.M, args.K, args.stride_A, ck_tile::is_row_major(ALayout{})));
-            ck_tile::HostTensor<BDataType> b_n(ck_tile::host_tensor_descriptor(
-                args.K, args.group_count * args.N, args.stride_B, ck_tile::is_row_major(BLayout{})));
+            ck_tile::HostTensor<ADataType> a_m(
+                ck_tile::host_tensor_descriptor(args.group_count * args.M,
+                                                args.K,
+                                                args.stride_A,
+                                                ck_tile::is_row_major(ALayout{})));
+            ck_tile::HostTensor<BDataType> b_n(
+                ck_tile::host_tensor_descriptor(args.K,
+                                                args.group_count * args.N,
+                                                args.stride_B,
+                                                ck_tile::is_row_major(BLayout{})));
 
             auto size_a_buffer = a_m.get_element_space_size_in_bytes() / APackedSize;
             auto size_b_buffer = b_n.get_element_space_size_in_bytes() / BPackedSize;

--- a/projects/composablekernel/example/ck_tile/18_flatmm/grouped_flatmm.cpp
+++ b/projects/composablekernel/example/ck_tile/18_flatmm/grouped_flatmm.cpp
@@ -14,13 +14,6 @@
 
 #include "ck_tile/host.hpp"
 
-template <typename Layout>
-static constexpr inline auto is_row_major(Layout layout_)
-{
-    return ck_tile::bool_constant<std::is_same_v<ck_tile::remove_cvref_t<decltype(layout_)>,
-                                                 ck_tile::tensor_layout::gemm::RowMajor>>{};
-}
-
 auto create_args(int argc, char* argv[])
 {
     ck_tile::ArgParser arg_parser;
@@ -174,9 +167,9 @@ float grouped_flatmm(const KernelArguments& args, const ck_tile::stream_config& 
                 std::is_same_v<BDataType, ck_tile::pk_int4_t> ? 2 : 1;
 
             ck_tile::HostTensor<ADataType> a_m(ck_tile::host_tensor_descriptor(
-                args.group_count * args.M, args.K, args.stride_A, is_row_major(ALayout{})));
+                args.group_count * args.M, args.K, args.stride_A, ck_tile::is_row_major(ALayout{})));
             ck_tile::HostTensor<BDataType> b_n(ck_tile::host_tensor_descriptor(
-                args.K, args.group_count * args.N, args.stride_B, is_row_major(BLayout{})));
+                args.K, args.group_count * args.N, args.stride_B, ck_tile::is_row_major(BLayout{})));
 
             auto size_a_buffer = a_m.get_element_space_size_in_bytes() / APackedSize;
             auto size_b_buffer = b_n.get_element_space_size_in_bytes() / BPackedSize;

--- a/projects/composablekernel/example/ck_tile/18_flatmm/mixed_prec/a16w4_moe_flatmm.cpp
+++ b/projects/composablekernel/example/ck_tile/18_flatmm/mixed_prec/a16w4_moe_flatmm.cpp
@@ -20,13 +20,6 @@
 #include "ck_tile/host.hpp"
 #include "ck_tile/host/reference/reference_moe_gemm.hpp"
 
-template <typename Layout>
-static constexpr inline auto is_row_major(Layout layout_)
-{
-    return ck_tile::bool_constant<std::is_same_v<ck_tile::remove_cvref_t<decltype(layout_)>,
-                                                 ck_tile::tensor_layout::gemm::RowMajor>>{};
-}
-
 // gemm1
 //   operand-A = [num_token, d_model]
 //   operand-B = [num_expert, hidden, d_model]
@@ -217,9 +210,9 @@ float a16w4_moe_gemm(const MoeFlatmmHostArgs& args, const ck_tile::stream_config
                                                                : args.NumTokens,
                 args.K,
                 args.stride_A,
-                is_row_major(ALayout{})));
+                ck_tile::is_row_major(ALayout{})));
             ck_tile::HostTensor<BDataType> b_n(ck_tile::host_tensor_descriptor(
-                args.K, args.N * args.NumExperts, args.stride_B, is_row_major(BLayout{})));
+                args.K, args.N * args.NumExperts, args.stride_B, ck_tile::is_row_major(BLayout{})));
 
             const int outputN =
                 moe_kind == ck_tile::MoeFlatmmKind::kFFN_gemm1_gate_up ? args.N / 2 : args.N;

--- a/projects/composablekernel/example/ck_tile/18_flatmm/mixed_prec/mixed_prec_flatmm.cpp
+++ b/projects/composablekernel/example/ck_tile/18_flatmm/mixed_prec/mixed_prec_flatmm.cpp
@@ -13,13 +13,6 @@
 #include "ck_tile/host.hpp"
 #include "mixed_prec_flatmm.hpp"
 
-template <typename Layout>
-static constexpr inline auto is_row_major(Layout layout_)
-{
-    return ck_tile::bool_constant<std::is_same_v<ck_tile::remove_cvref_t<decltype(layout_)>,
-                                                 ck_tile::tensor_layout::gemm::RowMajor>>{};
-}
-
 template <typename FlatmmConfig,
           typename ADataType,
           typename BDataType,
@@ -162,9 +155,9 @@ float mixed_prec_flatmm_calc(const ck_tile::ScaleFlatmmHostArgs<ScaleM, ScaleN>&
             constexpr ck_tile::index_t BPackedSize = ck_tile::numeric_traits<BDataType>::PackedSize;
 
             ck_tile::HostTensor<ADataType> a_m(ck_tile::host_tensor_descriptor(
-                args.M, args.K, args.stride_A, is_row_major(ALayout{})));
+                args.M, args.K, args.stride_A, ck_tile::is_row_major(ALayout{})));
             ck_tile::HostTensor<BDataType> b_n(ck_tile::host_tensor_descriptor(
-                args.K, args.N, args.stride_B, is_row_major(BLayout{})));
+                args.K, args.N, args.stride_B, ck_tile::is_row_major(BLayout{})));
 
             auto size_a_buffer = a_m.get_element_space_size_in_bytes() / APackedSize;
             auto size_b_buffer = b_n.get_element_space_size_in_bytes() / BPackedSize;

--- a/projects/composablekernel/example/ck_tile/18_flatmm/mixed_prec/run_a16w4_moe_flatmm_example.inc
+++ b/projects/composablekernel/example/ck_tile/18_flatmm/mixed_prec/run_a16w4_moe_flatmm_example.inc
@@ -107,19 +107,19 @@ int run_a16w4_moe_gemm_example_with_layouts(int argc,
     constexpr bool IsInputGemm = kind != ck_tile::MoeFlatmmKind::kFFN_gemm2;
 
     stride_A = ck_tile::get_default_stride(
-        IsInputGemm ? num_tokens : num_tokens * topk, K, stride_A, is_row_major(a_layout));
-    stride_B = ck_tile::get_default_stride(K, N, stride_B, is_row_major(b_layout));
+        IsInputGemm ? num_tokens : num_tokens * topk, K, stride_A, ck_tile::is_row_major(a_layout));
+    stride_B = ck_tile::get_default_stride(K, N, stride_B, ck_tile::is_row_major(b_layout));
     stride_C = ck_tile::get_default_stride(
-        IsInputGemm ? num_tokens * topk : num_tokens, outputN, stride_C, is_row_major(CLayout{}));
+        IsInputGemm ? num_tokens * topk : num_tokens, outputN, stride_C, ck_tile::is_row_major(CLayout{}));
 
     auto a_m_k_tensor = ck_tile::HostTensor<ADataType>(ck_tile::host_tensor_descriptor(
-        IsInputGemm ? num_tokens : num_tokens * topk, K, stride_A, is_row_major(a_layout)));
+        IsInputGemm ? num_tokens : num_tokens * topk, K, stride_A, ck_tile::is_row_major(a_layout)));
     auto b_k_n_tensor = ck_tile::HostTensor<BDataType>(
-        is_row_major(b_layout)
-            ? ck_tile::host_tensor_descriptor(experts * N, K, stride_B, is_row_major(b_layout))
-            : ck_tile::host_tensor_descriptor(K, experts * N, stride_B, is_row_major(b_layout)));
+        ck_tile::is_row_major(b_layout)
+            ? ck_tile::host_tensor_descriptor(experts * N, K, stride_B, ck_tile::is_row_major(b_layout))
+            : ck_tile::host_tensor_descriptor(K, experts * N, stride_B, ck_tile::is_row_major(b_layout)));
     auto c_m_n_tensor = ck_tile::HostTensor<CDataType>(ck_tile::host_tensor_descriptor(
-        IsInputGemm ? num_tokens * topk : num_tokens, outputN, stride_C, is_row_major(CLayout{})));
+        IsInputGemm ? num_tokens * topk : num_tokens, outputN, stride_C, ck_tile::is_row_major(CLayout{})));
 
     ck_tile::HostTensor<ScaleType> scale_b(ck_tile::HostTensorDescriptor(
         {K * experts / ScaleGranularityK, N / ScaleGranularityN}, {N / ScaleGranularityN, 1}));
@@ -138,7 +138,7 @@ int run_a16w4_moe_gemm_example_with_layouts(int argc,
     }
 
     ck_tile::HostTensor<BDataType> b_shuffle_host(
-        ck_tile::host_tensor_descriptor(K, experts * N, stride_B, is_row_major(b_layout)));
+        ck_tile::host_tensor_descriptor(K, experts * N, stride_B, ck_tile::is_row_major(b_layout)));
     shuffle_mxfp4_weight<FlatmmConfig, kind>(
         b_k_n_tensor.begin(), b_shuffle_host.begin(), experts, N, K);
 
@@ -287,7 +287,7 @@ int run_a16w4_moe_gemm_example_with_layouts(int argc,
             ck_tile::host_tensor_descriptor(IsInputGemm ? num_tokens * topk : num_tokens,
                                             outputN,
                                             stride_C,
-                                            is_row_major(CLayout{})));
+                                            ck_tile::is_row_major(CLayout{})));
         c_m_n_host_ref.SetZero();
 
         ck_tile::HostTensor<AccDataType> scale_A(

--- a/projects/composablekernel/example/ck_tile/18_flatmm/mixed_prec/run_a16w4_moe_flatmm_example.inc
+++ b/projects/composablekernel/example/ck_tile/18_flatmm/mixed_prec/run_a16w4_moe_flatmm_example.inc
@@ -109,17 +109,27 @@ int run_a16w4_moe_gemm_example_with_layouts(int argc,
     stride_A = ck_tile::get_default_stride(
         IsInputGemm ? num_tokens : num_tokens * topk, K, stride_A, ck_tile::is_row_major(a_layout));
     stride_B = ck_tile::get_default_stride(K, N, stride_B, ck_tile::is_row_major(b_layout));
-    stride_C = ck_tile::get_default_stride(
-        IsInputGemm ? num_tokens * topk : num_tokens, outputN, stride_C, ck_tile::is_row_major(CLayout{}));
+    stride_C = ck_tile::get_default_stride(IsInputGemm ? num_tokens * topk : num_tokens,
+                                           outputN,
+                                           stride_C,
+                                           ck_tile::is_row_major(CLayout{}));
 
-    auto a_m_k_tensor = ck_tile::HostTensor<ADataType>(ck_tile::host_tensor_descriptor(
-        IsInputGemm ? num_tokens : num_tokens * topk, K, stride_A, ck_tile::is_row_major(a_layout)));
+    auto a_m_k_tensor = ck_tile::HostTensor<ADataType>(
+        ck_tile::host_tensor_descriptor(IsInputGemm ? num_tokens : num_tokens * topk,
+                                        K,
+                                        stride_A,
+                                        ck_tile::is_row_major(a_layout)));
     auto b_k_n_tensor = ck_tile::HostTensor<BDataType>(
         ck_tile::is_row_major(b_layout)
-            ? ck_tile::host_tensor_descriptor(experts * N, K, stride_B, ck_tile::is_row_major(b_layout))
-            : ck_tile::host_tensor_descriptor(K, experts * N, stride_B, ck_tile::is_row_major(b_layout)));
-    auto c_m_n_tensor = ck_tile::HostTensor<CDataType>(ck_tile::host_tensor_descriptor(
-        IsInputGemm ? num_tokens * topk : num_tokens, outputN, stride_C, ck_tile::is_row_major(CLayout{})));
+            ? ck_tile::host_tensor_descriptor(
+                  experts * N, K, stride_B, ck_tile::is_row_major(b_layout))
+            : ck_tile::host_tensor_descriptor(
+                  K, experts * N, stride_B, ck_tile::is_row_major(b_layout)));
+    auto c_m_n_tensor = ck_tile::HostTensor<CDataType>(
+        ck_tile::host_tensor_descriptor(IsInputGemm ? num_tokens * topk : num_tokens,
+                                        outputN,
+                                        stride_C,
+                                        ck_tile::is_row_major(CLayout{})));
 
     ck_tile::HostTensor<ScaleType> scale_b(ck_tile::HostTensorDescriptor(
         {K * experts / ScaleGranularityK, N / ScaleGranularityN}, {N / ScaleGranularityN, 1}));

--- a/projects/composablekernel/example/ck_tile/18_flatmm/mixed_prec/run_mixed_prec_flatmm.inc
+++ b/projects/composablekernel/example/ck_tile/18_flatmm/mixed_prec/run_mixed_prec_flatmm.inc
@@ -41,16 +41,16 @@ int run_mixed_prec_flatmm_with_layouts(int argc,
     ck_tile::index_t n_warmup    = arg_parser.get_int("warmup");
     ck_tile::index_t n_repeat    = arg_parser.get_int("repeat");
 
-    stride_A = ck_tile::get_default_stride(M, K, stride_A, is_row_major(a_layout));
-    stride_B = ck_tile::get_default_stride(K, N, stride_B, is_row_major(b_layout));
-    stride_C = ck_tile::get_default_stride(M, N, stride_C, is_row_major(CLayout{}));
+    stride_A = ck_tile::get_default_stride(M, K, stride_A, ck_tile::is_row_major(a_layout));
+    stride_B = ck_tile::get_default_stride(K, N, stride_B, ck_tile::is_row_major(b_layout));
+    stride_C = ck_tile::get_default_stride(M, N, stride_C, ck_tile::is_row_major(CLayout{}));
 
     ck_tile::HostTensor<ADataType> a_host(
-        ck_tile::host_tensor_descriptor(M, K, stride_A, is_row_major(a_layout)));
+        ck_tile::host_tensor_descriptor(M, K, stride_A, ck_tile::is_row_major(a_layout)));
     ck_tile::HostTensor<BDataType> b_origin_host(
-        ck_tile::host_tensor_descriptor(K, N, stride_B, is_row_major(b_layout)));
+        ck_tile::host_tensor_descriptor(K, N, stride_B, ck_tile::is_row_major(b_layout)));
     ck_tile::HostTensor<CDataType> c_rslt_host(
-        ck_tile::host_tensor_descriptor(M, N, stride_C, is_row_major(CLayout{})));
+        ck_tile::host_tensor_descriptor(M, N, stride_C, ck_tile::is_row_major(CLayout{})));
 
     ck_tile::HostTensor<ScaleType> scale_b(ck_tile::HostTensorDescriptor(
         {K / DequantGranularityK, N / DequantGranularityN}, {N / DequantGranularityN, 1}));
@@ -69,7 +69,7 @@ int run_mixed_prec_flatmm_with_layouts(int argc,
     }
 
     ck_tile::HostTensor<BDataType> b_shuffle_host(
-        ck_tile::host_tensor_descriptor(K, N, stride_B, is_row_major(b_layout)));
+        ck_tile::host_tensor_descriptor(K, N, stride_B, ck_tile::is_row_major(b_layout)));
     preShuffleWeight<FlatmmConfig>(b_origin_host.begin(), b_shuffle_host.begin(), N, K);
 
     ck_tile::HostTensor<ScaleType> scale_b_shuffle = preShuffleScale<FlatmmConfig>(scale_b);
@@ -123,7 +123,7 @@ int run_mixed_prec_flatmm_with_layouts(int argc,
         b_origin_dev_buf.ToDevice(b_origin_host.data());
 
         ck_tile::HostTensor<CDataType> c_gpu_ref_host(
-            ck_tile::host_tensor_descriptor(M, N, stride_C, is_row_major(CLayout{})));
+            ck_tile::host_tensor_descriptor(M, N, stride_C, ck_tile::is_row_major(CLayout{})));
         ck_tile::DeviceMem c_gpu_ref_dev_buf(c_gpu_ref_host.get_element_space_size_in_bytes());
 
         ck_tile::HostTensor<AccDataType> scale_A(

--- a/projects/composablekernel/example/ck_tile/18_flatmm/moe_flatmm.cpp
+++ b/projects/composablekernel/example/ck_tile/18_flatmm/moe_flatmm.cpp
@@ -18,7 +18,6 @@
 #include "ck_tile/ops/flatmm.hpp"
 #include "ck_tile/ops/moe_flatmm.hpp"
 #include "ck_tile/host.hpp"
-#include "ck_tile/host/gemm_rtol_atol.hpp"
 #include "ck_tile/host/reference/reference_moe_gemm.hpp"
 
 template <typename Layout>

--- a/projects/composablekernel/example/ck_tile/18_flatmm/moe_flatmm.cpp
+++ b/projects/composablekernel/example/ck_tile/18_flatmm/moe_flatmm.cpp
@@ -20,13 +20,6 @@
 #include "ck_tile/host.hpp"
 #include "ck_tile/host/reference/reference_moe_gemm.hpp"
 
-template <typename Layout>
-static constexpr inline auto is_row_major(Layout layout_)
-{
-    return ck_tile::bool_constant<std::is_same_v<ck_tile::remove_cvref_t<decltype(layout_)>,
-                                                 ck_tile::tensor_layout::gemm::RowMajor>>{};
-}
-
 template <typename FlatmmConfig, typename T>
 auto flatmm_shuffle_b(const ck_tile::HostTensor<T>& t)
 {
@@ -205,9 +198,9 @@ float moe_gemm(const ck_tile::MoeFlatmmHostArgs<ScaleM, ScaleN>& args,
                                                                : args.NumTokens,
                 args.K,
                 args.stride_A,
-                is_row_major(ALayout{})));
+                ck_tile::is_row_major(ALayout{})));
             ck_tile::HostTensor<BDataType> b_n(ck_tile::host_tensor_descriptor(
-                args.K, args.N * args.NumExperts, args.stride_B, is_row_major(BLayout{})));
+                args.K, args.N * args.NumExperts, args.stride_B, ck_tile::is_row_major(BLayout{})));
 
             const int outputN =
                 moe_kind == ck_tile::MoeFlatmmKind::kFFN_gemm1_gate_up ? args.N / 2 : args.N;

--- a/projects/composablekernel/example/ck_tile/18_flatmm/moe_flatmm.cpp
+++ b/projects/composablekernel/example/ck_tile/18_flatmm/moe_flatmm.cpp
@@ -18,6 +18,7 @@
 #include "ck_tile/ops/flatmm.hpp"
 #include "ck_tile/ops/moe_flatmm.hpp"
 #include "ck_tile/host.hpp"
+#include "ck_tile/host/gemm_rtol_atol.hpp"
 #include "ck_tile/host/reference/reference_moe_gemm.hpp"
 
 template <typename Layout>
@@ -44,27 +45,6 @@ auto flatmm_shuffle_b(const ck_tile::HostTensor<T>& t)
                                    ItemsPerAccess});
     std::copy(t.begin(), t.end(), t_view.begin());
     return ck_tile::reference_permute(t_view, {0, 2, 1, 3});
-}
-
-template <typename ADataType, typename BDataType, typename AccDataType, typename CDataType>
-auto calculate_rtol_atol(const ck_tile::index_t K,
-                         const ck_tile::index_t kbatch,
-                         const float max_accumulated_value)
-{
-    using ComputeType =
-        std::conditional_t<sizeof(ADataType) < sizeof(BDataType), ADataType, BDataType>;
-    // Calculate thresholds
-    const auto rtol = ck_tile::get_relative_threshold<ComputeType, CDataType, AccDataType>(
-        ck_tile::integer_divide_ceil(K, kbatch));
-    const auto atol = ck_tile::get_absolute_threshold<ComputeType, CDataType, AccDataType>(
-        max_accumulated_value / kbatch, ck_tile::integer_divide_ceil(K, kbatch));
-    // Calculate error due to split_k accumulation
-    const auto rtol_split_k =
-        ck_tile::get_relative_threshold<CDataType, CDataType, CDataType>(kbatch);
-    const auto atol_split_k = ck_tile::get_absolute_threshold<CDataType, CDataType, CDataType>(
-        max_accumulated_value, kbatch);
-    // Use higher threshold
-    return ck_tile::make_tuple(std::max(rtol, rtol_split_k), std::max(atol, atol_split_k));
 }
 
 // gemm1

--- a/projects/composablekernel/example/ck_tile/18_flatmm/mxgemm/mx_flatmm.cpp
+++ b/projects/composablekernel/example/ck_tile/18_flatmm/mxgemm/mx_flatmm.cpp
@@ -13,13 +13,6 @@
 #include "ck_tile/host.hpp"
 #include "mx_flatmm.hpp"
 
-template <typename Layout>
-static constexpr inline auto is_row_major(Layout layout_)
-{
-    return ck_tile::bool_constant<std::is_same_v<ck_tile::remove_cvref_t<decltype(layout_)>,
-                                                 ck_tile::tensor_layout::gemm::RowMajor>>{};
-}
-
 template <typename MXFlatmmArchTraits,
           typename ADataType,
           typename BDataType,

--- a/projects/composablekernel/example/ck_tile/18_flatmm/mxgemm/run_mx_flatmm.inc
+++ b/projects/composablekernel/example/ck_tile/18_flatmm/mxgemm/run_mx_flatmm.inc
@@ -58,10 +58,16 @@ int run_mx_flatmm_with_layouts(const ck_tile::ArgParser& arg_parser,
     ck_tile::HostTensor<CDataType> c_rslt_host(
         ck_tile::host_tensor_descriptor(M, N, stride_C, ck_tile::is_row_major(CLayout{})));
 
-    ck_tile::HostTensor<ScaleType> scale_a(ck_tile::host_tensor_descriptor(
-        M / ScaleGranularityM, K / ScaleGranularityK, scale_stride_A, ck_tile::is_row_major(a_layout)));
-    ck_tile::HostTensor<ScaleType> scale_b(ck_tile::host_tensor_descriptor(
-        K / ScaleGranularityK, N / ScaleGranularityN, scale_stride_B, ck_tile::is_row_major(b_layout)));
+    ck_tile::HostTensor<ScaleType> scale_a(
+        ck_tile::host_tensor_descriptor(M / ScaleGranularityM,
+                                        K / ScaleGranularityK,
+                                        scale_stride_A,
+                                        ck_tile::is_row_major(a_layout)));
+    ck_tile::HostTensor<ScaleType> scale_b(
+        ck_tile::host_tensor_descriptor(K / ScaleGranularityK,
+                                        N / ScaleGranularityN,
+                                        scale_stride_B,
+                                        ck_tile::is_row_major(b_layout)));
     if constexpr(std::is_same_v<ADataType, ck_tile::pk_fp6x16_t>)
     {
         auto a_buffer_bytes = a_host.get_element_space_size_in_bytes();

--- a/projects/composablekernel/example/ck_tile/18_flatmm/mxgemm/run_mx_flatmm.inc
+++ b/projects/composablekernel/example/ck_tile/18_flatmm/mxgemm/run_mx_flatmm.inc
@@ -36,14 +36,14 @@ int run_mx_flatmm_with_layouts(const ck_tile::ArgParser& arg_parser,
     ck_tile::index_t n_warmup    = arg_parser.get_int("warmup");
     ck_tile::index_t n_repeat    = arg_parser.get_int("repeat");
 
-    stride_A = ck_tile::get_default_stride(M, K, stride_A, is_row_major(a_layout));
-    stride_B = ck_tile::get_default_stride(K, N, stride_B, is_row_major(b_layout));
-    stride_C = ck_tile::get_default_stride(M, N, stride_C, is_row_major(c_layout));
+    stride_A = ck_tile::get_default_stride(M, K, stride_A, ck_tile::is_row_major(a_layout));
+    stride_B = ck_tile::get_default_stride(K, N, stride_B, ck_tile::is_row_major(b_layout));
+    stride_C = ck_tile::get_default_stride(M, N, stride_C, ck_tile::is_row_major(c_layout));
 
     auto scale_stride_A = ck_tile::get_default_stride(
-        M / ScaleGranularityM, K / ScaleGranularityK, 0, is_row_major(a_layout));
+        M / ScaleGranularityM, K / ScaleGranularityK, 0, ck_tile::is_row_major(a_layout));
     auto scale_stride_B = ck_tile::get_default_stride(
-        K / ScaleGranularityK, N / ScaleGranularityN, 0, is_row_major(b_layout));
+        K / ScaleGranularityK, N / ScaleGranularityN, 0, ck_tile::is_row_major(b_layout));
 
     if(K % ScaleGranularityK != 0)
         throw std::runtime_error("wrong! K must be multiple of ScaleGranularityK.");
@@ -52,16 +52,16 @@ int run_mx_flatmm_with_layouts(const ck_tile::ArgParser& arg_parser,
         throw std::runtime_error("wrong! K must be multiple of packed size.");
 
     ck_tile ::HostTensor<ADataType> a_host(
-        ck_tile::host_tensor_descriptor(M, K, stride_A, is_row_major(a_layout)));
+        ck_tile::host_tensor_descriptor(M, K, stride_A, ck_tile::is_row_major(a_layout)));
     ck_tile::HostTensor<BDataType> b_origin_host(
-        ck_tile::host_tensor_descriptor(K, N, stride_B, is_row_major(b_layout)));
+        ck_tile::host_tensor_descriptor(K, N, stride_B, ck_tile::is_row_major(b_layout)));
     ck_tile::HostTensor<CDataType> c_rslt_host(
-        ck_tile::host_tensor_descriptor(M, N, stride_C, is_row_major(CLayout{})));
+        ck_tile::host_tensor_descriptor(M, N, stride_C, ck_tile::is_row_major(CLayout{})));
 
     ck_tile::HostTensor<ScaleType> scale_a(ck_tile::host_tensor_descriptor(
-        M / ScaleGranularityM, K / ScaleGranularityK, scale_stride_A, is_row_major(a_layout)));
+        M / ScaleGranularityM, K / ScaleGranularityK, scale_stride_A, ck_tile::is_row_major(a_layout)));
     ck_tile::HostTensor<ScaleType> scale_b(ck_tile::host_tensor_descriptor(
-        K / ScaleGranularityK, N / ScaleGranularityN, scale_stride_B, is_row_major(b_layout)));
+        K / ScaleGranularityK, N / ScaleGranularityN, scale_stride_B, ck_tile::is_row_major(b_layout)));
     if constexpr(std::is_same_v<ADataType, ck_tile::pk_fp6x16_t>)
     {
         auto a_buffer_bytes = a_host.get_element_space_size_in_bytes();
@@ -161,7 +161,7 @@ int run_mx_flatmm_with_layouts(const ck_tile::ArgParser& arg_parser,
     if(arg_parser.get_int("v") == 1)
     {
         ck_tile::HostTensor<CDataType> c_m_n_host_ref(
-            ck_tile::host_tensor_descriptor(M, N, stride_C, is_row_major(CLayout{})));
+            ck_tile::host_tensor_descriptor(M, N, stride_C, ck_tile::is_row_major(CLayout{})));
         c_m_n_host_ref.SetZero();
 
         ck_tile::reference_mx_gemm<ADataType, BDataType, ScaleType, AccDataType, CDataType>(

--- a/projects/composablekernel/example/ck_tile/18_flatmm/run_flatmm_example.inc
+++ b/projects/composablekernel/example/ck_tile/18_flatmm/run_flatmm_example.inc
@@ -38,16 +38,16 @@ int run_flatmm_example_with_layouts(int argc,
     ck_tile::index_t init_method = arg_parser.get_int("init");
     // persistent not added
 
-    stride_A = ck_tile::get_default_stride(M, K, stride_A, is_row_major(a_layout));
-    stride_B = ck_tile::get_default_stride(K, N, stride_B, is_row_major(b_layout));
-    stride_C = ck_tile::get_default_stride(M, N, stride_C, is_row_major(CLayout{}));
+    stride_A = ck_tile::get_default_stride(M, K, stride_A, ck_tile::is_row_major(a_layout));
+    stride_B = ck_tile::get_default_stride(K, N, stride_B, ck_tile::is_row_major(b_layout));
+    stride_C = ck_tile::get_default_stride(M, N, stride_C, ck_tile::is_row_major(CLayout{}));
 
     ck_tile::HostTensor<ADataType> a_host(
-        ck_tile::host_tensor_descriptor(M, K, stride_A, is_row_major(a_layout)));
+        ck_tile::host_tensor_descriptor(M, K, stride_A, ck_tile::is_row_major(a_layout)));
     ck_tile::HostTensor<BDataType> b_origin_host(
-        ck_tile::host_tensor_descriptor(K, N, stride_B, is_row_major(b_layout)));
+        ck_tile::host_tensor_descriptor(K, N, stride_B, ck_tile::is_row_major(b_layout)));
     ck_tile::HostTensor<CDataType> c_rslt_host(
-        ck_tile::host_tensor_descriptor(M, N, stride_C, is_row_major(CLayout{})));
+        ck_tile::host_tensor_descriptor(M, N, stride_C, ck_tile::is_row_major(CLayout{})));
 
     ck_tile::HostTensor<AccDataType> per_token_scale(ck_tile::HostTensorDescriptor({M}, {1}));
     ck_tile::HostTensor<AccDataType> per_channel_scale(ck_tile::HostTensorDescriptor({N}, {1}));
@@ -149,7 +149,7 @@ int run_flatmm_example_with_layouts(int argc,
         if(ScaleGranularityM != -1 || ScaleGranularityN != -1)
             throw std::runtime_error("ScaleAB is not supported for CPU verification!\n");
         ck_tile::HostTensor<CDataType> c_ref_host(
-            ck_tile::host_tensor_descriptor(M, N, stride_C, is_row_major(CLayout{})));
+            ck_tile::host_tensor_descriptor(M, N, stride_C, ck_tile::is_row_major(CLayout{})));
         c_ref_host.SetZero();
 
         ck_tile::reference_gemm<ADataType, BDataType, AccDataType, CDataType>(
@@ -176,7 +176,7 @@ int run_flatmm_example_with_layouts(int argc,
         b_origin_dev_buf.ToDevice(b_origin_host.data());
 
         ck_tile::HostTensor<CDataType> c_gpu_ref_host(
-            ck_tile::host_tensor_descriptor(M, N, stride_C, is_row_major(CLayout{})));
+            ck_tile::host_tensor_descriptor(M, N, stride_C, ck_tile::is_row_major(CLayout{})));
         ck_tile::DeviceMem c_gpu_ref_dev_buf(c_gpu_ref_host.get_element_space_size_in_bytes());
         c_gpu_ref_host.SetZero();
         c_gpu_ref_dev_buf.SetZero();

--- a/projects/composablekernel/example/ck_tile/18_flatmm/run_flatmm_example.inc
+++ b/projects/composablekernel/example/ck_tile/18_flatmm/run_flatmm_example.inc
@@ -156,7 +156,7 @@ int run_flatmm_example_with_layouts(int argc,
             a_host, b_origin_host, c_ref_host);
         const float max_accumulated_value =
             *std::max_element(c_ref_host.mData.begin(), c_ref_host.mData.end());
-        const auto rtol_atol = calculate_rtol_atol<ADataType, BDataType, AccDataType, CDataType>(
+        const auto rtol_atol = ck_tile::calculateRtolAtol<ADataType, BDataType, AccDataType, CDataType>(
             K, kbatch, max_accumulated_value);
         pass = ck_tile::check_err(c_rslt_host,
                                   c_ref_host,
@@ -243,7 +243,7 @@ int run_flatmm_example_with_layouts(int argc,
         c_gpu_ref_dev_buf.FromDevice(c_gpu_ref_host.data());
         const float max_accumulated_value =
             *std::max_element(c_gpu_ref_host.mData.begin(), c_gpu_ref_host.mData.end());
-        const auto rtol_atol = calculate_rtol_atol<ADataType, BDataType, AccDataType, CDataType>(
+        const auto rtol_atol = ck_tile::calculateRtolAtol<ADataType, BDataType, AccDataType, CDataType>(
             K, kbatch, max_accumulated_value);
         pass = ck_tile::check_err(c_rslt_host,
                                   c_gpu_ref_host,

--- a/projects/composablekernel/example/ck_tile/18_flatmm/run_flatmm_example.inc
+++ b/projects/composablekernel/example/ck_tile/18_flatmm/run_flatmm_example.inc
@@ -156,8 +156,9 @@ int run_flatmm_example_with_layouts(int argc,
             a_host, b_origin_host, c_ref_host);
         const float max_accumulated_value =
             *std::max_element(c_ref_host.mData.begin(), c_ref_host.mData.end());
-        const auto rtol_atol = ck_tile::calculateRtolAtol<ADataType, BDataType, AccDataType, CDataType>(
-            K, kbatch, max_accumulated_value);
+        const auto rtol_atol =
+            ck_tile::calculateRtolAtol<ADataType, BDataType, AccDataType, CDataType>(
+                K, kbatch, max_accumulated_value);
         pass = ck_tile::check_err(c_rslt_host,
                                   c_ref_host,
                                   "Error: Incorrect results!",
@@ -243,8 +244,9 @@ int run_flatmm_example_with_layouts(int argc,
         c_gpu_ref_dev_buf.FromDevice(c_gpu_ref_host.data());
         const float max_accumulated_value =
             *std::max_element(c_gpu_ref_host.mData.begin(), c_gpu_ref_host.mData.end());
-        const auto rtol_atol = ck_tile::calculateRtolAtol<ADataType, BDataType, AccDataType, CDataType>(
-            K, kbatch, max_accumulated_value);
+        const auto rtol_atol =
+            ck_tile::calculateRtolAtol<ADataType, BDataType, AccDataType, CDataType>(
+                K, kbatch, max_accumulated_value);
         pass = ck_tile::check_err(c_rslt_host,
                                   c_gpu_ref_host,
                                   "Error: Incorrect results!",

--- a/projects/composablekernel/example/ck_tile/18_flatmm/run_grouped_flatmm_example.inc
+++ b/projects/composablekernel/example/ck_tile/18_flatmm/run_grouped_flatmm_example.inc
@@ -160,13 +160,15 @@ int run_contiguous_grouped_flatmm_example_with_layouts(
     ck_tile::index_t stride_C = 0;
 
     stride_A = ck_tile::get_default_stride(M, K, stride_A, ck_tile::is_row_major(a_layout));
-    stride_B = ck_tile::get_default_stride(K, N * group_count, stride_B, ck_tile::is_row_major(b_layout));
+    stride_B =
+        ck_tile::get_default_stride(K, N * group_count, stride_B, ck_tile::is_row_major(b_layout));
     stride_C = ck_tile::get_default_stride(M, N, stride_C, ck_tile::is_row_major(c_layout));
 
     ck_tile::HostTensor<ADataType> a_m_k_tensor(
         ck_tile::host_tensor_descriptor(M, K, stride_A, ck_tile::is_row_major(a_layout)));
-    ck_tile::HostTensor<BDataType> b_k_n_tensor(ck_tile::HostTensor<BDataType>(
-        ck_tile::host_tensor_descriptor(K, N * group_count, stride_B, ck_tile::is_row_major(b_layout))));
+    ck_tile::HostTensor<BDataType> b_k_n_tensor(
+        ck_tile::HostTensor<BDataType>(ck_tile::host_tensor_descriptor(
+            K, N * group_count, stride_B, ck_tile::is_row_major(b_layout))));
     ck_tile::HostTensor<CDataType> c_m_n_tensor(ck_tile::HostTensor<CDataType>(
         ck_tile::host_tensor_descriptor(M, N, stride_C, ck_tile::is_row_major(c_layout))));
 
@@ -375,16 +377,21 @@ int run_masked_grouped_flatmm_example_with_layouts(
     ck_tile::index_t stride_B = K;
     ck_tile::index_t stride_C = N;
 
-    stride_A = ck_tile::get_default_stride(group_count * M, K, stride_A, ck_tile::is_row_major(a_layout));
-    stride_B = ck_tile::get_default_stride(K, N * group_count, stride_B, ck_tile::is_row_major(b_layout));
-    stride_C = ck_tile::get_default_stride(group_count * M, N, stride_C, ck_tile::is_row_major(c_layout));
+    stride_A =
+        ck_tile::get_default_stride(group_count * M, K, stride_A, ck_tile::is_row_major(a_layout));
+    stride_B =
+        ck_tile::get_default_stride(K, N * group_count, stride_B, ck_tile::is_row_major(b_layout));
+    stride_C =
+        ck_tile::get_default_stride(group_count * M, N, stride_C, ck_tile::is_row_major(c_layout));
 
-    ck_tile::HostTensor<ADataType> a_m_k_tensor(
-        ck_tile::host_tensor_descriptor(group_count * M, K, stride_A, ck_tile::is_row_major(a_layout)));
-    ck_tile::HostTensor<BDataType> b_k_n_tensor(ck_tile::HostTensor<BDataType>(
-        ck_tile::host_tensor_descriptor(K, N * group_count, stride_B, ck_tile::is_row_major(b_layout))));
-    ck_tile::HostTensor<CDataType> c_m_n_tensor(ck_tile::HostTensor<CDataType>(
-        ck_tile::host_tensor_descriptor(group_count * M, N, stride_C, ck_tile::is_row_major(c_layout))));
+    ck_tile::HostTensor<ADataType> a_m_k_tensor(ck_tile::host_tensor_descriptor(
+        group_count * M, K, stride_A, ck_tile::is_row_major(a_layout)));
+    ck_tile::HostTensor<BDataType> b_k_n_tensor(
+        ck_tile::HostTensor<BDataType>(ck_tile::host_tensor_descriptor(
+            K, N * group_count, stride_B, ck_tile::is_row_major(b_layout))));
+    ck_tile::HostTensor<CDataType> c_m_n_tensor(
+        ck_tile::HostTensor<CDataType>(ck_tile::host_tensor_descriptor(
+            group_count * M, N, stride_C, ck_tile::is_row_major(c_layout))));
 
     ck_tile::HostTensor<AccDataType> per_token_scale(
         ck_tile::HostTensorDescriptor({group_count * M}, {1}));
@@ -490,8 +497,8 @@ int run_masked_grouped_flatmm_example_with_layouts(
         ck_tile::hip_check_error(hipMalloc(&d_C, group_count * M * N * sizeof(CDataType)));
         ck_tile::hip_check_error(hipMemset(d_C, 0, group_count * M * N * sizeof(CDataType)));
 
-        ck_tile::HostTensor<CDataType> c_gpu_ref_host(
-            ck_tile::host_tensor_descriptor(group_count * M, N, stride_C, ck_tile::is_row_major(CLayout{})));
+        ck_tile::HostTensor<CDataType> c_gpu_ref_host(ck_tile::host_tensor_descriptor(
+            group_count * M, N, stride_C, ck_tile::is_row_major(CLayout{})));
         for(int i = 0; i < group_count; ++i)
         {
             ck_tile::hip_check_error(hipMemcpy(d_B,

--- a/projects/composablekernel/example/ck_tile/18_flatmm/run_grouped_flatmm_example.inc
+++ b/projects/composablekernel/example/ck_tile/18_flatmm/run_grouped_flatmm_example.inc
@@ -159,16 +159,16 @@ int run_contiguous_grouped_flatmm_example_with_layouts(
     ck_tile::index_t stride_B = 0;
     ck_tile::index_t stride_C = 0;
 
-    stride_A = ck_tile::get_default_stride(M, K, stride_A, is_row_major(a_layout));
-    stride_B = ck_tile::get_default_stride(K, N * group_count, stride_B, is_row_major(b_layout));
-    stride_C = ck_tile::get_default_stride(M, N, stride_C, is_row_major(c_layout));
+    stride_A = ck_tile::get_default_stride(M, K, stride_A, ck_tile::is_row_major(a_layout));
+    stride_B = ck_tile::get_default_stride(K, N * group_count, stride_B, ck_tile::is_row_major(b_layout));
+    stride_C = ck_tile::get_default_stride(M, N, stride_C, ck_tile::is_row_major(c_layout));
 
     ck_tile::HostTensor<ADataType> a_m_k_tensor(
-        ck_tile::host_tensor_descriptor(M, K, stride_A, is_row_major(a_layout)));
+        ck_tile::host_tensor_descriptor(M, K, stride_A, ck_tile::is_row_major(a_layout)));
     ck_tile::HostTensor<BDataType> b_k_n_tensor(ck_tile::HostTensor<BDataType>(
-        ck_tile::host_tensor_descriptor(K, N * group_count, stride_B, is_row_major(b_layout))));
+        ck_tile::host_tensor_descriptor(K, N * group_count, stride_B, ck_tile::is_row_major(b_layout))));
     ck_tile::HostTensor<CDataType> c_m_n_tensor(ck_tile::HostTensor<CDataType>(
-        ck_tile::host_tensor_descriptor(M, N, stride_C, is_row_major(c_layout))));
+        ck_tile::host_tensor_descriptor(M, N, stride_C, ck_tile::is_row_major(c_layout))));
 
     ck_tile::HostTensor<AccDataType> per_token_scale(ck_tile::HostTensorDescriptor({M}, {1}));
     ck_tile::HostTensor<AccDataType> per_channel_scale(ck_tile::HostTensorDescriptor({N}, {1}));
@@ -271,7 +271,7 @@ int run_contiguous_grouped_flatmm_example_with_layouts(
         ck_tile::hip_check_error(hipMemset(d_C, 0, M * N * sizeof(CDataType)));
 
         ck_tile::HostTensor<CDataType> c_gpu_ref_host(
-            ck_tile::host_tensor_descriptor(M, N, stride_C, is_row_major(CLayout{})));
+            ck_tile::host_tensor_descriptor(M, N, stride_C, ck_tile::is_row_major(CLayout{})));
 
         ck_tile::index_t acc_m = 0;
         for(int i = 0; i < group_count; ++i)
@@ -375,16 +375,16 @@ int run_masked_grouped_flatmm_example_with_layouts(
     ck_tile::index_t stride_B = K;
     ck_tile::index_t stride_C = N;
 
-    stride_A = ck_tile::get_default_stride(group_count * M, K, stride_A, is_row_major(a_layout));
-    stride_B = ck_tile::get_default_stride(K, N * group_count, stride_B, is_row_major(b_layout));
-    stride_C = ck_tile::get_default_stride(group_count * M, N, stride_C, is_row_major(c_layout));
+    stride_A = ck_tile::get_default_stride(group_count * M, K, stride_A, ck_tile::is_row_major(a_layout));
+    stride_B = ck_tile::get_default_stride(K, N * group_count, stride_B, ck_tile::is_row_major(b_layout));
+    stride_C = ck_tile::get_default_stride(group_count * M, N, stride_C, ck_tile::is_row_major(c_layout));
 
     ck_tile::HostTensor<ADataType> a_m_k_tensor(
-        ck_tile::host_tensor_descriptor(group_count * M, K, stride_A, is_row_major(a_layout)));
+        ck_tile::host_tensor_descriptor(group_count * M, K, stride_A, ck_tile::is_row_major(a_layout)));
     ck_tile::HostTensor<BDataType> b_k_n_tensor(ck_tile::HostTensor<BDataType>(
-        ck_tile::host_tensor_descriptor(K, N * group_count, stride_B, is_row_major(b_layout))));
+        ck_tile::host_tensor_descriptor(K, N * group_count, stride_B, ck_tile::is_row_major(b_layout))));
     ck_tile::HostTensor<CDataType> c_m_n_tensor(ck_tile::HostTensor<CDataType>(
-        ck_tile::host_tensor_descriptor(group_count * M, N, stride_C, is_row_major(c_layout))));
+        ck_tile::host_tensor_descriptor(group_count * M, N, stride_C, ck_tile::is_row_major(c_layout))));
 
     ck_tile::HostTensor<AccDataType> per_token_scale(
         ck_tile::HostTensorDescriptor({group_count * M}, {1}));
@@ -491,7 +491,7 @@ int run_masked_grouped_flatmm_example_with_layouts(
         ck_tile::hip_check_error(hipMemset(d_C, 0, group_count * M * N * sizeof(CDataType)));
 
         ck_tile::HostTensor<CDataType> c_gpu_ref_host(
-            ck_tile::host_tensor_descriptor(group_count * M, N, stride_C, is_row_major(CLayout{})));
+            ck_tile::host_tensor_descriptor(group_count * M, N, stride_C, ck_tile::is_row_major(CLayout{})));
         for(int i = 0; i < group_count; ++i)
         {
             ck_tile::hip_check_error(hipMemcpy(d_B,

--- a/projects/composablekernel/example/ck_tile/18_flatmm/run_grouped_flatmm_example.inc
+++ b/projects/composablekernel/example/ck_tile/18_flatmm/run_grouped_flatmm_example.inc
@@ -3,27 +3,6 @@
 
 #pragma once
 
-template <typename ADataType, typename BDataType, typename AccDataType, typename CDataType>
-auto calculate_rtol_atol(const ck_tile::index_t K,
-                         const ck_tile::index_t kbatch,
-                         const float max_accumulated_value)
-{
-    using ComputeType =
-        std::conditional_t<sizeof(ADataType) < sizeof(BDataType), ADataType, BDataType>;
-    // Calculate thresholds
-    const auto rtol = ck_tile::get_relative_threshold<ComputeType, CDataType, AccDataType>(
-        ck_tile::integer_divide_ceil(K, kbatch));
-    const auto atol = ck_tile::get_absolute_threshold<ComputeType, CDataType, AccDataType>(
-        max_accumulated_value / kbatch, ck_tile::integer_divide_ceil(K, kbatch));
-    // Calculate error due to split_k accumulation
-    const auto rtol_split_k =
-        ck_tile::get_relative_threshold<CDataType, CDataType, CDataType>(kbatch);
-    const auto atol_split_k = ck_tile::get_absolute_threshold<CDataType, CDataType, CDataType>(
-        max_accumulated_value, kbatch);
-    // Use higher threshold
-    return ck_tile::make_tuple(std::max(rtol, rtol_split_k), std::max(atol, atol_split_k));
-}
-
 template <typename FlatmmConfig,
           typename ADataType,
           typename BDataType,

--- a/projects/composablekernel/example/ck_tile/18_flatmm/run_moe_flatmm_example.inc
+++ b/projects/composablekernel/example/ck_tile/18_flatmm/run_moe_flatmm_example.inc
@@ -97,19 +97,19 @@ int run_moe_gemm_example_with_layouts(int argc,
     constexpr bool IsInputGemm = kind != ck_tile::MoeFlatmmKind::kFFN_gemm2;
 
     stride_A = ck_tile::get_default_stride(
-        IsInputGemm ? num_tokens : num_tokens * topk, K, stride_A, is_row_major(a_layout));
-    stride_B = ck_tile::get_default_stride(K, N, stride_B, is_row_major(b_layout));
+        IsInputGemm ? num_tokens : num_tokens * topk, K, stride_A, ck_tile::is_row_major(a_layout));
+    stride_B = ck_tile::get_default_stride(K, N, stride_B, ck_tile::is_row_major(b_layout));
     stride_C = ck_tile::get_default_stride(
-        IsInputGemm ? num_tokens * topk : num_tokens, outputN, stride_C, is_row_major(CLayout{}));
+        IsInputGemm ? num_tokens * topk : num_tokens, outputN, stride_C, ck_tile::is_row_major(CLayout{}));
 
     auto a_m_k_tensor = ck_tile::HostTensor<ADataType>(ck_tile::host_tensor_descriptor(
-        IsInputGemm ? num_tokens : num_tokens * topk, K, stride_A, is_row_major(a_layout)));
+        IsInputGemm ? num_tokens : num_tokens * topk, K, stride_A, ck_tile::is_row_major(a_layout)));
     auto b_k_n_tensor = ck_tile::HostTensor<BDataType>(
-        is_row_major(b_layout)
-            ? ck_tile::host_tensor_descriptor(experts * N, K, stride_B, is_row_major(b_layout))
-            : ck_tile::host_tensor_descriptor(K, experts * N, stride_B, is_row_major(b_layout)));
+        ck_tile::is_row_major(b_layout)
+            ? ck_tile::host_tensor_descriptor(experts * N, K, stride_B, ck_tile::is_row_major(b_layout))
+            : ck_tile::host_tensor_descriptor(K, experts * N, stride_B, ck_tile::is_row_major(b_layout)));
     auto c_m_n_tensor = ck_tile::HostTensor<CDataType>(ck_tile::host_tensor_descriptor(
-        IsInputGemm ? num_tokens * topk : num_tokens, outputN, stride_C, is_row_major(CLayout{})));
+        IsInputGemm ? num_tokens * topk : num_tokens, outputN, stride_C, ck_tile::is_row_major(CLayout{})));
 
     ck_tile::FillUniformDistribution<ADataType>{0.0f, 1.0f}(a_m_k_tensor);
     ck_tile::FillUniformDistribution<BDataType>{-.5f, .5f}(b_k_n_tensor);
@@ -262,7 +262,7 @@ int run_moe_gemm_example_with_layouts(int argc,
             ck_tile::host_tensor_descriptor(IsInputGemm ? num_tokens * topk : num_tokens,
                                             outputN,
                                             stride_C,
-                                            is_row_major(CLayout{})));
+                                            ck_tile::is_row_major(CLayout{})));
 
         c_m_n_host_ref.SetZero();
 

--- a/projects/composablekernel/example/ck_tile/18_flatmm/run_moe_flatmm_example.inc
+++ b/projects/composablekernel/example/ck_tile/18_flatmm/run_moe_flatmm_example.inc
@@ -99,17 +99,27 @@ int run_moe_gemm_example_with_layouts(int argc,
     stride_A = ck_tile::get_default_stride(
         IsInputGemm ? num_tokens : num_tokens * topk, K, stride_A, ck_tile::is_row_major(a_layout));
     stride_B = ck_tile::get_default_stride(K, N, stride_B, ck_tile::is_row_major(b_layout));
-    stride_C = ck_tile::get_default_stride(
-        IsInputGemm ? num_tokens * topk : num_tokens, outputN, stride_C, ck_tile::is_row_major(CLayout{}));
+    stride_C = ck_tile::get_default_stride(IsInputGemm ? num_tokens * topk : num_tokens,
+                                           outputN,
+                                           stride_C,
+                                           ck_tile::is_row_major(CLayout{}));
 
-    auto a_m_k_tensor = ck_tile::HostTensor<ADataType>(ck_tile::host_tensor_descriptor(
-        IsInputGemm ? num_tokens : num_tokens * topk, K, stride_A, ck_tile::is_row_major(a_layout)));
+    auto a_m_k_tensor = ck_tile::HostTensor<ADataType>(
+        ck_tile::host_tensor_descriptor(IsInputGemm ? num_tokens : num_tokens * topk,
+                                        K,
+                                        stride_A,
+                                        ck_tile::is_row_major(a_layout)));
     auto b_k_n_tensor = ck_tile::HostTensor<BDataType>(
         ck_tile::is_row_major(b_layout)
-            ? ck_tile::host_tensor_descriptor(experts * N, K, stride_B, ck_tile::is_row_major(b_layout))
-            : ck_tile::host_tensor_descriptor(K, experts * N, stride_B, ck_tile::is_row_major(b_layout)));
-    auto c_m_n_tensor = ck_tile::HostTensor<CDataType>(ck_tile::host_tensor_descriptor(
-        IsInputGemm ? num_tokens * topk : num_tokens, outputN, stride_C, ck_tile::is_row_major(CLayout{})));
+            ? ck_tile::host_tensor_descriptor(
+                  experts * N, K, stride_B, ck_tile::is_row_major(b_layout))
+            : ck_tile::host_tensor_descriptor(
+                  K, experts * N, stride_B, ck_tile::is_row_major(b_layout)));
+    auto c_m_n_tensor = ck_tile::HostTensor<CDataType>(
+        ck_tile::host_tensor_descriptor(IsInputGemm ? num_tokens * topk : num_tokens,
+                                        outputN,
+                                        stride_C,
+                                        ck_tile::is_row_major(CLayout{})));
 
     ck_tile::FillUniformDistribution<ADataType>{0.0f, 1.0f}(a_m_k_tensor);
     ck_tile::FillUniformDistribution<BDataType>{-.5f, .5f}(b_k_n_tensor);

--- a/projects/composablekernel/example/ck_tile/19_gemm_multi_d/run_gemm_multi_d_fp16_example.inc
+++ b/projects/composablekernel/example/ck_tile/19_gemm_multi_d/run_gemm_multi_d_fp16_example.inc
@@ -98,22 +98,22 @@ int run_multiple_d_gemm_example_with_layouts(int argc,
     const int n_repeat = arg_parser.get_int("repeat");
     const int k_batch  = arg_parser.get_int("kbatch");
 
-    StrideA  = get_default_stride(M, K, StrideA, is_row_major(a_layout));
-    StrideB  = get_default_stride(K, N, StrideB, is_row_major(b_layout));
-    StrideD0 = get_default_stride(M, N, StrideD0, is_row_major(d0_layout));
-    StrideD1 = get_default_stride(M, N, StrideD1, is_row_major(d1_layout));
-    StrideE  = get_default_stride(M, N, StrideE, is_row_major(e_layout));
+    StrideA  = get_default_stride(M, K, StrideA, ck_tile::is_row_major(a_layout));
+    StrideB  = get_default_stride(K, N, StrideB, ck_tile::is_row_major(b_layout));
+    StrideD0 = get_default_stride(M, N, StrideD0, ck_tile::is_row_major(d0_layout));
+    StrideD1 = get_default_stride(M, N, StrideD1, ck_tile::is_row_major(d1_layout));
+    StrideE  = get_default_stride(M, N, StrideE, ck_tile::is_row_major(e_layout));
 
     ck_tile::HostTensor<ADataType> a_m_k_tesnor(
-        host_tensor_descriptor(M, K, StrideA, is_row_major(a_layout)));
+        host_tensor_descriptor(M, K, StrideA, ck_tile::is_row_major(a_layout)));
     ck_tile::HostTensor<BDataType> b_k_n_tensors(
-        host_tensor_descriptor(K, N, StrideB, is_row_major(b_layout)));
+        host_tensor_descriptor(K, N, StrideB, ck_tile::is_row_major(b_layout)));
     ck_tile::HostTensor<D0DataType> d0_m_n_tensors(
-        host_tensor_descriptor(M, N, StrideD0, is_row_major(d0_layout)));
+        host_tensor_descriptor(M, N, StrideD0, ck_tile::is_row_major(d0_layout)));
     ck_tile::HostTensor<D1DataType> d1_m_n_tensors(
-        host_tensor_descriptor(M, N, StrideD1, is_row_major(d1_layout)));
+        host_tensor_descriptor(M, N, StrideD1, ck_tile::is_row_major(d1_layout)));
     ck_tile::HostTensor<EDataType> e_m_n_device_result(
-        host_tensor_descriptor(M, N, StrideE, is_row_major(e_layout)));
+        host_tensor_descriptor(M, N, StrideE, ck_tile::is_row_major(e_layout)));
 
     ck_tile::FillUniformDistribution<ADataType>{-5.f, 5.f}(a_m_k_tesnor);
     ck_tile::FillUniformDistribution<BDataType>{-5.f, 5.f}(b_k_n_tensors);
@@ -191,7 +191,7 @@ int run_multiple_d_gemm_example_with_layouts(int argc,
     e_m_n_dev_buf.FromDevice(e_m_n_device_result.data());
 
     ck_tile::HostTensor<EDataType> e_m_n_host_ref(
-        host_tensor_descriptor(M, N, StrideE, is_row_major(e_layout)));
+        host_tensor_descriptor(M, N, StrideE, ck_tile::is_row_major(e_layout)));
     e_m_n_host_ref.SetZero();
 
     ck_tile::reference_gemm_multiple_d<ADataType,

--- a/projects/composablekernel/example/ck_tile/19_gemm_multi_d/run_gemm_multi_d_fp16_example.inc
+++ b/projects/composablekernel/example/ck_tile/19_gemm_multi_d/run_gemm_multi_d_fp16_example.inc
@@ -208,7 +208,9 @@ int run_multiple_d_gemm_example_with_layouts(int argc,
         const float max_accumulated_value =
             *std::max_element(e_m_n_host_ref.mData.begin(), e_m_n_host_ref.mData.end());
 
-        const auto rtol_atol = calculate_rtol_atol(K, 1, max_accumulated_value);
+        const auto rtol_atol =
+            ck_tile::calculateRtolAtol<ADataType, BDataType, D0DataType, EDataType, AccDataType>(
+                K, 1, max_accumulated_value);
 
         pass &= ck_tile::check_err(e_m_n_device_result,
                                    e_m_n_host_ref,

--- a/projects/composablekernel/example/ck_tile/19_gemm_multi_d/utils.hpp
+++ b/projects/composablekernel/example/ck_tile/19_gemm_multi_d/utils.hpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
+#include "ck_tile/host/gemm_rtol_atol.hpp"
 
 struct MultiplyMultiply
 {
@@ -22,29 +23,3 @@ static constexpr inline auto is_row_major(Layout layout_)
                                                  ck_tile::tensor_layout::gemm::RowMajor>>{};
 }
 
-auto calculate_rtol_atol(const ck_tile::index_t K,
-                         const ck_tile::index_t kbatch,
-                         const float max_accumulated_value)
-{
-    using ComputeTypeAB =
-        std::conditional_t<sizeof(ADataType) < sizeof(BDataType), ADataType, BDataType>;
-
-    using ComputeType =
-        std::conditional_t<sizeof(ComputeTypeAB) < sizeof(D0DataType), ComputeTypeAB, D0DataType>;
-    // Calculate thresholds
-    const auto rtol = ck_tile::get_relative_threshold<ComputeType, EDataType, AccDataType>(
-        ck_tile::integer_divide_ceil(K, kbatch));
-
-    const auto atol = ck_tile::get_absolute_threshold<ComputeType, EDataType, AccDataType>(
-        max_accumulated_value / kbatch, ck_tile::integer_divide_ceil(K, kbatch));
-
-    // Calculate error due to split_k accumulation
-    const auto rtol_split_k =
-        ck_tile::get_relative_threshold<EDataType, EDataType, EDataType>(kbatch);
-
-    const auto atol_split_k = ck_tile::get_absolute_threshold<EDataType, EDataType, EDataType>(
-        max_accumulated_value, kbatch);
-
-    // Use higher threshold
-    return ck_tile::make_tuple(std::max(rtol, rtol_split_k), std::max(atol, atol_split_k));
-}

--- a/projects/composablekernel/example/ck_tile/19_gemm_multi_d/utils.hpp
+++ b/projects/composablekernel/example/ck_tile/19_gemm_multi_d/utils.hpp
@@ -22,4 +22,3 @@ static constexpr inline auto is_row_major(Layout layout_)
     return ck_tile::bool_constant<std::is_same_v<ck_tile::remove_cvref_t<decltype(layout_)>,
                                                  ck_tile::tensor_layout::gemm::RowMajor>>{};
 }
-

--- a/projects/composablekernel/example/ck_tile/19_gemm_multi_d/utils.hpp
+++ b/projects/composablekernel/example/ck_tile/19_gemm_multi_d/utils.hpp
@@ -15,4 +15,3 @@ struct MultiplyMultiply
         e = ck_tile::type_convert<E>(x0_f);
     }
 };
-

--- a/projects/composablekernel/example/ck_tile/19_gemm_multi_d/utils.hpp
+++ b/projects/composablekernel/example/ck_tile/19_gemm_multi_d/utils.hpp
@@ -16,9 +16,3 @@ struct MultiplyMultiply
     }
 };
 
-template <typename Layout>
-static constexpr inline auto is_row_major(Layout layout_)
-{
-    return ck_tile::bool_constant<std::is_same_v<ck_tile::remove_cvref_t<decltype(layout_)>,
-                                                 ck_tile::tensor_layout::gemm::RowMajor>>{};
-}

--- a/projects/composablekernel/example/ck_tile/20_grouped_convolution/grouped_convolution_utils.hpp
+++ b/projects/composablekernel/example/ck_tile/20_grouped_convolution/grouped_convolution_utils.hpp
@@ -9,33 +9,12 @@
 
 #include "ck_tile/core.hpp"
 #include "ck_tile/host/kernel_launch.hpp"
+#include "ck_tile/host/gemm_rtol_atol.hpp"
 #include "ck_tile/ops/epilogue.hpp"
 #include "ck_tile/ops/gemm.hpp"
 #include "ck_tile/ops/grouped_convolution.hpp"
 #include "ck_tile/ops/elementwise/unary_element_wise_operation.hpp"
 #include "conv_configs.hpp"
-
-template <typename InDataType, typename WeiDataType, typename AccDataType, typename OutDataType>
-auto calculate_rtol_atol(const ck_tile::index_t GemmK,
-                         const ck_tile::index_t kbatch,
-                         const float max_accumulated_value)
-{
-    using ComputeType =
-        std::conditional_t<sizeof(InDataType) < sizeof(WeiDataType), InDataType, WeiDataType>;
-    // Calculate thresholds
-    const auto rtol = ck_tile::get_relative_threshold<ComputeType, OutDataType, AccDataType>(
-        ck_tile::integer_divide_ceil(GemmK, kbatch));
-    const auto atol = ck_tile::get_absolute_threshold<ComputeType, OutDataType, AccDataType>(
-        max_accumulated_value / kbatch, ck_tile::integer_divide_ceil(GemmK, kbatch));
-    // Calculate error due to split_k accumulation
-    const auto rtol_split_k =
-        ck_tile::get_relative_threshold<OutDataType, OutDataType, OutDataType>(kbatch);
-    const auto atol_split_k =
-        ck_tile::get_absolute_threshold<OutDataType, OutDataType, OutDataType>(
-            max_accumulated_value, kbatch);
-    // Use higher threshold
-    return ck_tile::make_tuple(std::max(rtol, rtol_split_k), std::max(atol, atol_split_k));
-}
 
 ck_tile::index_t fill_spatial_dimensions(std::vector<ck_tile::index_t>& filter_spatial_lengths,
                                          std::vector<ck_tile::index_t>& image_spatial_lengths,

--- a/projects/composablekernel/example/ck_tile/20_grouped_convolution/run_grouped_convolution_bwd_data_example.inc
+++ b/projects/composablekernel/example/ck_tile/20_grouped_convolution/run_grouped_convolution_bwd_data_example.inc
@@ -173,7 +173,7 @@ int run_grouped_conv_bwd_data_example_with_layouts(
         const float max_accumulated_value =
             *std::max_element(input_host_ref.mData.begin(), input_host_ref.mData.end());
         const auto rtol_atol =
-            calculate_rtol_atol<InDataType, WeiDataType, AccDataType, OutDataType>(
+            ck_tile::calculateRtolAtol<InDataType, WeiDataType, AccDataType, OutDataType>(
                 GemmK, kbatch, max_accumulated_value);
         pass = ck_tile::check_err(input,
                                   input_host_ref,
@@ -217,7 +217,7 @@ int run_grouped_conv_bwd_data_example_with_layouts(
         const float max_accumulated_value =
             *std::max_element(input_gpu_ref.mData.begin(), input_gpu_ref.mData.end());
         const auto rtol_atol =
-            calculate_rtol_atol<InDataType, WeiDataType, AccDataType, OutDataType>(
+            ck_tile::calculateRtolAtol<InDataType, WeiDataType, AccDataType, OutDataType>(
                 GemmK, kbatch, max_accumulated_value);
         pass = ck_tile::check_err(input,
                                   input_gpu_ref,

--- a/projects/composablekernel/example/ck_tile/20_grouped_convolution/run_grouped_convolution_bwd_weight_example.inc
+++ b/projects/composablekernel/example/ck_tile/20_grouped_convolution/run_grouped_convolution_bwd_weight_example.inc
@@ -176,7 +176,7 @@ int run_grouped_conv_bwd_weight_example_with_layouts(ck_tile::ArgParser& arg_par
 
         const ck_tile::index_t split_k = res.split_k;
         const auto rtol_atol =
-            calculate_rtol_atol<InDataType, WeiDataType, AccDataType, OutDataType>(
+            ck_tile::calculateRtolAtol<InDataType, WeiDataType, AccDataType, OutDataType>(
                 GemmK, split_k, max_accumulated_value);
         pass = ck_tile::check_err(weight,
                                   weight_host_ref,
@@ -224,7 +224,7 @@ int run_grouped_conv_bwd_weight_example_with_layouts(ck_tile::ArgParser& arg_par
         const float max_accumulated_value =
             *std::max_element(weight_gpu_ref.mData.begin(), weight_gpu_ref.mData.end());
         const auto rtol_atol =
-            calculate_rtol_atol<InDataType, WeiDataType, AccDataType, OutDataType>(
+            ck_tile::calculateRtolAtol<InDataType, WeiDataType, AccDataType, OutDataType>(
                 GemmK, kbatch, max_accumulated_value);
         pass = ck_tile::check_err(weight,
                                   weight_gpu_ref,

--- a/projects/composablekernel/example/ck_tile/20_grouped_convolution/run_grouped_convolution_fwd_bias_clamp_example.inc
+++ b/projects/composablekernel/example/ck_tile/20_grouped_convolution/run_grouped_convolution_fwd_bias_clamp_example.inc
@@ -215,7 +215,7 @@ int run_grouped_conv_fwd_bias_clamp_example_with_layouts(
         const float max_accumulated_value =
             *std::max_element(output_host_ref.mData.begin(), output_host_ref.mData.end());
         const auto rtol_atol =
-            calculate_rtol_atol<InDataType, WeiDataType, AccDataType, OutDataType>(
+            ck_tile::calculateRtolAtol<InDataType, WeiDataType, AccDataType, OutDataType>(
                 GemmK, kbatch, max_accumulated_value);
         pass = ck_tile::check_err(output,
                                   output_host_ref,

--- a/projects/composablekernel/example/ck_tile/20_grouped_convolution/run_grouped_convolution_fwd_example.inc
+++ b/projects/composablekernel/example/ck_tile/20_grouped_convolution/run_grouped_convolution_fwd_example.inc
@@ -174,7 +174,7 @@ int run_grouped_conv_fwd_example_with_layouts(
         const float max_accumulated_value =
             *std::max_element(output_host_ref.mData.begin(), output_host_ref.mData.end());
         const auto rtol_atol =
-            calculate_rtol_atol<InDataType, WeiDataType, AccDataType, OutDataType>(
+            ck_tile::calculateRtolAtol<InDataType, WeiDataType, AccDataType, OutDataType>(
                 GemmK, kbatch, max_accumulated_value);
         pass = ck_tile::check_err(output,
                                   output_host_ref,
@@ -220,7 +220,7 @@ int run_grouped_conv_fwd_example_with_layouts(
         const float max_accumulated_value =
             *std::max_element(output_gpu_ref.mData.begin(), output_gpu_ref.mData.end());
         const auto rtol_atol =
-            calculate_rtol_atol<InDataType, WeiDataType, AccDataType, OutDataType>(
+            ck_tile::calculateRtolAtol<InDataType, WeiDataType, AccDataType, OutDataType>(
                 GemmK, kbatch, max_accumulated_value);
         pass = ck_tile::check_err(output,
                                   output_gpu_ref,

--- a/projects/composablekernel/example/ck_tile/22_gemm_multi_abd/run_gemm_multi_abd_fp16_example.inc
+++ b/projects/composablekernel/example/ck_tile/22_gemm_multi_abd/run_gemm_multi_abd_fp16_example.inc
@@ -134,34 +134,34 @@ int run_gemm_multi_abd_example_with_layouts(int argc,
     const int n_repeat = arg_parser.get_int("repeat");
     const int k_batch  = arg_parser.get_int("kbatch");
 
-    StrideA0 = get_default_stride(M, N, StrideA0, is_row_major(a1_layout));
-    StrideA1 = get_default_stride(M, N, StrideA1, is_row_major(a1_layout));
+    StrideA0 = get_default_stride(M, N, StrideA0, ck_tile::is_row_major(a1_layout));
+    StrideA1 = get_default_stride(M, N, StrideA1, ck_tile::is_row_major(a1_layout));
 
-    StrideB0 = get_default_stride(K, N, StrideB0, is_row_major(b0_layout));
-    StrideB1 = get_default_stride(K, N, StrideB1, is_row_major(b1_layout));
+    StrideB0 = get_default_stride(K, N, StrideB0, ck_tile::is_row_major(b0_layout));
+    StrideB1 = get_default_stride(K, N, StrideB1, ck_tile::is_row_major(b1_layout));
 
-    StrideD0 = get_default_stride(M, N, StrideD0, is_row_major(d0_layout));
-    StrideD1 = get_default_stride(M, N, StrideD1, is_row_major(d1_layout));
+    StrideD0 = get_default_stride(M, N, StrideD0, ck_tile::is_row_major(d0_layout));
+    StrideD1 = get_default_stride(M, N, StrideD1, ck_tile::is_row_major(d1_layout));
 
-    StrideE = get_default_stride(M, N, StrideE, is_row_major(e_layout));
+    StrideE = get_default_stride(M, N, StrideE, ck_tile::is_row_major(e_layout));
 
     ck_tile::HostTensor<A0DataType> a0_m_k_tesnor(
-        host_tensor_descriptor(M, K, StrideA0, is_row_major(a0_layout)));
+        host_tensor_descriptor(M, K, StrideA0, ck_tile::is_row_major(a0_layout)));
     ck_tile::HostTensor<A1DataType> a1_m_k_tesnor(
-        host_tensor_descriptor(M, K, StrideA1, is_row_major(a1_layout)));
+        host_tensor_descriptor(M, K, StrideA1, ck_tile::is_row_major(a1_layout)));
 
     ck_tile::HostTensor<B0DataType> b0_k_n_tensors(
-        host_tensor_descriptor(K, N, StrideB0, is_row_major(b0_layout)));
+        host_tensor_descriptor(K, N, StrideB0, ck_tile::is_row_major(b0_layout)));
     ck_tile::HostTensor<B1DataType> b1_k_n_tensors(
-        host_tensor_descriptor(K, N, StrideB1, is_row_major(b1_layout)));
+        host_tensor_descriptor(K, N, StrideB1, ck_tile::is_row_major(b1_layout)));
 
     ck_tile::HostTensor<D0DataType> d0_m_n_tensors(
-        host_tensor_descriptor(M, N, StrideD0, is_row_major(d0_layout)));
+        host_tensor_descriptor(M, N, StrideD0, ck_tile::is_row_major(d0_layout)));
     ck_tile::HostTensor<D1DataType> d1_m_n_tensors(
-        host_tensor_descriptor(M, N, StrideD1, is_row_major(d1_layout)));
+        host_tensor_descriptor(M, N, StrideD1, ck_tile::is_row_major(d1_layout)));
 
     ck_tile::HostTensor<EDataType> e_m_n_device_result(
-        host_tensor_descriptor(M, N, StrideE, is_row_major(e_layout)));
+        host_tensor_descriptor(M, N, StrideE, ck_tile::is_row_major(e_layout)));
 
     ck_tile::FillUniformDistribution<A0DataType>{-1.f, 1.f}(a0_m_k_tesnor);
     ck_tile::FillUniformDistribution<A1DataType>{-1.f, 1.f}(a1_m_k_tesnor);
@@ -238,11 +238,11 @@ int run_gemm_multi_abd_example_with_layouts(int argc,
     e_m_n_dev_buf.FromDevice(e_m_n_device_result.data());
 
     ck_tile::HostTensor<A0DataType> a_m_k_host_ref_element_result(
-        host_tensor_descriptor(M, K, StrideA0, is_row_major(a0_layout)));
+        host_tensor_descriptor(M, K, StrideA0, ck_tile::is_row_major(a0_layout)));
     ck_tile::HostTensor<B0DataType> b_k_n_host_ref_element_result(
-        host_tensor_descriptor(K, N, StrideB0, is_row_major(b0_layout)));
+        host_tensor_descriptor(K, N, StrideB0, ck_tile::is_row_major(b0_layout)));
     ck_tile::HostTensor<EDataType> e_m_n_host_ref(
-        host_tensor_descriptor(M, N, StrideE, is_row_major(e_layout)));
+        host_tensor_descriptor(M, N, StrideE, ck_tile::is_row_major(e_layout)));
     a_m_k_host_ref_element_result.SetZero();
     b_k_n_host_ref_element_result.SetZero();
     e_m_n_host_ref.SetZero();

--- a/projects/composablekernel/example/ck_tile/22_gemm_multi_abd/run_gemm_multi_abd_fp16_example.inc
+++ b/projects/composablekernel/example/ck_tile/22_gemm_multi_abd/run_gemm_multi_abd_fp16_example.inc
@@ -267,7 +267,9 @@ int run_gemm_multi_abd_example_with_layouts(int argc,
         const float max_accumulated_value =
             *std::max_element(e_m_n_host_ref.mData.begin(), e_m_n_host_ref.mData.end());
 
-        const auto rtol_atol = calculate_rtol_atol(K, 1, max_accumulated_value);
+        const auto rtol_atol =
+            ck_tile::calculateRtolAtol<A0DataType, B0DataType, D0DataType, EDataType, AccDataType>(
+                K, 1, max_accumulated_value);
 
         pass &= ck_tile::check_err(e_m_n_device_result,
                                    e_m_n_host_ref,

--- a/projects/composablekernel/example/ck_tile/22_gemm_multi_abd/utils.hpp
+++ b/projects/composablekernel/example/ck_tile/22_gemm_multi_abd/utils.hpp
@@ -4,9 +4,3 @@
 #pragma once
 #include "ck_tile/host/gemm_rtol_atol.hpp"
 
-template <typename Layout>
-static constexpr inline auto is_row_major(Layout layout_)
-{
-    return ck_tile::bool_constant<std::is_same_v<ck_tile::remove_cvref_t<decltype(layout_)>,
-                                                 ck_tile::tensor_layout::gemm::RowMajor>>{};
-}

--- a/projects/composablekernel/example/ck_tile/22_gemm_multi_abd/utils.hpp
+++ b/projects/composablekernel/example/ck_tile/22_gemm_multi_abd/utils.hpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
+#include "ck_tile/host/gemm_rtol_atol.hpp"
 
 template <typename Layout>
 static constexpr inline auto is_row_major(Layout layout_)
@@ -10,29 +11,3 @@ static constexpr inline auto is_row_major(Layout layout_)
                                                  ck_tile::tensor_layout::gemm::RowMajor>>{};
 }
 
-auto calculate_rtol_atol(const ck_tile::index_t K,
-                         const ck_tile::index_t kbatch,
-                         const float max_accumulated_value)
-{
-    using ComputeTypeAB =
-        std::conditional_t<sizeof(A0DataType) < sizeof(B0DataType), A0DataType, B0DataType>;
-
-    using ComputeType =
-        std::conditional_t<sizeof(ComputeTypeAB) < sizeof(D0DataType), ComputeTypeAB, D0DataType>;
-    // Calculate thresholds
-    const auto rtol = ck_tile::get_relative_threshold<ComputeType, EDataType, AccDataType>(
-        ck_tile::integer_divide_ceil(K, kbatch));
-
-    const auto atol = ck_tile::get_absolute_threshold<ComputeType, EDataType, AccDataType>(
-        max_accumulated_value / kbatch, ck_tile::integer_divide_ceil(K, kbatch));
-
-    // Calculate error due to split_k accumulation
-    const auto rtol_split_k =
-        ck_tile::get_relative_threshold<EDataType, EDataType, EDataType>(kbatch);
-
-    const auto atol_split_k = ck_tile::get_absolute_threshold<EDataType, EDataType, EDataType>(
-        max_accumulated_value, kbatch);
-
-    // Use higher threshold
-    return ck_tile::make_tuple(std::max(rtol, rtol_split_k), std::max(atol, atol_split_k));
-}

--- a/projects/composablekernel/example/ck_tile/22_gemm_multi_abd/utils.hpp
+++ b/projects/composablekernel/example/ck_tile/22_gemm_multi_abd/utils.hpp
@@ -10,4 +10,3 @@ static constexpr inline auto is_row_major(Layout layout_)
     return ck_tile::bool_constant<std::is_same_v<ck_tile::remove_cvref_t<decltype(layout_)>,
                                                  ck_tile::tensor_layout::gemm::RowMajor>>{};
 }
-

--- a/projects/composablekernel/example/ck_tile/22_gemm_multi_abd/utils.hpp
+++ b/projects/composablekernel/example/ck_tile/22_gemm_multi_abd/utils.hpp
@@ -3,4 +3,3 @@
 
 #pragma once
 #include "ck_tile/host/gemm_rtol_atol.hpp"
-

--- a/projects/composablekernel/example/ck_tile/38_block_scale_gemm/gemm_utils.hpp
+++ b/projects/composablekernel/example/ck_tile/38_block_scale_gemm/gemm_utils.hpp
@@ -32,13 +32,6 @@ inline size_t hash_multiple_strings(const std::vector<std::string>& inputs)
     return combined_hash;
 }
 
-template <typename Layout>
-static constexpr inline auto is_row_major(Layout layout_)
-{
-    return ck_tile::bool_constant<std::is_same_v<ck_tile::remove_cvref_t<decltype(layout_)>,
-                                                 ck_tile::tensor_layout::gemm::RowMajor>>{};
-}
-
 template <typename ADataType, typename BDataType, typename AccDataType, typename CDataType>
 auto calculate_rtol_atol(const ck_tile::index_t K,
                          const ck_tile::index_t kbatch,

--- a/projects/composablekernel/example/ck_tile/38_block_scale_gemm/run_gemm_quant_example.inc
+++ b/projects/composablekernel/example/ck_tile/38_block_scale_gemm/run_gemm_quant_example.inc
@@ -262,9 +262,9 @@ float gemm_calc_quant(const ck_tile::QuantGemmHostArgs& args, const ck_tile::str
             std::cout << "Flushing cache..." << std::endl;
 
             ck_tile::HostTensor<typename TypeConfig::ADataType> a_m(ck_tile::host_tensor_descriptor(
-                args.M, args.K, args.stride_A, is_row_major(ALayout{})));
+                args.M, args.K, args.stride_A, ck_tile::is_row_major(ALayout{})));
             ck_tile::HostTensor<typename TypeConfig::BDataType> b_n(ck_tile::host_tensor_descriptor(
-                args.K, args.N, args.stride_B, is_row_major(BLayout{})));
+                args.K, args.N, args.stride_B, ck_tile::is_row_major(BLayout{})));
 
             auto size_a_buffer = a_m.get_element_space_size_in_bytes();
             auto size_b_buffer = b_n.get_element_space_size_in_bytes();
@@ -497,30 +497,30 @@ int run_gemm_example_with_layouts(const ck_tile::ArgParser& arg_parser,
     bool flush_cache             = arg_parser.get_bool("flush_cache");
     int rotating_count           = arg_parser.get_int("rotating_count");
 
-    stride_A = ck_tile::get_default_stride(M, K, stride_A, is_row_major(a_layout));
-    stride_B = ck_tile::get_default_stride(K, N, stride_B, is_row_major(b_layout));
-    stride_C = ck_tile::get_default_stride(M, N, stride_C, is_row_major(CLayout{}));
+    stride_A = ck_tile::get_default_stride(M, K, stride_A, ck_tile::is_row_major(a_layout));
+    stride_B = ck_tile::get_default_stride(K, N, stride_B, ck_tile::is_row_major(b_layout));
+    stride_C = ck_tile::get_default_stride(M, N, stride_C, ck_tile::is_row_major(CLayout{}));
 
     // Conditional stride calculation based on QuantMode
     if constexpr(QuantMode == ck_tile::QuantType::AQuantGrouped)
     {
-        stride_AQ = ck_tile::get_default_stride(M, AQK, stride_AQ, is_row_major(aq_layout));
+        stride_AQ = ck_tile::get_default_stride(M, AQK, stride_AQ, ck_tile::is_row_major(aq_layout));
         stride_BQ = 0; // No B quantization
     }
     else if constexpr(QuantMode == ck_tile::QuantType::BQuantGrouped)
     {
         stride_AQ = 0; // No A quantization
-        stride_BQ = ck_tile::get_default_stride(BQK, BQN, stride_BQ, is_row_major(bq_layout));
+        stride_BQ = ck_tile::get_default_stride(BQK, BQN, stride_BQ, ck_tile::is_row_major(bq_layout));
     }
     else if constexpr(QuantMode == ck_tile::QuantType::ABQuantGrouped)
     {
-        stride_AQ = ck_tile::get_default_stride(M, AQK, stride_AQ, is_row_major(aq_layout));
-        stride_BQ = ck_tile::get_default_stride(BQK, BQN, stride_BQ, is_row_major(bq_layout));
+        stride_AQ = ck_tile::get_default_stride(M, AQK, stride_AQ, ck_tile::is_row_major(aq_layout));
+        stride_BQ = ck_tile::get_default_stride(BQK, BQN, stride_BQ, ck_tile::is_row_major(bq_layout));
     }
     else if constexpr(QuantMode == ck_tile::QuantType::RowColQuant)
     {
-        stride_AQ = ck_tile::get_default_stride(M, 1, stride_AQ, is_row_major(aq_layout));
-        stride_BQ = ck_tile::get_default_stride(1, N, stride_BQ, is_row_major(bq_layout));
+        stride_AQ = ck_tile::get_default_stride(M, 1, stride_AQ, ck_tile::is_row_major(aq_layout));
+        stride_BQ = ck_tile::get_default_stride(1, N, stride_BQ, ck_tile::is_row_major(bq_layout));
     }
     else if constexpr(QuantMode == ck_tile::QuantType::TensorQuant)
     {
@@ -529,11 +529,11 @@ int run_gemm_example_with_layouts(const ck_tile::ArgParser& arg_parser,
     }
 
     ck_tile::HostTensor<ADataType> a_m_k(
-        ck_tile::host_tensor_descriptor(M, K, stride_A, is_row_major(a_layout)));
+        ck_tile::host_tensor_descriptor(M, K, stride_A, ck_tile::is_row_major(a_layout)));
     ck_tile::HostTensor<BDataType> b_k_n(
-        ck_tile::host_tensor_descriptor(K, N, stride_B, is_row_major(b_layout)));
+        ck_tile::host_tensor_descriptor(K, N, stride_B, ck_tile::is_row_major(b_layout)));
     ck_tile::HostTensor<CDataType> c_m_n_dev_result(
-        ck_tile::host_tensor_descriptor(M, N, stride_C, is_row_major(CLayout{})));
+        ck_tile::host_tensor_descriptor(M, N, stride_C, ck_tile::is_row_major(CLayout{})));
 
     // Create AQ tensor with appropriate shape
     std::unique_ptr<ck_tile::HostTensor<AQDataType>> aq_tensor_ptr = nullptr;
@@ -542,12 +542,12 @@ int run_gemm_example_with_layouts(const ck_tile::ArgParser& arg_parser,
                  QuantMode == ck_tile::QuantType::RowColQuant)
     {
         aq_tensor_ptr = std::make_unique<ck_tile::HostTensor<AQDataType>>(
-            ck_tile::host_tensor_descriptor(M, AQK, stride_AQ, is_row_major(aq_layout)));
+            ck_tile::host_tensor_descriptor(M, AQK, stride_AQ, ck_tile::is_row_major(aq_layout)));
     }
     else if constexpr(QuantMode == ck_tile::QuantType::TensorQuant)
     {
         aq_tensor_ptr = std::make_unique<ck_tile::HostTensor<AQDataType>>(
-            ck_tile::host_tensor_descriptor(1, 1, stride_AQ, is_row_major(aq_layout)));
+            ck_tile::host_tensor_descriptor(1, 1, stride_AQ, ck_tile::is_row_major(aq_layout)));
     }
 
     // Create BQ tensor with appropriate shape
@@ -558,7 +558,7 @@ int run_gemm_example_with_layouts(const ck_tile::ArgParser& arg_parser,
                  QuantMode == ck_tile::QuantType::TensorQuant)
     {
         bq_tensor_ptr = std::make_unique<ck_tile::HostTensor<BQDataType>>(
-            ck_tile::host_tensor_descriptor(BQK, BQN, stride_BQ, is_row_major(bq_layout)));
+            ck_tile::host_tensor_descriptor(BQK, BQN, stride_BQ, ck_tile::is_row_major(bq_layout)));
     }
 
     std::mt19937 gen(42);
@@ -842,7 +842,7 @@ int run_gemm_example_with_layouts(const ck_tile::ArgParser& arg_parser,
         std::cout << "Performing CPU verification..." << std::endl;
 
         ck_tile::HostTensor<CDataType> c_m_n_host_ref(
-            ck_tile::host_tensor_descriptor(M, N, stride_C, is_row_major(CLayout{})));
+            ck_tile::host_tensor_descriptor(M, N, stride_C, ck_tile::is_row_major(CLayout{})));
         c_m_n_host_ref.SetZero();
 
         // Track start time for reference operation

--- a/projects/composablekernel/example/ck_tile/38_block_scale_gemm/run_gemm_quant_example.inc
+++ b/projects/composablekernel/example/ck_tile/38_block_scale_gemm/run_gemm_quant_example.inc
@@ -504,18 +504,22 @@ int run_gemm_example_with_layouts(const ck_tile::ArgParser& arg_parser,
     // Conditional stride calculation based on QuantMode
     if constexpr(QuantMode == ck_tile::QuantType::AQuantGrouped)
     {
-        stride_AQ = ck_tile::get_default_stride(M, AQK, stride_AQ, ck_tile::is_row_major(aq_layout));
+        stride_AQ =
+            ck_tile::get_default_stride(M, AQK, stride_AQ, ck_tile::is_row_major(aq_layout));
         stride_BQ = 0; // No B quantization
     }
     else if constexpr(QuantMode == ck_tile::QuantType::BQuantGrouped)
     {
         stride_AQ = 0; // No A quantization
-        stride_BQ = ck_tile::get_default_stride(BQK, BQN, stride_BQ, ck_tile::is_row_major(bq_layout));
+        stride_BQ =
+            ck_tile::get_default_stride(BQK, BQN, stride_BQ, ck_tile::is_row_major(bq_layout));
     }
     else if constexpr(QuantMode == ck_tile::QuantType::ABQuantGrouped)
     {
-        stride_AQ = ck_tile::get_default_stride(M, AQK, stride_AQ, ck_tile::is_row_major(aq_layout));
-        stride_BQ = ck_tile::get_default_stride(BQK, BQN, stride_BQ, ck_tile::is_row_major(bq_layout));
+        stride_AQ =
+            ck_tile::get_default_stride(M, AQK, stride_AQ, ck_tile::is_row_major(aq_layout));
+        stride_BQ =
+            ck_tile::get_default_stride(BQK, BQN, stride_BQ, ck_tile::is_row_major(bq_layout));
     }
     else if constexpr(QuantMode == ck_tile::QuantType::RowColQuant)
     {

--- a/projects/composablekernel/example/ck_tile/40_streamk_gemm/run_gemm_example.inc
+++ b/projects/composablekernel/example/ck_tile/40_streamk_gemm/run_gemm_example.inc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
+#include "ck_tile/host/gemm_rtol_atol.hpp"
 #include "ck_tile/ops/common/utils.hpp"
 
 template <typename Layout>
@@ -9,31 +10,6 @@ static constexpr inline auto is_row_major(Layout)
 {
     return ck_tile::bool_constant<
         std::is_same_v<ck_tile::remove_cvref_t<Layout>, ck_tile::tensor_layout::gemm::RowMajor>>{};
-}
-
-template <typename ADataType, typename BDataType, typename AccDataType, typename CDataType>
-auto calculateRtolAtol(const ck_tile::index_t k_dim,
-                       const ck_tile::index_t k_batch,
-                       const float max_accumulated_value)
-{
-    using ComputeType =
-        std::conditional_t<sizeof(ADataType) < sizeof(BDataType), ADataType, BDataType>;
-    // Calculate thresholds
-    const auto relative_tolerance =
-        ck_tile::get_relative_threshold<ComputeType, CDataType, AccDataType>(
-            ck_tile::integer_divide_ceil(k_dim, k_batch));
-    const auto absolute_tolerance =
-        ck_tile::get_absolute_threshold<ComputeType, CDataType, AccDataType>(
-            max_accumulated_value / k_batch, ck_tile::integer_divide_ceil(k_dim, k_batch));
-    // Calculate error due to multiple WGs working in the same C macro tile
-    const auto relative_tolerance_split_k =
-        ck_tile::get_relative_threshold<CDataType, CDataType, CDataType>(k_batch);
-    const auto absolute_tolerance_split_k =
-        ck_tile::get_absolute_threshold<CDataType, CDataType, CDataType>(max_accumulated_value,
-                                                                         k_batch);
-    // Use higher threshold
-    return ck_tile::make_tuple(std::max(relative_tolerance, relative_tolerance_split_k),
-                               std::max(absolute_tolerance, absolute_tolerance_split_k));
 }
 
 template <typename GemmConfiguration,
@@ -298,7 +274,7 @@ int runGemmExampleWithLayouts(int argc,
         const float max_accumulated_value =
             *std::max_element(c_m_n_reference.mData.begin(), c_m_n_reference.mData.end());
         const auto relative_absolute_tolerances =
-            calculateRtolAtol<ADataType, BDataType, AccumulatorDataType, CDataType>(
+            ck_tile::calculateRtolAtol<ADataType, BDataType, AccumulatorDataType, CDataType>(
                 k_dim, num_wgs_per_tile, max_accumulated_value);
         pass = doVerify(c_m_n_device_result, c_m_n_reference, relative_absolute_tolerances, "CPU");
     }
@@ -325,7 +301,7 @@ int runGemmExampleWithLayouts(int argc,
         const float max_accumulated_value =
             *std::max_element(c_m_n_reference.mData.begin(), c_m_n_reference.mData.end());
         const auto relative_absolute_tolerances =
-            calculateRtolAtol<ADataType, BDataType, AccumulatorDataType, CDataType>(
+            ck_tile::calculateRtolAtol<ADataType, BDataType, AccumulatorDataType, CDataType>(
                 k_dim, num_wgs_per_tile, max_accumulated_value);
         pass = doVerify(c_m_n_device_result, c_m_n_reference, relative_absolute_tolerances, "GPU");
     }

--- a/projects/composablekernel/example/ck_tile/40_streamk_gemm/run_gemm_example.inc
+++ b/projects/composablekernel/example/ck_tile/40_streamk_gemm/run_gemm_example.inc
@@ -5,13 +5,6 @@
 #include "ck_tile/host/gemm_rtol_atol.hpp"
 #include "ck_tile/ops/common/utils.hpp"
 
-template <typename Layout>
-static constexpr inline auto is_row_major(Layout)
-{
-    return ck_tile::bool_constant<
-        std::is_same_v<ck_tile::remove_cvref_t<Layout>, ck_tile::tensor_layout::gemm::RowMajor>>{};
-}
-
 template <typename GemmConfiguration,
           typename ADataType,
           typename BDataType,
@@ -180,16 +173,16 @@ int runGemmExampleWithLayouts(int argc,
     ck_tile::StreamKReductionStrategy reduction_strategy =
         getReductionStrategyValue(arg_parser.get_str("reduction_strategy"));
 
-    stride_a = ck_tile::get_default_stride(m_dim, k_dim, stride_a, is_row_major(a_layout));
-    stride_b = ck_tile::get_default_stride(k_dim, n_dim, stride_b, is_row_major(b_layout));
-    stride_c = ck_tile::get_default_stride(m_dim, n_dim, stride_c, is_row_major(CLayout{}));
+    stride_a = ck_tile::get_default_stride(m_dim, k_dim, stride_a, ck_tile::is_row_major(a_layout));
+    stride_b = ck_tile::get_default_stride(k_dim, n_dim, stride_b, ck_tile::is_row_major(b_layout));
+    stride_c = ck_tile::get_default_stride(m_dim, n_dim, stride_c, ck_tile::is_row_major(CLayout{}));
 
     ck_tile::HostTensor<ADataType> a_m_k_host(
-        ck_tile::host_tensor_descriptor(m_dim, k_dim, stride_a, is_row_major(a_layout)));
+        ck_tile::host_tensor_descriptor(m_dim, k_dim, stride_a, ck_tile::is_row_major(a_layout)));
     ck_tile::HostTensor<BDataType> b_k_n_host(
-        ck_tile::host_tensor_descriptor(k_dim, n_dim, stride_b, is_row_major(b_layout)));
+        ck_tile::host_tensor_descriptor(k_dim, n_dim, stride_b, ck_tile::is_row_major(b_layout)));
     ck_tile::HostTensor<CDataType> c_m_n_device_result(
-        ck_tile::host_tensor_descriptor(m_dim, n_dim, stride_c, is_row_major(CLayout{})));
+        ck_tile::host_tensor_descriptor(m_dim, n_dim, stride_c, ck_tile::is_row_major(CLayout{})));
 
     if(init_method == 0)
     {
@@ -264,7 +257,7 @@ int runGemmExampleWithLayouts(int argc,
 
     // Memory on host to store gpu reference result
     ck_tile::HostTensor<CDataType> c_m_n_reference(
-        ck_tile::host_tensor_descriptor(m_dim, n_dim, stride_c, is_row_major(CLayout{})));
+        ck_tile::host_tensor_descriptor(m_dim, n_dim, stride_c, ck_tile::is_row_major(CLayout{})));
     c_m_n_reference.SetZero();
 
     if(arg_parser.get_int("v") == 1) // Validate on the CPU

--- a/projects/composablekernel/example/ck_tile/40_streamk_gemm/run_gemm_example.inc
+++ b/projects/composablekernel/example/ck_tile/40_streamk_gemm/run_gemm_example.inc
@@ -175,7 +175,8 @@ int runGemmExampleWithLayouts(int argc,
 
     stride_a = ck_tile::get_default_stride(m_dim, k_dim, stride_a, ck_tile::is_row_major(a_layout));
     stride_b = ck_tile::get_default_stride(k_dim, n_dim, stride_b, ck_tile::is_row_major(b_layout));
-    stride_c = ck_tile::get_default_stride(m_dim, n_dim, stride_c, ck_tile::is_row_major(CLayout{}));
+    stride_c =
+        ck_tile::get_default_stride(m_dim, n_dim, stride_c, ck_tile::is_row_major(CLayout{}));
 
     ck_tile::HostTensor<ADataType> a_m_k_host(
         ck_tile::host_tensor_descriptor(m_dim, k_dim, stride_a, ck_tile::is_row_major(a_layout)));

--- a/projects/composablekernel/example/ck_tile/41_batched_contraction/run_batched_contraction_example.inc
+++ b/projects/composablekernel/example/ck_tile/41_batched_contraction/run_batched_contraction_example.inc
@@ -8,28 +8,8 @@
 #include <cmath>
 #include <chrono>
 #include "contraction_utils.hpp"
+#include "ck_tile/host/gemm_rtol_atol.hpp"
 #include "ck_tile/host/reference/reference_batched_contraction.hpp"
-
-template <typename ADataType, typename BDataType, typename EDataType, typename AccDataType>
-auto calculate_rtol_atol(const ck_tile::index_t K,
-                         const ck_tile::index_t kbatch,
-                         const float max_accumulated_value)
-{
-    using ComputeType =
-        std::conditional_t<sizeof(ADataType) < sizeof(BDataType), ADataType, BDataType>;
-
-    const auto rtol = ck_tile::get_relative_threshold<ComputeType, EDataType, AccDataType>(
-        ck_tile::integer_divide_ceil(K, kbatch));
-    const auto atol = ck_tile::get_absolute_threshold<ComputeType, EDataType, AccDataType>(
-        max_accumulated_value / kbatch, ck_tile::integer_divide_ceil(K, kbatch));
-
-    const auto rtol_split_k =
-        ck_tile::get_relative_threshold<EDataType, EDataType, EDataType>(kbatch);
-    const auto atol_split_k = ck_tile::get_absolute_threshold<EDataType, EDataType, EDataType>(
-        max_accumulated_value, kbatch);
-
-    return ck_tile::make_tuple(std::max(rtol, rtol_split_k), std::max(atol, atol_split_k));
-}
 
 template <typename ADataType,
           typename BDataType,
@@ -455,7 +435,7 @@ int run_batched_contraction_example_with_layouts(
             *std::max_element(e_full_dims_host_ref.mData.begin(), e_full_dims_host_ref.mData.end());
 
         const auto rtol_atol =
-            calculate_rtol_atol<::ADataType, ::BDataType, ::EDataType, ::AccDataType>(
+            ck_tile::calculateRtolAtol<::ADataType, ::BDataType, ::AccDataType, ::EDataType>(
                 K_total, kbatch, max_accumulated_value);
 
         pass = ck_tile::check_err(e_full_dims_host,

--- a/projects/composablekernel/example/ck_tile/42_mx_gemm/mx_gemm.cpp
+++ b/projects/composablekernel/example/ck_tile/42_mx_gemm/mx_gemm.cpp
@@ -11,6 +11,7 @@
 #include <type_traits>
 
 #include "ck_tile/host.hpp"
+#include "ck_tile/host/gemm_rtol_atol.hpp"
 #include "mx_gemm.hpp"
 #include "mx_gemm_instance.hpp"
 

--- a/projects/composablekernel/example/ck_tile/42_mx_gemm/mx_gemm.cpp
+++ b/projects/composablekernel/example/ck_tile/42_mx_gemm/mx_gemm.cpp
@@ -15,13 +15,6 @@
 #include "mx_gemm.hpp"
 #include "mx_gemm_instance.hpp"
 
-template <typename Layout>
-static constexpr inline auto is_row_major(Layout layout_)
-{
-    return ck_tile::bool_constant<std::is_same_v<ck_tile::remove_cvref_t<decltype(layout_)>,
-                                                 ck_tile::tensor_layout::gemm::RowMajor>>{};
-}
-
 template <typename GemmConfig,
           typename ADataType,
           typename BDataType,

--- a/projects/composablekernel/example/ck_tile/42_mx_gemm/run_mx_gemm.inc
+++ b/projects/composablekernel/example/ck_tile/42_mx_gemm/run_mx_gemm.inc
@@ -107,10 +107,10 @@ int run_mx_gemm_with_layouts(int argc, char* argv[], ALayout, BLayout, CLayout)
     ck_tile::index_t stride_scale_b =
         ck_tile::get_default_stride(scale_k_size, N, 0, ck_tile::is_row_major(BLayout{}));
 
-    ck_tile::HostTensor<ScaleType> scale_a_host(
-        ck_tile::host_tensor_descriptor(M, scale_k_size, stride_scale_a, ck_tile::is_row_major(ALayout{})));
-    ck_tile::HostTensor<ScaleType> scale_b_host(
-        ck_tile::host_tensor_descriptor(scale_k_size, N, stride_scale_b, ck_tile::is_row_major(BLayout{})));
+    ck_tile::HostTensor<ScaleType> scale_a_host(ck_tile::host_tensor_descriptor(
+        M, scale_k_size, stride_scale_a, ck_tile::is_row_major(ALayout{})));
+    ck_tile::HostTensor<ScaleType> scale_b_host(ck_tile::host_tensor_descriptor(
+        scale_k_size, N, stride_scale_b, ck_tile::is_row_major(BLayout{})));
     int seed = 1234;
     switch(init_method)
     {

--- a/projects/composablekernel/example/ck_tile/42_mx_gemm/run_mx_gemm.inc
+++ b/projects/composablekernel/example/ck_tile/42_mx_gemm/run_mx_gemm.inc
@@ -82,18 +82,18 @@ int run_mx_gemm_with_layouts(int argc, char* argv[], ALayout, BLayout, CLayout)
     // Use get_default_stride helper for automatic leading dimension calculation (only if not
     // explicitly provided)
     if(stride_A == 0)
-        stride_A = ck_tile::get_default_stride(M, K, 0, is_row_major(ALayout{}));
+        stride_A = ck_tile::get_default_stride(M, K, 0, ck_tile::is_row_major(ALayout{}));
     if(stride_B == 0)
-        stride_B = ck_tile::get_default_stride(K, N, 0, is_row_major(BLayout{}));
+        stride_B = ck_tile::get_default_stride(K, N, 0, ck_tile::is_row_major(BLayout{}));
     if(stride_C == 0)
-        stride_C = ck_tile::get_default_stride(M, N, 0, is_row_major(CLayout{}));
+        stride_C = ck_tile::get_default_stride(M, N, 0, ck_tile::is_row_major(CLayout{}));
 
     ck_tile::HostTensor<ADataType> a_host(
-        ck_tile::host_tensor_descriptor(M, K, stride_A, is_row_major(ALayout{})));
+        ck_tile::host_tensor_descriptor(M, K, stride_A, ck_tile::is_row_major(ALayout{})));
     ck_tile::HostTensor<BDataType> b_host(
-        ck_tile::host_tensor_descriptor(K, N, stride_B, is_row_major(BLayout{})));
+        ck_tile::host_tensor_descriptor(K, N, stride_B, ck_tile::is_row_major(BLayout{})));
     ck_tile::HostTensor<CDataType> c_host(
-        ck_tile::host_tensor_descriptor(M, N, stride_C, is_row_major(CLayout{})));
+        ck_tile::host_tensor_descriptor(M, N, stride_C, ck_tile::is_row_major(CLayout{})));
 
     // Scale tensors - follow parent matrix layouts for optimal memory access
     // A scales: [M, K/32] with A's layout
@@ -103,14 +103,14 @@ int run_mx_gemm_with_layouts(int argc, char* argv[], ALayout, BLayout, CLayout)
 
     // Follow A/BLayout to get the layouts for the scale tensors
     ck_tile::index_t stride_scale_a =
-        ck_tile::get_default_stride(M, scale_k_size, 0, is_row_major(ALayout{}));
+        ck_tile::get_default_stride(M, scale_k_size, 0, ck_tile::is_row_major(ALayout{}));
     ck_tile::index_t stride_scale_b =
-        ck_tile::get_default_stride(scale_k_size, N, 0, is_row_major(BLayout{}));
+        ck_tile::get_default_stride(scale_k_size, N, 0, ck_tile::is_row_major(BLayout{}));
 
     ck_tile::HostTensor<ScaleType> scale_a_host(
-        ck_tile::host_tensor_descriptor(M, scale_k_size, stride_scale_a, is_row_major(ALayout{})));
+        ck_tile::host_tensor_descriptor(M, scale_k_size, stride_scale_a, ck_tile::is_row_major(ALayout{})));
     ck_tile::HostTensor<ScaleType> scale_b_host(
-        ck_tile::host_tensor_descriptor(scale_k_size, N, stride_scale_b, is_row_major(BLayout{})));
+        ck_tile::host_tensor_descriptor(scale_k_size, N, stride_scale_b, ck_tile::is_row_major(BLayout{})));
     int seed = 1234;
     switch(init_method)
     {
@@ -213,7 +213,7 @@ int run_mx_gemm_with_layouts(int argc, char* argv[], ALayout, BLayout, CLayout)
 
         // compute reference
         ck_tile::HostTensor<CDataType> c_m_n_host_ref(
-            ck_tile::host_tensor_descriptor(M, N, stride_C, is_row_major(CLayout{})));
+            ck_tile::host_tensor_descriptor(M, N, stride_C, ck_tile::is_row_major(CLayout{})));
         c_m_n_host_ref.SetZero();
 
         ck_tile::reference_mx_gemm<ADataType, BDataType, ScaleType, AccDataType, CDataType>(

--- a/projects/composablekernel/example/ck_tile/42_mx_gemm/run_mx_gemm.inc
+++ b/projects/composablekernel/example/ck_tile/42_mx_gemm/run_mx_gemm.inc
@@ -1,19 +1,6 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// Calculate relative and absolute error thresholds for MX GEMM
-template <typename ADataType, typename BDataType, typename AccDataType, typename CDataType>
-auto calculate_rtol_atol(const ck_tile::index_t K, const float max_accumulated_value)
-{
-    using ComputeType =
-        std::conditional_t<sizeof(ADataType) < sizeof(BDataType), ADataType, BDataType>;
-    // Calculate thresholds
-    const auto rtol = ck_tile::get_relative_threshold<ComputeType, CDataType, AccDataType>(K);
-    const auto atol = ck_tile::get_absolute_threshold<ComputeType, CDataType, AccDataType>(
-        max_accumulated_value, K);
-    return ck_tile::make_tuple(rtol, atol);
-}
-
 // Pack [MN, K/32] e8m0_t scales into [MN/MNPack, K/32/KPack] int32_t
 // Each int32_t contains MNPack * KPack e8m0_t values with byte layout matching
 // the GPU tile distribution: values are XdlMNThread apart in M and XdlKThread apart in K.
@@ -234,8 +221,9 @@ int run_mx_gemm_with_layouts(int argc, char* argv[], ALayout, BLayout, CLayout)
 
         const float max_accumulated_value =
             *std::max_element(c_m_n_host_ref.mData.begin(), c_m_n_host_ref.mData.end());
-        const auto rtol_atol = calculate_rtol_atol<ADataType, BDataType, AccDataType, CDataType>(
-            K, max_accumulated_value);
+        const auto rtol_atol =
+            ck_tile::calculateRtolAtol<ADataType, BDataType, AccDataType, CDataType>(
+                K, max_accumulated_value);
         const double rtol = rtol_atol.at(ck_tile::number<0>{});
         const double atol = rtol_atol.at(ck_tile::number<1>{});
         pass = ck_tile::check_err(c_host, c_m_n_host_ref, "Error: Incorrect results!", rtol, atol);

--- a/projects/composablekernel/include/ck_tile/host/gemm_rtol_atol.hpp
+++ b/projects/composablekernel/include/ck_tile/host/gemm_rtol_atol.hpp
@@ -8,6 +8,20 @@
 
 namespace ck_tile {
 
+/// Computes relative and absolute error tolerance thresholds for GEMM verification
+/// without split-K accumulation error (single-WG, no split-K).
+template <typename ADataType, typename BDataType, typename AccDataType, typename CDataType>
+auto calculateRtolAtol(const index_t k_dim, const float max_accumulated_value)
+{
+    using ComputeType =
+        std::conditional_t<sizeof(ADataType) < sizeof(BDataType), ADataType, BDataType>;
+    const auto relative_tolerance =
+        get_relative_threshold<ComputeType, CDataType, AccDataType>(k_dim);
+    const auto absolute_tolerance =
+        get_absolute_threshold<ComputeType, CDataType, AccDataType>(max_accumulated_value, k_dim);
+    return make_tuple(relative_tolerance, absolute_tolerance);
+}
+
 /// Computes relative and absolute error tolerance thresholds for GEMM verification.
 /// Accounts for split-K (or multi-WG) accumulation error in addition to per-element
 /// compute error.

--- a/projects/composablekernel/include/ck_tile/host/gemm_rtol_atol.hpp
+++ b/projects/composablekernel/include/ck_tile/host/gemm_rtol_atol.hpp
@@ -35,4 +35,36 @@ auto calculateRtolAtol(const index_t k_dim,
                       std::max(absolute_tolerance, absolute_tolerance_split_k));
 }
 
+/// 5-parameter variant for multi-D GEMMs where a D tensor participates in the accumulation
+/// and its precision affects the effective compute type (3-way minimum-precision selection).
+template <typename ADataType,
+          typename BDataType,
+          typename D0DataType,
+          typename EDataType,
+          typename AccDataType>
+auto calculateRtolAtol(const index_t k_dim,
+                       const index_t k_batch,
+                       const float max_accumulated_value)
+{
+    using ComputeTypeAB =
+        std::conditional_t<sizeof(ADataType) < sizeof(BDataType), ADataType, BDataType>;
+    using ComputeType =
+        std::conditional_t<sizeof(ComputeTypeAB) < sizeof(D0DataType), ComputeTypeAB, D0DataType>;
+    // Calculate thresholds
+    const auto relative_tolerance =
+        get_relative_threshold<ComputeType, EDataType, AccDataType>(
+            integer_divide_ceil(k_dim, k_batch));
+    const auto absolute_tolerance =
+        get_absolute_threshold<ComputeType, EDataType, AccDataType>(
+            max_accumulated_value / k_batch, integer_divide_ceil(k_dim, k_batch));
+    // Calculate error due to multiple WGs working in the same E macro tile
+    const auto relative_tolerance_split_k =
+        get_relative_threshold<EDataType, EDataType, EDataType>(k_batch);
+    const auto absolute_tolerance_split_k =
+        get_absolute_threshold<EDataType, EDataType, EDataType>(max_accumulated_value, k_batch);
+    // Use higher threshold
+    return make_tuple(std::max(relative_tolerance, relative_tolerance_split_k),
+                      std::max(absolute_tolerance, absolute_tolerance_split_k));
+}
+
 } // namespace ck_tile

--- a/projects/composablekernel/include/ck_tile/host/gemm_rtol_atol.hpp
+++ b/projects/composablekernel/include/ck_tile/host/gemm_rtol_atol.hpp
@@ -10,6 +10,11 @@ namespace ck_tile {
 
 /// Computes relative and absolute error tolerance thresholds for GEMM verification
 /// without split-K accumulation error (single-WG, no split-K).
+/// @return tuple<double, double> where [0] = relative tolerance (rtol),
+///                                     [1] = absolute tolerance (atol).
+/// @note Does NOT support pk_fp4_t operand types. For block-scale quantized GEMMs
+///       using pk_fp4_t, use the local calculate_rtol_atol in
+///       example/ck_tile/38_block_scale_gemm/gemm_utils.hpp instead.
 template <typename ADataType, typename BDataType, typename AccDataType, typename CDataType>
 auto calculateRtolAtol(const index_t k_dim, const float max_accumulated_value)
 {
@@ -25,6 +30,11 @@ auto calculateRtolAtol(const index_t k_dim, const float max_accumulated_value)
 /// Computes relative and absolute error tolerance thresholds for GEMM verification.
 /// Accounts for split-K (or multi-WG) accumulation error in addition to per-element
 /// compute error.
+/// @return tuple<double, double> where [0] = relative tolerance (rtol),
+///                                     [1] = absolute tolerance (atol).
+/// @note Does NOT support pk_fp4_t operand types. For block-scale quantized GEMMs
+///       using pk_fp4_t, use the local calculate_rtol_atol in
+///       example/ck_tile/38_block_scale_gemm/gemm_utils.hpp instead.
 template <typename ADataType, typename BDataType, typename AccDataType, typename CDataType>
 auto calculateRtolAtol(const index_t k_dim,
                        const index_t k_batch,
@@ -51,6 +61,9 @@ auto calculateRtolAtol(const index_t k_dim,
 
 /// 5-parameter variant for multi-D GEMMs where a D tensor participates in the accumulation
 /// and its precision affects the effective compute type (3-way minimum-precision selection).
+/// D0DataType = first D-tensor (bias/residual input); EDataType = output tensor (replaces C).
+/// @return tuple<double, double> where [0] = relative tolerance (rtol),
+///                                     [1] = absolute tolerance (atol).
 template <typename ADataType,
           typename BDataType,
           typename D0DataType,

--- a/projects/composablekernel/include/ck_tile/host/gemm_rtol_atol.hpp
+++ b/projects/composablekernel/include/ck_tile/host/gemm_rtol_atol.hpp
@@ -1,0 +1,38 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "ck_tile/core.hpp"
+#include "ck_tile/host/check_err.hpp"
+
+namespace ck_tile {
+
+/// Computes relative and absolute error tolerance thresholds for GEMM verification.
+/// Accounts for split-K (or multi-WG) accumulation error in addition to per-element
+/// compute error.
+template <typename ADataType, typename BDataType, typename AccDataType, typename CDataType>
+auto calculateRtolAtol(const index_t k_dim,
+                       const index_t k_batch,
+                       const float max_accumulated_value)
+{
+    using ComputeType =
+        std::conditional_t<sizeof(ADataType) < sizeof(BDataType), ADataType, BDataType>;
+    // Calculate thresholds
+    const auto relative_tolerance =
+        get_relative_threshold<ComputeType, CDataType, AccDataType>(
+            integer_divide_ceil(k_dim, k_batch));
+    const auto absolute_tolerance =
+        get_absolute_threshold<ComputeType, CDataType, AccDataType>(
+            max_accumulated_value / k_batch, integer_divide_ceil(k_dim, k_batch));
+    // Calculate error due to multiple WGs working in the same C macro tile
+    const auto relative_tolerance_split_k =
+        get_relative_threshold<CDataType, CDataType, CDataType>(k_batch);
+    const auto absolute_tolerance_split_k =
+        get_absolute_threshold<CDataType, CDataType, CDataType>(max_accumulated_value, k_batch);
+    // Use higher threshold
+    return make_tuple(std::max(relative_tolerance, relative_tolerance_split_k),
+                      std::max(absolute_tolerance, absolute_tolerance_split_k));
+}
+
+} // namespace ck_tile

--- a/projects/composablekernel/include/ck_tile/host/gemm_rtol_atol.hpp
+++ b/projects/composablekernel/include/ck_tile/host/gemm_rtol_atol.hpp
@@ -43,12 +43,10 @@ auto calculateRtolAtol(const index_t k_dim,
     using ComputeType =
         std::conditional_t<sizeof(ADataType) < sizeof(BDataType), ADataType, BDataType>;
     // Calculate thresholds
-    const auto relative_tolerance =
-        get_relative_threshold<ComputeType, CDataType, AccDataType>(
-            integer_divide_ceil(k_dim, k_batch));
-    const auto absolute_tolerance =
-        get_absolute_threshold<ComputeType, CDataType, AccDataType>(
-            max_accumulated_value / k_batch, integer_divide_ceil(k_dim, k_batch));
+    const auto relative_tolerance = get_relative_threshold<ComputeType, CDataType, AccDataType>(
+        integer_divide_ceil(k_dim, k_batch));
+    const auto absolute_tolerance = get_absolute_threshold<ComputeType, CDataType, AccDataType>(
+        max_accumulated_value / k_batch, integer_divide_ceil(k_dim, k_batch));
     // Calculate error due to multiple WGs working in the same C macro tile
     const auto relative_tolerance_split_k =
         get_relative_threshold<CDataType, CDataType, CDataType>(k_batch);
@@ -78,12 +76,10 @@ auto calculateRtolAtol(const index_t k_dim,
     using ComputeType =
         std::conditional_t<sizeof(ComputeTypeAB) < sizeof(D0DataType), ComputeTypeAB, D0DataType>;
     // Calculate thresholds
-    const auto relative_tolerance =
-        get_relative_threshold<ComputeType, EDataType, AccDataType>(
-            integer_divide_ceil(k_dim, k_batch));
-    const auto absolute_tolerance =
-        get_absolute_threshold<ComputeType, EDataType, AccDataType>(
-            max_accumulated_value / k_batch, integer_divide_ceil(k_dim, k_batch));
+    const auto relative_tolerance = get_relative_threshold<ComputeType, EDataType, AccDataType>(
+        integer_divide_ceil(k_dim, k_batch));
+    const auto absolute_tolerance = get_absolute_threshold<ComputeType, EDataType, AccDataType>(
+        max_accumulated_value / k_batch, integer_divide_ceil(k_dim, k_batch));
     // Calculate error due to multiple WGs working in the same E macro tile
     const auto relative_tolerance_split_k =
         get_relative_threshold<EDataType, EDataType, EDataType>(k_batch);

--- a/projects/composablekernel/include/ck_tile/host/host_tensor.hpp
+++ b/projects/composablekernel/include/ck_tile/host/host_tensor.hpp
@@ -866,8 +866,7 @@ auto get_default_stride(std::size_t row,
 template <typename Layout>
 static constexpr inline auto is_row_major(Layout)
 {
-    return bool_constant<
-        std::is_same_v<remove_cvref_t<Layout>, tensor_layout::gemm::RowMajor>>{};
+    return bool_constant<std::is_same_v<remove_cvref_t<Layout>, tensor_layout::gemm::RowMajor>>{};
 }
 
 } // namespace ck_tile

--- a/projects/composablekernel/include/ck_tile/host/host_tensor.hpp
+++ b/projects/composablekernel/include/ck_tile/host/host_tensor.hpp
@@ -861,5 +861,14 @@ auto get_default_stride(std::size_t row,
     else
         return stride;
 }
+/// Returns a bool_constant indicating whether the given layout tag is row-major.
+/// Used with host_tensor_descriptor() to select stride ordering at compile time.
+template <typename Layout>
+static constexpr inline auto is_row_major(Layout)
+{
+    return bool_constant<
+        std::is_same_v<remove_cvref_t<Layout>, tensor_layout::gemm::RowMajor>>{};
+}
+
 } // namespace ck_tile
 #pragma clang diagnostic pop


### PR DESCRIPTION
## Summary

Two behavior-preserving refactorings across `example/ck_tile/`, all build-verified.

| Refactoring | Files | +Lines | −Lines | Net |
|---|---:|---:|---:|---:|
| Extract `calculateRtolAtol` shared header | ~30 | +63 | −430 | −367 |
| Migrate `is_row_major` to `ck_tile::is_row_major` | ~20 | +60 | −240 | −180 |

- `calculateRtolAtol`: ~15 per-directory duplicates → single shared header `include/ck_tile/host/gemm_rtol_atol.hpp` with 3 overloads (2-param, 3-param with k_batch, 5-param multi-D). `38_block_scale_gemm` intentionally excluded (`pk_fp4_t`-specific variant).
- `is_row_major`: ~33 per-file duplicates removed; call sites now use the canonical `ck_tile::is_row_major` from `host_tensor.hpp`.