### PR TITLE
[CK] poll every 6 hours as workaround

### DIFF
--- a/projects/composablekernel/Jenkinsfile
+++ b/projects/composablekernel/Jenkinsfile
@@ -1189,7 +1189,7 @@ CRON_SETTINGS = BRANCH_NAME == "develop" ? '''0 23 * * * % RUN_FULL_QA=true;RUN_
                                               0 11 * * * % RUN_FULL_CONV_TILE_TESTS=true;RUN_AITER_TESTS=true;USE_SCCACHE=false;RUN_PERFORMANCE_TESTS=false;FORCE_CI=true
                                               0 9 * * * % RUN_PYTORCH_TESTS=true;USE_SCCACHE=false;RUN_PERFORMANCE_TESTS=false;BUILD_GFX101=false;BUILD_GFX103=false;BUILD_GFX11=false;BUILD_GFX12=false;BUILD_GFX90A=false;FORCE_CI=true''' : ""
 
-POLL_SPEC = BRANCH_NAME == "develop" ? 'H/15 * * * *' : ''
+POLL_SPEC = BRANCH_NAME == "develop" ? 'H H/6 * * *' : ''
 
 pipeline {
     agent none


### PR DESCRIPTION
## Motivation

This is a workaround because the SCM polling seems to kick off builds for all changes to rocm-libraries, not just CK ones.  For now, it's better to have a new build every 6 hours than no build off of the changes in develop at all.

## Technical Details
## Test Plan
## Test Result
## Submission Checklist