### PR TITLE
[Fusilli] Missing INT8 case from hipdnn data type conversion

### DIFF
--- a/dnn-providers/fusilli-provider/include/graph_import.h
+++ b/dnn-providers/fusilli-provider/include/graph_import.h
@@ -45,6 +45,8 @@ inline fusilli::ErrorOr<fusilli::DataType> hipDnnDataTypeToFusilliDataType(
     return ok(fusilli::DataType::Float);
   case hipdnn_data_sdk::data_objects::DataType::DOUBLE:
     return ok(fusilli::DataType::Double);
+  case hipdnn_data_sdk::data_objects::DataType::INT8:
+    return ok(fusilli::DataType::Int8);
   case hipdnn_data_sdk::data_objects::DataType::UINT8:
     return ok(fusilli::DataType::Uint8);
   case hipdnn_data_sdk::data_objects::DataType::INT32:

--- a/dnn-providers/fusilli-provider/test/test_graph_import.cpp
+++ b/dnn-providers/fusilli-provider/test/test_graph_import.cpp
@@ -33,6 +33,10 @@ TEST(TestGraphImport, ConvertHipDnnToFusilli) {
                         hipdnn_data_sdk::data_objects::DataType::UINT8));
   EXPECT_EQ(uint8Dt, fusilli::DataType::Uint8);
   FUSILLI_PLUGIN_EXPECT_OR_ASSIGN(
+      auto int8Dt, hipDnnDataTypeToFusilliDataType(
+                       hipdnn_data_sdk::data_objects::DataType::INT8));
+  EXPECT_EQ(int8Dt, fusilli::DataType::Int8);
+  FUSILLI_PLUGIN_EXPECT_OR_ASSIGN(
       auto int32Dt, hipDnnDataTypeToFusilliDataType(
                         hipdnn_data_sdk::data_objects::DataType::INT32));
   EXPECT_EQ(int32Dt, fusilli::DataType::Int32);


### PR DESCRIPTION
A case was missing in the hipdnn data type conversion.

## Motivation

Required for conversion from hipdnn graphs to fusilli

## Technical Details

Just a missing case statement

## Test Plan

Minor change. Could include new sample test with int8 datatype

## Test Result

Trivial change. External test suite validated pass.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
