### PR TITLE
[tensilelite] Speed up getKeyNoInternalArgs and _getName

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Naming.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Naming.py
@@ -183,12 +183,15 @@ def _getName(state, requiredParameters: frozenset, splitGSU: bool, ignoreInterna
     components.append('CMS')
 
   components.append('SN')
-  for key in sorted(state.keys()):
-    # Skip SFA tag if using default wgm algo
-    if key == "SpaceFillingAlgo" and len(state[key]) == 0:
+
+  # Skip SFA tag if using default wgm algo
+  if "SpaceFillingAlgo" in requiredParametersTemp and len(state["SpaceFillingAlgo"]) == 0:
+    requiredParametersTemp.discard("SpaceFillingAlgo")
+
+  for key in sorted(requiredParametersTemp):
+    if key not in state:
       continue
-    if key[0] != '_' and key != "CustomKernelName" and key in requiredParametersTemp:
-        components.append(f'{getParameterNameAbbreviation(key)}{getParameterValueAbbreviation(key, state[key])}')
+    components.append(f'{getParameterNameAbbreviation(key)}{getParameterValueAbbreviation(key, state[key])}')
 
   state["GlobalSplitU"] = gsuBackup
   state["ProblemType"]["GroupedGemm"] = ggBackup

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Naming.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Naming.py
@@ -21,7 +21,6 @@
 # SOFTWARE.
 #
 ################################################################################
-from copy import deepcopy
 from functools import lru_cache
 
 from Tensile.Common.Constants import MAX_FILENAME_LENGTH
@@ -30,23 +29,66 @@ from Tensile.Common.RequiredParameters import getRequiredParametersMin, getRequi
 from .Problem import ProblemType
 
 
-def getKeyNoInternalArgs(state, splitGSU: bool):
-  state_copy = deepcopy(state)
-  state_copy["ProblemType"]["GroupedGemm"] = False
+# Parameters that are "internal args" — runtime dispatch parameters that don't
+# affect the generated kernel assembly. Two kernels differing only in these
+# fields compile to identical code objects.
+_INTERNAL_ARGS = (
+    "WorkGroupMapping",
+    "WorkGroupMappingXCC",
+    "WorkGroupMappingXCCGroup",
+    "StaggerU",
+    "StaggerUStride",
+    "StaggerUMapping",
+    "GlobalSplitUCoalesced",
+    "GlobalSplitUWorkGroupMappingRoundRobin",
+    "SFCWGM",
+)
+
+def getKeyNoInternalArgs(state, splitGSU: bool) -> str:
+  """Return a string key that identifies a kernel ignoring internal args.
+
+  Internal args (WorkGroupMapping, StaggerU, etc.) are runtime dispatch
+  parameters — they don't change the generated assembly. This function
+  produces a canonical key where those parameters are masked to "M" and
+  GroupedGemm is forced to False, so that kernels differing only in
+  internal args map to the same key.
+
+  Used to:
+    - Deduplicate kernels before code generation (BenchmarkProblems.py,
+      Run.py:getUniqueKernels) — avoids compiling the same assembly twice.
+    - Identify invalid kernels after compilation and propagate failures
+      to all solutions sharing that kernel (Run.py:removeInvalidSolutionsAndKernels).
+    - Build kernel-to-solution mappings for post-processing
+      (Run.py:passPostKernelInfoToSolution).
+  """
+  # Work on the raw dict to avoid Solution.__setitem__ invalidating _name cache
+  s = state._state if hasattr(state, '_state') else state
+  pt = s["ProblemType"]
+
+  # Save originals
+  backups = {k: s[k] for k in _INTERNAL_ARGS}
+  gsu_backup = s["GlobalSplitU"]
+  gg_backup = pt["GroupedGemm"]
+
+  # Mask internal args
+  pt["GroupedGemm"] = False
   if splitGSU:
-    state_copy["GlobalSplitU"] = "M" if (state_copy["GlobalSplitU"] > 1 or state_copy["GlobalSplitU"] == -1) else state_copy["GlobalSplitU"]
-  elif state["GlobalSplitU"] != 0:
-    state_copy["GlobalSplitU"] = "M"
-  state_copy["WorkGroupMapping"] = "M"
-  state_copy["WorkGroupMappingXCC"] = "M"
-  state_copy["WorkGroupMappingXCCGroup"] = "M"
-  state_copy["StaggerU"] = "M"
-  state_copy["StaggerUStride"] = "M"
-  state_copy["StaggerUMapping"] = "M"
-  state_copy["GlobalSplitUCoalesced"] = "M"
-  state_copy["GlobalSplitUWorkGroupMappingRoundRobin"] = "M"
-  state_copy["SFCWGM"] = "M"
-  return state_copy
+    s["GlobalSplitU"] = "M" if (gsu_backup > 1 or gsu_backup == -1) else gsu_backup
+  elif gsu_backup != 0:
+    s["GlobalSplitU"] = "M"
+  for k in _INTERNAL_ARGS:
+    s[k] = "M"
+
+  # Compute string key (same as what str(deep_copied_solution) would produce)
+  key = _getName(s, getRequiredParametersFull(), splitGSU, False)
+
+  # Restore
+  pt["GroupedGemm"] = gg_backup
+  s["GlobalSplitU"] = gsu_backup
+  for k in _INTERNAL_ARGS:
+    s[k] = backups[k]
+
+  return key
 
 
 @lru_cache(maxsize=None)

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Naming.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Naming.py
@@ -189,7 +189,7 @@ def _getName(state, requiredParameters: frozenset, splitGSU: bool, ignoreInterna
     requiredParametersTemp.discard("SpaceFillingAlgo")
 
   for key in sorted(requiredParametersTemp):
-    if key not in state:
+    if key not in state or key == "CustomKernelName":
       continue
     components.append(f'{getParameterNameAbbreviation(key)}{getParameterValueAbbreviation(key, state[key])}')
 

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Naming.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Naming.py
@@ -88,7 +88,13 @@ def getKeyNoInternalArgs(state, splitGSU: bool) -> str:
   for k in _INTERNAL_ARGS:
     s[k] = backups[k]
 
-  return key
+  # Include codeObjectFile and DeviceNames in the key to prevent
+  # over-deduplication across different code object files / devices.
+  # The old code returned a Solution object whose __hash__ included these
+  # fields, so kernels targeting different .co files were kept separate.
+  cof = s.get("codeObjectFile", "")
+  dn = str(s.get("DeviceNames", ""))
+  return key + cof + dn
 
 
 @lru_cache(maxsize=None)


### PR DESCRIPTION
## Motivation

Speed up getKeyNoInternalArgs and _getName to shave up to 13% off the compilation stage of Tensile runs. This timing is based on all of the other optimization PRs I have up landing (specifically #5100) and doing multiple runs to get the maximum cache hits from 5100.

## Technical Details

**getKeyNoInternalArgs:** have it return the key itself, allow for the deepcopy to be bypassed, instead the internal states is locally replaced for the key creation and then restored.

**_getName:** Flip for-loop to iterate only over required keys (rather than all keys and then filtering with checks).

## Test Plan

Run current tests.

## Test Result

Pass locally.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
