### PR TITLE
Fix calSwizzlePackK integer truncation for sub-byte types

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
@@ -7320,8 +7320,10 @@ class KernelWriter(metaclass=abc.ABCMeta):
     tP["isSwizzled"] = (kernel["ProblemType"]["SwizzleTensorB"] and tP["isB"]) or (kernel["ProblemType"]["SwizzleTensorA"] and tP["isA"])
 
     if tP["isSwizzled"]:
-      # 16 means bytes of buffer_load_dwordx4
-      tP["swizzlePackK"] = 16 // kernel["MIInputPerThread%s"%cM] // int(kernel["ProblemType"]["DataType%s"%cM].numBytes())
+      # 128 bits = 16 bytes in a buffer_load_dwordx4.
+      # Using bits avoids integer truncation for sub-byte types (FP4, FP6).
+      numBits = int(kernel["ProblemType"]["DataType%s"%cM].numBytes() * 8)
+      tP["swizzlePackK"] = 128 // kernel["MIInputPerThread%s"%cM] // numBits
       tP["swizzleK"] = kernel["MatrixInstK"] * tP["swizzlePackK"]
 
   ##############################################################################

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -2482,7 +2482,10 @@ class Solution(collections.abc.Mapping):
         return optGRVW
 
       def calSwizzlePackK(state, tc):
-        return 16 // state[f"MIInputPerThread{tc}"] // int(state["ProblemType"][f"DataType{tc}"].numBytes())
+        # 128 bits = 16 bytes in a buffer_load_dwordx4.
+        # Using bits avoids integer truncation for sub-byte types (FP4, FP6).
+        numBits = int(state["ProblemType"][f"DataType{tc}"].numBytes() * 8)
+        return 128 // state[f"MIInputPerThread{tc}"] // numBits
 
       genGRVWA = False
       genGRVWB = False


### PR DESCRIPTION
## Motivation

This is a fix for a function that computes how many elements of a 
specified type fit in 16-bytes.

For FP4 (0.5 bytes), `int(numBytes())` truncates to 0, which was causing 
division by zero. This PR switches to bit-width arithmetic: 
128 bits / MIInputPerThread / numBits. 

## Test Plan

This code has no unit testing, so I have relied on end-to-end testing (which will be in a later PR)

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
