### PR TITLE
[hipblaslt] Fix hipblaslt-test abort issue on Windows

### DIFF
--- a/projects/hipblaslt/clients/common/include/d_vector.hpp
+++ b/projects/hipblaslt/clients/common/include/d_vector.hpp
@@ -248,6 +248,22 @@ private:
     M get(size_t bytes, bool use_HMM = false)
     {
         auto& pool = use_HMM ? m_pool_managed : m_pool;
+        
+        // For Windows system with not enough system memory, 
+        // not suitable for memory pool management when it needs another allocation
+        #ifdef _WIN32
+        MEMORYSTATUSEX memStatus = {};
+        memStatus.dwLength = sizeof(memStatus);
+        if(GlobalMemoryStatusEx(&memStatus))
+        {
+            // If the shared memory is less than 64GB(128 / 2), may not enough for the hipblaslt-test to run
+            if(memStatus.ullTotalPhys <= (128ULL << 30))
+            {
+                pool.clear();
+            }
+        }
+        #endif
+
         auto  it   = std::lower_bound(pool.begin(), pool.end(), bytes);
         if(it != pool.end() && // found a buffer that is large enough ..
            it->capacity() < 2 * bytes) // but not way too large
@@ -269,21 +285,6 @@ private:
             // remove the (largest) buffer that was too small
             if(it != pool.begin())
                 pool.erase(it - 1);
-
-            // For Windows system with not enough system memory, 
-            // not suitable for memory pool management when it needs another allocation
-            #ifdef _WIN32
-            MEMORYSTATUSEX memStatus = {};
-            memStatus.dwLength = sizeof(memStatus);
-            if(GlobalMemoryStatusEx(&memStatus))
-            {
-                // If the shared memory is less than 64GB(128 / 2), may not enough for the hipblaslt-test to run
-                if(memStatus.ullTotalPhys <= (128ULL << 30))
-                {
-                    pool.clear();
-                }
-            }
-            #endif
 
             // Allocate 20% extra if it is not huge_request for later reuse
             size_t alloc_capacity = huge_request ? bytes : static_cast<size_t>(bytes * 1.2);

--- a/projects/hipblaslt/clients/common/include/d_vector.hpp
+++ b/projects/hipblaslt/clients/common/include/d_vector.hpp
@@ -73,7 +73,7 @@ public:
         return capacity() < s;
     }
 
-    size_t get_available_host_memory(size_t allocated_capacity)
+    size_t get_available_host_memory()
     {
 #ifdef __linux__
         struct sysinfo info;
@@ -92,8 +92,9 @@ public:
         memStatus.dwLength = sizeof(memStatus);
         if(GlobalMemoryStatusEx(&memStatus))
         {
-            // In the windows system, the host memory(pinned memory)'s capacity is the half of the physical memory
-            return (memStatus.ullTotalPhys / 2) - allocated_capacity;
+            // In the windows system, the host memory's capacity is the half of the physical memory
+            // And previous allocation of host memory is got cleared before
+            return memStatus.ullTotalPhys / 2;
         }
         else
         {
@@ -132,15 +133,14 @@ public:
     {
     }
 
-    d_memory(size_t size, size_t capacity, bool use_HMM = false, size_t allocated_capacity = 0)
-        : hip_memory(size, capacity, use_HMM, allocated_capacity)
+    d_memory(size_t size, size_t capacity, bool use_HMM = false)
+        : hip_memory(size, capacity, use_HMM)
     {
         char* d = nullptr;
 
         if(use_HMM)
         {
-            // Keep 20% of the available system memory for room of emergency
-            size_t available_host_memory = get_available_host_memory(allocated_capacity) * 0.8;
+            size_t available_host_memory = get_available_host_memory();
             // Need to ensure sufficient host memory, otherwise hipMallocManaged may OOM and hip api won't return error code,
             // and will cause the gtest get aborted
             if(available_host_memory < capacity || hipMallocManaged(&d, capacity) != hipSuccess)
@@ -186,13 +186,12 @@ public:
     {
     }
 
-    h_memory(size_t size, size_t capacity, bool use_HMM = false, size_t allocated_capacity = 0)
-        : hip_memory(size, capacity, false, allocated_capacity)
+    h_memory(size_t size, size_t capacity, bool use_HMM = false)
+        : hip_memory(size, capacity, false)
     {
         char* d = nullptr;
 
-        // Keep 20% of the available system memory for room of emergency
-        size_t available_host_memory = get_available_host_memory(allocated_capacity) * 0.8;
+        size_t available_host_memory = get_available_host_memory();
         // Need to ensure sufficient host memory, otherwise hipHostMalloc may OOM and hip api won't return error code,
         // and will cause the gtest get aborted
         if(available_host_memory < capacity || hipHostMalloc(&d, capacity) != hipSuccess)
@@ -271,17 +270,25 @@ private:
             if(it != pool.begin())
                 pool.erase(it - 1);
 
-            // Allocate 20% extra if it is not huge_request for later reuse
-            size_t alloc_capacity = huge_request ? bytes : static_cast<size_t>(bytes * 1.2); 
-
-            // Calculate the total allocated capacity of the memory pool
-            size_t allocated_capacity = 0;
-            for(const auto& mem : pool)
+            // For Windows system with not enough system memory, 
+            // not suitable for memory pool management when it needs another allocation
+            #ifdef _WIN32
+            MEMORYSTATUSEX memStatus = {};
+            memStatus.dwLength = sizeof(memStatus);
+            if(GlobalMemoryStatusEx(&memStatus))
             {
-                allocated_capacity += mem.capacity();
+                // If the shared memory is less than 64GB(128 / 2), may not enough for the hipblaslt-test to run
+                if(memStatus.ullTotalPhys <= (128ULL << 30))
+                {
+                    pool.clear();
+                }
             }
+            #endif
 
-            auto e = M(bytes, alloc_capacity, use_HMM, allocated_capacity);
+            // Allocate 20% extra if it is not huge_request for later reuse
+            size_t alloc_capacity = huge_request ? bytes : static_cast<size_t>(bytes * 1.2);
+
+            auto e = M(bytes, alloc_capacity, use_HMM);
             if(e.get())
                 return e;
             hipblaslt_cerr << "Clearing memory pool and retrying" << std::endl;
@@ -293,8 +300,7 @@ private:
             if(err == hipErrorOutOfMemory || err == hipErrorMemoryAllocation )
                 (void)hipGetLastError();
 
-            // Pool has been cleared, so allocated_capacity is 0
-            return M(bytes, bytes, use_HMM, 0);
+            return M(bytes, bytes, use_HMM);
         }
     }
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
According to [SWDEV-574584](https://ontrack-internal.amd.com/browse/SWDEV-574584), the gtest aborts on the Windows environment with a gfx1201 arch GPU when running a series of large problem sizes. 

The root cause is that the memory pool manager relies on the return error code of hipHostMalloc to determine whether it should perform pool cleanup and reallocation. However, hipHostMalloc does not guarantee that it will return an error code—for example, when encountering an OOM condition, the process may be killed directly.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
This commit only affects hipblaslt-test on Windows. It reverts most of the changes introduced in [PR1](https://github.com/ROCm/rocm-libraries/pull/4793) & [PR2](https://github.com/ROCm/rocm-libraries/pull/5270).

The reason is that, in the Windows environment, the logic inside get_available_host_memory() cannot reliably determine when to clear the memory pool in order to release space for the next host memory allocation.

Although previous PRs attempted to accumulate host memory usage via h_memory, this approach cannot reflect the actual shared memory usage due to unpredictable host memory behavior. This was observed by running a sequence of small problems, where a large amount of host memory was consumed without any new allocations being recorded.
Additionally, the Windows environment does not provide an API to query available shared host memory.

For the above reasons, hipblaslt-test is not suitable for retaining old allocations under tight shared-memory conditions on Windows.
Therefore, this commit cleans the memory pool whenever a new allocation is required, in order to prevent the process from being killed by an OOM condition.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
