### PR TITLE
[hipTensor] Add compiling options for unary ops

### DIFF
--- a/projects/hiptensor/CMakeLists.txt
+++ b/projects/hiptensor/CMakeLists.txt
@@ -74,6 +74,7 @@ if(CMAKE_PROJECT_NAME STREQUAL "hiptensor")
     option(HIPTENSOR_DEFAULT_STRIDES_COL_MAJOR "Set hiptensor default strides to column major" ON)
     option(BUILD_OFFLOAD_COMPRESS "Build hiptensor with offload compression" ON)
     option(HIPTENSOR_CODE_COVERAGE "Build with code coverage flags (clang only)" OFF)
+    option(HIPTENSOR_INLINE_UNARY_OPS "Inline all unary ops for best runtime performance (slower compilation)" OFF)
 endif()
 
 # Setup output paths
@@ -156,6 +157,13 @@ else()
     add_compile_definitions(HIPTENSOR_DEFAULT_STRIDES_COL_MAJOR=0)
 endif()
 message(STATUS "HIPTENSOR_DEFAULT_STRIDES_COL_MAJOR=${HIPTENSOR_DEFAULT_STRIDES_COL_MAJOR}")
+
+if(HIPTENSOR_INLINE_UNARY_OPS)
+  add_compile_definitions(HIPTENSOR_INLINE_UNARY_OPS=1)
+else()
+  add_compile_definitions(HIPTENSOR_INLINE_UNARY_OPS=0)
+endif()
+message(STATUS "HIPTENSOR_INLINE_UNARY_OPS=${HIPTENSOR_INLINE_UNARY_OPS}")
 
 # Setup HIP
 find_package(hip REQUIRED)

--- a/projects/hiptensor/README.md
+++ b/projects/hiptensor/README.md
@@ -41,6 +41,7 @@ For more detailed information, please refer to the [hipTensor installation guide
 | HIPTENSOR_BUILD_SAMPLES             | Build the samples                                       | ON                                                      |
 | HIPTENSOR_BUILD_COMPRESSED_DBG      | Enable compressed debug symbols                         | ON                                                      |
 | HIPTENSOR_DEFAULT_STRIDES_COL_MAJOR | Set the hipTensor default data layout to column major   | ON                                                      |
+| HIPTENSOR_INLINE_UNARY_OPS          | Inline all unary ops for best runtime performance       | OFF                                                     |
 
 ### Example configurations
 

--- a/projects/hiptensor/README.md
+++ b/projects/hiptensor/README.md
@@ -34,14 +34,14 @@ For more detailed information, please refer to the [hipTensor installation guide
 
 ### Project options
 
-| Option                              | Description                                             | Default Value                                           |
-|-------------------------------------|---------------------------------------------------------|---------------------------------------------------------|
-| GPU_TARGETS                         | Build code for specific GPU target(s)                   | gfx908;gfx90a;gfx942;gfx950;gfx11-generic;gfx12-generic |
-| HIPTENSOR_BUILD_TESTS               | Build the tests                                         | ON                                                      |
-| HIPTENSOR_BUILD_SAMPLES             | Build the samples                                       | ON                                                      |
-| HIPTENSOR_BUILD_COMPRESSED_DBG      | Enable compressed debug symbols                         | ON                                                      |
-| HIPTENSOR_DEFAULT_STRIDES_COL_MAJOR | Set the hipTensor default data layout to column major   | ON                                                      |
-| HIPTENSOR_INLINE_UNARY_OPS          | Inline all unary ops for best runtime performance       | OFF                                                     |
+| Option                              | Description                                                              | Default Value                                           |
+|-------------------------------------|--------------------------------------------------------------------------|---------------------------------------------------------|
+| GPU_TARGETS                         | Build code for specific GPU target(s)                                    | gfx908;gfx90a;gfx942;gfx950;gfx11-generic;gfx12-generic |
+| HIPTENSOR_BUILD_TESTS               | Build the tests                                                          | ON                                                      |
+| HIPTENSOR_BUILD_SAMPLES             | Build the samples                                                        | ON                                                      |
+| HIPTENSOR_BUILD_COMPRESSED_DBG      | Enable compressed debug symbols                                          | ON                                                      |
+| HIPTENSOR_DEFAULT_STRIDES_COL_MAJOR | Set the hipTensor default data layout to column major                    | ON                                                      |
+| HIPTENSOR_INLINE_UNARY_OPS          | Inline all unary ops for best runtime performance (slower compilation)   | OFF                                                     |
 
 ### Example configurations
 

--- a/projects/hiptensor/docs/install/installation.rst
+++ b/projects/hiptensor/docs/install/installation.rst
@@ -185,7 +185,7 @@ Here are the available options to build the hipTensor library, with or without c
         -   Set the hipTensor default data layout to column major
         -   ``ON``
     *   -   ``HIPTENSOR_INLINE_UNARY_OPS``
-        -   Set the default compiling option of unary operations to use __attribute__((noinline))
+        -   Inline all contraction unary ops for best runtime performance (slower compilation)
         -   ``OFF``
 
 Here are some example project configurations:

--- a/projects/hiptensor/docs/install/installation.rst
+++ b/projects/hiptensor/docs/install/installation.rst
@@ -184,6 +184,9 @@ Here are the available options to build the hipTensor library, with or without c
     *   -   ``HIPTENSOR_DEFAULT_STRIDES_COL_MAJOR``
         -   Set the hipTensor default data layout to column major
         -   ``ON``
+    *   -   ``HIPTENSOR_INLINE_UNARY_OPS``
+        -   Set the default compiling option of unary operations to use __attribute__((noinline))
+        -   ``OFF``
 
 Here are some example project configurations:
 

--- a/projects/hiptensor/library/src/include/hiptensor_element_wise_operation.hpp
+++ b/projects/hiptensor/library/src/include/hiptensor_element_wise_operation.hpp
@@ -36,6 +36,12 @@
 #include <ck/tensor_operation/gpu/element/binary_element_wise_operation.hpp>
 #include <hiptensor/hiptensor_types.h>
 
+#if HIPTENSOR_INLINE_UNARY_OPS
+#define HIPTENSOR_UNARY_INLINE
+#else
+#define HIPTENSOR_UNARY_INLINE __attribute__((noinline))
+#endif
+
 namespace ck
 {
     namespace tensor_operation
@@ -179,7 +185,7 @@ namespace ck
                     = default;
 
                 template <typename T>
-                __host__ __device__ void switch_op(T& y, T const& x) const
+                __host__ __device__ HIPTENSOR_UNARY_INLINE void switch_op(T& y, T const& x) const
                 {
                     switch(op_type)
                     {


### PR DESCRIPTION
## Motivation

Add compiling options for unary ops and make hipTensor compiling fast

## Technical Details

This PR resolves an issue where the introduction of unary ops in contraction caused hipTensor compile times to increase by 3–4x.
A new compile-time option, HIPTENSOR_INLINE_UNARY_OPS, has been added to control this behavior. When set to ON, the switch_op method in the HiptensorUnaryOp class is compiled inline, which was identified as the root cause of the compile time regression. When set to OFF, switch_op is compiled with noinline, restoring compile times to their baseline levels prior to the addition of unary op support.
The default value of HIPTENSOR_INLINE_UNARY_OPS is OFF.

## Test Plan

run normal tests.
test compiling when HIPTENSOR_INLINE_UNARY_OPS is OFF or ON.

## Test Result

all tests passed.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
