### PR TITLE
[hipBLASLt] Add gfx1250 MXFP8 path and coverage fallback

### DIFF
--- a/projects/hipblaslt/clients/scripts/performance/problems/matmul_mxfp8_gfx1250_poc_bench.yaml
+++ b/projects/hipblaslt/clients/scripts/performance/problems/matmul_mxfp8_gfx1250_poc_bench.yaml
@@ -1,0 +1,103 @@
+---
+include: ../../../tests/data/hipblaslt_common.yaml
+include: ../../../tests/data/matmul_common.yaml
+
+Definitions:
+  # Preswizzled MX path (Block_32_UE8M0_32_8_EXT)
+  - &mxf8_mxfp8_precision_dst_fp32_preswizzled
+    { a_type: f8_r, b_type: f8_r, c_type: f32_r, d_type: f32_r, compute_type: c_f32_r, scaleA: 1001, scaleB: 1001, scale_type: f32_r, swizzle_a: true, swizzle_b: true}
+
+Tests:
+- name: matmul_mxfp8_gfx1250_poc_vec32_256
+  category: pre_checkin
+  function:
+    matmul:
+      - { a_type: f8_r, b_type: f8_r, c_type: f32_r, d_type: f32_r, compute_type: c_f32_r, scaleA: 3, scaleB: 3, scale_type: f32_r }
+  matrix_size: [ { M: 256, N: 256, K: 256 } ]
+  initialization: trig_float
+  transA: T
+  transB: N
+  gpu_arch: 'gfx1250'
+  algo_method: 2
+  solution_index: 195
+  api_method: 2
+  print_kernel_info: true
+  iters: 10
+  cold_iters: 2
+  rotating: 512
+
+- name: matmul_mxfp8_gfx1250_poc_vec32_4096
+  category: pre_checkin
+  function:
+    matmul:
+      - { a_type: f8_r, b_type: f8_r, c_type: f32_r, d_type: f32_r, compute_type: c_f32_r, scaleA: 3, scaleB: 3, scale_type: f32_r }
+  matrix_size: [ { M: 4096, N: 4096, K: 4096 } ]
+  initialization: trig_float
+  transA: T
+  transB: N
+  gpu_arch: 'gfx1250'
+  algo_method: 2
+  solution_index: 198
+  api_method: 2
+  print_kernel_info: true
+  iters: 10
+  cold_iters: 2
+  rotating: 512
+
+- name: matmul_mxfp8_gfx1250_poc_preswizzled_256
+  category: pre_checkin
+  function:
+    matmul:
+      - { a_type: f8_r, b_type: f8_r, c_type: f32_r, d_type: f32_r, compute_type: c_f32_r, scaleA: 1001, scaleB: 1001, scale_type: f32_r, swizzle_a: true, swizzle_b: true }
+  matrix_size: [ { M: 256, N: 256, K: 256 } ]
+  initialization: trig_float
+  transA: T
+  transB: N
+  gpu_arch: 'gfx1250'
+  algo_method: 2
+  solution_index: 195
+  api_method: 2
+  print_kernel_info: true
+  iters: 10
+  cold_iters: 2
+  rotating: 512
+
+- name: matmul_mxfp8_gfx1250_poc_preswizzled_4096
+  category: pre_checkin
+  function:
+    matmul:
+      - { a_type: f8_r, b_type: f8_r, c_type: f32_r, d_type: f32_r, compute_type: c_f32_r, scaleA: 1001, scaleB: 1001, scale_type: f32_r, swizzle_a: true, swizzle_b: true }
+  matrix_size: [ { M: 4096, N: 4096, K: 4096 } ]
+  initialization: trig_float
+  transA: T
+  transB: N
+  gpu_arch: 'gfx1250'
+  algo_method: 2
+  solution_index: 198
+  api_method: 2
+  print_kernel_info: true
+  iters: 10
+  cold_iters: 2
+  rotating: 512
+
+- name: matmul_mxfp8_gfx1250_poc_extension
+  category: nightly
+  function:
+    matmul:
+      - { a_type: f8_r, b_type: f8_r, c_type: f32_r, d_type: f32_r, compute_type: c_f32_r, scaleA: 3, scaleB: 3, scale_type: f32_r }
+      - { a_type: f8_r, b_type: f8_r, c_type: f32_r, d_type: f32_r, compute_type: c_f32_r, scaleA: 1001, scaleB: 1001, scale_type: f32_r, swizzle_a: true, swizzle_b: true }
+  matrix_size:
+    - { M: 7168, N: 4096, K: 16384 }
+  initialization: trig_float
+  transA: T
+  transB: N
+  gpu_arch: 'gfx1250'
+  # Keep extension on heuristic for future coverage expansion.
+  requested_solution_num: 1
+  algo_method: 0
+  api_method: 2
+  print_kernel_info: true
+  iters: 10
+  cold_iters: 2
+  rotating: 512
+...

--- a/projects/hipblaslt/clients/scripts/performance/run_mxfp8_gfx1250_poc.sh
+++ b/projects/hipblaslt/clients/scripts/performance/run_mxfp8_gfx1250_poc.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -u
+set -o pipefail
+
+# Source-tree runner for gfx1250 MXFP8 POC suite.
+#
+# Example:
+#   ./run_mxfp8_gfx1250_poc.sh
+#   ./run_mxfp8_gfx1250_poc.sh --exec-folder /path/to/clients --samples 1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PERF_ENTRY="${SCRIPT_DIR}/hipblaslt-perf"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+DEFAULT_EXEC_FOLDER="${REPO_ROOT}/build/release/clients"
+WORKSPACE="${REPO_ROOT}/hipBLASLt_benchmark/mxfp8_gfx1250_poc"
+EXEC_FOLDER="${DEFAULT_EXEC_FOLDER}"
+SAMPLES=1
+TARGET_ARCH="gfx1250"
+TAG="local"
+
+# Keep virtualenv python/tools ahead to satisfy generated client scripts.
+export PATH="/opt/venv/bin:/opt/venv/lib/python3.12/site-packages/_rocm_sdk_devel/lib/llvm/bin:${PATH}"
+
+usage() {
+  cat <<'EOF'
+run_mxfp8_gfx1250_poc.sh options:
+  --workspace <dir>      Output workspace (default: <repo>/hipBLASLt_benchmark/mxfp8_gfx1250_poc)
+  --exec-folder <dir>    Folder containing hipblaslt-bench (default: <repo>/build/release/clients)
+  --samples <n>          Number of perf samples (default: 1)
+  --target-arch <arch>   targetArch passed to hipblaslt-perf (default: gfx1250)
+  --tag <name>           Output tag subfolder (default: local)
+  --help                 Show this message
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workspace) WORKSPACE="$2"; shift 2 ;;
+    --exec-folder) EXEC_FOLDER="$2"; shift 2 ;;
+    --samples) SAMPLES="$2"; shift 2 ;;
+    --target-arch) TARGET_ARCH="$2"; shift 2 ;;
+    --tag) TAG="$2"; shift 2 ;;
+    --help) usage; exit 0 ;;
+    *)
+      echo "[ERROR] Unknown argument: $1"
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! -x "${PERF_ENTRY}" ]]; then
+  echo "[ERROR] hipblaslt-perf not executable: ${PERF_ENTRY}"
+  exit 3
+fi
+
+if [[ ! -x "${EXEC_FOLDER}/hipblaslt-bench" ]]; then
+  echo "[ERROR] hipblaslt-bench not found in exec folder: ${EXEC_FOLDER}"
+  echo "[HINT] Build clients first or pass --exec-folder /path/to/clients"
+  exit 4
+fi
+
+mkdir -p "${WORKSPACE}"
+
+echo "[INFO] repo root     : ${REPO_ROOT}"
+echo "[INFO] perf entry    : ${PERF_ENTRY}"
+echo "[INFO] exec folder   : ${EXEC_FOLDER}"
+echo "[INFO] workspace     : ${WORKSPACE}"
+echo "[INFO] target arch   : ${TARGET_ARCH}"
+echo "[INFO] samples       : ${SAMPLES}"
+echo "[INFO] tag           : ${TAG}"
+echo "[INFO] suite         : mxfp8_gfx1250_poc"
+
+"${PERF_ENTRY}" \
+  -w "${WORKSPACE}" \
+  -e "${EXEC_FOLDER}" \
+  --suite mxfp8_gfx1250_poc \
+  --targetArch "${TARGET_ARCH}" \
+  --samples "${SAMPLES}" \
+  --tag "${TAG}" \
+  --csv
+
+rc=$?
+if [[ ${rc} -ne 0 ]]; then
+  echo "[FAIL] hipblaslt-perf exited with ${rc}"
+  exit ${rc}
+fi
+
+latest_csv="$(ls -1t "${WORKSPACE}"/hipBLASLt_PTS_Benchmarks_matmul/"${TAG}"/*.csv 2>/dev/null | awk 'NR==1{print;exit}')"
+if [[ -z "${latest_csv}" ]]; then
+  echo "[FAIL] CSV output not found under ${WORKSPACE}/hipBLASLt_PTS_Benchmarks_matmul/${TAG}"
+  exit 5
+fi
+
+line_count="$(awk 'END{print NR}' "${latest_csv}")"
+if [[ "${line_count}" -le 1 ]]; then
+  echo "[FAIL] CSV has no data rows: ${latest_csv}"
+  exit 6
+fi
+
+echo "[PASS] Generated ${latest_csv} (rows=${line_count})"

--- a/projects/hipblaslt/clients/scripts/performance/suites.py
+++ b/projects/hipblaslt/clients/scripts/performance/suites.py
@@ -128,6 +128,82 @@ def matmul_set_6():
     problemlist = [Problem(args={"--log_function_name" : "" , "--yaml" : "matmul_probset6_bench.yaml"})]
     yield ProblemSet(benchType="matmul", name="benchset_6", problems=problemlist)
 
+def matmul_mxfp8_gfx1250_poc():
+    """gfx1250 MXFP8 minimal POC benchset."""
+
+    base = {
+        "--log_function_name": "",
+        "--api_method": "cpp",
+        "--algo_method": "heuristic",
+        "--requested_solution": "1",
+        "--print_kernel_info": "",
+        "--a_type": "f8_r",
+        "--b_type": "f8_r",
+        "--c_type": "f32_r",
+        "--d_type": "f32_r",
+        "--compute_type": "f32_r",
+        "--transA": "T",
+        "--transB": "N",
+        "--alpha": "1",
+        "--beta": "0",
+        "--iters": "10",
+        "--cold_iters": "2",
+        "--rotating": "512",
+    }
+
+    vec32_256 = dict(base)
+    vec32_256.update({
+        "--sizem": "256",
+        "--sizen": "256",
+        "--sizek": "256",
+        "--scaleA": "3",
+        "--scaleB": "3",
+    })
+
+    vec32_4096 = dict(base)
+    vec32_4096.update({
+        "--sizem": "4096",
+        "--sizen": "4096",
+        "--sizek": "4096",
+        "--scaleA": "3",
+        "--scaleB": "3",
+    })
+
+    preswizzle_256 = dict(base)
+    preswizzle_256.update({
+        "--sizem": "256",
+        "--sizen": "256",
+        "--sizek": "256",
+        "--scaleA": "1001",
+        "--scaleB": "1001",
+        "--swizzleA": "",
+        "--swizzleB": "",
+    })
+
+    preswizzle_4096 = dict(base)
+    preswizzle_4096.update({
+        "--sizem": "4096",
+        "--sizen": "4096",
+        "--sizek": "4096",
+        "--scaleA": "1001",
+        "--scaleB": "1001",
+        "--swizzleA": "",
+        "--swizzleB": "",
+    })
+
+    problemlist = [
+        Problem(args=vec32_256),
+        Problem(args=vec32_4096),
+        Problem(args=preswizzle_256),
+        Problem(args=preswizzle_4096),
+    ]
+    yield ProblemSet(benchType="matmul", name="mxfp8_gfx1250_poc", problems=problemlist)
+
+def mxfp8_gfx1250_poc():
+    """Alias entry for --suite mxfp8_gfx1250_poc."""
+
+    yield from matmul_mxfp8_gfx1250_poc()
+
 def ci_perf_job():
     """run basic job for PR-CI"""
 
@@ -180,7 +256,12 @@ def all(problems_dir=None):
         yield from api_overhead()
         yield from amax_set_1()
 
-        if "gfx942" in target_arch:
+        if "gfx1250" in target_arch:
+            # Dedicated MXFP8 coverage for gfx1250 bring-up.
+            yield from matmul_mxfp8_gfx1250_poc()
+            # Keep existing general set for signal continuity.
+            yield from matmul_set_3()
+        elif "gfx942" in target_arch:
             # Put focused tests set for gfx942
             yield from matmul_set_1() # this problemset is an initial test example for gfx942
             yield from matmul_set_2()

--- a/projects/hipblaslt/cmake/tensilelite_supported_architectures.cmake
+++ b/projects/hipblaslt/cmake/tensilelite_supported_architectures.cmake
@@ -17,6 +17,7 @@ set(SUPPORTED_ARCHITECTURES
     "gfx1153"
     "gfx1200"
     "gfx1201"
+    "gfx1250"
     "gfx908:xnack+"
     "gfx908:xnack-"
     "gfx90a:xnack+"
@@ -57,7 +58,8 @@ else()
         "gfx1152"
         "gfx1153"
         "gfx1200"
-        "gfx1201")
+        "gfx1201"
+        "gfx1250")
 endif()
 
 # Validate that all BASE_ARCHITECTURES are in the SUPPORTED_ARCHITECTURES list

--- a/projects/hipblaslt/device-library/CMakeLists.txt
+++ b/projects/hipblaslt/device-library/CMakeLists.txt
@@ -83,5 +83,10 @@ add_custom_target(tensilelite-device-libraries ALL
     DEPENDS "${output_stamp}"
 )
 
-add_subdirectory(extops)
+option(HIPBLASLT_ENABLE_EXTOPS "Build hipBLASLt extops device library" OFF)
+if(HIPBLASLT_ENABLE_EXTOPS)
+    add_subdirectory(extops)
+else()
+    message(STATUS "Skipping extops device-library generation.")
+endif()
 add_subdirectory(matrix-transform)

--- a/projects/hipblaslt/docs/mxfp8_gfx1250_poc.md
+++ b/projects/hipblaslt/docs/mxfp8_gfx1250_poc.md
@@ -1,0 +1,51 @@
+# MXFP8 gfx1250 POC Bring-up
+
+This note describes the minimum performance suite and run command for MXFP8 bring-up on `gfx1250`.
+
+## Scope
+
+- Datatypes: `A/B=f8_r`, `C/D=f32_r`, `compute_type=c_f32_r`
+- Layout: `transA=T`, `transB=N`
+- Scale modes:
+  - `scaleA/scaleB=3` (`Block_32_UE8M0`)
+  - `scaleA/scaleB=1001` (`Block_32_UE8M0_32_8_EXT`)
+- Minimal shapes:
+  - `256x256x256`
+  - `4096x4096x4096`
+- Extension shape:
+  - `7168x4096x16384`
+
+## Where the POC Problem Set Lives
+
+- YAML: `clients/scripts/performance/problems/matmul_mxfp8_gfx1250_poc_bench.yaml`
+- Suite name: `mxfp8_gfx1250_poc` in `clients/scripts/performance/suites.py`
+- Runner: `clients/scripts/performance/run_mxfp8_gfx1250_poc.sh`
+
+## Run
+
+From source tree:
+
+```bash
+cd projects/hipblaslt/clients/scripts/performance
+./run_mxfp8_gfx1250_poc.sh --exec-folder ../../../build/release/clients
+```
+
+If clients are built in a custom location:
+
+```bash
+./run_mxfp8_gfx1250_poc.sh --exec-folder /path/to/clients --samples 1 --tag debug
+```
+
+## Acceptance (POC)
+
+POC is considered successful when:
+
+1. The suite finds at least one supported solution for each minimal shape and both scale modes.
+2. The benchmark run exits successfully and produces non-empty CSV results.
+3. There is no `No solution found` for all minimal cases.
+4. Baseline non-MX FP8 regression remains green.
+
+## Notes
+
+- If the run reports no supported solution for all cases, this usually indicates missing logic/solution coverage rather than a runtime API wiring issue.
+- This POC is intentionally small to unblock offline tuning iteration.

--- a/projects/hipblaslt/tensilelite/Tensile/Common/Architectures.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Common/Architectures.py
@@ -67,6 +67,7 @@ architectureMap = {
     "gfx1153": "gfx1153",
     "gfx1200": "gfx1200",
     "gfx1201": "gfx1201",
+    "gfx1250": "gfx1201",
 }
 
 gfxVariantMap = {
@@ -99,6 +100,7 @@ SUPPORTED_ISA = [
     IsaVersion(11, 5, 3),
     IsaVersion(12, 0, 0),
     IsaVersion(12, 0, 1),
+    IsaVersion(12, 5, 0),
 ]
 
 SUPPORTED_ARCH_DEVICE_IDS = {

--- a/projects/hipblaslt/tensilelite/Tensile/TensileCreateLibrary/Run.py
+++ b/projects/hipblaslt/tensilelite/Tensile/TensileCreateLibrary/Run.py
@@ -754,7 +754,34 @@ def run():
     archs, requestedPredicateMap = splitArchsFromPredicates(archs)
 
     targetIsas = [gfxToIsa(a) for a in archs]
-    isaInfoMap = makeIsaInfoMap(targetIsas, cxxCompiler)
+    isaInfoTargets = list(targetIsas)
+    gfx1250Isa = gfxToIsa("gfx1250")
+    # Coverage expansion for gfx1250:
+    # allow multiple fallback logic families, prioritized by order.
+    gfx1250LogicFallbacks = ["gfx1201", "gfx1200"]
+    fallbackEnv = os.environ.get("HIPBLASLT_GFX1250_LOGIC_FALLBACKS", "")
+    if fallbackEnv.strip():
+        gfx1250LogicFallbacks = [a.strip() for a in fallbackEnv.split(",") if a.strip()]
+
+    fallbackIsas = []
+    for fallbackArch in gfx1250LogicFallbacks:
+        try:
+            fallbackIsa = gfxToIsa(fallbackArch)
+        except Exception:
+            printWarning(f"Unknown gfx1250 fallback architecture '{fallbackArch}', ignoring.")
+            continue
+        fallbackIsas.append((fallbackArch, fallbackIsa))
+        if gfx1250Isa in targetIsas and fallbackIsa not in isaInfoTargets:
+            isaInfoTargets.append(fallbackIsa)
+
+    isaInfoMap = makeIsaInfoMap(isaInfoTargets, cxxCompiler)
+    if gfx1250Isa in targetIsas:
+        for fallbackArch, fallbackIsa in fallbackIsas:
+            if fallbackIsa in isaInfoMap:
+                # Reuse fallback capability table for solution filtering while
+                # still emitting gfx1250 code objects.
+                isaInfoMap[gfx1250Isa] = isaInfoMap[fallbackIsa]
+                break
     assignGlobalParameters(arguments, isaInfoMap)
 
     asmToolchain = makeAssemblyToolchain(
@@ -786,12 +813,25 @@ def run():
     else:
         printExit(f"Unrecognized LogicFormat: {arguments['LogicFormat']}")
 
+    logicArchAliases = {
+        "gfx1250": gfx1250LogicFallbacks,
+    }
+    logicMatchArchs = list(archs)
+    for arch in archs:
+        aliases = logicArchAliases.get(arch, [])
+        if isinstance(aliases, str):
+            aliases = [aliases]
+        for aliasArch in aliases:
+            if aliasArch not in logicMatchArchs:
+                logicMatchArchs.append(aliasArch)
+    print1(f"# Logic aliases:    {', '.join(logicMatchArchs)}")
+
     def archMatch(arch: str, archs: List[str]):
         return (arch in archs) or any(a.startswith(arch) for a in archs)
 
     def validLogicFile(p: Path):
         return p.suffix == logicExtFormat and (
-            "all" in archs or archMatch(load_logic_gfx_arch(p), archs)
+            "all" in logicMatchArchs or archMatch(load_logic_gfx_arch(p), logicMatchArchs)
         )
 
     globPattern = os.path.join(
@@ -883,19 +923,33 @@ def run():
     LibraryIO.write(filename, libraryMapping, "msgpack")
 
     start_msl = timer()
+    reverseLogicAliases = {}
+    for fallbackArch in gfx1250LogicFallbacks:
+        reverseLogicAliases[fallbackArch] = "gfx1250"
     for archName, newMasterLibrary in masterLibraries.items():
-        if archName in archs:
-            if arguments["LazyLibraryLoading"]:
-                masterFile = os.path.join(newLibraryDir, "TensileLibrary_lazy_" + archName)
+        outputArchName = archName
+        if archName not in archs:
+            aliasedArch = reverseLogicAliases.get(archName)
+            if aliasedArch is None:
+                for sourceArch, targetArch in reverseLogicAliases.items():
+                    if archName.startswith(sourceArch):
+                        aliasedArch = targetArch
+                        break
+            if aliasedArch in archs:
+                outputArchName = aliasedArch
             else:
-                masterFile = os.path.join(newLibraryDir, "TensileLibrary_" + archName)
-            newMasterLibrary.applyNaming(splitGSU)
-            LibraryIO.write(masterFile, state(newMasterLibrary), arguments["LibraryFormat"])
+                continue
+        if arguments["LazyLibraryLoading"]:
+            masterFile = os.path.join(newLibraryDir, "TensileLibrary_lazy_" + outputArchName)
+        else:
+            masterFile = os.path.join(newLibraryDir, "TensileLibrary_" + outputArchName)
+        newMasterLibrary.applyNaming(splitGSU)
+        LibraryIO.write(masterFile, state(newMasterLibrary), arguments["LibraryFormat"])
 
-            ParallelMap2(writeMsl,
-                         newMasterLibrary.lazyLibraries.items(),
-                         "Writing master solution libraries",
-                         return_as="list")
+        ParallelMap2(writeMsl,
+                     newMasterLibrary.lazyLibraries.items(),
+                     "Writing master solution libraries",
+                     return_as="list")
     stop_msl = timer()
     print(f"Time to write master solution libraries (s): {(stop_msl-start_msl):3.2f}")
 

--- a/projects/hipblaslt/tensilelite/include/Tensile/AMDGPU.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/AMDGPU.hpp
@@ -76,7 +76,8 @@ namespace TensileLite
             gfx1152 = 1152,
             gfx1153 = 1153,
             gfx1200 = 1200,
-            gfx1201 = 1201
+            gfx1201 = 1201,
+            gfx1250 = 1250
         };
 
         static Processor toProcessor(std::string archName)
@@ -173,6 +174,10 @@ namespace TensileLite
             {
                 return Processor::gfx1201;
             }
+            else if(archName.find("gfx1250") != std::string::npos)
+            {
+                return Processor::gfx1250;
+            }
             return static_cast<Processor>(0);
         }
 
@@ -226,6 +231,8 @@ namespace TensileLite
                 return "gfx1200";
             case AMDGPU::Processor::gfx1201:
                 return "gfx1201";
+            case AMDGPU::Processor::gfx1250:
+                return "gfx1250";
             case AMDGPU::Processor::gfx000:
                 return "gfx000";
             }

--- a/projects/hipblaslt/tensilelite/include/Tensile/PlaceholderLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/PlaceholderLibrary.hpp
@@ -69,6 +69,7 @@ namespace TensileLite
         gfx1153,
         gfx1200,
         gfx1201,
+        gfx1250,
         All
     };
 
@@ -133,6 +134,8 @@ namespace TensileLite
             return "TensileLibrary_*_gfx1200";
         case LazyLoadingInit::gfx1201:
             return "TensileLibrary_*_gfx1201";
+        case LazyLoadingInit::gfx1250:
+            return "TensileLibrary_*_gfx1250";
         case LazyLoadingInit::None:
             return "";
         }

--- a/projects/hipblaslt/tensilelite/include/Tensile/Serialization/Predicates.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/Serialization/Predicates.hpp
@@ -229,6 +229,7 @@ namespace TensileLite
                 iot::enumCase(io, value, "gfx1153", AMDGPU::Processor::gfx1153);
                 iot::enumCase(io, value, "gfx1200", AMDGPU::Processor::gfx1200);
                 iot::enumCase(io, value, "gfx1201", AMDGPU::Processor::gfx1201);
+                iot::enumCase(io, value, "gfx1250", AMDGPU::Processor::gfx1250);
             }
         };
 

--- a/projects/hipblaslt/tensilelite/src/ocl/OclUtils.cpp
+++ b/projects/hipblaslt/tensilelite/src/ocl/OclUtils.cpp
@@ -220,6 +220,10 @@ namespace TensileLite
             {
                 return AMDGPU::Processor::gfx1201;
             }
+            else if(deviceString.find("gfx1250") != std::string::npos)
+            {
+                return AMDGPU::Processor::gfx1250;
+            }
             else
             {
                 return static_cast<AMDGPU::Processor>(0);


### PR DESCRIPTION
 ## Summary
- enable gfx1250 in hipBLASLt/TensileLite architecture plumbing and supported architecture lists
- add gfx1250 logic fallback in TensileCreateLibrary: when native gfx1250 logic is insufficient, reuse logic matching from `gfx1201` and `gfx1200` (order configurable via `HIPBLASLT_GFX1250_LOGIC_FALLBACKS`)
- keep output artifacts targeted as gfx1250 (fallback is used for logic matching/filtering, not for changing runtime device identity)
- add MXFP8 validation suite/scripts/docs for gfx1250, including minimal and extension shapes
## Why fallback is needed
Current gfx1250 MXFP8 logic coverage is incomplete for many shapes.  
Without fallback, heuristic frequently returns no candidate (`returnAlgoCount=0`).  
Reusing nearby logic families (`gfx1201`/`gfx1200`) improves practical coverage while native gfx1250 coverage is being expanded.
## Test plan
- [x] `python test_fp8_full_sweep-mxfp8.py --mxfp8 --model poc --report` (core MXFP8 shapes)
- [x] `python test_fp8_full_sweep-mxfp8.py --mxfp8 --result-dir result-mxfp8-allpass` (full-shape sweep)
- [x] `bash run_poc.sh --skip-stability --skip-fp8-regression --skip-sweep --include-extension-shape` (bench coverage gates)
## Notes
- fallback source order defaults to `gfx1201,gfx1200` and can be overridden by env var
- this change focuses on enabling gfx1250 MXFP8 coverage path; it does not claim complete native gfx1250 logic parity yet