### PR TITLE
[fft shared] Use unified memory usage accounting strategies and limit-enforcing

### DIFF
--- a/projects/hipfft/clients/tests/gtest_main.cpp
+++ b/projects/hipfft/clients/tests/gtest_main.cpp
@@ -639,14 +639,20 @@ int main(int argc, char* argv[])
               << byte_size_to_str(system_memory::singleton().get_limit_bytes())
               << " of system memory." << std::endl;
     device_memory_accountant::singleton().set_limit_bytes_for_all_devices(vramgb_limit * ONE_GiB);
-    std::cout << "Refraining from using more than" << std::endl;
+    std::cout << "Refraining from using more than ";
     for(size_t dev_id = 0; dev_id < device_memory_accountant::singleton().num_devices(); dev_id++)
     {
-        std::cout << "\t"
-                  << byte_size_to_str(
-                         device_memory_accountant::singleton().get_limit_bytes_on_device(dev_id))
-                  << " of device memory for device ID " << dev_id << std::endl;
+        if(device_memory_accountant::singleton().num_devices() > 1)
+            std::cout << "\n\t";
+        std::cout << byte_size_to_str(
+            device_memory_accountant::singleton().get_limit_bytes_on_device(dev_id))
+                  << " of device memory";
+        if(device_memory_accountant::singleton().num_devices() > 1)
+            std::cout << " for device ID " << dev_id;
+        std::cout << (dev_id == device_memory_accountant::singleton().num_devices() - 1 ? "."
+                                                                                        : ";");
     }
+    std::cout << std::endl;
 
     if(use_fftw_wisdom)
     {

--- a/projects/hipfft/clients/tests/gtest_main.cpp
+++ b/projects/hipfft/clients/tests/gtest_main.cpp
@@ -490,7 +490,7 @@ int main(int argc, char* argv[])
         "--version",
         "Print queryable version information from the hipfft library's backend (and return)");
     app.add_option("--R", ramgb, "RAM limit in GiB for tests")
-        ->default_val(host_memory::singleton().get_total_gbytes());
+        ->default_val(system_memory::singleton().get_total_gbytes());
     app.add_option("--V", vramgb, "VRAM limit in GiB for tests")->default_val(0);
     app.add_option("--half_epsilon", half_epsilon)->default_val(9.77e-4);
     app.add_option("--single_epsilon", single_epsilon)->default_val(3.75e-5);
@@ -634,12 +634,10 @@ int main(int argc, char* argv[])
     fftwf_plan_with_nthreads(rocfft_concurrency());
 #endif
 
-    // Set host memory limit from command-line options (if more restrictive)
-    const auto usable_bytes = host_memory::singleton().get_usable_bytes();
-    if(ramgb * ONE_GiB < usable_bytes)
-        host_memory::singleton().set_limit_gbytes(ramgb);
-    std::cout << "Usable host memory: " << bytes_to_GiB(host_memory::singleton().get_usable_bytes())
-              << " GiB" << std::endl;
+    system_memory::singleton().set_limit_bytes(ramgb * ONE_GiB);
+    std::cout << "Refraining from using more than "
+              << byte_size_to_str(system_memory::singleton().get_limit_bytes())
+              << " of system memory." << std::endl;
 
     if(use_fftw_wisdom)
     {

--- a/projects/hipfft/clients/tests/gtest_main.cpp
+++ b/projects/hipfft/clients/tests/gtest_main.cpp
@@ -73,12 +73,6 @@ std::string hipfftw_token_for_functional_test;
 // Transform parameters for manual test:
 hipfft_params manual_params;
 
-// Host memory limitation for tests (GiB):
-size_t ramgb;
-
-// Device memory limitation for tests (GiB):
-size_t vramgb;
-
 // Allow skipping tests if there is a runtime error
 bool skip_runtime_fails;
 // But count the number of failures
@@ -303,6 +297,10 @@ void precompile_test_kernels(const std::string& precompile_file)
 
 int main(int argc, char* argv[])
 {
+    // Unless specified otherwise by the user, no limit on host/device memory usage
+    // (see corresponding default values)
+    size_t ramgb_limit, vramgb_limit;
+
     CLI::App app{
         "\n"
         "hipFFT/hipFFTW Runtime Test command line options\n"
@@ -489,9 +487,11 @@ int main(int argc, char* argv[])
     const auto* opt_version = app.add_flag(
         "--version",
         "Print queryable version information from the hipfft library's backend (and return)");
-    app.add_option("--R", ramgb, "RAM limit in GiB for tests")
+    app.add_option("--R", ramgb_limit, "RAM limit in GiB for tests")
         ->default_val(system_memory::singleton().get_total_gbytes());
-    app.add_option("--V", vramgb, "VRAM limit in GiB for tests")->default_val(0);
+    app.add_option("--V", vramgb_limit, "VRAM limit in GiB for tests (per device)")
+        ->default_val(DivRoundingUp(
+            device_memory_accountant::singleton().get_max_total_mem_on_devices(), ONE_GiB));
     app.add_option("--half_epsilon", half_epsilon)->default_val(9.77e-4);
     app.add_option("--single_epsilon", single_epsilon)->default_val(3.75e-5);
     app.add_option("--double_epsilon", double_epsilon)->default_val(1e-15);
@@ -634,10 +634,19 @@ int main(int argc, char* argv[])
     fftwf_plan_with_nthreads(rocfft_concurrency());
 #endif
 
-    system_memory::singleton().set_limit_bytes(ramgb * ONE_GiB);
+    system_memory::singleton().set_limit_bytes(ramgb_limit * ONE_GiB);
     std::cout << "Refraining from using more than "
               << byte_size_to_str(system_memory::singleton().get_limit_bytes())
               << " of system memory." << std::endl;
+    device_memory_accountant::singleton().set_limit_bytes_for_all_devices(vramgb_limit * ONE_GiB);
+    std::cout << "Refraining from using more than" << std::endl;
+    for(size_t dev_id = 0; dev_id < device_memory_accountant::singleton().num_devices(); dev_id++)
+    {
+        std::cout << "\t"
+                  << byte_size_to_str(
+                         device_memory_accountant::singleton().get_limit_bytes_on_device(dev_id))
+                  << " of device memory for device ID " << dev_id << std::endl;
+    }
 
     if(use_fftw_wisdom)
     {

--- a/projects/hipfft/clients/tests/hipfft_accuracy_test.cpp
+++ b/projects/hipfft/clients/tests/hipfft_accuracy_test.cpp
@@ -159,6 +159,10 @@ TEST_P(accuracy_test, vs_fftw)
             last_cpu_fft_data = last_cpu_fft_cache();
             GTEST_SKIP() << e.what();
         }
+        catch(const DEVICEBUF_MEM_USAGE& e)
+        {
+            GTEST_SKIP() << e.what();
+        }
         catch(const ROCFFT_SKIP& e)
         {
             GTEST_SKIP() << e.what();

--- a/projects/hipfft/clients/tests/hipfftw_test.cpp
+++ b/projects/hipfft/clients/tests/hipfftw_test.cpp
@@ -57,24 +57,18 @@ namespace
     size_t max_byte_size_for_hipfftw_tests()
     {
         auto get_io_byte_size_limit = []() {
-            size_t tmp = vramgb * ONE_GiB;
-            if(tmp == 0)
+            size_t tmp = system_memory::singleton().get_limit_bytes();
+            for(size_t dev_id = 0; dev_id < device_memory_accountant::singleton().num_devices();
+                dev_id++)
             {
-                size_t free = 0, total = 0;
-                if(hipMemGetInfo(&free, &total) == hipSuccess)
-                    tmp = total / 8;
+                tmp = std::min(
+                    tmp, device_memory_accountant::singleton().get_limit_bytes_on_device(dev_id));
             }
-            tmp = std::min(tmp, ramgb * ONE_GiB);
             tmp = std::min(tmp, max_io_gb_for_hipfftw_test * ONE_GiB);
             if(verbose > 0)
             {
-                std::cout << "Limit for the size of I/O data used in hipfftw tests: ";
-                if(tmp >= ONE_GiB)
-                    std::cout << float(tmp) / ONE_GiB << " GiB." << std ::endl;
-                else if(tmp >= ONE_MiB)
-                    std::cout << float(tmp) / ONE_MiB << " MiB." << std ::endl;
-                else
-                    std::cout << float(tmp) / ONE_KiB << " KiB." << std ::endl;
+                std::cout << "Limit for the size of I/O data used in hipfftw tests: "
+                          << byte_size_to_str(tmp) << std ::endl;
             }
             return tmp;
         };

--- a/projects/hipfft/clients/tests/hipfftw_test.cpp
+++ b/projects/hipfft/clients/tests/hipfftw_test.cpp
@@ -1987,6 +1987,10 @@ namespace
             {
                 GTEST_SKIP() << e.what();
             }
+            catch(const DEVICEBUF_MEM_USAGE& e)
+            {
+                GTEST_SKIP() << e.what();
+            }
             catch(const std::bad_alloc&)
             {
                 GTEST_SKIP() << "host memory allocation failure";
@@ -2740,6 +2744,10 @@ namespace
                     GTEST_FAIL() << e.what() << "\nError code: " << e.hip_error << ".";
             }
             catch(const HOSTBUF_MEM_USAGE& e)
+            {
+                GTEST_SKIP() << e.what();
+            }
+            catch(const DEVICEBUF_MEM_USAGE& e)
             {
                 GTEST_SKIP() << e.what();
             }

--- a/projects/hipfft/clients/tests/multi_stream_test.cpp
+++ b/projects/hipfft/clients/tests/multi_stream_test.cpp
@@ -627,6 +627,10 @@ TEST_P(multiStreamTest, impulseSignalOnOutput)
     {
         GTEST_SKIP() << e.what();
     }
+    catch(const DEVICEBUF_MEM_USAGE& e)
+    {
+        GTEST_SKIP() << e.what();
+    }
 
     std::vector<size_t> expected_harmonic(parameters.dim());
     for(size_t i = 0; i < parameters.dim(); i++)

--- a/projects/hipfft/shared/accuracy_test.h
+++ b/projects/hipfft/shared/accuracy_test.h
@@ -116,7 +116,7 @@ inline void check_problem_fits_device_memory(Tparams& params, const int verbose)
         }
         std::stringstream ss;
         ss << "Problem size (" << byte_size_to_str(vram_footprint)
-           << " GiB) exceeds usable memory on device (" << byte_size_to_str(vram_avail) << ")";
+           << ") exceeds usable memory on device (" << byte_size_to_str(vram_avail) << ")";
         throw ROCFFT_SKIP{ss.str()};
     }
 }
@@ -718,14 +718,14 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
             std::stringstream ss;
             if(hip_status == hipErrorOutOfMemory)
             {
-                ss << "Input buffer size (" << bytes_to_GiB(ibuffer_sizes[i])
-                   << " GiB) raw data too large for device";
+                ss << "Input buffer size (" << byte_size_to_str(ibuffer_sizes[i])
+                   << ") raw data too large for device";
             }
             else
             {
                 ss << "hipMalloc failure for input buffer " << i << " size " << ibuffer_sizes[i]
-                   << "(" << bytes_to_GiB(ibuffer_sizes[i]) << " GiB)"
-                   << " with code " << hipError_to_string(hip_status);
+                   << "(" << byte_size_to_str(ibuffer_sizes[i]) << ") with code "
+                   << hipError_to_string(hip_status);
             }
             ++n_hip_failures;
             if(skip_runtime_fails)
@@ -1126,8 +1126,8 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
                 ++n_hip_failures;
                 std::stringstream ss;
                 ss << "hipMalloc failure for output buffer " << i << " size " << obuffer_sizes[i]
-                   << "(" << bytes_to_GiB(obuffer_sizes[i]) << " GiB)"
-                   << " with code " << hipError_to_string(hip_status);
+                   << "(" << byte_size_to_str(obuffer_sizes[i]) << ") with code "
+                   << hipError_to_string(hip_status);
                 if(skip_runtime_fails)
                 {
                     throw ROCFFT_SKIP{ss.str()};

--- a/projects/hipfft/shared/accuracy_test.h
+++ b/projects/hipfft/shared/accuracy_test.h
@@ -94,8 +94,8 @@ inline void check_problem_fits_device_memory(Tparams& params, const int verbose)
     if(!vram_fits_problem(raw_vram_footprint, vram_avail))
     {
         std::stringstream ss;
-        ss << "Raw problem size (" << bytes_to_GiB(raw_vram_footprint)
-           << " GiB) raw data too large for device";
+        ss << "Raw problem size (" << byte_size_to_str(raw_vram_footprint)
+           << ") exceeds usable memory on device (" << byte_size_to_str(vram_avail) << ")";
         throw ROCFFT_SKIP{ss.str()};
     }
 
@@ -115,8 +115,8 @@ inline void check_problem_fits_device_memory(Tparams& params, const int verbose)
             std::cout << "Problem raw data won't fit on device; skipped." << std::endl;
         }
         std::stringstream ss;
-        ss << "Problem size (" << bytes_to_GiB(vram_footprint)
-           << " GiB) raw data too large for device";
+        ss << "Problem size (" << byte_size_to_str(vram_footprint)
+           << " GiB) exceeds usable memory on device (" << byte_size_to_str(vram_avail) << ")";
         throw ROCFFT_SKIP{ss.str()};
     }
 }

--- a/projects/hipfft/shared/accuracy_test.h
+++ b/projects/hipfft/shared/accuracy_test.h
@@ -67,37 +67,24 @@ template <class Tparams>
 inline void check_problem_fits_device_memory(Tparams& params, const int verbose)
 {
 
-    size_t vram_avail = 0;
-
-    if(vramgb == 0)
+    int  dev_id     = hipInvalidDeviceId;
+    auto hip_status = hipGetDevice(&dev_id);
+    if(hip_status != hipSuccess || dev_id == hipInvalidDeviceId)
     {
-        // Check free and total available memory:
-        size_t free       = 0;
-        size_t total      = 0;
-        auto   hip_status = hipMemGetInfo(&free, &total);
-        if(hip_status != hipSuccess || total == 0)
+        ++n_hip_failures;
+        std::stringstream ss;
+        ss << "hipGetDevice failed with error code " << hip_status << " reporting device ID "
+           << dev_id;
+        if(skip_runtime_fails)
         {
-            ++n_hip_failures;
-            std::stringstream ss;
-            if(total == 0)
-                ss << "hipMemGetInfo claims there there isn't any vram";
-            else
-                ss << "hipMemGetInfo failure with error " << hip_status;
-            if(skip_runtime_fails)
-            {
-                throw ROCFFT_SKIP{ss.str()};
-            }
-            else
-            {
-                throw ROCFFT_FAIL{ss.str()};
-            }
+            throw ROCFFT_SKIP{ss.str()};
         }
-        vram_avail = total;
+        else
+        {
+            throw ROCFFT_FAIL{ss.str()};
+        }
     }
-    else
-    {
-        vram_avail = vramgb * ONE_GiB;
-    }
+    const auto vram_avail = device_memory_accountant::singleton().get_usable_bytes(dev_id);
 
     // First try a quick estimation of vram footprint, to speed up skipping tests
     // that are too large to fit in the gpu (no plan created with the rocFFT backend)

--- a/projects/hipfft/shared/gpubuf.h
+++ b/projects/hipfft/shared/gpubuf.h
@@ -80,16 +80,13 @@ public:
         if(dev_id < 0 || static_cast<size_t>(dev_id) >= num_devices())
             throw std::invalid_argument(
                 "Invalid device ID given to device memory accountant (observation).");
-        rocfft_scoped_device dev(dev_id);
-        update_free_bytes_on_valid_current_device(dev_id);
         std::shared_lock lock(dev_mem_account_mutex);
         const auto&      dev_account = mem_account_on_device[dev_id];
 
         if(dev_account.limit_bytes <= dev_account.used_bytes)
             return 0;
 
-        auto usable_bytes
-            = std::min(dev_account.limit_bytes - dev_account.used_bytes, dev_account.free_bytes);
+        auto usable_bytes = dev_account.limit_bytes - dev_account.used_bytes;
         if(dev_account.is_integrated_device)
             usable_bytes = std::min(usable_bytes, system_memory::singleton().get_usable_bytes());
         return usable_bytes;
@@ -113,10 +110,8 @@ public:
         std::shared_lock  lock(dev_mem_account_mutex);
         std::stringstream ss;
         ss << "\tUsable device memory: " << byte_size_to_str(usable_bytes) << "\n"
-           << "\tFree device memory: " << byte_size_to_str(dev_account.free_bytes) << "\n"
            << "\tUsed device memory: " << byte_size_to_str(dev_account.used_bytes) << "\n"
-           << "\tEnforced limit on device memory usage: "
-           << byte_size_to_str(dev_account.limit_bytes);
+           << "\tLimit on device memory usage: " << byte_size_to_str(dev_account.limit_bytes);
         if(dev_account.is_integrated_device)
         {
             constexpr bool use_double_tabs = true;
@@ -148,14 +143,12 @@ private:
     {
         mem_account_t(size_t total_dev_mem, bool integrated_device)
             : total_bytes(total_dev_mem)
-            , free_bytes(total_dev_mem)
             , limit_bytes(total_dev_mem)
             , used_bytes(0)
             , is_integrated_device(integrated_device)
         {
         }
         const size_t total_bytes;
-        size_t       free_bytes;
         size_t       limit_bytes;
         size_t       used_bytes;
         const bool   is_integrated_device;
@@ -181,22 +174,6 @@ private:
             rocfft_scoped_device dev(dev_id);
             const auto           dev_prop = get_curr_device_prop();
             mem_account_on_device.emplace_back(dev_prop.totalGlobalMem, dev_prop.integrated);
-            update_free_bytes_on_valid_current_device(dev_id);
-        }
-    }
-
-    // private function assuming dev_id is valid and is indeed the current device ID (hence the name)
-    void update_free_bytes_on_valid_current_device(int dev_id)
-    {
-        std::unique_lock lock(dev_mem_account_mutex);
-        size_t     placeholder; // hipMemGetInfo also returns total memory, we don't need it here
-        const auto hip_status
-            = hipMemGetInfo(&mem_account_on_device[dev_id].free_bytes, &placeholder);
-        if(hip_status != hipSuccess)
-        {
-            throw std::runtime_error("hipMemGetInfo failed with code " + std::to_string(hip_status)
-                                     + " while updating free device memory available on device ID "
-                                     + std::to_string(dev_id) + ".");
         }
     }
 };

--- a/projects/hipfft/shared/gpubuf.h
+++ b/projects/hipfft/shared/gpubuf.h
@@ -127,6 +127,22 @@ public:
         return ss.str();
     }
 
+    size_t get_max_total_mem_on_devices() const
+    {
+        size_t ret = 0;
+        for(const auto& account : mem_account_on_device)
+            ret = std::max(ret, account.total_bytes);
+        return ret;
+    }
+
+    size_t get_limit_bytes_on_device(int dev_id) const
+    {
+        if(dev_id < 0 || static_cast<size_t>(dev_id) >= num_devices())
+            throw std::invalid_argument("Invalid device ID given to device memory accountant "
+                                        "(querying limit bytes on device).");
+        return mem_account_on_device[dev_id].limit_bytes;
+    }
+
 private:
     struct mem_account_t
     {

--- a/projects/hipfft/shared/gpubuf.h
+++ b/projects/hipfft/shared/gpubuf.h
@@ -21,8 +21,169 @@
 #ifndef ROCFFT_GPUBUF_H
 #define ROCFFT_GPUBUF_H
 
+#include "device_properties.h"
 #include "rocfft_hip.h"
+#include "sys_mem.h"
 #include <cstdlib>
+#include <mutex>
+#include <shared_mutex>
+#include <sstream>
+#include <string>
+#include <vector>
+
+struct DEVICEBUF_MEM_USAGE : public std::runtime_error
+{
+    using std::runtime_error::runtime_error;
+};
+
+struct device_memory_accountant
+{
+public:
+    // acquire a reference to a singleton of this struct
+    static device_memory_accountant& singleton()
+    {
+        static device_memory_accountant instance;
+        return instance;
+    }
+
+    const size_t num_devices() const
+    {
+        return mem_account_on_device.size();
+    }
+
+    void record_used_bytes(size_t allocation_size, int dev_id)
+    {
+        if(dev_id < 0 || static_cast<size_t>(dev_id) >= num_devices())
+            throw std::invalid_argument(
+                "Invalid device ID given to device memory accountant (recording).");
+        std::unique_lock lock(dev_mem_account_mutex);
+        auto&            dev_account = mem_account_on_device[dev_id];
+        dev_account.used_bytes += allocation_size;
+        if(dev_account.is_integrated_device)
+            system_memory::singleton().record_used_bytes(allocation_size);
+    }
+
+    void release_used_bytes(size_t allocation_size, int dev_id)
+    {
+        if(dev_id < 0 || static_cast<size_t>(dev_id) >= num_devices())
+            throw std::invalid_argument(
+                "Invalid device ID given to device memory accountant (releasing).");
+        std::unique_lock lock(dev_mem_account_mutex);
+        auto&            dev_account = mem_account_on_device[dev_id];
+        // prevent underflows
+        dev_account.used_bytes -= std::min(dev_account.used_bytes, allocation_size);
+        if(dev_account.is_integrated_device)
+            system_memory::singleton().release_used_bytes(allocation_size);
+    }
+    size_t get_usable_bytes(int dev_id)
+    {
+        if(dev_id < 0 || static_cast<size_t>(dev_id) >= num_devices())
+            throw std::invalid_argument(
+                "Invalid device ID given to device memory accountant (observation).");
+        rocfft_scoped_device dev(dev_id);
+        update_free_bytes_on_valid_current_device(dev_id);
+        std::shared_lock lock(dev_mem_account_mutex);
+        const auto&      dev_account = mem_account_on_device[dev_id];
+
+        if(dev_account.limit_bytes <= dev_account.used_bytes)
+            return 0;
+
+        auto usable_bytes
+            = std::min(dev_account.limit_bytes - dev_account.used_bytes, dev_account.free_bytes);
+        if(dev_account.is_integrated_device)
+            usable_bytes = std::min(usable_bytes, system_memory::singleton().get_usable_bytes());
+        return usable_bytes;
+    }
+
+    void set_limit_bytes_for_all_devices(size_t limit_bytes)
+    {
+        std::unique_lock lock(dev_mem_account_mutex);
+        for(auto& account : mem_account_on_device)
+            account.limit_bytes = std::min(account.total_bytes, limit_bytes);
+    }
+
+    std::string get_details(int dev_id)
+    {
+        if(dev_id < 0 || static_cast<size_t>(dev_id) >= num_devices())
+            throw std::invalid_argument(
+                "Invalid device ID given to device memory accountant (detail query).");
+
+        const auto        usable_bytes = get_usable_bytes(dev_id);
+        const auto&       dev_account  = mem_account_on_device[dev_id];
+        std::shared_lock  lock(dev_mem_account_mutex);
+        std::stringstream ss;
+        ss << "\tUsable device memory: " << byte_size_to_str(usable_bytes) << "\n"
+           << "\tFree device memory: " << byte_size_to_str(dev_account.free_bytes) << "\n"
+           << "\tUsed device memory: " << byte_size_to_str(dev_account.used_bytes) << "\n"
+           << "\tEnforced limit on device memory usage: "
+           << byte_size_to_str(dev_account.limit_bytes);
+        if(dev_account.is_integrated_device)
+        {
+            constexpr bool use_double_tabs = true;
+            ss << "\n"
+               << "\tNOTE: integrated device, system memory details below:\n"
+               << system_memory::singleton().get_details(use_double_tabs);
+        }
+        return ss.str();
+    }
+
+private:
+    struct mem_account_t
+    {
+        mem_account_t(size_t total_dev_mem, bool integrated_device)
+            : total_bytes(total_dev_mem)
+            , free_bytes(total_dev_mem)
+            , limit_bytes(total_dev_mem)
+            , used_bytes(0)
+            , is_integrated_device(integrated_device)
+        {
+        }
+        const size_t total_bytes;
+        size_t       free_bytes;
+        size_t       limit_bytes;
+        size_t       used_bytes;
+        const bool   is_integrated_device;
+    };
+
+    std::vector<mem_account_t> mem_account_on_device;
+
+    mutable std::shared_mutex dev_mem_account_mutex;
+
+    device_memory_accountant()
+    {
+        int  dev_count  = 0;
+        auto hip_status = hipGetDeviceCount(&dev_count);
+        if(hip_status != hipSuccess || dev_count <= 0)
+        {
+            throw std::runtime_error("Device count failed with code " + std::to_string(hip_status)
+                                     + " in initialization of device memory account (dev_count = "
+                                     + std::to_string(dev_count) + ").");
+        }
+        mem_account_on_device.reserve(dev_count);
+        for(int dev_id = 0; dev_id < dev_count; dev_id++)
+        {
+            rocfft_scoped_device dev(dev_id);
+            const auto           dev_prop = get_curr_device_prop();
+            mem_account_on_device.emplace_back(dev_prop.totalGlobalMem, dev_prop.integrated);
+            update_free_bytes_on_valid_current_device(dev_id);
+        }
+    }
+
+    // private function assuming dev_id is valid and is indeed the current device ID (hence the name)
+    void update_free_bytes_on_valid_current_device(int dev_id)
+    {
+        std::unique_lock lock(dev_mem_account_mutex);
+        size_t     placeholder; // hipMemGetInfo also returns total memory, we don't need it here
+        const auto hip_status
+            = hipMemGetInfo(&mem_account_on_device[dev_id].free_bytes, &placeholder);
+        if(hip_status != hipSuccess)
+        {
+            throw std::runtime_error("hipMemGetInfo failed with code " + std::to_string(hip_status)
+                                     + " while updating free device memory available on device ID "
+                                     + std::to_string(dev_id) + ".");
+        }
+    }
+};
 
 // Simple RAII class for GPU buffers.  T is the type of pointer that
 // data() returns
@@ -74,21 +235,33 @@ public:
 
     hipError_t alloc(const size_t size, bool make_it_shared = false)
     {
+        free();
         // remember the device that was current as of alloc, so we can
         // free on the correct device
         auto ret = hipGetDevice(&device);
         if(ret != hipSuccess)
             return ret;
 
+        if(bsize > device_memory_accountant::singleton().get_usable_bytes(device))
+        {
+            std::stringstream msg;
+            msg << "Unauthorized device allocation (device ID: " << device << ").\n"
+                << "\tRequested size is " << byte_size_to_str(bsize) << "\n"
+                << device_memory_accountant::singleton().get_details(device);
+            throw DEVICEBUF_MEM_USAGE{msg.str()};
+        }
+
         bsize             = size;
         is_managed_memory = use_alloc_managed() || make_it_shared;
-        free();
         ret = is_managed_memory ? hipMallocManaged(&buf, bsize) : hipMalloc(&buf, bsize);
         if(ret != hipSuccess)
         {
             buf   = nullptr;
             bsize = 0;
         }
+
+        device_memory_accountant::singleton().record_used_bytes(bsize, device);
+
         return ret;
     }
 
@@ -106,6 +279,7 @@ public:
                 // free on the device we allocated on
                 rocfft_scoped_device dev(device);
                 (void)hipFree(buf);
+                device_memory_accountant::singleton().release_used_bytes(bsize, device);
             }
             buf   = nullptr;
             bsize = 0;

--- a/projects/hipfft/shared/gpubuf.h
+++ b/projects/hipfft/shared/gpubuf.h
@@ -235,11 +235,11 @@ public:
         if(ret != hipSuccess)
             return ret;
 
-        if(bsize > device_memory_accountant::singleton().get_usable_bytes(device))
+        if(size > device_memory_accountant::singleton().get_usable_bytes(device))
         {
             std::stringstream msg;
             msg << "Unauthorized device allocation (device ID: " << device << ").\n"
-                << "\tRequested size is " << byte_size_to_str(bsize) << "\n"
+                << "\tRequested size is " << byte_size_to_str(size) << "\n"
                 << device_memory_accountant::singleton().get_details(device);
             throw DEVICEBUF_MEM_USAGE{msg.str()};
         }

--- a/projects/hipfft/shared/hostbuf.h
+++ b/projects/hipfft/shared/hostbuf.h
@@ -23,10 +23,12 @@
 
 #include "arithmetic.h"
 #include "sys_mem.h"
-#include <atomic>
 #include <cstdlib>
 #include <cstring>
-#include <iostream>
+#include <hip/hip_runtime_api.h>
+#include <sstream>
+#include <stdexcept>
+
 #include <new>
 
 #ifndef _WIN32
@@ -87,18 +89,17 @@ public:
     {
         free();
 
-        bsize = size;
-
-        auto usable_mem = host_memory::singleton().get_usable_bytes();
-        if(total_used_mem + size > usable_mem)
+        if(size > system_memory::singleton().get_usable_bytes())
         {
             std::stringstream msg;
-            msg << "Host memory usage limit exceed (used mem: "
-                << bytes_to_GiB(total_used_mem + size)
-                << "GiB, free mem: " << bytes_to_GiB(usable_mem) << " GiB)";
+            auto&             sys_mem = system_memory::singleton();
+            msg << "Unauthorized host allocation.\n"
+                << "\tRequested size is " << byte_size_to_str(size) << "\n"
+                << sys_mem.get_details();
             throw HOSTBUF_MEM_USAGE{msg.str()};
         }
 
+        bsize = size;
         if(make_it_pinned)
         {
             if(hipHostMalloc(&buf, size) != hipSuccess)
@@ -142,7 +143,7 @@ public:
 
         is_pinned_memory = make_it_pinned;
         bsize_track      = size;
-        total_used_mem += bsize_track;
+        system_memory::singleton().record_used_bytes(bsize_track);
     }
 
     size_t size() const
@@ -161,7 +162,6 @@ public:
         {
             if(owned)
             {
-                total_used_mem -= bsize_track;
                 if(is_pinned_memory)
                 {
                     (void)hipHostFree(buf);
@@ -174,6 +174,8 @@ public:
                     std::free(buf);
 #endif
                 }
+
+                system_memory::singleton().release_used_bytes(bsize_track);
             }
             buf   = nullptr;
             bsize = bsize_track = 0;
@@ -238,9 +240,6 @@ private:
     // Buffer size for tracking total memory usage.
     // When buffer is shrunk in place, bsize_track is not changed.
     size_t bsize_track = 0;
-
-    // Keeps track of total used memory for all hostbufs
-    inline static std::atomic<size_t> total_used_mem = 0;
 };
 
 // default hostbuf that gives out void* pointers

--- a/projects/hipfft/shared/rocfft_params.h
+++ b/projects/hipfft/shared/rocfft_params.h
@@ -322,18 +322,8 @@ public:
             if(hip_status != hipSuccess)
             {
                 std::ostringstream oss;
-                oss << "work buffer allocation failed (" << workbuffersize << " requested)";
-                size_t mem_free  = 0;
-                size_t mem_total = 0;
-                hip_status       = hipMemGetInfo(&mem_free, &mem_total);
-                if(hip_status == hipSuccess)
-                {
-                    oss << "free vram: " << mem_free << " total vram: " << mem_total;
-                }
-                else
-                {
-                    oss << "hipMemGetInfo also failed";
-                }
+                oss << "work buffer allocation failed (" << byte_size_to_str(workbuffersize)
+                    << " requested)";
                 throw work_buffer_alloc_failure(oss.str(), workbuffersize);
             }
 

--- a/projects/hipfft/shared/sys_mem.h
+++ b/projects/hipfft/shared/sys_mem.h
@@ -25,8 +25,10 @@
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
-
-#include "device_properties.h"
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -43,19 +45,47 @@ inline size_t bytes_to_GiB(const size_t bytes)
     return bytes == 0 ? 0 : (bytes - 1 + ONE_GiB) / ONE_GiB;
 }
 
-struct host_memory
+// returns a string reporting a byte size in a readable format,
+// rounding it up to the nearest KiB (MiB if `byte_sz` exceeds 1 GiB)
+static std::string byte_size_to_str(size_t byte_sz)
+{
+    if(byte_sz == 0)
+        return "0 B";
+    std::string                          ret;
+    const std::pair<size_t, std::string> mem_units[]
+        = {{ONE_GiB, "GiB"}, {ONE_MiB, "MiB"}, {ONE_KiB, "KiB"}};
+    for(const auto& u : mem_units)
+    {
+        auto tmp = byte_sz / u.first;
+        byte_sz -= tmp * u.first;
+        if(byte_sz > 0 && (u.first == ONE_KiB || !ret.empty()))
+        {
+            // round up to nearest relevant unit and finish
+            tmp++;
+            byte_sz = 0;
+        }
+        if(tmp > 0)
+        {
+            if(!ret.empty())
+                ret += " ";
+            ret += std::to_string(tmp) + " " + u.second;
+        }
+    }
+    return ret;
+}
+
+struct system_memory
 {
 public:
     // acquire a reference to a singleton of this struct
-    static host_memory& singleton()
+    static system_memory& singleton()
     {
-        static host_memory mem;
+        static system_memory mem;
         return mem;
     }
 
     size_t get_total_bytes() const
     {
-        std::shared_lock lock(host_memory_mutex);
         return total_bytes;
     }
 
@@ -66,11 +96,10 @@ public:
 
     void set_limit_bytes(size_t limit_bytes_)
     {
-        std::unique_lock lock(host_memory_mutex);
+        std::unique_lock lock(sys_memory_mutex);
         // Don't let limit use the total available memory, leave at
         // least a 1GiB buffer, otherwise process may get OOM killed.
-        limit_bytes
-            = limit_bytes_ > (total_bytes - ONE_GiB) ? (total_bytes - ONE_GiB) : limit_bytes_;
+        limit_bytes = std::min(limit_bytes_, total_bytes >= ONE_GiB ? total_bytes - ONE_GiB : 0);
     }
 
     void set_limit_gbytes(size_t limit_gbytes_)
@@ -80,17 +109,20 @@ public:
 
     size_t get_usable_bytes()
     {
-        update();
+        update_free_bytes();
 
         // Limit the amount of usable memory. If we are too aggressive
         // with host memory usage, the host process may get OOM killed
         // on systems with little or no swap space.
-        std::shared_lock lock(host_memory_mutex);
+        std::shared_lock lock(sys_memory_mutex);
+        return std::min(free_bytes < ONE_GiB ? 0 : free_bytes,
+                        used_bytes < limit_bytes ? limit_bytes - used_bytes : 0);
+    }
 
-        auto usable_bytes = free_bytes < ONE_GiB ? 0 : free_bytes;
-        usable_bytes      = usable_bytes > limit_bytes ? limit_bytes : usable_bytes;
-
-        return usable_bytes;
+    size_t get_limit_bytes() const
+    {
+        std::shared_lock lock(sys_memory_mutex);
+        return limit_bytes;
     }
 
     size_t get_usable_gbytes()
@@ -98,39 +130,75 @@ public:
         return bytes_to_GiB(get_usable_bytes());
     }
 
-private:
-    size_t total_bytes = 0;
-    size_t free_bytes  = 0;
-    size_t limit_bytes = 0;
-
-    mutable std::shared_mutex host_memory_mutex;
-
-    host_memory()
+    void record_used_bytes(size_t allocation_size)
     {
-        // Note: passing (reading) a member variable as argument to a member routine that
-        // requires a unique lock. This constructor is only possibly invoked at initialization
-        // of the local static variable in the "singleton" public member function though, and
-        // that initialization is guaranteed to be thread-safe in C++11.
-        update();
-        set_limit_bytes(total_bytes);
+        std::unique_lock lock(sys_memory_mutex);
+        used_bytes += allocation_size;
+    }
+    void release_used_bytes(size_t allocation_size)
+    {
+        std::unique_lock lock(sys_memory_mutex);
+        // prevent underflows
+        used_bytes -= std::min(allocation_size, used_bytes);
     }
 
-    void update()
+    std::string get_details(bool double_tab = false)
     {
-        std::unique_lock lock(host_memory_mutex);
+        const auto        usable_bytes = get_usable_bytes();
+        std::shared_lock  lock(sys_memory_mutex);
+        std::stringstream ss;
+        const auto        incr = (double_tab ? "\t\t" : "\t");
+        ss << incr << "Usable system memory: " << byte_size_to_str(usable_bytes) << "\n"
+           << incr << "Free system memory: " << byte_size_to_str(free_bytes) << "\n"
+           << incr << "Used system memory: " << byte_size_to_str(used_bytes) << "\n"
+           << incr << "Enforced limit on memory usage: " << byte_size_to_str(limit_bytes);
+        return ss.str();
+    }
+
+private:
+    const size_t total_bytes;
+    size_t       free_bytes;
+    size_t       limit_bytes;
+    size_t       used_bytes;
+
+    mutable std::shared_mutex sys_memory_mutex;
+
+    system_memory()
+        : total_bytes(read_sys_mem<sys_mem_label::TOTAL>())
+        , free_bytes(read_sys_mem<sys_mem_label::FREE>())
+        , limit_bytes(total_bytes)
+        , used_bytes(0)
+    {
+    }
+
+    void update_free_bytes()
+    {
+        std::unique_lock lock(sys_memory_mutex);
+        free_bytes = read_sys_mem<sys_mem_label::FREE>();
+    }
+
+    enum class sys_mem_label
+    {
+        TOTAL,
+        FREE
+    };
+
+    template <sys_mem_label mem_label>
+    static size_t read_sys_mem()
+    {
+        static_assert(mem_label == sys_mem_label::TOTAL || mem_label == sys_mem_label::FREE);
+        size_t ret = 0;
 #ifdef _WIN32
         MEMORYSTATUSEX info;
         info.dwLength = sizeof(info);
         if(!GlobalMemoryStatusEx(&info))
-            return;
-        total_bytes = info.ullTotalPhys;
-        free_bytes  = info.ullAvailPhys;
+            return ret;
+        if constexpr(mem_label == sys_mem_label::TOTAL)
+            ret = info.ullTotalPhys;
+        else
+            ret = info.ullAvailPhys;
 #else
-
-        // /proc/meminfo can tell us "available" memory (i.e. free +
-        // buffers + cache)
-        total_bytes = 0;
-        free_bytes  = 0;
+        // Read from /proc/meminfo if possible
         try
         {
             std::ifstream proc_meminfo("/proc/meminfo");
@@ -138,11 +206,17 @@ private:
             while(std::getline(proc_meminfo, proc_line))
             {
                 // meminfo counts in KiB
-                if(proc_line.compare(0, 9, "MemTotal:") == 0)
-                    total_bytes = std::stoull(proc_line.substr(9)) * 1024;
-                else if(proc_line.compare(0, 13, "MemAvailable:") == 0)
-                    free_bytes = std::stoull(proc_line.substr(13)) * 1024;
-                if(total_bytes && free_bytes)
+                if constexpr(mem_label == sys_mem_label::TOTAL)
+                {
+                    if(proc_line.compare(0, 9, "MemTotal:") == 0)
+                        ret = std::stoull(proc_line.substr(9)) * 1024;
+                }
+                else
+                {
+                    if(proc_line.compare(0, 13, "MemAvailable:") == 0)
+                        ret = std::stoull(proc_line.substr(13)) * 1024;
+                }
+                if(ret)
                     break;
             }
         }
@@ -151,67 +225,46 @@ private:
             // If there was a problem, we'll fall back to sysinfo
         }
 
-        if(total_bytes == 0)
+        if(ret == 0)
         {
             // Either something couldn't be parsed or proc is not
             // mounted.  Fall back to sysinfo which can tell total +
             // free, but not "available".
             struct sysinfo info;
             if(sysinfo(&info) != 0)
-                return;
-            total_bytes = info.totalram * info.mem_unit;
-            free_bytes  = (info.freeram + info.bufferram) * info.mem_unit;
-        }
-
-        // Adjust memory numbers for APU
-        try
-        {
-            auto deviceProp = get_curr_device_prop();
-            // on integrated APU, we can't expect to reuse "device" memory
-            // for "host" things.
-            if(deviceProp.integrated)
-            {
-                const auto dedicated_for_device_allocs
-                    = std::min(deviceProp.totalGlobalMem, std::min(free_bytes, total_bytes) / 2);
-                total_bytes -= dedicated_for_device_allocs;
-                free_bytes -= dedicated_for_device_allocs;
-            }
-        }
-        catch(std::runtime_error&)
-        {
-            // assume we're not on APU, can use full host memory
+                return ret;
+            if constexpr(mem_label == sys_mem_label::TOTAL)
+                ret = info.totalram * info.mem_unit;
+            else
+                ret = (info.freeram + info.bufferram) * info.mem_unit;
         }
 
         // top-level memory cgroup may restrict this further
-
-        // check cgroup v1
-        std::ifstream memcg1_limit_file("/sys/fs/cgroup/memory/memory.limit_in_bytes");
-        std::ifstream memcg1_usage_file("/sys/fs/cgroup/memory/memory.usage_in_bytes");
-        size_t        memcg1_limit_bytes;
-        size_t        memcg1_usage_bytes;
-        // use cgroupv1 limit if we can read the cgroup files and it's
-        // smaller
-        if((memcg1_limit_file >> memcg1_limit_bytes) && (memcg1_usage_file >> memcg1_usage_bytes)
-           && memcg1_limit_bytes < total_bytes)
+        const std::pair<std::string, std::string> memcg1_paths
+            = {"/sys/fs/cgroup/memory/memory.limit_in_bytes",
+               "/sys/fs/cgroup/memory/memory.usage_in_bytes"};
+        const std::pair<std::string, std::string> memcg2_paths
+            = {"/sys/fs/cgroup/memory.max", "/sys/fs/cgroup/memory.current"};
+        for(const auto& memcg_paths : {memcg1_paths, memcg2_paths})
         {
-            total_bytes = memcg1_limit_bytes;
-            free_bytes  = total_bytes - memcg1_usage_bytes;
-        }
-
-        // check cgroup v2
-        std::ifstream memcg2_max_file("/sys/fs/cgroup/memory.max");
-        std::ifstream memcg2_current_file("/sys/fs/cgroup/memory.current");
-        size_t        memcg2_max_bytes;
-        size_t        memcg2_current_bytes;
-        // use cgroupv2 limit if we can read the cgroup files and it's
-        // smaller
-        if((memcg2_max_file >> memcg2_max_bytes) && (memcg2_current_file >> memcg2_current_bytes)
-           && memcg2_max_bytes < total_bytes)
-        {
-            total_bytes = memcg2_max_bytes;
-            free_bytes  = total_bytes - memcg2_current_bytes;
+            std::ifstream memcg_limit_file(memcg_paths.first.c_str());
+            std::ifstream memcg_usage_file(memcg_paths.second.c_str());
+            size_t        memcg_limit_bytes;
+            size_t        memcg_usage_bytes;
+            // use cgroup limit if we can read the cgroup files and it's smaller
+            if((memcg_limit_file >> memcg_limit_bytes) && (memcg_usage_file >> memcg_usage_bytes))
+            {
+                if constexpr(mem_label == sys_mem_label::TOTAL)
+                    ret = std::min(ret, memcg_limit_bytes);
+                else
+                    ret = std::min(ret,
+                                   memcg_usage_bytes <= memcg_limit_bytes
+                                       ? memcg_limit_bytes - memcg_usage_bytes
+                                       : 0);
+            }
         }
 #endif
+        return ret;
     }
 };
 

--- a/projects/hipfft/shared/test_params.h
+++ b/projects/hipfft/shared/test_params.h
@@ -24,10 +24,8 @@
 
 #include <stdexcept>
 
-extern int    verbose;
-extern size_t ramgb;
-extern size_t vramgb;
-extern int    ngpus;
+extern int verbose;
+extern int ngpus;
 
 extern size_t n_random_tests;
 

--- a/projects/rocfft/clients/tests/bitwise_repro/bitwise_repro_test.cpp
+++ b/projects/rocfft/clients/tests/bitwise_repro/bitwise_repro_test.cpp
@@ -61,7 +61,11 @@ TEST(bitwise_repro_test, compare_precisions)
     {
         GTEST_SKIP() << "host memory allocation failure";
     }
-    catch(HOSTBUF_MEM_USAGE& e)
+    catch(const HOSTBUF_MEM_USAGE& e)
+    {
+        GTEST_SKIP() << e.what();
+    }
+    catch(const DEVICEBUF_MEM_USAGE& e)
     {
         GTEST_SKIP() << e.what();
     }
@@ -106,7 +110,11 @@ TEST(bitwise_repro_test, compare_lengths)
     {
         GTEST_SKIP() << "host memory allocation failure";
     }
-    catch(HOSTBUF_MEM_USAGE& e)
+    catch(const HOSTBUF_MEM_USAGE& e)
+    {
+        GTEST_SKIP() << e.what();
+    }
+    catch(const DEVICEBUF_MEM_USAGE& e)
     {
         GTEST_SKIP() << e.what();
     }
@@ -151,7 +159,11 @@ TEST(bitwise_repro_test, compare_transform_types)
     {
         GTEST_SKIP() << "host memory allocation failure";
     }
-    catch(HOSTBUF_MEM_USAGE& e)
+    catch(const HOSTBUF_MEM_USAGE& e)
+    {
+        GTEST_SKIP() << e.what();
+    }
+    catch(const DEVICEBUF_MEM_USAGE& e)
     {
         GTEST_SKIP() << e.what();
     }
@@ -199,7 +211,11 @@ TEST_P(bitwise_repro_test, compare_to_reference)
     {
         GTEST_SKIP() << "host memory allocation failure";
     }
-    catch(HOSTBUF_MEM_USAGE& e)
+    catch(const HOSTBUF_MEM_USAGE& e)
+    {
+        GTEST_SKIP() << e.what();
+    }
+    catch(const DEVICEBUF_MEM_USAGE& e)
     {
         GTEST_SKIP() << e.what();
     }

--- a/projects/rocfft/clients/tests/bitwise_repro/bitwise_repro_test.h
+++ b/projects/rocfft/clients/tests/bitwise_repro/bitwise_repro_test.h
@@ -143,8 +143,8 @@ void compute_fft_data(Tparams&              params,
         {
             std::stringstream msg;
             msg << "hipMalloc failure for input buffer " << i << " size " << ibuffer_sizes[i] << "("
-                << bytes_to_GiB(ibuffer_sizes[i]) << " GiB)"
-                << " with code " << hipError_to_string(hip_status);
+                << byte_size_to_str(ibuffer_sizes[i]) << ") with code "
+                << hipError_to_string(hip_status);
             ++n_hip_failures;
             if(skip_runtime_fails)
                 throw ROCFFT_SKIP{msg.str()};
@@ -235,8 +235,8 @@ void compute_fft_data(Tparams&              params,
                 ++n_hip_failures;
                 std::stringstream msg;
                 msg << "hipMalloc failure for output buffer " << i << " size " << obuffer_sizes[i]
-                    << "(" << bytes_to_GiB(obuffer_sizes[i]) << " GiB)"
-                    << " with code " << hipError_to_string(hip_status);
+                    << "(" << byte_size_to_str(obuffer_sizes[i]) << ") with code "
+                    << hipError_to_string(hip_status);
                 if(skip_runtime_fails)
                     throw ROCFFT_SKIP{msg.str()};
                 else

--- a/projects/rocfft/clients/tests/buffer_hash_test.cpp
+++ b/projects/rocfft/clients/tests/buffer_hash_test.cpp
@@ -370,7 +370,11 @@ TEST(rocfft_UnitTest, buffer_hashing_half)
     {
         run_test(params);
     }
-    catch(HOSTBUF_MEM_USAGE& e)
+    catch(const HOSTBUF_MEM_USAGE& e)
+    {
+        GTEST_SKIP() << e.what();
+    }
+    catch(const DEVICEBUF_MEM_USAGE& e)
     {
         GTEST_SKIP() << e.what();
     }
@@ -392,7 +396,11 @@ TEST(rocfft_UnitTest, buffer_hashing_single)
     {
         run_test(params);
     }
-    catch(HOSTBUF_MEM_USAGE& e)
+    catch(const HOSTBUF_MEM_USAGE& e)
+    {
+        GTEST_SKIP() << e.what();
+    }
+    catch(const DEVICEBUF_MEM_USAGE& e)
     {
         GTEST_SKIP() << e.what();
     }
@@ -414,7 +422,11 @@ TEST(rocfft_UnitTest, buffer_hashing_double)
     {
         run_test(params);
     }
-    catch(HOSTBUF_MEM_USAGE& e)
+    catch(const HOSTBUF_MEM_USAGE& e)
+    {
+        GTEST_SKIP() << e.what();
+    }
+    catch(const DEVICEBUF_MEM_USAGE& e)
     {
         GTEST_SKIP() << e.what();
     }

--- a/projects/rocfft/clients/tests/callback_change_type.cpp
+++ b/projects/rocfft/clients/tests/callback_change_type.cpp
@@ -228,7 +228,11 @@ TEST_P(change_type, short_to_float)
     {
         GTEST_SKIP() << "host memory allocation failure";
     }
-    catch(HOSTBUF_MEM_USAGE& e)
+    catch(const HOSTBUF_MEM_USAGE& e)
+    {
+        GTEST_SKIP() << e.what();
+    }
+    catch(const DEVICEBUF_MEM_USAGE& e)
     {
         GTEST_SKIP() << e.what();
     }

--- a/projects/rocfft/clients/tests/gtest_main.cpp
+++ b/projects/rocfft/clients/tests/gtest_main.cpp
@@ -652,14 +652,20 @@ int main(int argc, char* argv[])
               << byte_size_to_str(system_memory::singleton().get_limit_bytes())
               << " of system memory." << std::endl;
     device_memory_accountant::singleton().set_limit_bytes_for_all_devices(vramgb_limit * ONE_GiB);
-    std::cout << "Refraining from using more than" << std::endl;
+    std::cout << "Refraining from using more than ";
     for(size_t dev_id = 0; dev_id < device_memory_accountant::singleton().num_devices(); dev_id++)
     {
-        std::cout << "\t"
-                  << byte_size_to_str(
-                         device_memory_accountant::singleton().get_limit_bytes_on_device(dev_id))
-                  << " of device memory on device ID " << dev_id << std::endl;
+        if(device_memory_accountant::singleton().num_devices() > 1)
+            std::cout << "\n\t";
+        std::cout << byte_size_to_str(
+            device_memory_accountant::singleton().get_limit_bytes_on_device(dev_id))
+                  << " of device memory";
+        if(device_memory_accountant::singleton().num_devices() > 1)
+            std::cout << " on device ID " << dev_id;
+        std::cout << (dev_id == device_memory_accountant::singleton().num_devices() - 1 ? "."
+                                                                                        : ";");
     }
+    std::cout << std::endl;
 
     if(use_fftw_wisdom)
     {

--- a/projects/rocfft/clients/tests/gtest_main.cpp
+++ b/projects/rocfft/clients/tests/gtest_main.cpp
@@ -79,12 +79,6 @@ GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(bitwise_repro_test);
 // Transform parameters for manual test:
 fft_params manual_params;
 
-// Host memory limitation for tests (GiB):
-size_t ramgb;
-
-// Device memory limitation for tests (GiB):
-size_t vramgb;
-
 // Number of hip devices to use.
 int ngpus{};
 
@@ -304,6 +298,10 @@ int main(int argc, char* argv[])
     // we re-parse the arguments with gtest and CLI.
     std::string argv0 = argv[0];
 
+    // Unless specified otherwise by the user, no limit on host/device memory usage
+    // (see corresponding default values)
+    size_t ramgb_limit, vramgb_limit;
+
     CLI::App app{
         "\n"
         "rocFFT Runtime Test command line options\n"
@@ -395,13 +393,13 @@ int main(int argc, char* argv[])
             if(nidx(emulationtype) == nidx("smoke"))
             {
                 // 2GB vram limit, approx 1 minute GPU time with short tests.
-                vramgb         = 2;
+                vramgb_limit   = 2;
                 test_prob      = 0;
                 emulation_prob = 0.005;
             }
             if(nidx(emulationtype) == nidx("regression"))
             {
-                vramgb         = 16;
+                vramgb_limit   = 16;
                 emulation_prob = 1;
                 test_prob      = 0.01;
             }
@@ -533,9 +531,11 @@ int main(int argc, char* argv[])
     non_token->add_option("--ooffset", manual_params.ooffset, "Output offset");
     app.add_option("--isize", manual_params.isize, "Logical size of input buffer");
     app.add_option("--osize", manual_params.osize, "Logical size of output buffer");
-    app.add_option("--R", ramgb, "RAM limit in GiB for tests")
+    app.add_option("--R", ramgb_limit, "RAM limit in GiB for tests")
         ->default_val(system_memory::singleton().get_total_gbytes());
-    app.add_option("--V", vramgb, "VRAM limit in GiB for tests")->default_val(0);
+    app.add_option("--V", vramgb_limit, "VRAM limit in GiB for tests (per device)")
+        ->default_val(DivRoundingUp(
+            device_memory_accountant::singleton().get_max_total_mem_on_devices(), ONE_GiB));
     app.add_option("--half_epsilon", half_epsilon)->default_val(9.77e-4);
     app.add_option("--single_epsilon", single_epsilon)->default_val(3.75e-5);
     app.add_option("--double_epsilon", double_epsilon)->default_val(1e-15);
@@ -647,12 +647,18 @@ int main(int argc, char* argv[])
     fftwf_plan_with_nthreads(rocfft_concurrency());
 #endif
 
-    system_memory::singleton().set_limit_bytes(ramgb * ONE_GiB);
+    system_memory::singleton().set_limit_bytes(ramgb_limit * ONE_GiB);
     std::cout << "Refraining from using more than "
               << byte_size_to_str(system_memory::singleton().get_limit_bytes())
               << " of system memory." << std::endl;
-    if(vramgb > 0)
+    device_memory_accountant::singleton().set_limit_bytes_for_all_devices(vramgb_limit * ONE_GiB);
+    std::cout << "Refraining from using more than" << std::endl;
+    for(size_t dev_id = 0; dev_id < device_memory_accountant::singleton().num_devices(); dev_id++)
     {
+        std::cout << "\t"
+                  << byte_size_to_str(
+                         device_memory_accountant::singleton().get_limit_bytes_on_device(dev_id))
+                  << " of device memory on device ID " << dev_id << std::endl;
     }
 
     if(use_fftw_wisdom)

--- a/projects/rocfft/clients/tests/gtest_main.cpp
+++ b/projects/rocfft/clients/tests/gtest_main.cpp
@@ -534,7 +534,7 @@ int main(int argc, char* argv[])
     app.add_option("--isize", manual_params.isize, "Logical size of input buffer");
     app.add_option("--osize", manual_params.osize, "Logical size of output buffer");
     app.add_option("--R", ramgb, "RAM limit in GiB for tests")
-        ->default_val(host_memory::singleton().get_total_gbytes());
+        ->default_val(system_memory::singleton().get_total_gbytes());
     app.add_option("--V", vramgb, "VRAM limit in GiB for tests")->default_val(0);
     app.add_option("--half_epsilon", half_epsilon)->default_val(9.77e-4);
     app.add_option("--single_epsilon", single_epsilon)->default_val(3.75e-5);
@@ -647,12 +647,13 @@ int main(int argc, char* argv[])
     fftwf_plan_with_nthreads(rocfft_concurrency());
 #endif
 
-    // Set host memory limit from command-line options (if more restrictive)
-    const auto usable_bytes = host_memory::singleton().get_usable_bytes();
-    if(ramgb * ONE_GiB < usable_bytes)
-        host_memory::singleton().set_limit_gbytes(ramgb);
-    std::cout << "Usable host memory: " << bytes_to_GiB(host_memory::singleton().get_usable_bytes())
-              << " GiB" << std::endl;
+    system_memory::singleton().set_limit_bytes(ramgb * ONE_GiB);
+    std::cout << "Refraining from using more than "
+              << byte_size_to_str(system_memory::singleton().get_limit_bytes())
+              << " of system memory." << std::endl;
+    if(vramgb > 0)
+    {
+    }
 
     if(use_fftw_wisdom)
     {
@@ -827,10 +828,14 @@ TEST(manual, vs_fftw) // MANUAL TESTS HERE
     {
         GTEST_SKIP() << "host memory allocation failure";
     }
-    catch(HOSTBUF_MEM_USAGE& e)
+    catch(const HOSTBUF_MEM_USAGE& e)
     {
         // explicitly clear test cache
         last_cpu_fft_data = last_cpu_fft_cache();
+        GTEST_SKIP() << e.what();
+    }
+    catch(const DEVICEBUF_MEM_USAGE& e)
+    {
         GTEST_SKIP() << e.what();
     }
     catch(ROCFFT_SKIP& e)
@@ -880,6 +885,10 @@ TEST(manual, bitwise_reproducibility) // MANUAL TESTS HERE
         GTEST_FAIL() << e.what();
     }
     catch(const HOSTBUF_MEM_USAGE& e)
+    {
+        GTEST_SKIP() << e.what();
+    }
+    catch(const DEVICEBUF_MEM_USAGE& e)
     {
         GTEST_SKIP() << e.what();
     }

--- a/projects/rocfft/clients/tests/hermitian_test.cpp
+++ b/projects/rocfft/clients/tests/hermitian_test.cpp
@@ -485,9 +485,9 @@ TEST(rocfft_UnitTest, compare_cpu_gpu_symmetrizers)
                             ++n_hip_failures;
                             std::stringstream msg;
                             msg << "allocation failure for gpu buffer of " << i << " size "
-                                << p.ibuffer_sizes()[i] << "(" << bytes_to_GiB(p.ibuffer_sizes()[i])
-                                << " GiB)"
-                                << " with code " << hipError_to_string(hip_status);
+                                << p.ibuffer_sizes()[i] << "("
+                                << byte_size_to_str(p.ibuffer_sizes()[i]) << ") with code "
+                                << hipError_to_string(hip_status);
 
                             if(skip_runtime_fails)
                                 GTEST_SKIP() << msg.str();
@@ -517,9 +517,9 @@ TEST(rocfft_UnitTest, compare_cpu_gpu_symmetrizers)
                             ++n_hip_failures;
                             std::stringstream msg;
                             msg << "hipMemcpy failure for buffer of " << i << " size "
-                                << p.ibuffer_sizes()[i] << "(" << bytes_to_GiB(p.ibuffer_sizes()[i])
-                                << " GiB)"
-                                << " with code " << hipError_to_string(hip_status);
+                                << p.ibuffer_sizes()[i] << "("
+                                << byte_size_to_str(p.ibuffer_sizes()[i]) << ") with code "
+                                << hipError_to_string(hip_status);
 
                             if(skip_runtime_fails)
                                 GTEST_SKIP() << msg.str();

--- a/projects/rocfft/clients/tests/hermitian_test.cpp
+++ b/projects/rocfft/clients/tests/hermitian_test.cpp
@@ -199,6 +199,10 @@ TEST(rocfft_UnitTest, 1D_hermitian_single_small)
     {
         GTEST_SKIP() << e.what();
     }
+    catch(const DEVICEBUF_MEM_USAGE& e)
+    {
+        GTEST_SKIP() << e.what();
+    }
 }
 
 // test a case that's big enough that it needs multiple kernels
@@ -227,6 +231,10 @@ TEST(rocfft_UnitTest, 1D_hermitian_single_large)
         GTEST_FAIL() << e.what();
     }
     catch(const HOSTBUF_MEM_USAGE& e)
+    {
+        GTEST_SKIP() << e.what();
+    }
+    catch(const DEVICEBUF_MEM_USAGE& e)
     {
         GTEST_SKIP() << e.what();
     }
@@ -416,6 +424,10 @@ TEST(rocfft_UnitTest, gpu_symmetrizer)
     {
         GTEST_SKIP() << e.what();
     }
+    catch(const DEVICEBUF_MEM_USAGE& e)
+    {
+        GTEST_SKIP() << e.what();
+    }
 }
 
 // Test that the host and device Hermitian symmetrizers produce the same results.
@@ -553,6 +565,10 @@ TEST(rocfft_UnitTest, compare_cpu_gpu_symmetrizers)
         GTEST_FAIL() << e.what();
     }
     catch(const HOSTBUF_MEM_USAGE& e)
+    {
+        GTEST_SKIP() << e.what();
+    }
+    catch(const DEVICEBUF_MEM_USAGE& e)
     {
         GTEST_SKIP() << e.what();
     }

--- a/projects/rocfft/clients/tests/rocfft_accuracy_test.cpp
+++ b/projects/rocfft/clients/tests/rocfft_accuracy_test.cpp
@@ -129,6 +129,10 @@ TEST_P(accuracy_test, vs_fftw)
             last_cpu_fft_data = last_cpu_fft_cache();
             GTEST_SKIP() << e.what();
         }
+        catch(const DEVICEBUF_MEM_USAGE& e)
+        {
+            GTEST_SKIP() << e.what();
+        }
         catch(const ROCFFT_SKIP& e)
         {
             GTEST_SKIP() << e.what();

--- a/projects/rocfft/clients/tests/unit_test.cpp
+++ b/projects/rocfft/clients/tests/unit_test.cpp
@@ -128,6 +128,10 @@ TEST(rocfft_UnitTest, plan_description)
     {
         GTEST_SKIP() << e.what();
     }
+    catch(const DEVICEBUF_MEM_USAGE& e)
+    {
+        GTEST_SKIP() << e.what();
+    }
 }
 
 TEST(rocfft_UnitTest, plan_description_reuse)
@@ -240,6 +244,10 @@ TEST(rocfft_UnitTest, plan_description_reuse)
         GTEST_FAIL() << e.what();
     }
     catch(const HOSTBUF_MEM_USAGE& e)
+    {
+        GTEST_SKIP() << e.what();
+    }
+    catch(const DEVICEBUF_MEM_USAGE& e)
     {
         GTEST_SKIP() << e.what();
     }
@@ -357,6 +365,10 @@ TEST(rocfft_UnitTest, log_levels)
     {
         GTEST_SKIP() << e.what();
     }
+    catch(const DEVICEBUF_MEM_USAGE& e)
+    {
+        GTEST_SKIP() << e.what();
+    }
 }
 
 // Check whether logs can be emitted from multiple threads properly
@@ -436,6 +448,10 @@ TEST(rocfft_UnitTest, log_multithreading)
         GTEST_FAIL() << e.what();
     }
     catch(const HOSTBUF_MEM_USAGE& e)
+    {
+        GTEST_SKIP() << e.what();
+    }
+    catch(const DEVICEBUF_MEM_USAGE& e)
     {
         GTEST_SKIP() << e.what();
     }
@@ -539,6 +555,10 @@ TEST(rocfft_UnitTest, workmem_missing)
     {
         GTEST_SKIP() << e.what();
     }
+    catch(const DEVICEBUF_MEM_USAGE& e)
+    {
+        GTEST_SKIP() << e.what();
+    }
 }
 
 // check what happens if work memory is required but not enough is provided
@@ -568,6 +588,10 @@ TEST(rocfft_UnitTest, workmem_small)
         GTEST_FAIL() << e.what();
     }
     catch(const HOSTBUF_MEM_USAGE& e)
+    {
+        GTEST_SKIP() << e.what();
+    }
+    catch(const DEVICEBUF_MEM_USAGE& e)
     {
         GTEST_SKIP() << e.what();
     }
@@ -602,6 +626,10 @@ TEST(rocfft_UnitTest, workmem_big)
     {
         GTEST_SKIP() << e.what();
     }
+    catch(const DEVICEBUF_MEM_USAGE& e)
+    {
+        GTEST_SKIP() << e.what();
+    }
 }
 
 // check if a user explicitly gives a null pointer - set work buffer
@@ -632,6 +660,10 @@ TEST(rocfft_UnitTest, workmem_null)
         GTEST_FAIL() << e.what();
     }
     catch(const HOSTBUF_MEM_USAGE& e)
+    {
+        GTEST_SKIP() << e.what();
+    }
+    catch(const DEVICEBUF_MEM_USAGE& e)
     {
         GTEST_SKIP() << e.what();
     }
@@ -816,6 +848,10 @@ TEST(rocfft_UnitTest, rtc_cache_iter_1)
     {
         GTEST_SKIP() << e.what();
     }
+    catch(const DEVICEBUF_MEM_USAGE& e)
+    {
+        GTEST_SKIP() << e.what();
+    }
 }
 
 TEST(rocfft_UnitTest, rtc_cache_iter_2)
@@ -837,6 +873,10 @@ TEST(rocfft_UnitTest, rtc_cache_iter_2)
         GTEST_FAIL() << e.what();
     }
     catch(const HOSTBUF_MEM_USAGE& e)
+    {
+        GTEST_SKIP() << e.what();
+    }
+    catch(const DEVICEBUF_MEM_USAGE& e)
     {
         GTEST_SKIP() << e.what();
     }
@@ -874,6 +914,10 @@ TEST(rocfft_UnitTest, rtc_cache_null)
         GTEST_FAIL() << e.what();
     }
     catch(const HOSTBUF_MEM_USAGE& e)
+    {
+        GTEST_SKIP() << e.what();
+    }
+    catch(const DEVICEBUF_MEM_USAGE& e)
     {
         GTEST_SKIP() << e.what();
     }
@@ -965,6 +1009,10 @@ TEST(rocfft_UnitTest, rtc_helper_crash)
         GTEST_FAIL() << e.what();
     }
     catch(const HOSTBUF_MEM_USAGE& e)
+    {
+        GTEST_SKIP() << e.what();
+    }
+    catch(const DEVICEBUF_MEM_USAGE& e)
     {
         GTEST_SKIP() << e.what();
     }

--- a/projects/rocfft/library/src/CMakeLists.txt
+++ b/projects/rocfft/library/src/CMakeLists.txt
@@ -129,6 +129,7 @@ set( kgen_embed_files
      ${CMAKE_SOURCE_DIR}/library/src/device/generator/rtc_radix_functions/radix_17.h
 
      # extra files for generating standalone test harnesses for kernels
+     ${CMAKE_SOURCE_DIR}/shared/sys_mem.h
      ${CMAKE_SOURCE_DIR}/shared/device_properties.h
      ${CMAKE_SOURCE_DIR}/shared/rocfft_hip.h
      ${CMAKE_SOURCE_DIR}/shared/gpubuf.h

--- a/projects/rocfft/library/src/device/kernel-generator-embed.h
+++ b/projects/rocfft/library/src/device/kernel-generator-embed.h
@@ -48,6 +48,7 @@ extern const char* radix_13_h;
 extern const char* radix_16_h;
 extern const char* radix_17_h;
 
+extern const char* sys_mem_h;
 extern const char* device_properties_h;
 extern const char* rocfft_hip_h;
 extern const char* gpubuf_h;

--- a/projects/rocfft/library/src/rtc_test_harness.cpp
+++ b/projects/rocfft/library/src/rtc_test_harness.cpp
@@ -306,16 +306,27 @@ void write_standalone_test_harness(const Function& f, const std::string& src)
     main_file << "#include <functional>\n";
     main_file << "#include <future>\n";
     main_file << "#include <memory>\n";
+    main_file << "#include <mutex>\n";
     main_file << "#include <random>\n";
+    main_file << "#include <shared_mutex>\n";
+    main_file << "#include <sstream>\n";
+    main_file << "#include <stdexcept>\n";
     main_file << "#include <string>\n";
     main_file << "#include <vector>\n";
+    main_file << "#include <utility>\n";
+#ifdef _WIN32
+    main_file << "#include <windows.h>\n";
+#else
+    main_file << "#include <sys/sysinfo.h>\n";
+#endif
 
     main_file << "#define ROCFFT_DEBUG_GENERATE_KERNEL_HARNESS\n";
     main_file << rocfft_hip_h;
     main_file << rocfft_complex_h;
+    main_file << sys_mem_h;
+    main_file << device_properties_h;
     main_file << gpubuf_h;
     main_file << hip_object_wrapper_h;
-    main_file << device_properties_h;
     main_file << rtc_kernel_h;
     main_file << rtc_kernel_cpp;
     main_file << rtc_test_harness_helper_cpp;

--- a/projects/rocfft/shared/accuracy_test.h
+++ b/projects/rocfft/shared/accuracy_test.h
@@ -116,7 +116,7 @@ inline void check_problem_fits_device_memory(Tparams& params, const int verbose)
         }
         std::stringstream ss;
         ss << "Problem size (" << byte_size_to_str(vram_footprint)
-           << " GiB) exceeds usable memory on device (" << byte_size_to_str(vram_avail) << ")";
+           << ") exceeds usable memory on device (" << byte_size_to_str(vram_avail) << ")";
         throw ROCFFT_SKIP{ss.str()};
     }
 }
@@ -718,14 +718,14 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
             std::stringstream ss;
             if(hip_status == hipErrorOutOfMemory)
             {
-                ss << "Input buffer size (" << bytes_to_GiB(ibuffer_sizes[i])
-                   << " GiB) raw data too large for device";
+                ss << "Input buffer size (" << byte_size_to_str(ibuffer_sizes[i])
+                   << ") raw data too large for device";
             }
             else
             {
                 ss << "hipMalloc failure for input buffer " << i << " size " << ibuffer_sizes[i]
-                   << "(" << bytes_to_GiB(ibuffer_sizes[i]) << " GiB)"
-                   << " with code " << hipError_to_string(hip_status);
+                   << "(" << byte_size_to_str(ibuffer_sizes[i]) << ") with code "
+                   << hipError_to_string(hip_status);
             }
             ++n_hip_failures;
             if(skip_runtime_fails)
@@ -1126,8 +1126,8 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
                 ++n_hip_failures;
                 std::stringstream ss;
                 ss << "hipMalloc failure for output buffer " << i << " size " << obuffer_sizes[i]
-                   << "(" << bytes_to_GiB(obuffer_sizes[i]) << " GiB)"
-                   << " with code " << hipError_to_string(hip_status);
+                   << "(" << byte_size_to_str(obuffer_sizes[i]) << ") with code "
+                   << hipError_to_string(hip_status);
                 if(skip_runtime_fails)
                 {
                     throw ROCFFT_SKIP{ss.str()};

--- a/projects/rocfft/shared/accuracy_test.h
+++ b/projects/rocfft/shared/accuracy_test.h
@@ -94,8 +94,8 @@ inline void check_problem_fits_device_memory(Tparams& params, const int verbose)
     if(!vram_fits_problem(raw_vram_footprint, vram_avail))
     {
         std::stringstream ss;
-        ss << "Raw problem size (" << bytes_to_GiB(raw_vram_footprint)
-           << " GiB) raw data too large for device";
+        ss << "Raw problem size (" << byte_size_to_str(raw_vram_footprint)
+           << ") exceeds usable memory on device (" << byte_size_to_str(vram_avail) << ")";
         throw ROCFFT_SKIP{ss.str()};
     }
 
@@ -115,8 +115,8 @@ inline void check_problem_fits_device_memory(Tparams& params, const int verbose)
             std::cout << "Problem raw data won't fit on device; skipped." << std::endl;
         }
         std::stringstream ss;
-        ss << "Problem size (" << bytes_to_GiB(vram_footprint)
-           << " GiB) raw data too large for device";
+        ss << "Problem size (" << byte_size_to_str(vram_footprint)
+           << " GiB) exceeds usable memory on device (" << byte_size_to_str(vram_avail) << ")";
         throw ROCFFT_SKIP{ss.str()};
     }
 }

--- a/projects/rocfft/shared/accuracy_test.h
+++ b/projects/rocfft/shared/accuracy_test.h
@@ -67,37 +67,24 @@ template <class Tparams>
 inline void check_problem_fits_device_memory(Tparams& params, const int verbose)
 {
 
-    size_t vram_avail = 0;
-
-    if(vramgb == 0)
+    int  dev_id     = hipInvalidDeviceId;
+    auto hip_status = hipGetDevice(&dev_id);
+    if(hip_status != hipSuccess || dev_id == hipInvalidDeviceId)
     {
-        // Check free and total available memory:
-        size_t free       = 0;
-        size_t total      = 0;
-        auto   hip_status = hipMemGetInfo(&free, &total);
-        if(hip_status != hipSuccess || total == 0)
+        ++n_hip_failures;
+        std::stringstream ss;
+        ss << "hipGetDevice failed with error code " << hip_status << " reporting device ID "
+           << dev_id;
+        if(skip_runtime_fails)
         {
-            ++n_hip_failures;
-            std::stringstream ss;
-            if(total == 0)
-                ss << "hipMemGetInfo claims there there isn't any vram";
-            else
-                ss << "hipMemGetInfo failure with error " << hip_status;
-            if(skip_runtime_fails)
-            {
-                throw ROCFFT_SKIP{ss.str()};
-            }
-            else
-            {
-                throw ROCFFT_FAIL{ss.str()};
-            }
+            throw ROCFFT_SKIP{ss.str()};
         }
-        vram_avail = total;
+        else
+        {
+            throw ROCFFT_FAIL{ss.str()};
+        }
     }
-    else
-    {
-        vram_avail = vramgb * ONE_GiB;
-    }
+    const auto vram_avail = device_memory_accountant::singleton().get_usable_bytes(dev_id);
 
     // First try a quick estimation of vram footprint, to speed up skipping tests
     // that are too large to fit in the gpu (no plan created with the rocFFT backend)

--- a/projects/rocfft/shared/gpubuf.h
+++ b/projects/rocfft/shared/gpubuf.h
@@ -80,16 +80,13 @@ public:
         if(dev_id < 0 || static_cast<size_t>(dev_id) >= num_devices())
             throw std::invalid_argument(
                 "Invalid device ID given to device memory accountant (observation).");
-        rocfft_scoped_device dev(dev_id);
-        update_free_bytes_on_valid_current_device(dev_id);
         std::shared_lock lock(dev_mem_account_mutex);
         const auto&      dev_account = mem_account_on_device[dev_id];
 
         if(dev_account.limit_bytes <= dev_account.used_bytes)
             return 0;
 
-        auto usable_bytes
-            = std::min(dev_account.limit_bytes - dev_account.used_bytes, dev_account.free_bytes);
+        auto usable_bytes = dev_account.limit_bytes - dev_account.used_bytes;
         if(dev_account.is_integrated_device)
             usable_bytes = std::min(usable_bytes, system_memory::singleton().get_usable_bytes());
         return usable_bytes;
@@ -113,10 +110,8 @@ public:
         std::shared_lock  lock(dev_mem_account_mutex);
         std::stringstream ss;
         ss << "\tUsable device memory: " << byte_size_to_str(usable_bytes) << "\n"
-           << "\tFree device memory: " << byte_size_to_str(dev_account.free_bytes) << "\n"
            << "\tUsed device memory: " << byte_size_to_str(dev_account.used_bytes) << "\n"
-           << "\tEnforced limit on device memory usage: "
-           << byte_size_to_str(dev_account.limit_bytes);
+           << "\tLimit on device memory usage: " << byte_size_to_str(dev_account.limit_bytes);
         if(dev_account.is_integrated_device)
         {
             constexpr bool use_double_tabs = true;
@@ -148,14 +143,12 @@ private:
     {
         mem_account_t(size_t total_dev_mem, bool integrated_device)
             : total_bytes(total_dev_mem)
-            , free_bytes(total_dev_mem)
             , limit_bytes(total_dev_mem)
             , used_bytes(0)
             , is_integrated_device(integrated_device)
         {
         }
         const size_t total_bytes;
-        size_t       free_bytes;
         size_t       limit_bytes;
         size_t       used_bytes;
         const bool   is_integrated_device;
@@ -181,22 +174,6 @@ private:
             rocfft_scoped_device dev(dev_id);
             const auto           dev_prop = get_curr_device_prop();
             mem_account_on_device.emplace_back(dev_prop.totalGlobalMem, dev_prop.integrated);
-            update_free_bytes_on_valid_current_device(dev_id);
-        }
-    }
-
-    // private function assuming dev_id is valid and is indeed the current device ID (hence the name)
-    void update_free_bytes_on_valid_current_device(int dev_id)
-    {
-        std::unique_lock lock(dev_mem_account_mutex);
-        size_t     placeholder; // hipMemGetInfo also returns total memory, we don't need it here
-        const auto hip_status
-            = hipMemGetInfo(&mem_account_on_device[dev_id].free_bytes, &placeholder);
-        if(hip_status != hipSuccess)
-        {
-            throw std::runtime_error("hipMemGetInfo failed with code " + std::to_string(hip_status)
-                                     + " while updating free device memory available on device ID "
-                                     + std::to_string(dev_id) + ".");
         }
     }
 };

--- a/projects/rocfft/shared/gpubuf.h
+++ b/projects/rocfft/shared/gpubuf.h
@@ -127,6 +127,22 @@ public:
         return ss.str();
     }
 
+    size_t get_max_total_mem_on_devices() const
+    {
+        size_t ret = 0;
+        for(const auto& account : mem_account_on_device)
+            ret = std::max(ret, account.total_bytes);
+        return ret;
+    }
+
+    size_t get_limit_bytes_on_device(int dev_id) const
+    {
+        if(dev_id < 0 || static_cast<size_t>(dev_id) >= num_devices())
+            throw std::invalid_argument("Invalid device ID given to device memory accountant "
+                                        "(querying limit bytes on device).");
+        return mem_account_on_device[dev_id].limit_bytes;
+    }
+
 private:
     struct mem_account_t
     {

--- a/projects/rocfft/shared/gpubuf.h
+++ b/projects/rocfft/shared/gpubuf.h
@@ -21,8 +21,169 @@
 #ifndef ROCFFT_GPUBUF_H
 #define ROCFFT_GPUBUF_H
 
+#include "device_properties.h"
 #include "rocfft_hip.h"
+#include "sys_mem.h"
 #include <cstdlib>
+#include <mutex>
+#include <shared_mutex>
+#include <sstream>
+#include <string>
+#include <vector>
+
+struct DEVICEBUF_MEM_USAGE : public std::runtime_error
+{
+    using std::runtime_error::runtime_error;
+};
+
+struct device_memory_accountant
+{
+public:
+    // acquire a reference to a singleton of this struct
+    static device_memory_accountant& singleton()
+    {
+        static device_memory_accountant instance;
+        return instance;
+    }
+
+    const size_t num_devices() const
+    {
+        return mem_account_on_device.size();
+    }
+
+    void record_used_bytes(size_t allocation_size, int dev_id)
+    {
+        if(dev_id < 0 || static_cast<size_t>(dev_id) >= num_devices())
+            throw std::invalid_argument(
+                "Invalid device ID given to device memory accountant (recording).");
+        std::unique_lock lock(dev_mem_account_mutex);
+        auto&            dev_account = mem_account_on_device[dev_id];
+        dev_account.used_bytes += allocation_size;
+        if(dev_account.is_integrated_device)
+            system_memory::singleton().record_used_bytes(allocation_size);
+    }
+
+    void release_used_bytes(size_t allocation_size, int dev_id)
+    {
+        if(dev_id < 0 || static_cast<size_t>(dev_id) >= num_devices())
+            throw std::invalid_argument(
+                "Invalid device ID given to device memory accountant (releasing).");
+        std::unique_lock lock(dev_mem_account_mutex);
+        auto&            dev_account = mem_account_on_device[dev_id];
+        // prevent underflows
+        dev_account.used_bytes -= std::min(dev_account.used_bytes, allocation_size);
+        if(dev_account.is_integrated_device)
+            system_memory::singleton().release_used_bytes(allocation_size);
+    }
+    size_t get_usable_bytes(int dev_id)
+    {
+        if(dev_id < 0 || static_cast<size_t>(dev_id) >= num_devices())
+            throw std::invalid_argument(
+                "Invalid device ID given to device memory accountant (observation).");
+        rocfft_scoped_device dev(dev_id);
+        update_free_bytes_on_valid_current_device(dev_id);
+        std::shared_lock lock(dev_mem_account_mutex);
+        const auto&      dev_account = mem_account_on_device[dev_id];
+
+        if(dev_account.limit_bytes <= dev_account.used_bytes)
+            return 0;
+
+        auto usable_bytes
+            = std::min(dev_account.limit_bytes - dev_account.used_bytes, dev_account.free_bytes);
+        if(dev_account.is_integrated_device)
+            usable_bytes = std::min(usable_bytes, system_memory::singleton().get_usable_bytes());
+        return usable_bytes;
+    }
+
+    void set_limit_bytes_for_all_devices(size_t limit_bytes)
+    {
+        std::unique_lock lock(dev_mem_account_mutex);
+        for(auto& account : mem_account_on_device)
+            account.limit_bytes = std::min(account.total_bytes, limit_bytes);
+    }
+
+    std::string get_details(int dev_id)
+    {
+        if(dev_id < 0 || static_cast<size_t>(dev_id) >= num_devices())
+            throw std::invalid_argument(
+                "Invalid device ID given to device memory accountant (detail query).");
+
+        const auto        usable_bytes = get_usable_bytes(dev_id);
+        const auto&       dev_account  = mem_account_on_device[dev_id];
+        std::shared_lock  lock(dev_mem_account_mutex);
+        std::stringstream ss;
+        ss << "\tUsable device memory: " << byte_size_to_str(usable_bytes) << "\n"
+           << "\tFree device memory: " << byte_size_to_str(dev_account.free_bytes) << "\n"
+           << "\tUsed device memory: " << byte_size_to_str(dev_account.used_bytes) << "\n"
+           << "\tEnforced limit on device memory usage: "
+           << byte_size_to_str(dev_account.limit_bytes);
+        if(dev_account.is_integrated_device)
+        {
+            constexpr bool use_double_tabs = true;
+            ss << "\n"
+               << "\tNOTE: integrated device, system memory details below:\n"
+               << system_memory::singleton().get_details(use_double_tabs);
+        }
+        return ss.str();
+    }
+
+private:
+    struct mem_account_t
+    {
+        mem_account_t(size_t total_dev_mem, bool integrated_device)
+            : total_bytes(total_dev_mem)
+            , free_bytes(total_dev_mem)
+            , limit_bytes(total_dev_mem)
+            , used_bytes(0)
+            , is_integrated_device(integrated_device)
+        {
+        }
+        const size_t total_bytes;
+        size_t       free_bytes;
+        size_t       limit_bytes;
+        size_t       used_bytes;
+        const bool   is_integrated_device;
+    };
+
+    std::vector<mem_account_t> mem_account_on_device;
+
+    mutable std::shared_mutex dev_mem_account_mutex;
+
+    device_memory_accountant()
+    {
+        int  dev_count  = 0;
+        auto hip_status = hipGetDeviceCount(&dev_count);
+        if(hip_status != hipSuccess || dev_count <= 0)
+        {
+            throw std::runtime_error("Device count failed with code " + std::to_string(hip_status)
+                                     + " in initialization of device memory account (dev_count = "
+                                     + std::to_string(dev_count) + ").");
+        }
+        mem_account_on_device.reserve(dev_count);
+        for(int dev_id = 0; dev_id < dev_count; dev_id++)
+        {
+            rocfft_scoped_device dev(dev_id);
+            const auto           dev_prop = get_curr_device_prop();
+            mem_account_on_device.emplace_back(dev_prop.totalGlobalMem, dev_prop.integrated);
+            update_free_bytes_on_valid_current_device(dev_id);
+        }
+    }
+
+    // private function assuming dev_id is valid and is indeed the current device ID (hence the name)
+    void update_free_bytes_on_valid_current_device(int dev_id)
+    {
+        std::unique_lock lock(dev_mem_account_mutex);
+        size_t     placeholder; // hipMemGetInfo also returns total memory, we don't need it here
+        const auto hip_status
+            = hipMemGetInfo(&mem_account_on_device[dev_id].free_bytes, &placeholder);
+        if(hip_status != hipSuccess)
+        {
+            throw std::runtime_error("hipMemGetInfo failed with code " + std::to_string(hip_status)
+                                     + " while updating free device memory available on device ID "
+                                     + std::to_string(dev_id) + ".");
+        }
+    }
+};
 
 // Simple RAII class for GPU buffers.  T is the type of pointer that
 // data() returns
@@ -74,21 +235,33 @@ public:
 
     hipError_t alloc(const size_t size, bool make_it_shared = false)
     {
+        free();
         // remember the device that was current as of alloc, so we can
         // free on the correct device
         auto ret = hipGetDevice(&device);
         if(ret != hipSuccess)
             return ret;
 
+        if(bsize > device_memory_accountant::singleton().get_usable_bytes(device))
+        {
+            std::stringstream msg;
+            msg << "Unauthorized device allocation (device ID: " << device << ").\n"
+                << "\tRequested size is " << byte_size_to_str(bsize) << "\n"
+                << device_memory_accountant::singleton().get_details(device);
+            throw DEVICEBUF_MEM_USAGE{msg.str()};
+        }
+
         bsize             = size;
         is_managed_memory = use_alloc_managed() || make_it_shared;
-        free();
         ret = is_managed_memory ? hipMallocManaged(&buf, bsize) : hipMalloc(&buf, bsize);
         if(ret != hipSuccess)
         {
             buf   = nullptr;
             bsize = 0;
         }
+
+        device_memory_accountant::singleton().record_used_bytes(bsize, device);
+
         return ret;
     }
 
@@ -106,6 +279,7 @@ public:
                 // free on the device we allocated on
                 rocfft_scoped_device dev(device);
                 (void)hipFree(buf);
+                device_memory_accountant::singleton().release_used_bytes(bsize, device);
             }
             buf   = nullptr;
             bsize = 0;

--- a/projects/rocfft/shared/gpubuf.h
+++ b/projects/rocfft/shared/gpubuf.h
@@ -235,11 +235,11 @@ public:
         if(ret != hipSuccess)
             return ret;
 
-        if(bsize > device_memory_accountant::singleton().get_usable_bytes(device))
+        if(size > device_memory_accountant::singleton().get_usable_bytes(device))
         {
             std::stringstream msg;
             msg << "Unauthorized device allocation (device ID: " << device << ").\n"
-                << "\tRequested size is " << byte_size_to_str(bsize) << "\n"
+                << "\tRequested size is " << byte_size_to_str(size) << "\n"
                 << device_memory_accountant::singleton().get_details(device);
             throw DEVICEBUF_MEM_USAGE{msg.str()};
         }

--- a/projects/rocfft/shared/hostbuf.h
+++ b/projects/rocfft/shared/hostbuf.h
@@ -23,10 +23,12 @@
 
 #include "arithmetic.h"
 #include "sys_mem.h"
-#include <atomic>
 #include <cstdlib>
 #include <cstring>
-#include <iostream>
+#include <hip/hip_runtime_api.h>
+#include <sstream>
+#include <stdexcept>
+
 #include <new>
 
 #ifndef _WIN32
@@ -87,18 +89,17 @@ public:
     {
         free();
 
-        bsize = size;
-
-        auto usable_mem = host_memory::singleton().get_usable_bytes();
-        if(total_used_mem + size > usable_mem)
+        if(size > system_memory::singleton().get_usable_bytes())
         {
             std::stringstream msg;
-            msg << "Host memory usage limit exceed (used mem: "
-                << bytes_to_GiB(total_used_mem + size)
-                << "GiB, free mem: " << bytes_to_GiB(usable_mem) << " GiB)";
+            auto&             sys_mem = system_memory::singleton();
+            msg << "Unauthorized host allocation.\n"
+                << "\tRequested size is " << byte_size_to_str(size) << "\n"
+                << sys_mem.get_details();
             throw HOSTBUF_MEM_USAGE{msg.str()};
         }
 
+        bsize = size;
         if(make_it_pinned)
         {
             if(hipHostMalloc(&buf, size) != hipSuccess)
@@ -142,7 +143,7 @@ public:
 
         is_pinned_memory = make_it_pinned;
         bsize_track      = size;
-        total_used_mem += bsize_track;
+        system_memory::singleton().record_used_bytes(bsize_track);
     }
 
     size_t size() const
@@ -161,7 +162,6 @@ public:
         {
             if(owned)
             {
-                total_used_mem -= bsize_track;
                 if(is_pinned_memory)
                 {
                     (void)hipHostFree(buf);
@@ -174,6 +174,8 @@ public:
                     std::free(buf);
 #endif
                 }
+
+                system_memory::singleton().release_used_bytes(bsize_track);
             }
             buf   = nullptr;
             bsize = bsize_track = 0;
@@ -238,9 +240,6 @@ private:
     // Buffer size for tracking total memory usage.
     // When buffer is shrunk in place, bsize_track is not changed.
     size_t bsize_track = 0;
-
-    // Keeps track of total used memory for all hostbufs
-    inline static std::atomic<size_t> total_used_mem = 0;
 };
 
 // default hostbuf that gives out void* pointers

--- a/projects/rocfft/shared/rocfft_params.h
+++ b/projects/rocfft/shared/rocfft_params.h
@@ -322,18 +322,8 @@ public:
             if(hip_status != hipSuccess)
             {
                 std::ostringstream oss;
-                oss << "work buffer allocation failed (" << workbuffersize << " requested)";
-                size_t mem_free  = 0;
-                size_t mem_total = 0;
-                hip_status       = hipMemGetInfo(&mem_free, &mem_total);
-                if(hip_status == hipSuccess)
-                {
-                    oss << "free vram: " << mem_free << " total vram: " << mem_total;
-                }
-                else
-                {
-                    oss << "hipMemGetInfo also failed";
-                }
+                oss << "work buffer allocation failed (" << byte_size_to_str(workbuffersize)
+                    << " requested)";
                 throw work_buffer_alloc_failure(oss.str(), workbuffersize);
             }
 

--- a/projects/rocfft/shared/sys_mem.h
+++ b/projects/rocfft/shared/sys_mem.h
@@ -25,8 +25,10 @@
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
-
-#include "device_properties.h"
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -43,19 +45,47 @@ inline size_t bytes_to_GiB(const size_t bytes)
     return bytes == 0 ? 0 : (bytes - 1 + ONE_GiB) / ONE_GiB;
 }
 
-struct host_memory
+// returns a string reporting a byte size in a readable format,
+// rounding it up to the nearest KiB (MiB if `byte_sz` exceeds 1 GiB)
+static std::string byte_size_to_str(size_t byte_sz)
+{
+    if(byte_sz == 0)
+        return "0 B";
+    std::string                          ret;
+    const std::pair<size_t, std::string> mem_units[]
+        = {{ONE_GiB, "GiB"}, {ONE_MiB, "MiB"}, {ONE_KiB, "KiB"}};
+    for(const auto& u : mem_units)
+    {
+        auto tmp = byte_sz / u.first;
+        byte_sz -= tmp * u.first;
+        if(byte_sz > 0 && (u.first == ONE_KiB || !ret.empty()))
+        {
+            // round up to nearest relevant unit and finish
+            tmp++;
+            byte_sz = 0;
+        }
+        if(tmp > 0)
+        {
+            if(!ret.empty())
+                ret += " ";
+            ret += std::to_string(tmp) + " " + u.second;
+        }
+    }
+    return ret;
+}
+
+struct system_memory
 {
 public:
     // acquire a reference to a singleton of this struct
-    static host_memory& singleton()
+    static system_memory& singleton()
     {
-        static host_memory mem;
+        static system_memory mem;
         return mem;
     }
 
     size_t get_total_bytes() const
     {
-        std::shared_lock lock(host_memory_mutex);
         return total_bytes;
     }
 
@@ -66,11 +96,10 @@ public:
 
     void set_limit_bytes(size_t limit_bytes_)
     {
-        std::unique_lock lock(host_memory_mutex);
+        std::unique_lock lock(sys_memory_mutex);
         // Don't let limit use the total available memory, leave at
         // least a 1GiB buffer, otherwise process may get OOM killed.
-        limit_bytes
-            = limit_bytes_ > (total_bytes - ONE_GiB) ? (total_bytes - ONE_GiB) : limit_bytes_;
+        limit_bytes = std::min(limit_bytes_, total_bytes >= ONE_GiB ? total_bytes - ONE_GiB : 0);
     }
 
     void set_limit_gbytes(size_t limit_gbytes_)
@@ -80,17 +109,20 @@ public:
 
     size_t get_usable_bytes()
     {
-        update();
+        update_free_bytes();
 
         // Limit the amount of usable memory. If we are too aggressive
         // with host memory usage, the host process may get OOM killed
         // on systems with little or no swap space.
-        std::shared_lock lock(host_memory_mutex);
+        std::shared_lock lock(sys_memory_mutex);
+        return std::min(free_bytes < ONE_GiB ? 0 : free_bytes,
+                        used_bytes < limit_bytes ? limit_bytes - used_bytes : 0);
+    }
 
-        auto usable_bytes = free_bytes < ONE_GiB ? 0 : free_bytes;
-        usable_bytes      = usable_bytes > limit_bytes ? limit_bytes : usable_bytes;
-
-        return usable_bytes;
+    size_t get_limit_bytes() const
+    {
+        std::shared_lock lock(sys_memory_mutex);
+        return limit_bytes;
     }
 
     size_t get_usable_gbytes()
@@ -98,39 +130,75 @@ public:
         return bytes_to_GiB(get_usable_bytes());
     }
 
-private:
-    size_t total_bytes = 0;
-    size_t free_bytes  = 0;
-    size_t limit_bytes = 0;
-
-    mutable std::shared_mutex host_memory_mutex;
-
-    host_memory()
+    void record_used_bytes(size_t allocation_size)
     {
-        // Note: passing (reading) a member variable as argument to a member routine that
-        // requires a unique lock. This constructor is only possibly invoked at initialization
-        // of the local static variable in the "singleton" public member function though, and
-        // that initialization is guaranteed to be thread-safe in C++11.
-        update();
-        set_limit_bytes(total_bytes);
+        std::unique_lock lock(sys_memory_mutex);
+        used_bytes += allocation_size;
+    }
+    void release_used_bytes(size_t allocation_size)
+    {
+        std::unique_lock lock(sys_memory_mutex);
+        // prevent underflows
+        used_bytes -= std::min(allocation_size, used_bytes);
     }
 
-    void update()
+    std::string get_details(bool double_tab = false)
     {
-        std::unique_lock lock(host_memory_mutex);
+        const auto        usable_bytes = get_usable_bytes();
+        std::shared_lock  lock(sys_memory_mutex);
+        std::stringstream ss;
+        const auto        incr = (double_tab ? "\t\t" : "\t");
+        ss << incr << "Usable system memory: " << byte_size_to_str(usable_bytes) << "\n"
+           << incr << "Free system memory: " << byte_size_to_str(free_bytes) << "\n"
+           << incr << "Used system memory: " << byte_size_to_str(used_bytes) << "\n"
+           << incr << "Enforced limit on memory usage: " << byte_size_to_str(limit_bytes);
+        return ss.str();
+    }
+
+private:
+    const size_t total_bytes;
+    size_t       free_bytes;
+    size_t       limit_bytes;
+    size_t       used_bytes;
+
+    mutable std::shared_mutex sys_memory_mutex;
+
+    system_memory()
+        : total_bytes(read_sys_mem<sys_mem_label::TOTAL>())
+        , free_bytes(read_sys_mem<sys_mem_label::FREE>())
+        , limit_bytes(total_bytes)
+        , used_bytes(0)
+    {
+    }
+
+    void update_free_bytes()
+    {
+        std::unique_lock lock(sys_memory_mutex);
+        free_bytes = read_sys_mem<sys_mem_label::FREE>();
+    }
+
+    enum class sys_mem_label
+    {
+        TOTAL,
+        FREE
+    };
+
+    template <sys_mem_label mem_label>
+    static size_t read_sys_mem()
+    {
+        static_assert(mem_label == sys_mem_label::TOTAL || mem_label == sys_mem_label::FREE);
+        size_t ret = 0;
 #ifdef _WIN32
         MEMORYSTATUSEX info;
         info.dwLength = sizeof(info);
         if(!GlobalMemoryStatusEx(&info))
-            return;
-        total_bytes = info.ullTotalPhys;
-        free_bytes  = info.ullAvailPhys;
+            return ret;
+        if constexpr(mem_label == sys_mem_label::TOTAL)
+            ret = info.ullTotalPhys;
+        else
+            ret = info.ullAvailPhys;
 #else
-
-        // /proc/meminfo can tell us "available" memory (i.e. free +
-        // buffers + cache)
-        total_bytes = 0;
-        free_bytes  = 0;
+        // Read from /proc/meminfo if possible
         try
         {
             std::ifstream proc_meminfo("/proc/meminfo");
@@ -138,11 +206,17 @@ private:
             while(std::getline(proc_meminfo, proc_line))
             {
                 // meminfo counts in KiB
-                if(proc_line.compare(0, 9, "MemTotal:") == 0)
-                    total_bytes = std::stoull(proc_line.substr(9)) * 1024;
-                else if(proc_line.compare(0, 13, "MemAvailable:") == 0)
-                    free_bytes = std::stoull(proc_line.substr(13)) * 1024;
-                if(total_bytes && free_bytes)
+                if constexpr(mem_label == sys_mem_label::TOTAL)
+                {
+                    if(proc_line.compare(0, 9, "MemTotal:") == 0)
+                        ret = std::stoull(proc_line.substr(9)) * 1024;
+                }
+                else
+                {
+                    if(proc_line.compare(0, 13, "MemAvailable:") == 0)
+                        ret = std::stoull(proc_line.substr(13)) * 1024;
+                }
+                if(ret)
                     break;
             }
         }
@@ -151,67 +225,46 @@ private:
             // If there was a problem, we'll fall back to sysinfo
         }
 
-        if(total_bytes == 0)
+        if(ret == 0)
         {
             // Either something couldn't be parsed or proc is not
             // mounted.  Fall back to sysinfo which can tell total +
             // free, but not "available".
             struct sysinfo info;
             if(sysinfo(&info) != 0)
-                return;
-            total_bytes = info.totalram * info.mem_unit;
-            free_bytes  = (info.freeram + info.bufferram) * info.mem_unit;
-        }
-
-        // Adjust memory numbers for APU
-        try
-        {
-            auto deviceProp = get_curr_device_prop();
-            // on integrated APU, we can't expect to reuse "device" memory
-            // for "host" things.
-            if(deviceProp.integrated)
-            {
-                const auto dedicated_for_device_allocs
-                    = std::min(deviceProp.totalGlobalMem, std::min(free_bytes, total_bytes) / 2);
-                total_bytes -= dedicated_for_device_allocs;
-                free_bytes -= dedicated_for_device_allocs;
-            }
-        }
-        catch(std::runtime_error&)
-        {
-            // assume we're not on APU, can use full host memory
+                return ret;
+            if constexpr(mem_label == sys_mem_label::TOTAL)
+                ret = info.totalram * info.mem_unit;
+            else
+                ret = (info.freeram + info.bufferram) * info.mem_unit;
         }
 
         // top-level memory cgroup may restrict this further
-
-        // check cgroup v1
-        std::ifstream memcg1_limit_file("/sys/fs/cgroup/memory/memory.limit_in_bytes");
-        std::ifstream memcg1_usage_file("/sys/fs/cgroup/memory/memory.usage_in_bytes");
-        size_t        memcg1_limit_bytes;
-        size_t        memcg1_usage_bytes;
-        // use cgroupv1 limit if we can read the cgroup files and it's
-        // smaller
-        if((memcg1_limit_file >> memcg1_limit_bytes) && (memcg1_usage_file >> memcg1_usage_bytes)
-           && memcg1_limit_bytes < total_bytes)
+        const std::pair<std::string, std::string> memcg1_paths
+            = {"/sys/fs/cgroup/memory/memory.limit_in_bytes",
+               "/sys/fs/cgroup/memory/memory.usage_in_bytes"};
+        const std::pair<std::string, std::string> memcg2_paths
+            = {"/sys/fs/cgroup/memory.max", "/sys/fs/cgroup/memory.current"};
+        for(const auto& memcg_paths : {memcg1_paths, memcg2_paths})
         {
-            total_bytes = memcg1_limit_bytes;
-            free_bytes  = total_bytes - memcg1_usage_bytes;
-        }
-
-        // check cgroup v2
-        std::ifstream memcg2_max_file("/sys/fs/cgroup/memory.max");
-        std::ifstream memcg2_current_file("/sys/fs/cgroup/memory.current");
-        size_t        memcg2_max_bytes;
-        size_t        memcg2_current_bytes;
-        // use cgroupv2 limit if we can read the cgroup files and it's
-        // smaller
-        if((memcg2_max_file >> memcg2_max_bytes) && (memcg2_current_file >> memcg2_current_bytes)
-           && memcg2_max_bytes < total_bytes)
-        {
-            total_bytes = memcg2_max_bytes;
-            free_bytes  = total_bytes - memcg2_current_bytes;
+            std::ifstream memcg_limit_file(memcg_paths.first.c_str());
+            std::ifstream memcg_usage_file(memcg_paths.second.c_str());
+            size_t        memcg_limit_bytes;
+            size_t        memcg_usage_bytes;
+            // use cgroup limit if we can read the cgroup files and it's smaller
+            if((memcg_limit_file >> memcg_limit_bytes) && (memcg_usage_file >> memcg_usage_bytes))
+            {
+                if constexpr(mem_label == sys_mem_label::TOTAL)
+                    ret = std::min(ret, memcg_limit_bytes);
+                else
+                    ret = std::min(ret,
+                                   memcg_usage_bytes <= memcg_limit_bytes
+                                       ? memcg_limit_bytes - memcg_usage_bytes
+                                       : 0);
+            }
         }
 #endif
+        return ret;
     }
 };
 

--- a/projects/rocfft/shared/test_params.h
+++ b/projects/rocfft/shared/test_params.h
@@ -24,10 +24,8 @@
 
 #include <stdexcept>
 
-extern int    verbose;
-extern size_t ramgb;
-extern size_t vramgb;
-extern int    ngpus;
+extern int verbose;
+extern int ngpus;
 
 extern size_t n_random_tests;
 


### PR DESCRIPTION
## Motivation

The current accounting of memory usage done by rocfft and hipfft tests need revisions to improve their limit-enforcing options/promises and to improve their robustness in low-resource testing environments.
The following aspects in particular need to be addressed:
- only the host memory footprint is tracked at the moment, no accounting of device memory usage is done;
- the accounting of host memory usage is invalid if more than one specializations of `hostbuf_t` is ever used;
- so-called "device allocations" on integrated devices are omitted from that accounting, albeit pooling from the same physical resources;
- the [condition required to allow host allocation](https://github.com/ROCm/rocm-libraries/blob/a5380848dcc357eea1b31ce722d80afd12b1b4c6/projects/rocfft/shared/hostbuf.h#L93) is more restrictive than needed if `usable_mem` is determined by the [amount of free memory](https://github.com/ROCm/rocm-libraries/blob/a5380848dcc357eea1b31ce722d80afd12b1b4c6/projects/rocfft/shared/sys_mem.h#L91) instead of the limit to be observed;
- the quick fix introduced in https://github.com/ROCm/rocm-libraries/pull/4953 supposedly reserves [some (arbitrary) amount of system memory](https://github.com/ROCm/rocm-libraries/blob/5737dd76af913a2074c0174809c7d9ef61f33edc/projects/rocfft/shared/sys_mem.h#L174) for "device allocations" on integrated devices, but
    - that reserved chunk's size is not guaranteed constant throughout an application's lifetime;
    - overall "device" allocations are not verified to be maintained under that reserve chunk's size at any point.

This PR is suggested to address the above concerns, and to introduce comparable accounting for device allocations. 

## Technical Details

- The `host_memory` singleton structure is renamed `system_memory` and modified as follows:
    - Its `total_bytes` member is qualified constant, guaranteeing a constant value thereof throughout relevant applications' lifetime. The `update` member function is renamed `update_free_bytes`, consistently;
    - It is responsible for the accounting of system memory usage via its new private `used_bytes` member. Two member functions `record_used_bytes` and `release_used_bytes` are to be used by host allocations _and_ device allocations on integrated devices, thereby maintaining an accurate picture of the system memory usage at any point;
    - Its `get_usable_bytes` member function is revised to always report the amount of system memory that remains usable and within the limits to be enforced at the time of query (accounting for `used_bytes` which is now owned by the object at all times);
    - Its `update` member function is replaced by a templated `read_sys_mem`, as total memory is read only once at construction and kept constant thereafter with the suggested changes;
    - The `system_memory` no longer fetches (nor needs) information about possible integrated devices, and remains agnostic of such questions, now delegated to the (newly introduced) `device_memory_accountant` singleton struct.
- The `hostbuf_t` template class is modified as follows:
    - The purpose supposedly served by the original atomic `total_used_mem` is now fulfilled by the singleton `system_memory` struct's `used_bytes` member (for all possible specializations of `hostbuf_t`);
    - The condition to fulfill for allowing host allocation was revised accordingly to what `system_memory::get_usable_bytes` is meant to report;
- A comparable singleton `device_memory_accountant` structure is introduced to operate similar accounting operations for the memory being used on the device(s):
   - When recording a new "device" allocation for an integrated device, that singleton structure proceeds to instruct `system_memory` to also record the allocation size (unifying accounting of system memory usage without hardcoded arbitrary assumptions for integrated devices);
   - A new dedicated exception `DEVICEBUF_MEM_USAGE` is introduced for handling excessive usage of device memory gracefully in tests (and reporting relevant, insightful information in logs).
- With the above changes, there is no longer a need to keep `ramgb` and `vramgb` as global variables, as they correspond to the set limits on some singleton structure which can be directly read in any context. 

## Test Plan

Current tests suffice. Fewer tests should be skipped when `--R` argument are provided with value under the system's total amount of memory.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
