### PR TITLE
[CK_Tile] Disable Stream-K Tile Engine on gfx12 

### DIFF
--- a/projects/composablekernel/test/ck_tile/gemm_streamk_tile_engine/CMakeLists.txt
+++ b/projects/composablekernel/test/ck_tile/gemm_streamk_tile_engine/CMakeLists.txt
@@ -234,7 +234,7 @@ message(STATUS "SUPPORTED_GPU_TARGETS: ${SUPPORTED_GPU_TARGETS}")
 
 # GPU architecture filtering - only build tests for supported architectures
 set(GEMM_TEST_GPU_TARGETS "")
-set(DESIRED_TARGETS "gfx90a;gfx942;gfx950;gfx12-generic")
+set(DESIRED_TARGETS "gfx90a;gfx942;gfx950")
 
 foreach(target IN LISTS SUPPORTED_GPU_TARGETS)
     if(target IN_LIST DESIRED_TARGETS)
@@ -245,7 +245,7 @@ endforeach()
 
 # Early exit if no compatible GPU architectures are available
 if(NOT GEMM_TEST_GPU_TARGETS)
-	message(WARNING "Skipping StreamK GEMM Tile Engine tests: No supported GPU targets (gfx90a, gfx942, gfx950, gfx12-generic) found in SUPPORTED_GPU_TARGETS: ${SUPPORTED_GPU_TARGETS}")
+	message(WARNING "Skipping StreamK GEMM Tile Engine tests: No supported GPU targets (gfx90a, gfx942, gfx950) found in SUPPORTED_GPU_TARGETS: ${SUPPORTED_GPU_TARGETS}")
     return()
 endif()
 

--- a/projects/composablekernel/tile_engine/ops/gemm_streamk/CMakeLists.txt
+++ b/projects/composablekernel/tile_engine/ops/gemm_streamk/CMakeLists.txt
@@ -216,7 +216,7 @@ message(STATUS "SUPPORTED_GPU_TARGETS: ${SUPPORTED_GPU_TARGETS}")
 
 # Filter GPU targets to only gfx90a, gfx942
 set(GEMM_GPU_TARGETS_INDIVIDUAL "")
-set(DESIRED_TARGETS "gfx90a;gfx942;gfx12-generic") # TODO: Add gfx950 when supported
+set(DESIRED_TARGETS "gfx90a;gfx942") # TODO: Add gfx950 when supported
 
 foreach(target IN LISTS SUPPORTED_GPU_TARGETS)
     if(target IN_LIST DESIRED_TARGETS)
@@ -227,7 +227,7 @@ endforeach()
 
 # Skip build if no matching targets found
 if(NOT GEMM_GPU_TARGETS_INDIVIDUAL)
-    message(WARNING "Skipping Tile Engine GEMM build: No supported GPU targets (gfx90a, gfx942, gfx12-generic) found in SUPPORTED_GPU_TARGETS: ${SUPPORTED_GPU_TARGETS}")
+    message(WARNING "Skipping Tile Engine GEMM build: No supported GPU targets (gfx90a, gfx942) found in SUPPORTED_GPU_TARGETS: ${SUPPORTED_GPU_TARGETS}")
 else()
     message(STATUS "Building individual GEMM targets for GPU targets: ${GEMM_GPU_TARGETS_INDIVIDUAL}")
 


### PR DESCRIPTION
## Motivation

PR https://github.com/ROCm/rocm-libraries/pull/4469/ added gfx12 as a supported architecture for Stream-K tile engine, which is currently an unsupported architecture. Hence, this change disables Stream-K support on gfx12.

## Technical Details

Since Stream-K does not yet support gfx12, we remove it from the list of supported architectures for Stream-K tile engine.

## Test Plan

I locally ran cmake for gfx1201 and verified that no Stream-K tile engine targets exist.

## Test Result

Local test passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
