### PR TITLE
Add merge queue for hipDNN and DNN providers

### DIFF
--- a/.github/scripts/github_cli_client.py
+++ b/.github/scripts/github_cli_client.py
@@ -47,7 +47,7 @@ import os
 import requests
 import time
 import logging
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -361,3 +361,107 @@ class GitHubCLIClient:
             else:
                 email = f"{username}@users.noreply.github.com"
         return name, email
+
+    # ── Merge Queue helpers ───────────────────────────────────────────
+
+    def get_pr_reviews(self, repo: str, pr_number: int) -> List[dict]:
+        """Fetch all reviews for a pull request."""
+        url = f"{self.api_url}/repos/{repo}/pulls/{pr_number}/reviews?per_page=100"
+        return self._get_paginated_json(
+            url, f"Failed to fetch reviews for PR #{pr_number} in {repo}"
+        )
+
+    def get_check_runs(self, repo: str, sha: str) -> List[dict]:
+        """Fetch check runs for a commit SHA."""
+        url = f"{self.api_url}/repos/{repo}/commits/{sha}/check-runs?per_page=100"
+        data = self._get_json(url, f"Failed to fetch check runs for {sha}")
+        return data.get("check_runs", [])
+
+    def get_combined_status(self, repo: str, sha: str) -> Dict:
+        """Fetch the combined commit status for a SHA."""
+        url = f"{self.api_url}/repos/{repo}/commits/{sha}/status"
+        return self._get_json(url, f"Failed to fetch status for {sha}")
+
+    def update_pr_branch(self, repo: str, pr_number: int) -> bool:
+        """Update a PR branch by merging the base branch into it.
+
+        Returns True on success, False on conflict or error.
+        """
+        url = f"{self.api_url}/repos/{repo}/pulls/{pr_number}/update-branch"
+        result = self._request_json(
+            "PUT", url, {"expected_head_sha": None},
+            f"Failed to update branch for PR #{pr_number} in {repo}",
+        )
+        # Empty dict with no error means 204/success, or result has "message"
+        if result.get("message") and "merge conflict" in result["message"].lower():
+            return False
+        return True
+
+    def merge_pr(self, repo: str, pr_number: int, method: str = "squash") -> bool:
+        """Merge a pull request. Returns True on success."""
+        url = f"{self.api_url}/repos/{repo}/pulls/{pr_number}/merge"
+        result = self._request_json(
+            "PUT",
+            url,
+            {"merge_method": method},
+            f"Failed to merge PR #{pr_number} in {repo}",
+        )
+        return result.get("merged", False)
+
+    def add_labels(self, repo: str, issue_number: int, labels: List[str]) -> None:
+        """Add labels to an issue or PR."""
+        url = f"{self.api_url}/repos/{repo}/issues/{issue_number}/labels"
+        self._request_json(
+            "POST", url, {"labels": labels},
+            f"Failed to add labels to #{issue_number} in {repo}",
+        )
+
+    def remove_label(self, repo: str, issue_number: int, label: str) -> None:
+        """Remove a single label from an issue or PR."""
+        url = f"{self.api_url}/repos/{repo}/issues/{issue_number}/labels/{label}"
+        self._request_json(
+            "DELETE", url, None,
+            f"Failed to remove label '{label}' from #{issue_number} in {repo}",
+        )
+
+    def add_comment(self, repo: str, issue_number: int, body: str) -> dict:
+        """Add a comment to an issue or PR."""
+        url = f"{self.api_url}/repos/{repo}/issues/{issue_number}/comments"
+        return self._request_json(
+            "POST", url, {"body": body},
+            f"Failed to add comment to #{issue_number} in {repo}",
+        )
+
+    def update_comment(self, repo: str, comment_id: int, body: str) -> dict:
+        """Update an existing comment."""
+        url = f"{self.api_url}/repos/{repo}/issues/comments/{comment_id}"
+        return self._request_json(
+            "PATCH", url, {"body": body},
+            f"Failed to update comment {comment_id} in {repo}",
+        )
+
+    def get_comments(self, repo: str, issue_number: int) -> List[dict]:
+        """Fetch all comments on an issue or PR."""
+        url = f"{self.api_url}/repos/{repo}/issues/{issue_number}/comments?per_page=100"
+        return self._get_paginated_json(
+            url, f"Failed to fetch comments for #{issue_number} in {repo}",
+        )
+
+    def get_collaborator_permission(self, repo: str, username: str) -> str:
+        """Get a user's permission level on a repository."""
+        url = f"{self.api_url}/repos/{repo}/collaborators/{username}/permission"
+        data = self._get_json(
+            url, f"Failed to check permissions for {username} in {repo}"
+        )
+        return data.get("permission", "")
+
+    def search_issues(
+        self, query: str, sort: str = "created", order: str = "asc"
+    ) -> List[dict]:
+        """Search issues/PRs using the GitHub search API."""
+        url = (
+            f"{self.api_url}/search/issues"
+            f"?q={requests.utils.quote(query)}&sort={sort}&order={order}&per_page=100"
+        )
+        data = self._get_json(url, f"Failed to search issues: {query}")
+        return data.get("items", [])

--- a/.github/scripts/merge_queue.py
+++ b/.github/scripts/merge_queue.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+
+"""
+Merge Queue Logic
+-----------------
+Shared functions for the hipDNN/provider merge queue system.
+
+Provides queue detection, FIFO ordering, multi-queue coordination,
+CI status checking, and PR merge operations.
+"""
+
+import json
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Tuple
+
+from github_cli_client import GitHubCLIClient
+from merge_queue_config import (
+    ALL_QUEUES,
+    LABEL_ACTIVE,
+    LABEL_PREFIX,
+    LABEL_QUEUED,
+    MERGE_METHOD,
+    METADATA_COMMENT_MARKER,
+    PATH_TO_QUEUES,
+    STATUS_COMMENT_MARKER,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def detect_queues(changed_files: List[str]) -> List[str]:
+    """Map changed file paths to the set of merge queues the PR should enter.
+
+    A file matching ``projects/hipdnn/`` enters all queues (core can break
+    providers).  Provider files enter only their own queue.  The union across
+    all changed files is returned, sorted and deduplicated.
+    """
+    queues: set[str] = set()
+    for filepath in changed_files:
+        for prefix, queue_list in PATH_TO_QUEUES.items():
+            if filepath.startswith(prefix):
+                queues.update(queue_list)
+                break  # first prefix match per file is enough
+    return sorted(queues)
+
+
+# ── Metadata comment helpers ─────────────────────────────────────────
+
+
+def _parse_metadata_comment(body: str) -> Optional[dict]:
+    """Extract JSON from a merge-queue metadata HTML comment."""
+    pattern = re.compile(
+        rf"{re.escape(METADATA_COMMENT_MARKER)}\s*(\{{.*?\}})\s*-->",
+        re.DOTALL,
+    )
+    match = pattern.search(body)
+    if match:
+        try:
+            return json.loads(match.group(1))
+        except json.JSONDecodeError:
+            return None
+    return None
+
+
+def _build_metadata_comment(metadata: dict) -> str:
+    """Build the hidden HTML comment that stores queue metadata on a PR."""
+    return f"{METADATA_COMMENT_MARKER} {json.dumps(metadata)} -->"
+
+
+def get_enqueue_metadata(
+    client: GitHubCLIClient, repo: str, pr_number: int
+) -> Optional[dict]:
+    """Read merge-queue metadata from PR comments.  Returns None if not queued."""
+    comments = client.get_comments(repo, pr_number)
+    for comment in comments:
+        meta = _parse_metadata_comment(comment.get("body", ""))
+        if meta is not None:
+            meta["_comment_id"] = comment["id"]
+            return meta
+    return None
+
+
+def _delete_metadata_comment(
+    client: GitHubCLIClient, repo: str, pr_number: int
+) -> None:
+    """Remove the metadata comment from a PR (cleanup on dequeue)."""
+    comments = client.get_comments(repo, pr_number)
+    for comment in comments:
+        if METADATA_COMMENT_MARKER in comment.get("body", ""):
+            url = f"{client.api_url}/repos/{repo}/issues/comments/{comment['id']}"
+            client._request_json("DELETE", url, None, "Failed to delete metadata comment")
+            break
+
+
+# ── Enqueue / Dequeue ────────────────────────────────────────────────
+
+
+def enqueue_pr(
+    client: GitHubCLIClient,
+    repo: str,
+    pr_number: int,
+    queues: List[str],
+    user: str,
+) -> None:
+    """Add a PR to the merge queue.
+
+    Adds the ``mq:queued`` label plus one ``mq:<queue>`` label per queue,
+    and posts a hidden metadata comment for FIFO ordering.
+    """
+    now = datetime.now(timezone.utc).isoformat()
+    metadata = {
+        "enqueued_at": now,
+        "queues": queues,
+        "enqueued_by": user,
+    }
+
+    labels = [LABEL_QUEUED] + [f"{LABEL_PREFIX}{q}" for q in queues]
+    client.add_labels(repo, pr_number, labels)
+    client.add_comment(repo, pr_number, _build_metadata_comment(metadata))
+
+    logger.info(f"PR #{pr_number} enqueued in {queues} by @{user}")
+
+
+def dequeue_pr(
+    client: GitHubCLIClient,
+    repo: str,
+    pr_number: int,
+    reason: str,
+) -> None:
+    """Remove a PR from all merge queues.
+
+    Strips every ``mq:*`` label and posts a comment explaining why.
+    """
+    existing = client.get_existing_labels_on_pr(repo, pr_number)
+    mq_labels = [l for l in existing if l.startswith(LABEL_PREFIX)]
+    for label in mq_labels:
+        client.remove_label(repo, pr_number, label)
+
+    _delete_metadata_comment(client, repo, pr_number)
+    client.add_comment(repo, pr_number, f"**Merge Queue:** {reason}")
+    logger.info(f"PR #{pr_number} dequeued: {reason}")
+
+
+# ── Queue membership queries ────────────────────────────────────────
+
+
+def get_queue_members(
+    client: GitHubCLIClient, repo: str, queue: str
+) -> List[dict]:
+    """Return all PRs in a given queue, sorted oldest-first (FIFO).
+
+    Each entry: ``{"pr_number": int, "enqueued_at": str, "queues": [str]}``.
+    """
+    label = f"{LABEL_PREFIX}{queue}"
+    # Search for open PRs with the queue label AND either queued or active
+    query = (
+        f"repo:{repo} is:pr is:open label:{label} "
+        f"(label:{LABEL_QUEUED} OR label:{LABEL_ACTIVE})"
+    )
+    items = client.search_issues(query, sort="created", order="asc")
+
+    members: list[dict] = []
+    for item in items:
+        pr_num = item["number"]
+        meta = get_enqueue_metadata(client, repo, pr_num)
+        if meta:
+            members.append(
+                {
+                    "pr_number": pr_num,
+                    "enqueued_at": meta["enqueued_at"],
+                    "queues": meta["queues"],
+                }
+            )
+        else:
+            # Fallback: use the issue created_at if metadata is missing
+            members.append(
+                {
+                    "pr_number": pr_num,
+                    "enqueued_at": item.get("created_at", ""),
+                    "queues": [],
+                }
+            )
+
+    # Sort by enqueue timestamp (FIFO)
+    members.sort(key=lambda m: m["enqueued_at"])
+    return members
+
+
+def get_queue_head(
+    client: GitHubCLIClient, repo: str, queue: str
+) -> Optional[int]:
+    """Return the PR number at the front of a queue, or None if empty."""
+    members = get_queue_members(client, repo, queue)
+    return members[0]["pr_number"] if members else None
+
+
+def is_at_front_of_all_queues(
+    client: GitHubCLIClient,
+    repo: str,
+    pr_number: int,
+    queues: List[str],
+) -> Tuple[bool, List[str]]:
+    """Check whether a PR is at the head of every queue it belongs to.
+
+    Returns ``(is_ready, blocking_queues)`` where *blocking_queues* lists
+    the queues where another PR is ahead.
+    """
+    blocking: list[str] = []
+    for queue in queues:
+        head = get_queue_head(client, repo, queue)
+        if head != pr_number:
+            blocking.append(queue)
+    return (len(blocking) == 0, blocking)
+
+
+# ── CI status ────────────────────────────────────────────────────────
+
+
+def check_ci_status(
+    client: GitHubCLIClient, repo: str, pr_number: int
+) -> str:
+    """Check CI status for the PR's current HEAD commit.
+
+    Returns ``"success"``, ``"pending"``, or ``"failure"``.
+    """
+    pr_data = client.get_pr_by_number(repo, pr_number)
+    if not pr_data:
+        return "failure"
+
+    sha = pr_data.get("head", {}).get("sha", "")
+    if not sha:
+        return "failure"
+
+    # Check both check-runs and commit statuses
+    check_runs = client.get_check_runs(repo, sha)
+    combined = client.get_combined_status(repo, sha)
+
+    # If there are no checks at all, treat as pending (CI hasn't started)
+    statuses = combined.get("statuses", [])
+    if not check_runs and not statuses:
+        return "pending"
+
+    # Check runs
+    for run in check_runs:
+        # Skip the merge queue's own status checks
+        if run.get("name", "").startswith("Merge Queue"):
+            continue
+        status = run.get("status", "")
+        conclusion = run.get("conclusion", "")
+        if status != "completed":
+            return "pending"
+        if conclusion not in ("success", "skipped", "neutral"):
+            return "failure"
+
+    # Commit statuses (from status API)
+    combined_state = combined.get("state", "pending")
+    if combined_state == "failure" or combined_state == "error":
+        return "failure"
+    if combined_state == "pending" and statuses:
+        return "pending"
+
+    return "success"
+
+
+# ── Branch update and merge ──────────────────────────────────────────
+
+
+def update_pr_branch(
+    client: GitHubCLIClient, repo: str, pr_number: int
+) -> bool:
+    """Merge the base branch into the PR branch.
+
+    Returns True on success, False on merge conflict.
+    """
+    pr_data = client.get_pr_by_number(repo, pr_number)
+    if not pr_data:
+        return False
+
+    # Check if already up to date
+    mergeable_state = pr_data.get("mergeable_state", "")
+    if mergeable_state == "clean":
+        logger.info(f"PR #{pr_number} is already up to date")
+        return True
+
+    return client.update_pr_branch(repo, pr_number)
+
+
+def merge_pr(
+    client: GitHubCLIClient, repo: str, pr_number: int
+) -> bool:
+    """Squash-merge a PR via the GitHub API."""
+    return client.merge_pr(repo, pr_number, method=MERGE_METHOD)
+
+
+# ── Status comment ───────────────────────────────────────────────────
+
+
+def _find_status_comment(
+    client: GitHubCLIClient, repo: str, pr_number: int
+) -> Optional[int]:
+    """Find the ID of the existing status comment on a PR, if any."""
+    comments = client.get_comments(repo, pr_number)
+    for comment in comments:
+        if STATUS_COMMENT_MARKER in comment.get("body", ""):
+            return comment["id"]
+    return None
+
+
+def update_status_comment(
+    client: GitHubCLIClient,
+    repo: str,
+    pr_number: int,
+    queues: List[str],
+    blocking: List[str],
+) -> None:
+    """Create or update the queue status table comment on a PR."""
+    rows: list[str] = []
+    for queue in queues:
+        members = get_queue_members(client, repo, queue)
+        total = len(members)
+        position = next(
+            (i + 1 for i, m in enumerate(members) if m["pr_number"] == pr_number),
+            total,
+        )
+        if queue in blocking:
+            ahead_pr = members[0]["pr_number"] if members else "?"
+            status = f"Waiting (PR #{ahead_pr} ahead)"
+        elif position == 1:
+            status = "At front"
+        else:
+            status = f"Position {position}"
+        rows.append(f"| `{queue}` | {position}/{total} | {status} |")
+
+    if blocking:
+        overall = f"Waiting for: {', '.join(f'`{q}`' for q in blocking)}"
+    else:
+        overall = "At front of all queues — processing"
+
+    table = "\n".join(rows)
+    body = (
+        f"{STATUS_COMMENT_MARKER} -->\n"
+        f"## Merge Queue Status\n\n"
+        f"| Queue | Position | Status |\n"
+        f"|-------|----------|--------|\n"
+        f"{table}\n\n"
+        f"**Overall:** {overall}"
+    )
+
+    comment_id = _find_status_comment(client, repo, pr_number)
+    if comment_id:
+        client.update_comment(repo, comment_id, body)
+    else:
+        client.add_comment(repo, pr_number, body)

--- a/.github/scripts/merge_queue_command.py
+++ b/.github/scripts/merge_queue_command.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+
+"""
+Merge Queue Command Handler
+----------------------------
+Handles ``/merge`` and ``/dequeue`` PR comment commands.
+
+Called by the ``merge-queue-command.yml`` workflow when a comment is
+created on a pull request.
+
+Environment variables (set by the workflow):
+    GH_TOKEN      – GitHub API token
+    REPO          – owner/repo (e.g. ``ROCm/rocm-libraries``)
+    PR_NUMBER     – pull request number
+    COMMENT_BODY  – the full comment text
+    COMMENT_AUTHOR – GitHub login of the commenter
+"""
+
+import logging
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from github_cli_client import GitHubCLIClient
+from merge_queue import (
+    detect_queues,
+    dequeue_pr,
+    enqueue_pr,
+    get_enqueue_metadata,
+    get_queue_members,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    client = GitHubCLIClient()
+    repo = os.environ["REPO"]
+    pr_number = int(os.environ["PR_NUMBER"])
+    comment_body = os.environ["COMMENT_BODY"].strip()
+    comment_author = os.environ["COMMENT_AUTHOR"]
+
+    if comment_body.startswith("/merge"):
+        handle_merge(client, repo, pr_number, comment_author)
+    elif comment_body.startswith("/dequeue"):
+        handle_dequeue(client, repo, pr_number, comment_author)
+    else:
+        logger.info("Comment does not contain a merge queue command")
+
+
+def _has_write_access(client: GitHubCLIClient, repo: str, username: str) -> bool:
+    perm = client.get_collaborator_permission(repo, username)
+    return perm in ("admin", "maintain", "write")
+
+
+def handle_merge(
+    client: GitHubCLIClient, repo: str, pr_number: int, user: str
+) -> None:
+    # Permission check
+    if not _has_write_access(client, repo, user):
+        client.add_comment(
+            repo,
+            pr_number,
+            f"@{user} You need write permission to use `/merge`.",
+        )
+        return
+
+    # Already queued?
+    existing = get_enqueue_metadata(client, repo, pr_number)
+    if existing:
+        client.add_comment(
+            repo,
+            pr_number,
+            "This PR is already in the merge queue. "
+            "Use `/dequeue` to remove it first.",
+        )
+        return
+
+    # Must have at least one approving review
+    reviews = client.get_pr_reviews(repo, pr_number)
+    approved = any(r.get("state") == "APPROVED" for r in reviews)
+    if not approved:
+        client.add_comment(
+            repo,
+            pr_number,
+            "This PR needs at least one approving review before "
+            "it can enter the merge queue.",
+        )
+        return
+
+    # Detect queues from changed files
+    changed_files = client.get_changed_files(repo, pr_number)
+    queues = detect_queues(changed_files)
+    if not queues:
+        client.add_comment(
+            repo,
+            pr_number,
+            "This PR does not touch any merge-queue-managed paths "
+            "(`projects/hipdnn/` or `dnn-providers/*/`). "
+            "It can be merged normally.",
+        )
+        return
+
+    # Enqueue
+    enqueue_pr(client, repo, pr_number, queues, user)
+
+    # Build confirmation with queue positions
+    lines = [f"**Merge Queue:** PR #{pr_number} has been enqueued by @{user}.\n"]
+    lines.append("| Queue | Position |")
+    lines.append("|-------|----------|")
+    for q in queues:
+        members = get_queue_members(client, repo, q)
+        position = next(
+            (i + 1 for i, m in enumerate(members) if m["pr_number"] == pr_number),
+            len(members),
+        )
+        lines.append(f"| `{q}` | {position}/{len(members)} |")
+
+    client.add_comment(repo, pr_number, "\n".join(lines))
+    logger.info(f"PR #{pr_number} enqueued in {queues}")
+
+
+def handle_dequeue(
+    client: GitHubCLIClient, repo: str, pr_number: int, user: str
+) -> None:
+    # PR author or write access can dequeue
+    pr_data = client.get_pr_by_number(repo, pr_number)
+    is_author = pr_data and pr_data.get("user", {}).get("login") == user
+    if not is_author and not _has_write_access(client, repo, user):
+        client.add_comment(
+            repo,
+            pr_number,
+            f"@{user} Only the PR author or a collaborator with write "
+            "permission can use `/dequeue`.",
+        )
+        return
+
+    dequeue_pr(client, repo, pr_number, f"Removed from queue by @{user} via `/dequeue`.")
+    logger.info(f"PR #{pr_number} dequeued by @{user}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/merge_queue_config.py
+++ b/.github/scripts/merge_queue_config.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+"""
+Merge Queue Configuration
+-------------------------
+Path-to-queue mappings and constants for the hipDNN/provider merge queue system.
+
+Queue model:
+- Each provider has its own independent FIFO queue
+- hipDNN core changes enter ALL queues (core can break providers)
+- Provider changes only enter their own queue
+- A PR merges only when at the front of every queue it belongs to
+"""
+
+# Path prefix -> list of queues the PR enters.
+# Order matters for matching: first prefix match wins per file.
+PATH_TO_QUEUES = {
+    "projects/hipdnn/": [
+        "hipdnn",
+        "miopen-provider",
+        "hipblaslt-provider",
+        "hip-kernel-provider",
+        "fusilli-provider",
+        "integration-tests",
+    ],
+    "dnn-providers/miopen-provider/": ["miopen-provider"],
+    "dnn-providers/hipblaslt-provider/": ["hipblaslt-provider"],
+    "dnn-providers/hip-kernel-provider/": ["hip-kernel-provider"],
+    "dnn-providers/fusilli-provider/": ["fusilli-provider"],
+    "dnn-providers/integration-tests/": ["integration-tests"],
+}
+
+ALL_QUEUES = sorted(
+    set(queue for queues in PATH_TO_QUEUES.values() for queue in queues)
+)
+
+LABEL_PREFIX = "mq:"
+LABEL_QUEUED = f"{LABEL_PREFIX}queued"
+LABEL_ACTIVE = f"{LABEL_PREFIX}active"
+
+METADATA_COMMENT_MARKER = "<!-- merge-queue-metadata"
+STATUS_COMMENT_MARKER = "<!-- merge-queue-status"
+
+# The base branch that queued PRs target.
+TARGET_BRANCH = "develop"
+
+# Merge method used when the queue merges a PR.
+MERGE_METHOD = "squash"

--- a/.github/scripts/merge_queue_process.py
+++ b/.github/scripts/merge_queue_process.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+
+"""
+Merge Queue Processor
+---------------------
+Scheduled processor that advances the merge queue each cycle.
+
+For each queue, finds the head PR (oldest ``enqueued_at``).  A PR is
+only processed when it is at the front of **all** queues it belongs to.
+
+Processing steps for an eligible PR:
+1. Transition from ``mq:queued`` → ``mq:active``
+2. Update PR branch (merge develop into it)
+3. Wait for CI on the next cycle
+4. On CI success → squash-merge
+5. On CI failure → eject from all queues
+
+Environment variables (set by the workflow):
+    GH_TOKEN – GitHub API token
+    REPO     – owner/repo
+"""
+
+import logging
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from github_cli_client import GitHubCLIClient
+from merge_queue import (
+    check_ci_status,
+    dequeue_pr,
+    get_queue_members,
+    is_at_front_of_all_queues,
+    merge_pr,
+    update_pr_branch,
+    update_status_comment,
+)
+from merge_queue_config import ALL_QUEUES, LABEL_ACTIVE, LABEL_QUEUED
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    client = GitHubCLIClient()
+    repo = os.environ["REPO"]
+
+    # Track PRs already processed this cycle to avoid duplicate work when a
+    # PR appears at the head of multiple queues.
+    processed: set[int] = set()
+
+    for queue in ALL_QUEUES:
+        members = get_queue_members(client, repo, queue)
+        if not members:
+            continue
+
+        head = members[0]
+        pr_number = head["pr_number"]
+
+        if pr_number in processed:
+            continue
+        processed.add(pr_number)
+
+        pr_queues = head["queues"]
+        if not pr_queues:
+            # Missing metadata — skip
+            logger.warning(f"PR #{pr_number} has no queue metadata, skipping")
+            continue
+
+        is_ready, blocking = is_at_front_of_all_queues(
+            client, repo, pr_number, pr_queues
+        )
+
+        # Update the status comment on this PR every cycle
+        update_status_comment(client, repo, pr_number, pr_queues, blocking)
+
+        if not is_ready:
+            logger.info(
+                f"PR #{pr_number} blocked by queues: {blocking}"
+            )
+            continue
+
+        # PR is at the front of all its queues — process it
+        labels = client.get_existing_labels_on_pr(repo, pr_number)
+        is_active = LABEL_ACTIVE in labels
+
+        if not is_active:
+            # First time at front: activate and update branch
+            logger.info(f"Activating PR #{pr_number}: updating branch")
+            client.add_labels(repo, pr_number, [LABEL_ACTIVE])
+            if LABEL_QUEUED in labels:
+                client.remove_label(repo, pr_number, LABEL_QUEUED)
+
+            success = update_pr_branch(client, repo, pr_number)
+            if not success:
+                dequeue_pr(
+                    client,
+                    repo,
+                    pr_number,
+                    "Merge conflict with the base branch. "
+                    "Please rebase and re-enqueue with `/merge`.",
+                )
+            # Either way, wait for next cycle (CI needs to run on the
+            # updated branch, or the PR was ejected).
+            continue
+
+        # Already active — check CI
+        ci = check_ci_status(client, repo, pr_number)
+        logger.info(f"PR #{pr_number} CI status: {ci}")
+
+        if ci == "pending":
+            continue
+
+        if ci == "failure":
+            dequeue_pr(
+                client,
+                repo,
+                pr_number,
+                "CI checks failed while at the front of the merge queue. "
+                "Please fix the failures and re-enqueue with `/merge`.",
+            )
+            continue
+
+        if ci == "success":
+            logger.info(f"Merging PR #{pr_number}")
+            success = merge_pr(client, repo, pr_number)
+            if success:
+                client.add_comment(
+                    repo,
+                    pr_number,
+                    "**Merge Queue:** PR merged successfully.",
+                )
+            else:
+                dequeue_pr(
+                    client,
+                    repo,
+                    pr_number,
+                    "Merge failed unexpectedly. "
+                    "Please check for conflicts and re-enqueue with `/merge`.",
+                )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/merge-queue-command.yml
+++ b/.github/workflows/merge-queue-command.yml
@@ -1,0 +1,39 @@
+name: Merge Queue Command
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  handle-command:
+    if: >-
+      github.event.issue.pull_request &&
+      (startsWith(github.event.comment.body, '/merge') ||
+       startsWith(github.event.comment.body, '/dequeue'))
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+          sparse-checkout-cone-mode: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - run: pip install requests
+        name: Install dependencies
+
+      - name: Handle merge queue command
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          REPO: ${{ github.repository }}
+        run: python .github/scripts/merge_queue_command.py

--- a/.github/workflows/merge-queue-process.yml
+++ b/.github/workflows/merge-queue-process.yml
@@ -1,0 +1,40 @@
+name: Merge Queue Processor
+
+on:
+  schedule:
+    - cron: "*/3 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  checks: read
+  statuses: read
+
+concurrency:
+  group: merge-queue-processor
+  cancel-in-progress: false
+
+jobs:
+  process:
+    if: github.repository == 'ROCm/rocm-libraries'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+          sparse-checkout-cone-mode: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - run: pip install requests
+        name: Install dependencies
+
+      - name: Process merge queues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: python .github/scripts/merge_queue_process.py

--- a/.github/workflows/merge-queue-status.yml
+++ b/.github/workflows/merge-queue-status.yml
@@ -1,0 +1,52 @@
+name: Merge Queue Status
+
+on:
+  pull_request_target:
+    types: [synchronize]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  eject-on-push:
+    # Only act on PRs that are in the merge queue, and only when a human
+    # pushed (not the bot updating the branch via the processor).
+    if: >-
+      contains(join(github.event.pull_request.labels.*.name, ','), 'mq:') &&
+      github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+          sparse-checkout-cone-mode: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - run: pip install requests
+        name: Install dependencies
+
+      - name: Eject PR from merge queue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          python -c "
+          import os, sys
+          sys.path.insert(0, '.github/scripts')
+          from github_cli_client import GitHubCLIClient
+          from merge_queue import dequeue_pr
+
+          client = GitHubCLIClient()
+          dequeue_pr(
+              client,
+              os.environ['REPO'],
+              int(os.environ['PR_NUMBER']),
+              'New commits were pushed while in the merge queue. '
+              'Removed from all queues — please re-enqueue with \`/merge\` after CI passes.',
+          )
+          "


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions-based merge queue for `projects/hipdnn/` and the 4 DNN providers under `dnn-providers/`
- Each provider has its own independent FIFO queue; hipDNN core changes automatically enter **all** provider queues (core changes can break providers, but not vice versa)
- PR commands: `/merge` to enqueue, `/dequeue` to remove
- PRs are automatically ejected if new commits are pushed while queued
- Processor runs every 3 minutes: updates branch with develop, waits for CI, squash-merges on success

## Queue model

| Queue | Enters on changes to |
|-------|---------------------|
| `hipdnn` | `projects/hipdnn/` |
| `miopen-provider` | `dnn-providers/miopen-provider/` **or** `projects/hipdnn/` |
| `hipblaslt-provider` | `dnn-providers/hipblaslt-provider/` **or** `projects/hipdnn/` |
| `hip-kernel-provider` | `dnn-providers/hip-kernel-provider/` **or** `projects/hipdnn/` |
| `fusilli-provider` | `dnn-providers/fusilli-provider/` **or** `projects/hipdnn/` |
| `integration-tests` | `dnn-providers/integration-tests/` **or** `projects/hipdnn/` |

A PR only merges when it reaches the front of **every** queue it belongs to.

## Files

| File | Purpose |
|------|---------|
| `.github/scripts/merge_queue_config.py` | Path-to-queue mappings, label constants |
| `.github/scripts/merge_queue.py` | Core queue logic (FIFO ordering, multi-queue coordination, CI checks) |
| `.github/scripts/merge_queue_command.py` | `/merge` and `/dequeue` comment handler |
| `.github/scripts/merge_queue_process.py` | Scheduled processor entry point |
| `.github/scripts/github_cli_client.py` | Extended with merge/CI/comment helper methods |
| `.github/workflows/merge-queue-command.yml` | Workflow for PR comment commands |
| `.github/workflows/merge-queue-process.yml` | Scheduled processor workflow (every 3 min) |
| `.github/workflows/merge-queue-status.yml` | Ejects PRs from queue on new pushes |

## Setup required

Before enabling, create these labels in the repo:
`mq:queued`, `mq:active`, `mq:hipdnn`, `mq:miopen-provider`, `mq:hipblaslt-provider`, `mq:hip-kernel-provider`, `mq:fusilli-provider`, `mq:integration-tests`

## Known limitation: `GITHUB_TOKEN`

This implementation uses `GITHUB_TOKEN` for all API calls. GitHub's `GITHUB_TOKEN` **cannot trigger other workflows** — so when the processor squash-merges a PR into `develop`, any workflows triggered by `push` to `develop` (e.g., `therock-ci.yml` nightly/post-merge builds) will **not fire automatically**.

**If post-merge workflow triggering is required**, a GitHub App token must be used in `merge-queue-process.yml` instead. This would require:
1. Creating a GitHub App with `contents:write` and `pull_requests:write` permissions
2. Installing it on the repo
3. Using `actions/create-github-app-token` in the processor workflow to generate a token

The merge queue itself (enqueue, CI check, merge) works fully with `GITHUB_TOKEN` — only downstream workflow triggering is affected.

## Test plan

- [ ] Create labels in repo
- [ ] Test `/merge` on a PR touching `projects/hipdnn/` — verify all 6 queue labels added
- [ ] Test `/merge` on a PR touching only `dnn-providers/miopen-provider/` — verify only `mq:miopen-provider`
- [ ] Test `/dequeue` removes all `mq:*` labels
- [ ] Test processor updates branch, checks CI, merges on success
- [ ] Test push invalidation: push new commits to a queued PR → verify ejection
- [ ] Test blocking: queue a core PR then a provider PR → verify provider waits

🤖 Generated with [Claude Code](https://claude.com/claude-code)