### PR TITLE
[rocsparse] Fix Memory Access Issues

### DIFF
--- a/projects/rocsparse/library/src/precond/bsrilu0/rocsparse_bsrilu0_kernel_2_8.cpp
+++ b/projects/rocsparse/library/src/precond/bsrilu0/rocsparse_bsrilu0_kernel_2_8.cpp
@@ -363,8 +363,10 @@ namespace rocsparse
                             bool is_val_host_mode)
     {
         const auto batch_index = hipBlockIdx_y;
-        ROCSPARSE_SCALAR_HOST_DEVICE_GET_IF(enable_boost, is_tol_host_mode, boost_tol_32);
-        ROCSPARSE_SCALAR_HOST_DEVICE_GET_IF(enable_boost, is_tol_host_mode, boost_tol_64);
+        ROCSPARSE_SCALAR_HOST_DEVICE_GET_IF(
+            enable_boost && (size_boost_tol == sizeof(float)), is_tol_host_mode, boost_tol_32);
+        ROCSPARSE_SCALAR_HOST_DEVICE_GET_IF(
+            enable_boost && (size_boost_tol == sizeof(double)), is_tol_host_mode, boost_tol_64);
         ROCSPARSE_SCALAR_HOST_DEVICE_GET_IF(enable_boost, is_val_host_mode, boost_val);
         const double boost_tol = (size_boost_tol == sizeof(double)) //
                                      ? boost_tol_64 //
@@ -404,8 +406,12 @@ namespace rocsparse
         const auto boost_tol_pointer_mode = boost->get_tol_pointer_mode();
         const auto boost_val_pointer_mode = boost->get_val_pointer_mode();
 
-        const float*  boost_tol_32 = reinterpret_cast<const float*>(boost->get_tol());
-        const double* boost_tol_64 = reinterpret_cast<const double*>(boost->get_tol());
+        const float*  boost_tol_32 = (boost_tol_size == sizeof(float))
+                                         ? reinterpret_cast<const float*>(boost->get_tol())
+                                         : nullptr;
+        const double* boost_tol_64 = (boost_tol_size == sizeof(double))
+                                         ? reinterpret_cast<const double*>(boost->get_tol())
+                                         : nullptr;
         const T*      boost_val    = reinterpret_cast<const T*>(boost->get_val());
 
         auto trm_info = bsrilu0_info->get(rocsparse_operation_none, rocsparse_fill_mode_lower);

--- a/projects/rocsparse/library/src/precond/bsrilu0/rocsparse_bsrilu0_kernel_33_64.cpp
+++ b/projects/rocsparse/library/src/precond/bsrilu0/rocsparse_bsrilu0_kernel_33_64.cpp
@@ -372,8 +372,10 @@ namespace rocsparse
                               bool is_val_host_mode)
     {
         const auto batch_index = hipBlockIdx_y;
-        ROCSPARSE_SCALAR_HOST_DEVICE_GET_IF(enable_boost, is_tol_host_mode, boost_tol_32);
-        ROCSPARSE_SCALAR_HOST_DEVICE_GET_IF(enable_boost, is_tol_host_mode, boost_tol_64);
+        ROCSPARSE_SCALAR_HOST_DEVICE_GET_IF(
+            enable_boost && (size_boost_tol == sizeof(float)), is_tol_host_mode, boost_tol_32);
+        ROCSPARSE_SCALAR_HOST_DEVICE_GET_IF(
+            enable_boost && (size_boost_tol == sizeof(double)), is_tol_host_mode, boost_tol_64);
         ROCSPARSE_SCALAR_HOST_DEVICE_GET_IF(enable_boost, is_val_host_mode, boost_val);
         const double boost_tol = (size_boost_tol == sizeof(double)) ? boost_tol_64 : boost_tol_32;
 
@@ -412,8 +414,12 @@ namespace rocsparse
         const auto boost_tol_pointer_mode = boost->get_tol_pointer_mode();
         const auto boost_val_pointer_mode = boost->get_val_pointer_mode();
 
-        const float*  boost_tol_32 = reinterpret_cast<const float*>(boost->get_tol());
-        const double* boost_tol_64 = reinterpret_cast<const double*>(boost->get_tol());
+        const float*  boost_tol_32 = (boost_tol_size == sizeof(float))
+                                         ? reinterpret_cast<const float*>(boost->get_tol())
+                                         : nullptr;
+        const double* boost_tol_64 = (boost_tol_size == sizeof(double))
+                                         ? reinterpret_cast<const double*>(boost->get_tol())
+                                         : nullptr;
         const T*      boost_val    = reinterpret_cast<const T*>(boost->get_val());
 
         auto trm_info = bsrilu0_info->get(rocsparse_operation_none, rocsparse_fill_mode_lower);

--- a/projects/rocsparse/library/src/precond/bsrilu0/rocsparse_bsrilu0_kernel_9_32.cpp
+++ b/projects/rocsparse/library/src/precond/bsrilu0/rocsparse_bsrilu0_kernel_9_32.cpp
@@ -392,8 +392,10 @@ namespace rocsparse
                              bool is_val_host_mode)
     {
         const auto batch_index = hipBlockIdx_y;
-        ROCSPARSE_SCALAR_HOST_DEVICE_GET_IF(enable_boost, is_tol_host_mode, boost_tol_32);
-        ROCSPARSE_SCALAR_HOST_DEVICE_GET_IF(enable_boost, is_tol_host_mode, boost_tol_64);
+        ROCSPARSE_SCALAR_HOST_DEVICE_GET_IF(
+            enable_boost && (size_boost_tol == sizeof(float)), is_tol_host_mode, boost_tol_32);
+        ROCSPARSE_SCALAR_HOST_DEVICE_GET_IF(
+            enable_boost && (size_boost_tol == sizeof(double)), is_tol_host_mode, boost_tol_64);
         ROCSPARSE_SCALAR_HOST_DEVICE_GET_IF(enable_boost, is_val_host_mode, boost_val);
         const double boost_tol = (size_boost_tol == sizeof(double)) ? boost_tol_64 : boost_tol_32;
 
@@ -432,8 +434,12 @@ namespace rocsparse
         const auto boost_tol_pointer_mode = boost->get_tol_pointer_mode();
         const auto boost_val_pointer_mode = boost->get_val_pointer_mode();
 
-        const float*  boost_tol_32 = reinterpret_cast<const float*>(boost->get_tol());
-        const double* boost_tol_64 = reinterpret_cast<const double*>(boost->get_tol());
+        const float*  boost_tol_32 = (boost_tol_size == sizeof(float))
+                                         ? reinterpret_cast<const float*>(boost->get_tol())
+                                         : nullptr;
+        const double* boost_tol_64 = (boost_tol_size == sizeof(double))
+                                         ? reinterpret_cast<const double*>(boost->get_tol())
+                                         : nullptr;
         const T*      boost_val    = reinterpret_cast<const T*>(boost->get_val());
 
         auto trm_info = bsrilu0_info->get(rocsparse_operation_none, rocsparse_fill_mode_lower);

--- a/projects/rocsparse/library/src/precond/bsrilu0/rocsparse_bsrilu0_kernel_general.cpp
+++ b/projects/rocsparse/library/src/precond/bsrilu0/rocsparse_bsrilu0_kernel_general.cpp
@@ -293,8 +293,10 @@ namespace rocsparse
                                 bool is_val_host_mode)
     {
         const auto batch_index = hipBlockIdx_y;
-        ROCSPARSE_SCALAR_HOST_DEVICE_GET_IF(enable_boost, is_tol_host_mode, boost_tol_32);
-        ROCSPARSE_SCALAR_HOST_DEVICE_GET_IF(enable_boost, is_tol_host_mode, boost_tol_64);
+        ROCSPARSE_SCALAR_HOST_DEVICE_GET_IF(
+            enable_boost && (size_boost_tol == sizeof(float)), is_tol_host_mode, boost_tol_32);
+        ROCSPARSE_SCALAR_HOST_DEVICE_GET_IF(
+            enable_boost && (size_boost_tol == sizeof(double)), is_tol_host_mode, boost_tol_64);
         ROCSPARSE_SCALAR_HOST_DEVICE_GET_IF(enable_boost, is_val_host_mode, boost_val);
         const double boost_tol = (size_boost_tol == sizeof(double)) ? boost_tol_64 : boost_tol_32;
 
@@ -328,8 +330,12 @@ namespace rocsparse
         const auto boost_tol_pointer_mode = boost->get_tol_pointer_mode();
         const auto boost_val_pointer_mode = boost->get_val_pointer_mode();
 
-        const float*  boost_tol_32 = reinterpret_cast<const float*>(boost->get_tol());
-        const double* boost_tol_64 = reinterpret_cast<const double*>(boost->get_tol());
+        const float*  boost_tol_32 = (boost_tol_size == sizeof(float))
+                                         ? reinterpret_cast<const float*>(boost->get_tol())
+                                         : nullptr;
+        const double* boost_tol_64 = (boost_tol_size == sizeof(double))
+                                         ? reinterpret_cast<const double*>(boost->get_tol())
+                                         : nullptr;
         const T*      boost_val    = reinterpret_cast<const T*>(boost->get_val());
         auto trm_info = bsrilu0_info->get(rocsparse_operation_none, rocsparse_fill_mode_lower);
 

--- a/projects/rocsparse/library/src/precond/csrilu0/rocsparse_csrilu0_kernel_hash.cpp
+++ b/projects/rocsparse/library/src/precond/csrilu0/rocsparse_csrilu0_kernel_hash.cpp
@@ -287,8 +287,10 @@ namespace rocsparse
     {
         const auto batch_index = hipBlockIdx_y;
 
-        ROCSPARSE_SCALAR_HOST_DEVICE_GET_IF(enable_boost, is_tol_host_mode, boost_tol_32);
-        ROCSPARSE_SCALAR_HOST_DEVICE_GET_IF(enable_boost, is_tol_host_mode, boost_tol_64);
+        ROCSPARSE_SCALAR_HOST_DEVICE_GET_IF(
+            enable_boost && (size_boost_tol == sizeof(float)), is_tol_host_mode, boost_tol_32);
+        ROCSPARSE_SCALAR_HOST_DEVICE_GET_IF(
+            enable_boost && (size_boost_tol == sizeof(double)), is_tol_host_mode, boost_tol_64);
         ROCSPARSE_SCALAR_HOST_DEVICE_GET_IF(enable_boost, is_val_host_mode, boost_val);
 
         const double boost_tol = (size_boost_tol == sizeof(double)) ? boost_tol_64 : boost_tol_32;


### PR DESCRIPTION
## Summary

Fixed type-punned pointer aliasing undefined behavior in ILU0 preconditioner kernels. The original code cast the same `boost_tol` pointer to both `float*` and `double*` and dereferenced both. The fix:
- Sets only the correctly-typed pointer (the other is `nullptr`)
- Adds size checks to the conditional dereference macro calls

**Affected files:**
- `rocsparse_bsrilu0_kernel_2_8.cpp`
- `rocsparse_bsrilu0_kernel_9_32.cpp`
- `rocsparse_bsrilu0_kernel_33_64.cpp`
- `rocsparse_bsrilu0_kernel_general.cpp`
- `rocsparse_csrilu0_kernel_hash.cpp`
