### PR TITLE
Fix cache key collision when A and B are swizzled

### DIFF
--- a/projects/hipblaslt/tensilelite/client/src/DataInitialization.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/DataInitialization.cpp
@@ -106,7 +106,9 @@ namespace TensileLite
 
         using BitWidth        = uint8_t;
         using Size            = uint64_t;
-        using SwizzleCacheKey = std::tuple<BitWidth, Size, Size>;
+        // Cache key includes tensor index (size_t) to prevent A and B from
+        // sharing cached permuted data when they have the same shape.
+        using SwizzleCacheKey = std::tuple<BitWidth, Size, Size, size_t>;
         using SwizzleCacheVal = ::Tensor::Manipulation::Tensor;
         using SwizzleCache    = LRUCache<SwizzleCacheKey, SwizzleCacheVal>;
         static thread_local SwizzleCache g_swizzleCache;
@@ -2242,7 +2244,7 @@ namespace TensileLite
                         (unrolledSize / (MiK * PackK) + !!(unrolledSize % (MiK * PackK))) * MiK
                             * PackK};
                     auto swizzleKey
-                        = std::make_tuple(toBitWidth(desc.dataType()), unrolledSize, tiledSize);
+                        = std::make_tuple(toBitWidth(desc.dataType()), unrolledSize, tiledSize, i);
 
                     if(g_swizzleCache.count(swizzleKey))
                     {


### PR DESCRIPTION
## Motivation

The swizzle cache keyed on (bitWidth, unrolledSize, tiledSize), which
collided when A and B had the same shape. When B hit the cache, it
received A's permuted data instead of its own. Fix: Add tensor index
to the key to prevent cross-tensor cache reuse.

## Test Plan

This code has no unit tests. I rely on end-to-end numerical validation to verify this fix is correct. 

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
