### PR TITLE
[fft shared] Re-syncing shared directories

### DIFF
--- a/projects/hipfft/shared/fft_params.h
+++ b/projects/hipfft/shared/fft_params.h
@@ -2484,6 +2484,18 @@ public:
 
         const auto total_bricks = product(brick_count_along.begin(), brick_count_along.end());
 
+        if(total_bricks == 1 && mp_lib == fft_mp_lib_none && num_ranks == 1
+           && start_global_dev_idx == 0)
+        {
+            // Specifying a unique field with a lone brick on the current device may
+            // be omitted in favor of plan's data layout parameters: test that by not
+            // using a lone-brick field sometimes, in such cases.
+            const auto stable_hash_str
+                = token() + (io == fft_io::fft_io_in ? "_input_field" : "_output_field");
+            if(std::hash<std::string>()(stable_hash_str) % 2 == 1)
+                return;
+        }
+
         struct length_division
         {
             size_t min_length;


### PR DESCRIPTION
## Motivation

`rocfft/shared` and `hipfft/shared` went slightly out of sync in https://github.com/ROCm/rocm-libraries/pull/5125/changes/0e1667dbb1c2cd3c003495fe6eebf8ca818f3816.

## Technical Details

Simply re-aligning `fft_params.h` in both directories.

## Test Plan

Current tests suffice.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
