### PR TITLE
[rocSOLVER] Check return code of rocBLAS calls

### DIFF
--- a/projects/rocsolver/library/src/include/rocblas.hpp
+++ b/projects/rocsolver/library/src/include/rocblas.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -330,6 +330,16 @@ constexpr auto rocblas2string_status(rocblas_status status)
         if(_status != rocblas_status_success)   \
             return _status;                     \
     }
+#define ROCBLAS_CHECK_WITH_POINTER_MODE(handle, old_mode, ...) \
+    do                                                         \
+    {                                                          \
+        rocblas_status _status = (__VA_ARGS__);                \
+        if(_status != rocblas_status_success)                  \
+        {                                                      \
+            rocblas_set_pointer_mode(handle, old_mode);        \
+            return _status;                                    \
+        }                                                      \
+    } while(0)
 #define THROW_IF_ROCBLAS_ERROR(...)             \
     {                                           \
         rocblas_status _status = (__VA_ARGS__); \

--- a/projects/rocsolver/library/src/lapack/roclapack_geblttrf_npvt.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_geblttrf_npvt.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -223,10 +223,10 @@ rocblas_status rocsolver_geblttrf_npvt_template(rocblas_handle handle,
             (rocblas_int*)nullptr, 0, C, shiftC + k * bsc, incc, ldc, strideC, batch_count, work1,
             work2, work3, work4, optim_mem, false);
 
-        rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, nb, nb, nb, &minone,
-                       A, shiftA + k * bsa, inca, lda, strideA, C, shiftC + k * bsc, incc, ldc,
-                       strideC, &one, B, shiftB + (k + 1) * bsb, incb, ldb, strideB, batch_count,
-                       (T**)nullptr);
+        ROCBLAS_CHECK(rocsolver_gemm(
+            handle, rocblas_operation_none, rocblas_operation_none, nb, nb, nb, &minone, A,
+            shiftA + k * bsa, inca, lda, strideA, C, shiftC + k * bsc, incc, ldc, strideC, &one, B,
+            shiftB + (k + 1) * bsb, incb, ldb, strideB, batch_count, (T**)nullptr));
 
         rocsolver_getrf_template<BATCHED, STRIDED, T>(
             handle, nb, nb, B, shiftB + (k + 1) * bsb, incb, ldb, strideB, (rocblas_int*)nullptr, 0,

--- a/projects/rocsolver/library/src/lapack/roclapack_geblttrs_npvt.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_geblttrs_npvt.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -170,10 +170,10 @@ rocblas_status rocsolver_geblttrs_npvt_template(rocblas_handle handle,
     for(rocblas_int k = 0; k < nblocks; k++)
     {
         if(k > 0)
-            rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, nb, nrhs, nb,
-                           &minone, A, shiftA + (k - 1) * bsa, inca, lda, strideA, X,
-                           shiftX + (k - 1) * bsx, incx, ldx, strideX, &one, X, shiftX + k * bsx,
-                           incx, ldx, strideX, batch_count, (T**)nullptr);
+            ROCBLAS_CHECK(rocsolver_gemm(
+                handle, rocblas_operation_none, rocblas_operation_none, nb, nrhs, nb, &minone, A,
+                shiftA + (k - 1) * bsa, inca, lda, strideA, X, shiftX + (k - 1) * bsx, incx, ldx,
+                strideX, &one, X, shiftX + k * bsx, incx, ldx, strideX, batch_count, (T**)nullptr));
 
         rocsolver_getrs_template<BATCHED, STRIDED, T>(
             handle, rocblas_operation_none, nb, nrhs, B, shiftB + k * bsb, incb, ldb, strideB,
@@ -184,10 +184,10 @@ rocblas_status rocsolver_geblttrs_npvt_template(rocblas_handle handle,
     // backward solve
     for(rocblas_int k = nblocks - 2; k >= 0; k--)
     {
-        rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, nb, nrhs, nb,
-                       &minone, C, shiftC + k * bsc, incc, ldc, strideC, X, shiftX + (k + 1) * bsx,
-                       incx, ldx, strideX, &one, X, shiftX + k * bsx, incx, ldx, strideX,
-                       batch_count, (T**)nullptr);
+        ROCBLAS_CHECK(rocsolver_gemm(
+            handle, rocblas_operation_none, rocblas_operation_none, nb, nrhs, nb, &minone, C,
+            shiftC + k * bsc, incc, ldc, strideC, X, shiftX + (k + 1) * bsx, incx, ldx, strideX,
+            &one, X, shiftX + k * bsx, incx, ldx, strideX, batch_count, (T**)nullptr));
     }
 
     return rocblas_status_success;

--- a/projects/rocsolver/library/src/lapack/roclapack_gebrd.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gebrd.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     November 2017
- * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -159,16 +159,21 @@ rocblas_status rocsolver_gebrd_template(rocblas_handle handle,
                                     strideY, batch_count, scalars, work_workArr, Abyx_norms);
 
         // update the rest of the matrix
-        rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_conjugate_transpose,
-                       m - j - jb, n - j - jb, jb, &minone, A, shiftA + idx2D(j + jb, j, lda), lda,
-                       strideA, Y, shiftY + jb, ldy, strideY, &one, A,
-                       shiftA + idx2D(j + jb, j + jb, lda), lda, strideA, batch_count,
-                       (T**)work_workArr);
+        ROCBLAS_CHECK_WITH_POINTER_MODE(
+            handle, old_mode,
+            rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_conjugate_transpose,
+                           m - j - jb, n - j - jb, jb, &minone, A, shiftA + idx2D(j + jb, j, lda),
+                           lda, strideA, Y, shiftY + jb, ldy, strideY, &one, A,
+                           shiftA + idx2D(j + jb, j + jb, lda), lda, strideA, batch_count,
+                           (T**)work_workArr));
 
-        rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, m - j - jb, n - j - jb,
-                       jb, &minone, X, shiftX + jb, ldx, strideX, A, shiftA + idx2D(j, j + jb, lda),
-                       lda, strideA, &one, A, shiftA + idx2D(j + jb, j + jb, lda), lda, strideA,
-                       batch_count, (T**)work_workArr);
+        ROCBLAS_CHECK_WITH_POINTER_MODE(
+            handle, old_mode,
+            rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, m - j - jb,
+                           n - j - jb, jb, &minone, X, shiftX + jb, ldx, strideX, A,
+                           shiftA + idx2D(j, j + jb, lda), lda, strideA, &one, A,
+                           shiftA + idx2D(j + jb, j + jb, lda), lda, strideA, batch_count,
+                           (T**)work_workArr));
 
         blocks = (jb - 1) / 64 + 1;
         if(m >= n)

--- a/projects/rocsolver/library/src/lapack/roclapack_gels.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gels.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -271,10 +271,12 @@ rocblas_status rocsolver_gels_template(rocblas_handle handle,
                                     shiftB, ldb, strideB, ipiv_savedB, info_mask(info));
 
             // solve RX = Q'B, overwriting B with X
-            rocsolver_trsm_upper<BATCHED, STRIDED, T>(
-                handle, rocblas_side_left, rocblas_operation_none, rocblas_diagonal_non_unit, n,
-                nrhs, A, shiftA, lda, strideA, B, shiftB, ldb, strideB, batch_count, optim_mem,
-                work_x_temp, workArr_temp_arr, diag_trfac_invA, trfact_workTrmm_invA_arr);
+            ROCBLAS_CHECK_WITH_POINTER_MODE(
+                handle, old_mode,
+                rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+                    handle, rocblas_side_left, rocblas_operation_none, rocblas_diagonal_non_unit, n,
+                    nrhs, A, shiftA, lda, strideA, B, shiftB, ldb, strideB, batch_count, optim_mem,
+                    work_x_temp, workArr_temp_arr, diag_trfac_invA, trfact_workTrmm_invA_arr));
 
             // restore elements of B that were overwritten in cases where info is nonzero
             ROCSOLVER_LAUNCH_KERNEL((copy_mat<T, U>), dim3(copyblocksmin, copyblocksy, batch_count),
@@ -294,11 +296,13 @@ rocblas_status rocsolver_gels_template(rocblas_handle handle,
                                     shiftB, ldb, strideB, ipiv_savedB, info_mask(info));
 
             // solve R'Y = B overwriting B with Y (here Y = Q'X)
-            rocsolver_trsm_upper<BATCHED, STRIDED, T>(
-                handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
-                rocblas_diagonal_non_unit, n, nrhs, A, shiftA, lda, strideA, B, shiftB, ldb,
-                strideB, batch_count, optim_mem, work_x_temp, workArr_temp_arr, diag_trfac_invA,
-                trfact_workTrmm_invA_arr);
+            ROCBLAS_CHECK_WITH_POINTER_MODE(
+                handle, old_mode,
+                rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+                    handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
+                    rocblas_diagonal_non_unit, n, nrhs, A, shiftA, lda, strideA, B, shiftB, ldb,
+                    strideB, batch_count, optim_mem, work_x_temp, workArr_temp_arr, diag_trfac_invA,
+                    trfact_workTrmm_invA_arr));
 
             // zero row n to m-1 of B in cases where info is zero
             const rocblas_int zeroblocksx = (m - n - 1) / BS2 + 1;
@@ -338,10 +342,12 @@ rocblas_status rocsolver_gels_template(rocblas_handle handle,
                                     shiftB, ldb, strideB, ipiv_savedB, info_mask(info));
 
             // solve LY = B overwriting B with Y (here Y = QX)
-            rocsolver_trsm_lower<BATCHED, STRIDED, T>(
-                handle, rocblas_side_left, rocblas_operation_none, rocblas_diagonal_non_unit, m,
-                nrhs, A, shiftA, lda, strideA, B, shiftB, ldb, strideB, batch_count, optim_mem,
-                work_x_temp, workArr_temp_arr, diag_trfac_invA, trfact_workTrmm_invA_arr);
+            ROCBLAS_CHECK_WITH_POINTER_MODE(
+                handle, old_mode,
+                rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+                    handle, rocblas_side_left, rocblas_operation_none, rocblas_diagonal_non_unit, m,
+                    nrhs, A, shiftA, lda, strideA, B, shiftB, ldb, strideB, batch_count, optim_mem,
+                    work_x_temp, workArr_temp_arr, diag_trfac_invA, trfact_workTrmm_invA_arr));
 
             // zero row m to n-1 of B in cases where info is zero
             const rocblas_int zeroblocksx = (n - m - 1) / BS2 + 1;
@@ -379,11 +385,13 @@ rocblas_status rocsolver_gels_template(rocblas_handle handle,
                                     shiftB, ldb, strideB, ipiv_savedB, info_mask(info));
 
             // solve L'X = QB, overwriting B with X
-            rocsolver_trsm_lower<BATCHED, STRIDED, T>(
-                handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
-                rocblas_diagonal_non_unit, m, nrhs, A, shiftA, lda, strideA, B, shiftB, ldb,
-                strideB, batch_count, optim_mem, work_x_temp, workArr_temp_arr, diag_trfac_invA,
-                trfact_workTrmm_invA_arr);
+            ROCBLAS_CHECK_WITH_POINTER_MODE(
+                handle, old_mode,
+                rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+                    handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
+                    rocblas_diagonal_non_unit, m, nrhs, A, shiftA, lda, strideA, B, shiftB, ldb,
+                    strideB, batch_count, optim_mem, work_x_temp, workArr_temp_arr, diag_trfac_invA,
+                    trfact_workTrmm_invA_arr));
 
             // restore elements of B that were overwritten in cases where info is nonzero
             ROCSOLVER_LAUNCH_KERNEL((copy_mat<T, U>), dim3(copyblocksmin, copyblocksy, batch_count),

--- a/projects/rocsolver/library/src/lapack/roclapack_gels_outofplace.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gels_outofplace.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -235,10 +235,12 @@ rocblas_status rocsolver_gels_outofplace_template(rocblas_handle handle,
                                     strideA, info);
 
             // solve RX = Q'B
-            rocsolver_trsm_upper<BATCHED, STRIDED, T>(
-                handle, rocblas_side_left, rocblas_operation_none, rocblas_diagonal_non_unit, n,
-                nrhs, A, shiftA, lda, strideA, B, shiftB, ldb, strideB, batch_count, optim_mem,
-                work_x_temp, workArr_temp_arr, diag_trfac_invA, trfact_workTrmm_invA_arr);
+            ROCBLAS_CHECK_WITH_POINTER_MODE(
+                handle, old_mode,
+                rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+                    handle, rocblas_side_left, rocblas_operation_none, rocblas_diagonal_non_unit, n,
+                    nrhs, A, shiftA, lda, strideA, B, shiftB, ldb, strideB, batch_count, optim_mem,
+                    work_x_temp, workArr_temp_arr, diag_trfac_invA, trfact_workTrmm_invA_arr));
 
             // copy result to X
             ROCSOLVER_LAUNCH_KERNEL((copy_mat<T, U>), dim3(copyblocksmin, copyblocksy, batch_count),
@@ -262,11 +264,13 @@ rocblas_status rocsolver_gels_outofplace_template(rocblas_handle handle,
                                     shiftX, ldx, strideX);
 
             // solve R'Y = B (here Y = Q'X)
-            rocsolver_trsm_upper<BATCHED, STRIDED, T>(
-                handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
-                rocblas_diagonal_non_unit, n, nrhs, A, shiftA, lda, strideA, X, shiftX, ldx,
-                strideX, batch_count, optim_mem, work_x_temp, workArr_temp_arr, diag_trfac_invA,
-                trfact_workTrmm_invA_arr);
+            ROCBLAS_CHECK_WITH_POINTER_MODE(
+                handle, old_mode,
+                rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+                    handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
+                    rocblas_diagonal_non_unit, n, nrhs, A, shiftA, lda, strideA, X, shiftX, ldx,
+                    strideX, batch_count, optim_mem, work_x_temp, workArr_temp_arr, diag_trfac_invA,
+                    trfact_workTrmm_invA_arr));
 
             // zero row n to m-1 of X in cases where info is zero
             const rocblas_int zeroblocksx = (m - n - 1) / BS2 + 1;
@@ -299,10 +303,12 @@ rocblas_status rocsolver_gels_outofplace_template(rocblas_handle handle,
                                     shiftX, ldx, strideX);
 
             // solve LY = B (here Y = QX)
-            rocsolver_trsm_lower<BATCHED, STRIDED, T>(
-                handle, rocblas_side_left, rocblas_operation_none, rocblas_diagonal_non_unit, m,
-                nrhs, A, shiftA, lda, strideA, X, shiftX, ldx, strideX, batch_count, optim_mem,
-                work_x_temp, workArr_temp_arr, diag_trfac_invA, trfact_workTrmm_invA_arr);
+            ROCBLAS_CHECK_WITH_POINTER_MODE(
+                handle, old_mode,
+                rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+                    handle, rocblas_side_left, rocblas_operation_none, rocblas_diagonal_non_unit, m,
+                    nrhs, A, shiftA, lda, strideA, X, shiftX, ldx, strideX, batch_count, optim_mem,
+                    work_x_temp, workArr_temp_arr, diag_trfac_invA, trfact_workTrmm_invA_arr));
 
             // zero row m to n-1 of X in cases where info is zero
             const rocblas_int zeroblocksx = (n - m - 1) / BS2 + 1;
@@ -332,11 +338,13 @@ rocblas_status rocsolver_gels_outofplace_template(rocblas_handle handle,
                                     strideA, info);
 
             // solve L'X = QB
-            rocsolver_trsm_lower<BATCHED, STRIDED, T>(
-                handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
-                rocblas_diagonal_non_unit, m, nrhs, A, shiftA, lda, strideA, B, shiftB, ldb,
-                strideB, batch_count, optim_mem, work_x_temp, workArr_temp_arr, diag_trfac_invA,
-                trfact_workTrmm_invA_arr);
+            ROCBLAS_CHECK_WITH_POINTER_MODE(
+                handle, old_mode,
+                rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+                    handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
+                    rocblas_diagonal_non_unit, m, nrhs, A, shiftA, lda, strideA, B, shiftB, ldb,
+                    strideB, batch_count, optim_mem, work_x_temp, workArr_temp_arr, diag_trfac_invA,
+                    trfact_workTrmm_invA_arr));
 
             // copy result to X
             ROCSOLVER_LAUNCH_KERNEL((copy_mat<T, U>), dim3(copyblocksmin, copyblocksy, batch_count),

--- a/projects/rocsolver/library/src/lapack/roclapack_gesdd.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gesdd.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     April 2012
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -409,9 +409,11 @@ rocblas_status rocsolver_gesdd_template(rocblas_handle handle,
         rocblas_int ldv_gemm = n;
         rocblas_int strideV_gemm = n * n;
 
-        rocsolver_gemm(handle, rocblas_operation_conjugate_transpose, rocblas_operation_none, n, n,
-                       m, &neg_one, A, shiftA, lda, strideA, A, shiftA, lda, strideA, &zero, V_gemm,
-                       0, ldv_gemm, strideV_gemm, batch_count, (T**)workArr);
+        ROCBLAS_CHECK_WITH_POINTER_MODE(
+            handle, old_mode,
+            rocsolver_gemm(handle, rocblas_operation_conjugate_transpose, rocblas_operation_none, n,
+                           n, m, &neg_one, A, shiftA, lda, strideA, A, shiftA, lda, strideA, &zero,
+                           V_gemm, 0, ldv_gemm, strideV_gemm, batch_count, (T**)workArr));
 
         rocsolver_syevd_heevd_template<false, STRIDED, T>(
             handle, rocblas_evect_original, rocblas_fill_upper, n, V_gemm, 0, ldv_gemm,
@@ -423,9 +425,11 @@ rocblas_status rocsolver_gesdd_template(rocblas_handle handle,
         rocblas_int ldu_gemm = (leftv ? ldu : m);
         rocblas_int strideU_gemm = (leftv ? strideU : m * n);
 
-        rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n, n, &one, A,
-                       shiftA, lda, strideA, V_gemm, 0, ldv_gemm, strideV_gemm, &zero, U_gemm, 0,
-                       ldu_gemm, strideU_gemm, batch_count, (T**)workArr);
+        ROCBLAS_CHECK_WITH_POINTER_MODE(
+            handle, old_mode,
+            rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n, n, &one, A,
+                           shiftA, lda, strideA, V_gemm, 0, ldv_gemm, strideV_gemm, &zero, U_gemm,
+                           0, ldu_gemm, strideU_gemm, batch_count, (T**)workArr));
 
         // Apply QR factorization to AV, obtaining U from Q and S from the
         // diagonal of R; notice that, since the QR decomposition is not
@@ -465,9 +469,11 @@ rocblas_status rocsolver_gesdd_template(rocblas_handle handle,
         rocblas_int ldu_gemm = (leftv ? ldu : m);
         rocblas_int strideU_gemm = (leftv ? strideU : m * m);
 
-        rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_conjugate_transpose, m, m,
-                       n, &neg_one, A, shiftA, lda, strideA, A, shiftA, lda, strideA, &zero, U_gemm,
-                       0, ldu_gemm, strideU_gemm, batch_count, (T**)workArr);
+        ROCBLAS_CHECK_WITH_POINTER_MODE(
+            handle, old_mode,
+            rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_conjugate_transpose, m,
+                           m, n, &neg_one, A, shiftA, lda, strideA, A, shiftA, lda, strideA, &zero,
+                           U_gemm, 0, ldu_gemm, strideU_gemm, batch_count, (T**)workArr));
 
         rocsolver_syevd_heevd_template<false, STRIDED, T>(
             handle, rocblas_evect_original, rocblas_fill_upper, m, U_gemm, 0, ldu_gemm,
@@ -479,9 +485,11 @@ rocblas_status rocsolver_gesdd_template(rocblas_handle handle,
         rocblas_int ldv_gemm = (rightv ? ldv : m);
         rocblas_int strideV_gemm = (rightv ? strideV : m * n);
 
-        rocsolver_gemm(handle, rocblas_operation_conjugate_transpose, rocblas_operation_none, m, n,
-                       m, &one, U_gemm, 0, ldu_gemm, strideU_gemm, A, shiftA, lda, strideA, &zero,
-                       V_gemm, 0, ldv_gemm, strideV_gemm, batch_count, (T**)workArr);
+        ROCBLAS_CHECK_WITH_POINTER_MODE(
+            handle, old_mode,
+            rocsolver_gemm(handle, rocblas_operation_conjugate_transpose, rocblas_operation_none, m,
+                           n, m, &one, U_gemm, 0, ldu_gemm, strideU_gemm, A, shiftA, lda, strideA,
+                           &zero, V_gemm, 0, ldv_gemm, strideV_gemm, batch_count, (T**)workArr));
 
         // Apply LQ factorization to U^*A, obtaining S from the diagonal of L and V^* from Q
         rocsolver_gelqf_template<false, STRIDED, T>(handle, m, n, V_gemm, 0, ldv_gemm, strideV_gemm,

--- a/projects/rocsolver/library/src/lapack/roclapack_gesvd.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gesvd.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     April 2012
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -653,13 +653,17 @@ rocblas_status rocsolver_gesvd_template(rocblas_handle handle,
 
                 // update
                 if(row)
-                    rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n, k,
-                                   &one, A, shiftA, lda, strideA, bufferT, shiftT, ldt, strideT,
-                                   &zero, bufferC, shiftC, ldc, strideC, batch_count, workArr);
+                    ROCBLAS_CHECK_WITH_POINTER_MODE(
+                        handle, old_mode,
+                        rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n,
+                                       k, &one, A, shiftA, lda, strideA, bufferT, shiftT, ldt, strideT,
+                                       &zero, bufferC, shiftC, ldc, strideC, batch_count, workArr));
                 else
-                    rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n, k,
-                                   &one, bufferT, shiftT, ldt, strideT, A, shiftA, lda, strideA,
-                                   &zero, bufferC, shiftC, ldc, strideC, batch_count, workArr);
+                    ROCBLAS_CHECK_WITH_POINTER_MODE(
+                        handle, old_mode,
+                        rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n,
+                                       k, &one, bufferT, shiftT, ldt, strideT, A, shiftA, lda, strideA,
+                                       &zero, bufferC, shiftC, ldc, strideC, batch_count, workArr));
 
                 // copy to overwrite A
                 ROCSOLVER_LAUNCH_KERNEL(copy_mat<T>, dim3(blocks_m, blocks_n, batch_count),
@@ -670,13 +674,17 @@ rocblas_status rocsolver_gesvd_template(rocblas_handle handle,
             {
                 // update
                 if(row)
-                    rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n, k,
-                                   &one, A, shiftA, lda, strideA, bufferT, shiftT, ldt, strideT,
-                                   &zero, UV, shiftUV, lduv, strideUV, batch_count, workArr);
+                    ROCBLAS_CHECK_WITH_POINTER_MODE(
+                        handle, old_mode,
+                        rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n,
+                                       k, &one, A, shiftA, lda, strideA, bufferT, shiftT, ldt, strideT,
+                                       &zero, UV, shiftUV, lduv, strideUV, batch_count, workArr));
                 else
-                    rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n, k,
-                                   &one, bufferT, shiftT, ldt, strideT, A, shiftA, lda, strideA,
-                                   &zero, UV, shiftUV, lduv, strideUV, batch_count, workArr);
+                    ROCBLAS_CHECK_WITH_POINTER_MODE(
+                        handle, old_mode,
+                        rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n,
+                                       k, &one, bufferT, shiftT, ldt, strideT, A, shiftA, lda, strideA,
+                                       &zero, UV, shiftUV, lduv, strideUV, batch_count, workArr));
 
                 // overwrite A if required
                 if(othervO)
@@ -688,13 +696,18 @@ rocblas_status rocsolver_gesvd_template(rocblas_handle handle,
             {
                 // update
                 if(row)
-                    rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n, k,
-                                   &one, UV, shiftUV, lduv, strideUV, bufferT, shiftT, ldt, strideT,
-                                   &zero, A, shiftA, lda, strideA, batch_count, workArr);
+                    ROCBLAS_CHECK_WITH_POINTER_MODE(
+                        handle, old_mode,
+                        rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n,
+                                       k, &one, UV, shiftUV, lduv, strideUV, bufferT, shiftT, ldt,
+                                       strideT, &zero, A, shiftA, lda, strideA, batch_count, workArr));
                 else
-                    rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n, k,
-                                   &one, bufferT, shiftT, ldt, strideT, UV, shiftUV, lduv, strideUV,
-                                   &zero, A, shiftA, lda, strideA, batch_count, workArr);
+                    ROCBLAS_CHECK_WITH_POINTER_MODE(
+                        handle, old_mode,
+                        rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n,
+                                       k, &one, bufferT, shiftT, ldt, strideT, UV, shiftUV, lduv,
+                                       strideUV, &zero, A, shiftA, lda, strideA, batch_count,
+                                       workArr));
 
                 // copy back to U/V
                 ROCSOLVER_LAUNCH_KERNEL(copy_mat<T>, dim3(blocks_m, blocks_n, batch_count),

--- a/projects/rocsolver/library/src/lapack/roclapack_gesvdj.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gesvdj.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     April 2012
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -317,9 +317,11 @@ rocblas_status rocsolver_gesvdj_template(rocblas_handle handle,
         rocblas_int ldv_gemm = n;
         rocblas_int strideV_gemm = n * n;
 
-        rocsolver_gemm(handle, rocblas_operation_conjugate_transpose, rocblas_operation_none, n, n,
-                       m, &minone, A, shiftA, lda, strideA, A, shiftA, lda, strideA, &zero, V_gemm,
-                       0, ldv_gemm, strideV_gemm, batch_count, (T**)work6_workArr);
+        ROCBLAS_CHECK_WITH_POINTER_MODE(
+            handle, old_mode,
+            rocsolver_gemm(handle, rocblas_operation_conjugate_transpose, rocblas_operation_none, n,
+                           n, m, &minone, A, shiftA, lda, strideA, A, shiftA, lda, strideA, &zero,
+                           V_gemm, 0, ldv_gemm, strideV_gemm, batch_count, (T**)work6_workArr));
 
         // apply eigenvalue decomposition to -A'A, obtaining V as eigenvectors
         rocsolver_syevj_heevj_template<false, STRIDED, T>(
@@ -333,9 +335,11 @@ rocblas_status rocsolver_gesvdj_template(rocblas_handle handle,
         rocblas_int ldu_gemm = (leftv ? ldu : m);
         rocblas_int strideU_gemm = (leftv ? strideU : m * n);
 
-        rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n, n, &one, A,
-                       shiftA, lda, strideA, V_gemm, 0, ldv_gemm, strideV_gemm, &zero, U_gemm, 0,
-                       ldu_gemm, strideU_gemm, batch_count, (T**)work6_workArr);
+        ROCBLAS_CHECK_WITH_POINTER_MODE(
+            handle, old_mode,
+            rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n, n, &one, A,
+                           shiftA, lda, strideA, V_gemm, 0, ldv_gemm, strideV_gemm, &zero, U_gemm,
+                           0, ldu_gemm, strideU_gemm, batch_count, (T**)work6_workArr));
 
         // apply QR factorization to AV, obtaining U = Q and S = R
         rocsolver_geqrf_template<false, STRIDED, T>(handle, m, n, U_gemm, 0, ldu_gemm, strideU_gemm,
@@ -369,9 +373,11 @@ rocblas_status rocsolver_gesvdj_template(rocblas_handle handle,
         rocblas_int ldu_gemm = (leftv ? ldu : m);
         rocblas_int strideU_gemm = (leftv ? strideU : m * m);
 
-        rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_conjugate_transpose, m, m,
-                       n, &minone, A, shiftA, lda, strideA, A, shiftA, lda, strideA, &zero, U_gemm,
-                       0, ldu_gemm, strideU_gemm, batch_count, (T**)work6_workArr);
+        ROCBLAS_CHECK_WITH_POINTER_MODE(
+            handle, old_mode,
+            rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_conjugate_transpose, m,
+                           m, n, &minone, A, shiftA, lda, strideA, A, shiftA, lda, strideA, &zero,
+                           U_gemm, 0, ldu_gemm, strideU_gemm, batch_count, (T**)work6_workArr));
 
         // apply eigenvalue decomposition to -AA', obtaining U as eigenvectors
         rocsolver_syevj_heevj_template<false, STRIDED, T>(
@@ -385,9 +391,11 @@ rocblas_status rocsolver_gesvdj_template(rocblas_handle handle,
         rocblas_int ldv_gemm = (rightv ? ldv : m);
         rocblas_int strideV_gemm = (rightv ? strideV : m * n);
 
-        rocsolver_gemm(handle, rocblas_operation_conjugate_transpose, rocblas_operation_none, m, n,
-                       m, &one, U_gemm, 0, ldu_gemm, strideU_gemm, A, shiftA, lda, strideA, &zero,
-                       V_gemm, 0, ldv_gemm, strideV_gemm, batch_count, (T**)work6_workArr);
+        ROCBLAS_CHECK_WITH_POINTER_MODE(
+            handle, old_mode,
+            rocsolver_gemm(handle, rocblas_operation_conjugate_transpose, rocblas_operation_none, m,
+                           n, m, &one, U_gemm, 0, ldu_gemm, strideU_gemm, A, shiftA, lda, strideA,
+                           &zero, V_gemm, 0, ldv_gemm, strideV_gemm, batch_count, (T**)work6_workArr));
 
         // apply LQ factorization to U'A, obtaining S = L and V' = Q
         rocsolver_gelqf_template<false, STRIDED, T>(handle, m, n, V_gemm, 0, ldv_gemm, strideV_gemm,

--- a/projects/rocsolver/library/src/lapack/roclapack_gesvdj_notransv.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gesvdj_notransv.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     April 2012
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -280,9 +280,11 @@ rocblas_status rocsolver_gesvdj_notransv_template(rocblas_handle handle,
         rocblas_int ldv_gemm = (rightv ? ldv : n);
         rocblas_int strideV_gemm = (rightv ? strideV : n * n);
 
-        rocsolver_gemm(handle, rocblas_operation_conjugate_transpose, rocblas_operation_none, n, n,
-                       m, &minone, A, shiftA, lda, strideA, A, shiftA, lda, strideA, &zero, V_gemm,
-                       0, ldv_gemm, strideV_gemm, batch_count, (T**)work6_workArr);
+        ROCBLAS_CHECK_WITH_POINTER_MODE(
+            handle, old_mode,
+            rocsolver_gemm(handle, rocblas_operation_conjugate_transpose, rocblas_operation_none, n,
+                           n, m, &minone, A, shiftA, lda, strideA, A, shiftA, lda, strideA, &zero,
+                           V_gemm, 0, ldv_gemm, strideV_gemm, batch_count, (T**)work6_workArr));
 
         // apply eigenvalue decomposition to -A'A, obtaining V as eigenvectors
         rocsolver_syevj_heevj_template<false, STRIDED, T>(
@@ -296,9 +298,11 @@ rocblas_status rocsolver_gesvdj_notransv_template(rocblas_handle handle,
         rocblas_int ldu_gemm = (leftv ? ldu : m);
         rocblas_int strideU_gemm = (leftv ? strideU : m * n);
 
-        rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n, n, &one, A,
-                       shiftA, lda, strideA, V_gemm, 0, ldv_gemm, strideV_gemm, &zero, U_gemm, 0,
-                       ldu_gemm, strideU_gemm, batch_count, (T**)work6_workArr);
+        ROCBLAS_CHECK_WITH_POINTER_MODE(
+            handle, old_mode,
+            rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n, n, &one, A,
+                           shiftA, lda, strideA, V_gemm, 0, ldv_gemm, strideV_gemm, &zero, U_gemm,
+                           0, ldu_gemm, strideU_gemm, batch_count, (T**)work6_workArr));
 
         // apply QR factorization to AV, obtaining U = Q and S = R
         rocsolver_geqrf_template<false, STRIDED, T>(handle, m, n, U_gemm, 0, ldu_gemm, strideU_gemm,
@@ -322,9 +326,11 @@ rocblas_status rocsolver_gesvdj_notransv_template(rocblas_handle handle,
         rocblas_int ldu_gemm = (leftv ? ldu : m);
         rocblas_int strideU_gemm = (leftv ? strideU : m * m);
 
-        rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_conjugate_transpose, m, m,
-                       n, &minone, A, shiftA, lda, strideA, A, shiftA, lda, strideA, &zero, U_gemm,
-                       0, ldu_gemm, strideU_gemm, batch_count, (T**)work6_workArr);
+        ROCBLAS_CHECK_WITH_POINTER_MODE(
+            handle, old_mode,
+            rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_conjugate_transpose, m,
+                           m, n, &minone, A, shiftA, lda, strideA, A, shiftA, lda, strideA, &zero,
+                           U_gemm, 0, ldu_gemm, strideU_gemm, batch_count, (T**)work6_workArr));
 
         // apply eigenvalue decomposition to -AA', obtaining U as eigenvectors
         rocsolver_syevj_heevj_template<false, STRIDED, T>(
@@ -338,9 +344,11 @@ rocblas_status rocsolver_gesvdj_notransv_template(rocblas_handle handle,
         rocblas_int ldv_gemm = (rightv ? ldv : n);
         rocblas_int strideV_gemm = (rightv ? strideV : n * m);
 
-        rocsolver_gemm(handle, rocblas_operation_conjugate_transpose, rocblas_operation_none, n, m,
-                       m, &one, A, shiftA, lda, strideA, U_gemm, 0, ldu_gemm, strideU_gemm, &zero,
-                       V_gemm, 0, ldv_gemm, strideV_gemm, batch_count, (T**)work6_workArr);
+        ROCBLAS_CHECK_WITH_POINTER_MODE(
+            handle, old_mode,
+            rocsolver_gemm(handle, rocblas_operation_conjugate_transpose, rocblas_operation_none, n,
+                           m, m, &one, A, shiftA, lda, strideA, U_gemm, 0, ldu_gemm, strideU_gemm,
+                           &zero, V_gemm, 0, ldv_gemm, strideV_gemm, batch_count, (T**)work6_workArr));
 
         // apply QR factorization to A'U, obtaining V = Q and S = R
         rocsolver_geqrf_template<false, STRIDED, T>(handle, n, m, V_gemm, 0, ldv_gemm, strideV_gemm,

--- a/projects/rocsolver/library/src/lapack/roclapack_getrf.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_getrf.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -520,18 +520,19 @@ rocblas_status getrf_panelLU(rocblas_handle handle,
         // update trailing sub-block
         if(k + jb < nn)
         {
-            rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+            ROCBLAS_CHECK(rocsolver_trsm_lower<BATCHED, STRIDED, T>(
                 handle, rocblas_side_left, rocblas_operation_none, rocblas_diagonal_unit, jb,
                 nn - k - jb, A, shiftA + idx2D(k, k, inca, lda), inca, lda, strideA, A,
                 shiftA + idx2D(k, k + jb, inca, lda), inca, lda, strideA, batch_count, optim_mem,
-                work1, work2, work3, work4);
+                work1, work2, work3, work4));
 
             if(k + jb < mm)
-                rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, mm - k - jb,
-                               nn - k - jb, jb, &minone, A, shiftA + idx2D(k + jb, k, inca, lda),
-                               inca, lda, strideA, A, shiftA + idx2D(k, k + jb, inca, lda), inca,
-                               lda, strideA, &one, A, shiftA + idx2D(k + jb, k + jb, inca, lda),
-                               inca, lda, strideA, batch_count, (T**)nullptr);
+                ROCBLAS_CHECK(rocsolver_gemm(
+                    handle, rocblas_operation_none, rocblas_operation_none, mm - k - jb,
+                    nn - k - jb, jb, &minone, A, shiftA + idx2D(k + jb, k, inca, lda), inca, lda,
+                    strideA, A, shiftA + idx2D(k, k + jb, inca, lda), inca, lda, strideA, &one, A,
+                    shiftA + idx2D(k + jb, k + jb, inca, lda), inca, lda, strideA, batch_count,
+                    (T**)nullptr));
         }
     }
 
@@ -724,11 +725,13 @@ rocblas_status rocsolver_getrf_template(rocblas_handle handle,
                                                work4, optim_mem, pivotval, pivotidx, j, iipiv, m);
 
             // update remaining rows in outer panel
-            rocsolver_trsm_upper<BATCHED, STRIDED, T>(
-                handle, rocblas_side_right, rocblas_operation_none, rocblas_diagonal_non_unit,
-                m - j - jb, jb, A, shiftA + idx2D(j, j, inca, lda), inca, lda, strideA, A,
-                shiftA + idx2D(jb + j, j, inca, lda), inca, lda, strideA, batch_count, optim_mem,
-                work1, work2, work3, work4);
+            ROCBLAS_CHECK_WITH_POINTER_MODE(
+                handle, old_mode,
+                rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+                    handle, rocblas_side_right, rocblas_operation_none, rocblas_diagonal_non_unit,
+                    m - j - jb, jb, A, shiftA + idx2D(j, j, inca, lda), inca, lda, strideA, A,
+                    shiftA + idx2D(jb + j, j, inca, lda), inca, lda, strideA, batch_count,
+                    optim_mem, work1, work2, work3, work4));
         }
 
         // update trailing matrix
@@ -737,19 +740,23 @@ rocblas_status rocsolver_getrf_template(rocblas_handle handle,
         nn = n - nextpiv; //size for the matrix update
         if(nextpiv < n)
         {
-            rocsolver_trsm_lower<BATCHED, STRIDED, T>(
-                handle, rocblas_side_left, rocblas_operation_none, rocblas_diagonal_unit, jb, nn, A,
-                shiftA + idx2D(j, j, inca, lda), inca, lda, strideA, A,
-                shiftA + idx2D(j, nextpiv, inca, lda), inca, lda, strideA, batch_count, optim_mem,
-                work1, work2, work3, work4);
+            ROCBLAS_CHECK_WITH_POINTER_MODE(
+                handle, old_mode,
+                rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+                    handle, rocblas_side_left, rocblas_operation_none, rocblas_diagonal_unit, jb,
+                    nn, A, shiftA + idx2D(j, j, inca, lda), inca, lda, strideA, A,
+                    shiftA + idx2D(j, nextpiv, inca, lda), inca, lda, strideA, batch_count,
+                    optim_mem, work1, work2, work3, work4));
 
             if(nextpiv < m)
             {
-                rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, mm, nn, jb,
-                               &minone, A, shiftA + idx2D(nextpiv, j, inca, lda), inca, lda,
-                               strideA, A, shiftA + idx2D(j, nextpiv, inca, lda), inca, lda,
-                               strideA, &one, A, shiftA + idx2D(nextpiv, nextpiv, inca, lda), inca,
-                               lda, strideA, batch_count, (T**)nullptr);
+                ROCBLAS_CHECK_WITH_POINTER_MODE(
+                    handle, old_mode,
+                    rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, mm, nn,
+                                   jb, &minone, A, shiftA + idx2D(nextpiv, j, inca, lda), inca, lda,
+                                   strideA, A, shiftA + idx2D(j, nextpiv, inca, lda), inca, lda,
+                                   strideA, &one, A, shiftA + idx2D(nextpiv, nextpiv, inca, lda),
+                                   inca, lda, strideA, batch_count, (T**)nullptr));
             }
         }
     }

--- a/projects/rocsolver/library/src/lapack/roclapack_getri.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_getri.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -382,10 +382,12 @@ rocblas_status rocsolver_getri_template(rocblas_handle handle,
                                 0, stream, n, j, jb, A, shiftA, lda, strideA, info, tmpcopy, strideW);
 
         if(j + jb < n)
-            rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, n, jb,
-                           n - j - jb, &minone, A, shiftA + idx2D(0, j + jb, lda), lda, strideA,
-                           tmpcopy, j + jb, ldw, strideW, &one, A, shiftA + idx2D(0, j, lda), lda,
-                           strideA, batch_count, workArr);
+            ROCBLAS_CHECK_WITH_POINTER_MODE(
+                handle, old_mode,
+                rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, n, jb,
+                               n - j - jb, &minone, A, shiftA + idx2D(0, j + jb, lda), lda, strideA,
+                               tmpcopy, j + jb, ldw, strideW, &one, A, shiftA + idx2D(0, j, lda),
+                               lda, strideA, batch_count, workArr));
 
         rocblasCall_trsm(handle, rocblas_side_right, rocblas_fill_lower, rocblas_operation_none,
                          rocblas_diagonal_unit, n, jb, &one, tmpcopy, j, ldw, strideW, A,

--- a/projects/rocsolver/library/src/lapack/roclapack_getrs.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_getrs.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -154,30 +154,38 @@ rocblas_status rocsolver_getrs_template(rocblas_handle handle,
                                            0, 1, strideP, batch_count);
 
         // solve L*X = B, overwriting B with X
-        rocsolver_trsm_lower<BATCHED, STRIDED, T>(handle, rocblas_side_left, trans,
-                                                  rocblas_diagonal_unit, n, nrhs, A, shiftA, inca,
-                                                  lda, strideA, B, shiftB, incb, ldb, strideB,
-                                                  batch_count, optim_mem, work1, work2, work3, work4);
+        ROCBLAS_CHECK_WITH_POINTER_MODE(handle, old_mode,
+                                        rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+                                            handle, rocblas_side_left, trans, rocblas_diagonal_unit,
+                                            n, nrhs, A, shiftA, inca, lda, strideA, B, shiftB, incb,
+                                            ldb, strideB, batch_count, optim_mem, work1, work2,
+                                            work3, work4));
 
         // solve U*X = B, overwriting B with X
-        rocsolver_trsm_upper<BATCHED, STRIDED, T>(handle, rocblas_side_left, trans,
-                                                  rocblas_diagonal_non_unit, n, nrhs, A, shiftA,
-                                                  inca, lda, strideA, B, shiftB, incb, ldb, strideB,
-                                                  batch_count, optim_mem, work1, work2, work3, work4);
+        ROCBLAS_CHECK_WITH_POINTER_MODE(handle, old_mode,
+                                        rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+                                            handle, rocblas_side_left, trans,
+                                            rocblas_diagonal_non_unit, n, nrhs, A, shiftA, inca,
+                                            lda, strideA, B, shiftB, incb, ldb, strideB,
+                                            batch_count, optim_mem, work1, work2, work3, work4));
     }
     else
     {
         // solve U'*X = B or U**H *X = B, overwriting B with X
-        rocsolver_trsm_upper<BATCHED, STRIDED, T>(handle, rocblas_side_left, trans,
-                                                  rocblas_diagonal_non_unit, n, nrhs, A, shiftA,
-                                                  inca, lda, strideA, B, shiftB, incb, ldb, strideB,
-                                                  batch_count, optim_mem, work1, work2, work3, work4);
+        ROCBLAS_CHECK_WITH_POINTER_MODE(handle, old_mode,
+                                        rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+                                            handle, rocblas_side_left, trans,
+                                            rocblas_diagonal_non_unit, n, nrhs, A, shiftA, inca,
+                                            lda, strideA, B, shiftB, incb, ldb, strideB,
+                                            batch_count, optim_mem, work1, work2, work3, work4));
 
         // solve L'*X = B, or L**H *X = B overwriting B with X
-        rocsolver_trsm_lower<BATCHED, STRIDED, T>(handle, rocblas_side_left, trans,
-                                                  rocblas_diagonal_unit, n, nrhs, A, shiftA, inca,
-                                                  lda, strideA, B, shiftB, incb, ldb, strideB,
-                                                  batch_count, optim_mem, work1, work2, work3, work4);
+        ROCBLAS_CHECK_WITH_POINTER_MODE(handle, old_mode,
+                                        rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+                                            handle, rocblas_side_left, trans, rocblas_diagonal_unit,
+                                            n, nrhs, A, shiftA, inca, lda, strideA, B, shiftB, incb,
+                                            ldb, strideB, batch_count, optim_mem, work1, work2,
+                                            work3, work4));
 
         // then apply row interchanges to the solution vectors
         if(pivot)

--- a/projects/rocsolver/library/src/lapack/roclapack_potrf.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_potrf.hpp
@@ -241,11 +241,13 @@ rocblas_status rocsolver_potrf_template(rocblas_handle handle,
             if(j + jb < n)
             {
                 // update trailing submatrix
-                rocsolver_trsm_upper<BATCHED, STRIDED, T>(
-                    handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
-                    rocblas_diagonal_non_unit, jb, (n - j - jb), A, shiftA + idx2D(j, j, lda), lda,
-                    strideA, A, shiftA + idx2D(j, j + jb, lda), lda, strideA, batch_count,
-                    optim_mem, work1, work2, work3, work4);
+                ROCBLAS_CHECK_WITH_POINTER_MODE(
+                    handle, old_mode,
+                    rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+                        handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
+                        rocblas_diagonal_non_unit, jb, (n - j - jb), A, shiftA + idx2D(j, j, lda),
+                        lda, strideA, A, shiftA + idx2D(j, j + jb, lda), lda, strideA, batch_count,
+                        optim_mem, work1, work2, work3, work4));
 
                 rocblasCall_syrk_herk<BATCHED, T>(
                     handle, uplo, rocblas_operation_conjugate_transpose, n - j - jb, jb, &s_minone,
@@ -273,11 +275,13 @@ rocblas_status rocsolver_potrf_template(rocblas_handle handle,
             if(j + jb < n)
             {
                 // update trailing submatrix
-                rocsolver_trsm_lower<BATCHED, STRIDED, T>(
-                    handle, rocblas_side_right, rocblas_operation_conjugate_transpose,
-                    rocblas_diagonal_non_unit, (n - j - jb), jb, A, shiftA + idx2D(j, j, lda), lda,
-                    strideA, A, shiftA + idx2D(j + jb, j, lda), lda, strideA, batch_count,
-                    optim_mem, work1, work2, work3, work4);
+                ROCBLAS_CHECK_WITH_POINTER_MODE(
+                    handle, old_mode,
+                    rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+                        handle, rocblas_side_right, rocblas_operation_conjugate_transpose,
+                        rocblas_diagonal_non_unit, (n - j - jb), jb, A, shiftA + idx2D(j, j, lda),
+                        lda, strideA, A, shiftA + idx2D(j + jb, j, lda), lda, strideA, batch_count,
+                        optim_mem, work1, work2, work3, work4));
 
                 rocblasCall_syrk_herk<BATCHED, T>(
                     handle, uplo, rocblas_operation_none, n - j - jb, jb, &s_minone, A,

--- a/projects/rocsolver/library/src/lapack/roclapack_potrs.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_potrs.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -146,30 +146,38 @@ rocblas_status rocsolver_potrs_template(rocblas_handle handle,
     if(uplo == rocblas_fill_upper)
     {
         // solve U'*X = B, overwriting B with X
-        rocsolver_trsm_upper<BATCHED, STRIDED, T>(
-            handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
-            rocblas_diagonal_non_unit, n, nrhs, A, shiftA, lda, strideA, B, shiftB, ldb, strideB,
-            batch_count, optim_mem, work1, work2, work3, work4);
+        ROCBLAS_CHECK_WITH_POINTER_MODE(
+            handle, old_mode,
+            rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+                handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
+                rocblas_diagonal_non_unit, n, nrhs, A, shiftA, lda, strideA, B, shiftB, ldb,
+                strideB, batch_count, optim_mem, work1, work2, work3, work4));
 
         // solve U*X = B, overwriting B with X
-        rocsolver_trsm_upper<BATCHED, STRIDED, T>(handle, rocblas_side_left, rocblas_operation_none,
-                                                  rocblas_diagonal_non_unit, n, nrhs, A, shiftA,
-                                                  lda, strideA, B, shiftB, ldb, strideB, batch_count,
-                                                  optim_mem, work1, work2, work3, work4);
+        ROCBLAS_CHECK_WITH_POINTER_MODE(handle, old_mode,
+                                        rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+                                            handle, rocblas_side_left, rocblas_operation_none,
+                                            rocblas_diagonal_non_unit, n, nrhs, A, shiftA, lda,
+                                            strideA, B, shiftB, ldb, strideB, batch_count,
+                                            optim_mem, work1, work2, work3, work4));
     }
     else
     {
         // solve L*X = B, overwriting B with X
-        rocsolver_trsm_lower<BATCHED, STRIDED, T>(handle, rocblas_side_left, rocblas_operation_none,
-                                                  rocblas_diagonal_non_unit, n, nrhs, A, shiftA,
-                                                  lda, strideA, B, shiftB, ldb, strideB, batch_count,
-                                                  optim_mem, work1, work2, work3, work4);
+        ROCBLAS_CHECK_WITH_POINTER_MODE(handle, old_mode,
+                                        rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+                                            handle, rocblas_side_left, rocblas_operation_none,
+                                            rocblas_diagonal_non_unit, n, nrhs, A, shiftA, lda,
+                                            strideA, B, shiftB, ldb, strideB, batch_count,
+                                            optim_mem, work1, work2, work3, work4));
 
         // solve L'*X = B, overwriting B with X
-        rocsolver_trsm_lower<BATCHED, STRIDED, T>(
-            handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
-            rocblas_diagonal_non_unit, n, nrhs, A, shiftA, lda, strideA, B, shiftB, ldb, strideB,
-            batch_count, optim_mem, work1, work2, work3, work4);
+        ROCBLAS_CHECK_WITH_POINTER_MODE(
+            handle, old_mode,
+            rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+                handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
+                rocblas_diagonal_non_unit, n, nrhs, A, shiftA, lda, strideA, B, shiftB, ldb,
+                strideB, batch_count, optim_mem, work1, work2, work3, work4));
     }
 
     rocblas_set_pointer_mode(handle, old_mode);

--- a/projects/rocsolver/library/src/lapack/roclapack_sygst_hegst.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_sygst_hegst.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -181,11 +181,13 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
 
                 if(k + kb < n)
                 {
-                    rocsolver_trsm_upper<BATCHED, STRIDED, T>(
-                        handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
-                        rocblas_diagonal_non_unit, kb, n - k - kb, B, shiftB + idx2D(k, k, ldb),
-                        ldb, strideB, A, shiftA + idx2D(k, k + kb, lda), lda, strideA, batch_count,
-                        optim_mem, work_x_temp, workArr_temp_arr, store_wcs_invA, invA_arr);
+                    ROCBLAS_CHECK_WITH_POINTER_MODE(
+                        handle, old_mode,
+                        rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+                            handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
+                            rocblas_diagonal_non_unit, kb, n - k - kb, B, shiftB + idx2D(k, k, ldb),
+                            ldb, strideB, A, shiftA + idx2D(k, k + kb, lda), lda, strideA, batch_count,
+                            optim_mem, work_x_temp, workArr_temp_arr, store_wcs_invA, invA_arr));
 
                     rocblasCall_symm_hemm(handle, rocblas_side_left, uplo, kb, n - k - kb,
                                           &t_minhalf, A, shiftA + idx2D(k, k, lda), lda, strideA, B,
@@ -203,11 +205,14 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
                                           shiftB + idx2D(k, k + kb, ldb), ldb, strideB, &t_one, A,
                                           shiftA + idx2D(k, k + kb, lda), lda, strideA, batch_count);
 
-                    rocsolver_trsm_upper<BATCHED, STRIDED, T>(
-                        handle, rocblas_side_right, rocblas_operation_none, rocblas_diagonal_non_unit,
-                        kb, n - k - kb, B, shiftB + idx2D(k + kb, k + kb, ldb), ldb, strideB, A,
-                        shiftA + idx2D(k, k + kb, lda), lda, strideA, batch_count, optim_mem,
-                        work_x_temp, workArr_temp_arr, store_wcs_invA, invA_arr);
+                    ROCBLAS_CHECK_WITH_POINTER_MODE(
+                        handle, old_mode,
+                        rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+                            handle, rocblas_side_right, rocblas_operation_none,
+                            rocblas_diagonal_non_unit, kb, n - k - kb, B,
+                            shiftB + idx2D(k + kb, k + kb, ldb), ldb, strideB, A,
+                            shiftA + idx2D(k, k + kb, lda), lda, strideA, batch_count, optim_mem,
+                            work_x_temp, workArr_temp_arr, store_wcs_invA, invA_arr));
                 }
             }
         }
@@ -225,11 +230,13 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
 
                 if(k + kb < n)
                 {
-                    rocsolver_trsm_lower<BATCHED, STRIDED, T>(
-                        handle, rocblas_side_right, rocblas_operation_conjugate_transpose,
-                        rocblas_diagonal_non_unit, n - k - kb, kb, B, shiftB + idx2D(k, k, ldb),
-                        ldb, strideB, A, shiftA + idx2D(k + kb, k, lda), lda, strideA, batch_count,
-                        optim_mem, work_x_temp, workArr_temp_arr, store_wcs_invA, invA_arr);
+                    ROCBLAS_CHECK_WITH_POINTER_MODE(
+                        handle, old_mode,
+                        rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+                            handle, rocblas_side_right, rocblas_operation_conjugate_transpose,
+                            rocblas_diagonal_non_unit, n - k - kb, kb, B, shiftB + idx2D(k, k, ldb),
+                            ldb, strideB, A, shiftA + idx2D(k + kb, k, lda), lda, strideA, batch_count,
+                            optim_mem, work_x_temp, workArr_temp_arr, store_wcs_invA, invA_arr));
 
                     rocblasCall_symm_hemm(handle, rocblas_side_right, uplo, n - k - kb, kb,
                                           &t_minhalf, A, shiftA + idx2D(k, k, lda), lda, strideA, B,
@@ -247,11 +254,14 @@ rocblas_status rocsolver_sygst_hegst_template(rocblas_handle handle,
                                           shiftB + idx2D(k + kb, k, ldb), ldb, strideB, &t_one, A,
                                           shiftA + idx2D(k + kb, k, lda), lda, strideA, batch_count);
 
-                    rocsolver_trsm_lower<BATCHED, STRIDED, T>(
-                        handle, rocblas_side_left, rocblas_operation_none, rocblas_diagonal_non_unit,
-                        n - k - kb, kb, B, shiftB + idx2D(k + kb, k + kb, ldb), ldb, strideB, A,
-                        shiftA + idx2D(k + kb, k, lda), lda, strideA, batch_count, optim_mem,
-                        work_x_temp, workArr_temp_arr, store_wcs_invA, invA_arr);
+                    ROCBLAS_CHECK_WITH_POINTER_MODE(
+                        handle, old_mode,
+                        rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+                            handle, rocblas_side_left, rocblas_operation_none,
+                            rocblas_diagonal_non_unit, n - k - kb, kb, B,
+                            shiftB + idx2D(k + kb, k + kb, ldb), ldb, strideB, A,
+                            shiftA + idx2D(k + kb, k, lda), lda, strideA, batch_count, optim_mem,
+                            work_x_temp, workArr_temp_arr, store_wcs_invA, invA_arr));
                 }
             }
         }

--- a/projects/rocsolver/library/src/lapack/roclapack_sygv_hegv.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_sygv_hegv.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -250,15 +250,19 @@ rocblas_status rocsolver_sygv_hegv_template(rocblas_handle handle,
         if(itype == rocblas_eform_ax || itype == rocblas_eform_abx)
         {
             if(uplo == rocblas_fill_upper)
-                rocsolver_trsm_upper<BATCHED, STRIDED, T>(
-                    handle, rocblas_side_left, rocblas_operation_none, rocblas_diagonal_non_unit, n,
-                    neig, B, shiftB, ldb, strideB, A, shiftA, lda, strideA, batch_count, optim_mem,
-                    work1, work2, work3, work4);
+                ROCBLAS_CHECK_WITH_POINTER_MODE(
+                    handle, old_mode,
+                    rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+                        handle, rocblas_side_left, rocblas_operation_none,
+                        rocblas_diagonal_non_unit, n, neig, B, shiftB, ldb, strideB, A, shiftA, lda,
+                        strideA, batch_count, optim_mem, work1, work2, work3, work4));
             else
-                rocsolver_trsm_lower<BATCHED, STRIDED, T>(
-                    handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
-                    rocblas_diagonal_non_unit, n, neig, B, shiftB, ldb, strideB, A, shiftA, lda,
-                    strideA, batch_count, optim_mem, work1, work2, work3, work4);
+                ROCBLAS_CHECK_WITH_POINTER_MODE(
+                    handle, old_mode,
+                    rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+                        handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
+                        rocblas_diagonal_non_unit, n, neig, B, shiftB, ldb, strideB, A, shiftA, lda,
+                        strideA, batch_count, optim_mem, work1, work2, work3, work4));
         }
         else
         {

--- a/projects/rocsolver/library/src/lapack/roclapack_sygvd_hegvd.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_sygvd_hegvd.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -255,15 +255,19 @@ rocblas_status rocsolver_sygvd_hegvd_template(rocblas_handle handle,
         if(itype == rocblas_eform_ax || itype == rocblas_eform_abx)
         {
             if(uplo == rocblas_fill_upper)
-                rocsolver_trsm_upper<BATCHED, STRIDED, T>(
-                    handle, rocblas_side_left, rocblas_operation_none, rocblas_diagonal_non_unit, n,
-                    n, B, shiftB, ldb, strideB, A, shiftA, lda, strideA, batch_count, optim_mem,
-                    work1, work2, work3, work4);
+                ROCBLAS_CHECK_WITH_POINTER_MODE(
+                    handle, old_mode,
+                    rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+                        handle, rocblas_side_left, rocblas_operation_none,
+                        rocblas_diagonal_non_unit, n, n, B, shiftB, ldb, strideB, A, shiftA, lda,
+                        strideA, batch_count, optim_mem, work1, work2, work3, work4));
             else
-                rocsolver_trsm_lower<BATCHED, STRIDED, T>(
-                    handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
-                    rocblas_diagonal_non_unit, n, n, B, shiftB, ldb, strideB, A, shiftA, lda,
-                    strideA, batch_count, optim_mem, work1, work2, work3, work4);
+                ROCBLAS_CHECK_WITH_POINTER_MODE(
+                    handle, old_mode,
+                    rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+                        handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
+                        rocblas_diagonal_non_unit, n, n, B, shiftB, ldb, strideB, A, shiftA, lda,
+                        strideA, batch_count, optim_mem, work1, work2, work3, work4));
         }
         else
         {

--- a/projects/rocsolver/library/src/lapack/roclapack_sygvdj_hegvdj.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_sygvdj_hegvdj.hpp
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -249,15 +249,19 @@ rocblas_status rocsolver_sygvdj_hegvdj_template(rocblas_handle handle,
         if(itype == rocblas_eform_ax || itype == rocblas_eform_abx)
         {
             if(uplo == rocblas_fill_upper)
-                rocsolver_trsm_upper<BATCHED, STRIDED, T>(
-                    handle, rocblas_side_left, rocblas_operation_none, rocblas_diagonal_non_unit, n,
-                    n, B, shiftB, ldb, strideB, A, shiftA, lda, strideA, batch_count, optim_mem,
-                    work1, work2, work3, work4);
+                ROCBLAS_CHECK_WITH_POINTER_MODE(
+                    handle, old_mode,
+                    rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+                        handle, rocblas_side_left, rocblas_operation_none,
+                        rocblas_diagonal_non_unit, n, n, B, shiftB, ldb, strideB, A, shiftA, lda,
+                        strideA, batch_count, optim_mem, work1, work2, work3, work4));
             else
-                rocsolver_trsm_lower<BATCHED, STRIDED, T>(
-                    handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
-                    rocblas_diagonal_non_unit, n, n, B, shiftB, ldb, strideB, A, shiftA, lda,
-                    strideA, batch_count, optim_mem, work1, work2, work3, work4);
+                ROCBLAS_CHECK_WITH_POINTER_MODE(
+                    handle, old_mode,
+                    rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+                        handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
+                        rocblas_diagonal_non_unit, n, n, B, shiftB, ldb, strideB, A, shiftA, lda,
+                        strideA, batch_count, optim_mem, work1, work2, work3, work4));
         }
         else
         {

--- a/projects/rocsolver/library/src/lapack/roclapack_sygvdx_hegvdx.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_sygvdx_hegvdx.hpp
@@ -1,5 +1,5 @@
 /************************************************************************
- * Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -297,15 +297,19 @@ rocblas_status rocsolver_sygvdx_hegvdx_template(rocblas_handle handle,
         if(itype == rocblas_eform_ax || itype == rocblas_eform_abx)
         {
             if(uplo == rocblas_fill_upper)
-                rocsolver_trsm_upper<BATCHED, STRIDED, T>(
-                    handle, rocblas_side_left, rocblas_operation_none, rocblas_diagonal_non_unit, n,
-                    h_nev, B, shiftB, ldb, strideB, Z, shiftZ, ldz, strideZ, batch_count, optim_mem,
-                    work1, work2, work3, work4);
+                ROCBLAS_CHECK_WITH_POINTER_MODE(
+                    handle, old_mode,
+                    rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+                        handle, rocblas_side_left, rocblas_operation_none,
+                        rocblas_diagonal_non_unit, n, h_nev, B, shiftB, ldb, strideB, Z, shiftZ,
+                        ldz, strideZ, batch_count, optim_mem, work1, work2, work3, work4));
             else
-                rocsolver_trsm_lower<BATCHED, STRIDED, T>(
-                    handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
-                    rocblas_diagonal_non_unit, n, h_nev, B, shiftB, ldb, strideB, Z, shiftZ, ldz,
-                    strideZ, batch_count, optim_mem, work1, work2, work3, work4);
+                ROCBLAS_CHECK_WITH_POINTER_MODE(
+                    handle, old_mode,
+                    rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+                        handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
+                        rocblas_diagonal_non_unit, n, h_nev, B, shiftB, ldb, strideB, Z, shiftZ,
+                        ldz, strideZ, batch_count, optim_mem, work1, work2, work3, work4));
         }
         else
         {

--- a/projects/rocsolver/library/src/lapack/roclapack_sygvdx_hegvdx_inplace.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_sygvdx_hegvdx_inplace.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -298,15 +298,19 @@ rocblas_status rocsolver_sygvdx_hegvdx_inplace_template(rocblas_handle handle,
         if(itype == rocblas_eform_ax || itype == rocblas_eform_abx)
         {
             if(uplo == rocblas_fill_upper)
-                rocsolver_trsm_upper<BATCHED, STRIDED, T>(
-                    handle, rocblas_side_left, rocblas_operation_none, rocblas_diagonal_non_unit, n,
-                    temp_nev, B, shiftB, ldb, strideB, A, shiftA, lda, strideA, batch_count,
-                    optim_mem, work1, work2, work3, work4);
+                ROCBLAS_CHECK_WITH_POINTER_MODE(
+                    handle, old_mode,
+                    rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+                        handle, rocblas_side_left, rocblas_operation_none,
+                        rocblas_diagonal_non_unit, n, temp_nev, B, shiftB, ldb, strideB, A, shiftA,
+                        lda, strideA, batch_count, optim_mem, work1, work2, work3, work4));
             else
-                rocsolver_trsm_lower<BATCHED, STRIDED, T>(
-                    handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
-                    rocblas_diagonal_non_unit, n, temp_nev, B, shiftB, ldb, strideB, A, shiftA, lda,
-                    strideA, batch_count, optim_mem, work1, work2, work3, work4);
+                ROCBLAS_CHECK_WITH_POINTER_MODE(
+                    handle, old_mode,
+                    rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+                        handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
+                        rocblas_diagonal_non_unit, n, temp_nev, B, shiftB, ldb, strideB, A, shiftA,
+                        lda, strideA, batch_count, optim_mem, work1, work2, work3, work4));
         }
         else
         {

--- a/projects/rocsolver/library/src/lapack/roclapack_sygvj_hegvj.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_sygvj_hegvj.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -273,15 +273,19 @@ rocblas_status rocsolver_sygvj_hegvj_template(rocblas_handle handle,
         if(itype == rocblas_eform_ax || itype == rocblas_eform_abx)
         {
             if(uplo == rocblas_fill_upper)
-                rocsolver_trsm_upper<BATCHED, STRIDED, T>(
-                    handle, rocblas_side_left, rocblas_operation_none, rocblas_diagonal_non_unit, n,
-                    n, B, shiftB, ldb, strideB, A, shiftA, lda, strideA, batch_count, optim_mem,
-                    work1, work2, work3, work4);
+                ROCBLAS_CHECK_WITH_POINTER_MODE(
+                    handle, old_mode,
+                    rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+                        handle, rocblas_side_left, rocblas_operation_none,
+                        rocblas_diagonal_non_unit, n, n, B, shiftB, ldb, strideB, A, shiftA, lda,
+                        strideA, batch_count, optim_mem, work1, work2, work3, work4));
             else
-                rocsolver_trsm_lower<BATCHED, STRIDED, T>(
-                    handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
-                    rocblas_diagonal_non_unit, n, n, B, shiftB, ldb, strideB, A, shiftA, lda,
-                    strideA, batch_count, optim_mem, work1, work2, work3, work4);
+                ROCBLAS_CHECK_WITH_POINTER_MODE(
+                    handle, old_mode,
+                    rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+                        handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
+                        rocblas_diagonal_non_unit, n, n, B, shiftB, ldb, strideB, A, shiftA, lda,
+                        strideA, batch_count, optim_mem, work1, work2, work3, work4));
         }
         else
         {

--- a/projects/rocsolver/library/src/lapack/roclapack_sygvx_hegvx.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_sygvx_hegvx.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -323,15 +323,19 @@ rocblas_status rocsolver_sygvx_hegvx_template(rocblas_handle handle,
         if(itype == rocblas_eform_ax || itype == rocblas_eform_abx)
         {
             if(uplo == rocblas_fill_upper)
-                rocsolver_trsm_upper<BATCHED, STRIDED, T>(
-                    handle, rocblas_side_left, rocblas_operation_none, rocblas_diagonal_non_unit, n,
-                    h_nev, B, shiftB, ldb, strideB, Z, shiftZ, ldz, strideZ, batch_count, optim_mem,
-                    work1, work2, work3, work4);
+                ROCBLAS_CHECK_WITH_POINTER_MODE(
+                    handle, old_mode,
+                    rocsolver_trsm_upper<BATCHED, STRIDED, T>(
+                        handle, rocblas_side_left, rocblas_operation_none,
+                        rocblas_diagonal_non_unit, n, h_nev, B, shiftB, ldb, strideB, Z, shiftZ,
+                        ldz, strideZ, batch_count, optim_mem, work1, work2, work3, work4));
             else
-                rocsolver_trsm_lower<BATCHED, STRIDED, T>(
-                    handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
-                    rocblas_diagonal_non_unit, n, h_nev, B, shiftB, ldb, strideB, Z, shiftZ, ldz,
-                    strideZ, batch_count, optim_mem, work1, work2, work3, work4);
+                ROCBLAS_CHECK_WITH_POINTER_MODE(
+                    handle, old_mode,
+                    rocsolver_trsm_lower<BATCHED, STRIDED, T>(
+                        handle, rocblas_side_left, rocblas_operation_conjugate_transpose,
+                        rocblas_diagonal_non_unit, n, h_nev, B, shiftB, ldb, strideB, Z, shiftZ,
+                        ldz, strideZ, batch_count, optim_mem, work1, work2, work3, work4));
         }
         else
         {

--- a/projects/rocsolver/library/src/lapack/roclapack_sytrd_hetrd.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_sytrd_hetrd.hpp
@@ -215,14 +215,18 @@ rocblas_status rocsolver_sytrd_hetrd_template(rocblas_handle handle,
 
             // update trailing matrix
             // A = A - V*W' - W*V'
-            rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_conjugate_transpose,
-                           n - j - k, n - j - k, k, &minone, A, shiftA + idx2D(j + k, j, lda), lda,
-                           strideA, tmptau_W, idx2D(k, 0, ldw), ldw, strideW, &one, A,
-                           shiftA + idx2D(j + k, j + k, lda), lda, strideA, batch_count, workArr);
-            rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_conjugate_transpose,
-                           n - j - k, n - j - k, k, &minone, tmptau_W, idx2D(k, 0, ldw), ldw,
-                           strideW, A, shiftA + idx2D(j + k, j, lda), lda, strideA, &one, A,
-                           shiftA + idx2D(j + k, j + k, lda), lda, strideA, batch_count, workArr);
+            ROCBLAS_CHECK_WITH_POINTER_MODE(
+                handle, old_mode,
+                rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_conjugate_transpose,
+                               n - j - k, n - j - k, k, &minone, A, shiftA + idx2D(j + k, j, lda),
+                               lda, strideA, tmptau_W, idx2D(k, 0, ldw), ldw, strideW, &one, A,
+                               shiftA + idx2D(j + k, j + k, lda), lda, strideA, batch_count, workArr));
+            ROCBLAS_CHECK_WITH_POINTER_MODE(
+                handle, old_mode,
+                rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_conjugate_transpose,
+                               n - j - k, n - j - k, k, &minone, tmptau_W, idx2D(k, 0, ldw), ldw,
+                               strideW, A, shiftA + idx2D(j + k, j, lda), lda, strideA, &one, A,
+                               shiftA + idx2D(j + k, j + k, lda), lda, strideA, batch_count, workArr));
 
             j += k;
         }
@@ -250,12 +254,18 @@ rocblas_status rocsolver_sytrd_hetrd_template(rocblas_handle handle,
 
             // update trailing matrix
             // A = A - V*W' - W*V'
-            rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_conjugate_transpose, j,
-                           j, k, &minone, A, shiftA + idx2D(0, j, lda), lda, strideA, tmptau_W, 0,
-                           ldw, strideW, &one, A, shiftA, lda, strideA, batch_count, workArr);
-            rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_conjugate_transpose, j,
-                           j, k, &minone, tmptau_W, 0, ldw, strideW, A, shiftA + idx2D(0, j, lda),
-                           lda, strideA, &one, A, shiftA, lda, strideA, batch_count, workArr);
+            ROCBLAS_CHECK_WITH_POINTER_MODE(
+                handle, old_mode,
+                rocsolver_gemm(handle, rocblas_operation_none,
+                               rocblas_operation_conjugate_transpose, j, j, k, &minone, A,
+                               shiftA + idx2D(0, j, lda), lda, strideA, tmptau_W, 0, ldw, strideW,
+                               &one, A, shiftA, lda, strideA, batch_count, workArr));
+            ROCBLAS_CHECK_WITH_POINTER_MODE(
+                handle, old_mode,
+                rocsolver_gemm(handle, rocblas_operation_none,
+                               rocblas_operation_conjugate_transpose, j, j, k, &minone, tmptau_W, 0,
+                               ldw, strideW, A, shiftA + idx2D(0, j, lda), lda, strideA, &one, A,
+                               shiftA, lda, strideA, batch_count, workArr));
 
             j -= k;
         }


### PR DESCRIPTION
## Motivation

We want to check for errors upon invoking `rocblas_gemm` and `rocblas_trsm`, our wrapper functions for the respective BLAS routines, since these could fail silently, such as in #6069.

### Note

This is a proposed solution, we should discuss this further as a team.

## Technical Details

In the issue, they recommend two potential error handling strategies:
1) quick return upon error
2) error accumulation

This PR follows strategy 1). 

The only downside to strategy 1) is any potential clean-up in the routine must be done before returning with the error code. For example, this manifests in some files through the use of the new macro, `ROCSOLVER_CHECK_WITH_POINTER_MODE`, intended to clean up the pointer mode that must be restored to `old_mode` before the routine returns.

At this point in time, it is simple to perform the cleanup required by rocSOLVER routines, which is why I opted to implement strategy 1). However, changes to the cleanup these routines perform in the future, such as memory allocations with `malloc()` or `hipMalloc()`, temporarily overwriting a matrix or array that should not be modified by the routine, etc., could add complexity that makes performing the cleanup in the macro too difficult to maintain or use for multiple routines in rocSOLVER.

## Test Plan

Run all rocSOLVER tests. Modify the `rocblas_gemm` function to return `rocblas_status_not_implemented` to emulate an error occuring, verify that the tests report `rocblas_status_not_implemented` rather than a numerical error.

## Test Result

Tests pass. When `rocsolver_gemm` is modified to emulate errors, the tests report `rocblas_status_not_implemented` was returned when it expted `rocblas_status_success`.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
