### PR TITLE
[hipTensor] hash: use FNV-1a for string hashing to ensure cross-platform uid stability

### DIFF
--- a/projects/hiptensor/library/src/contraction/contraction_solution.cpp
+++ b/projects/hiptensor/library/src/contraction/contraction_solution.cpp
@@ -285,10 +285,10 @@ namespace hiptensor
 
     size_t ContractionSolution::uid() const
     {
-        // Platform-stable uid: hash the kernel type string together with the
-        // data-type / op parameters so that distinct CK template instantiations
-        // that share the same geometry (GetTypeString) but differ in data types
-        // still produce distinct uids.
+        // Platform-stable uid: hash the kernel type string (via FNV-1a in Hash{})
+        // together with the data-type / op parameters so that distinct CK template
+        // instantiations that share the same geometry (GetTypeString) but differ in
+        // data types still produce distinct uids.
         auto const& params = mParams;
         return Hash{}(mDeviceOp->GetTypeString(),
                       params->typeA(),

--- a/projects/hiptensor/library/src/include/hash.hpp
+++ b/projects/hiptensor/library/src/include/hash.hpp
@@ -27,7 +27,7 @@
 #pragma once
 
 #include <functional>
-#include <iostream>
+#include <string>
 #include <vector>
 
 namespace hiptensor
@@ -48,6 +48,19 @@ namespace hiptensor
         }
 
     private:
+        // Platform-stable hash for strings: FNV-1a produces identical results on all compilers,
+        // unlike std::hash<std::string> which is implementation-defined.
+        void operator()(std::size_t& seed, std::string const& s) const
+        {
+            std::size_t h = 14695981039346656037ULL; // FNV-1a offset basis
+            for(unsigned char c : s)
+            {
+                h ^= c;
+                h *= 1099511628211ULL; // FNV-1a prime
+            }
+            seed ^= h + 0x9e3779b9 + (seed * 64) + (seed / 4);
+        }
+
         template <typename T, typename... Ts>
         void operator()(std::size_t& seed, T const& t, Ts const&... ts) const
         {
@@ -65,18 +78,6 @@ namespace hiptensor
             {
                 operator()(seed, element);
             }
-        }
-
-        template <typename T, typename... Ts>
-        void printArgs(T const& t, Ts const&... ts) const
-        {
-            std::cout << t << ", ";
-            printArgs(ts...);
-        }
-        template <typename T>
-        void printArgs(T const& t) const
-        {
-            std::cout << t << std::endl;
         }
     };
 


### PR DESCRIPTION
## Motivation

Since std::hash<std::string> is platform dependent, a plan cache file written on Linux would therefore not be readable on  Windows, as well as the other way around. This PR overload the hash operator for strings to use FNV-1a, which produces the same result across platforms and allows a plan cache file to be generated on one platform and consumed on another.

## Technical Details

  - Adds a non-template operator()(std::size_t& seed, std::string const&) overload that implements FNV-1a (Fowler–Noll–Vo), a fixed well-known algorithm producing identical 64-bit output on all compilers and platforms.
  - The string overload resolves before the variadic template for any std::string argument — no call-site changes required.
  - Replaces #include <iostream> with #include <string> and removes the unused printArgs debug methods that depended on it.

## Test Plan

Run plan cache tests on both Linux and Windows.

## Test Result

Tests are passing.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
