### PR TITLE
[ALMIOPEN-1729] Temporarily skip test_immed_conv2d to unblock ci

### DIFF
--- a/projects/miopen/test/CMakeLists.txt
+++ b/projects/miopen/test/CMakeLists.txt
@@ -324,6 +324,9 @@ endif()
 # Skip conv2d tests to capture flaky behavior                                                                             
 list(APPEND SKIP_TESTS test_conv2d test_conv2d_find2)
 
+# Skip test_immed_conv2d tests to capture flaky behavior                                                                             
+list(APPEND SKIP_TESTS test_immed_conv2d)
+
 
 # The usage is non-trivial, see function add_test_command.
 if(SKIP_TESTS)


### PR DESCRIPTION
## Motivation

This test is currently failing and blocking miopen CI

## Technical Details

Disable `test_immed_conv2d` until investigated and fixed or PR causing it found and reverted.

## Test Plan

CI skips test_immed_conv2d

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
