### PR TITLE
[rocBLAS][hipBLAS] users/torrezuk/rocm-20935 dll props

### DIFF
--- a/projects/hipblas/library/CMakeLists.txt
+++ b/projects/hipblas/library/CMakeLists.txt
@@ -60,6 +60,13 @@ message( STATUS "*** Building hipBLAS commit: ${hipblas_VERSION_COMMIT_ID}" )
 # configure a header file to pass the CMake version settings to the source, and package the header files in the output archive
 configure_file( "${CMAKE_CURRENT_SOURCE_DIR}/include/hipblas-version.h.in" "${PROJECT_BINARY_DIR}/include/hipblas/hipblas-version.h" )
 
+# Configure Windows version resource file
+if(WIN32)
+  string(TIMESTAMP HIPBLAS_COPYRIGHT_YEAR "%Y")
+  configure_file( "${CMAKE_CURRENT_SOURCE_DIR}/src/version.rc.in"
+    "${PROJECT_BINARY_DIR}/version.rc" @ONLY )
+endif()
+
 # Copy Public Headers to Build Dir
 configure_file( "${CMAKE_CURRENT_SOURCE_DIR}/include/hipblas.h" "${PROJECT_BINARY_DIR}/include/hipblas/hipblas.h" COPYONLY)
 

--- a/projects/hipblas/library/src/CMakeLists.txt
+++ b/projects/hipblas/library/src/CMakeLists.txt
@@ -58,6 +58,11 @@ add_library( hipblas
 )
 add_library( roc::hipblas ALIAS hipblas )
 
+# Add Windows version resource to library
+if(WIN32 AND BUILD_SHARED_LIBS)
+  target_sources(hipblas PRIVATE "${PROJECT_BINARY_DIR}/version.rc")
+endif()
+
 set(static_depends)
 
 find_package( hipblas-common REQUIRED CONFIG PATHS ${ROCM_PATH})

--- a/projects/hipblas/library/src/version.rc.in
+++ b/projects/hipblas/library/src/version.rc.in
@@ -1,0 +1,59 @@
+/* ************************************************************************
+ * Copyright (C) @HIPBLAS_COPYRIGHT_YEAR@ Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+ * ies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+ * PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+ * CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * ************************************************************************ */
+
+#include <winver.h>
+
+#ifdef DEBUG
+#define VER_DEBUG VS_FF_DEBUG
+#else
+#define VER_DEBUG 0
+#endif
+
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION     @hipblas_VERSION_MAJOR@,@hipblas_VERSION_MINOR@,@hipblas_VERSION_PATCH@,0
+PRODUCTVERSION  @hipblas_VERSION_MAJOR@,@hipblas_VERSION_MINOR@,@hipblas_VERSION_PATCH@,0
+FILEFLAGSMASK   VS_FFI_FILEFLAGSMASK
+FILEFLAGS       VER_DEBUG
+FILEOS          VOS__WINDOWS32
+FILETYPE        VFT_DLL
+FILESUBTYPE     VFT2_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904B0"
+        BEGIN
+            VALUE "CompanyName",      "Advanced Micro Devices, Inc."
+            VALUE "FileDescription",  "AMD hipBLAS - Portable BLAS Library for GPU Computing"
+            VALUE "FileVersion",      "@hipblas_VERSION_MAJOR@.@hipblas_VERSION_MINOR@.@hipblas_VERSION_PATCH@.0"
+            VALUE "InternalName",     "hipblas"
+            VALUE "LegalCopyright",   "Copyright (C) @HIPBLAS_COPYRIGHT_YEAR@ Advanced Micro Devices, Inc."
+            VALUE "OriginalFilename", "hipblas.dll"
+            VALUE "ProductName",      "AMD ROCm hipBLAS @hipblas_VERSION_MAJOR@.@hipblas_VERSION_MINOR@ (@hipblas_VERSION_TWEAK@)"
+            VALUE "ProductVersion",   "@hipblas_VERSION_MAJOR@.@hipblas_VERSION_MINOR@.@hipblas_VERSION_PATCH@.0"
+            VALUE "Comments",         "Git commit: @hipblas_VERSION_COMMIT_ID@"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END

--- a/projects/rocblas/library/CMakeLists.txt
+++ b/projects/rocblas/library/CMakeLists.txt
@@ -227,6 +227,13 @@ endif()
 configure_file( "${CMAKE_CURRENT_SOURCE_DIR}/include/internal/rocblas-version.h.in"
 	"${PROJECT_BINARY_DIR}/include/rocblas/internal/rocblas-version.h" )
 
+# Configure Windows version resource file
+if(WIN32)
+  string(TIMESTAMP ROCBLAS_COPYRIGHT_YEAR "%Y")
+  configure_file( "${CMAKE_CURRENT_SOURCE_DIR}/src/version.rc.in"
+    "${PROJECT_BINARY_DIR}/version.rc" @ONLY )
+endif()
+
 
 set( rocblas_headers_public
   include/rocblas.h

--- a/projects/rocblas/library/src/CMakeLists.txt
+++ b/projects/rocblas/library/src/CMakeLists.txt
@@ -668,6 +668,11 @@ add_library( rocblas
   ${subdir_src64_list}
 )
 
+# Add Windows version resource to library
+if(WIN32 AND BUILD_SHARED_LIBS)
+  target_sources(rocblas PRIVATE "${PROJECT_BINARY_DIR}/version.rc")
+endif()
+
 foreach( file ${subdir_src64_list} )
   SET_SOURCE_FILES_PROPERTIES( ${file} PROPERTIES COMPILE_DEFINITIONS ROCBLAS_INTERNAL_ILP64 )
 endforeach()

--- a/projects/rocblas/library/src/version.rc.in
+++ b/projects/rocblas/library/src/version.rc.in
@@ -1,0 +1,59 @@
+/* ************************************************************************
+ * Copyright (C) @ROCBLAS_COPYRIGHT_YEAR@ Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+ * ies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+ * PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+ * CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * ************************************************************************ */
+
+#include <winver.h>
+
+#ifdef DEBUG
+#define VER_DEBUG VS_FF_DEBUG
+#else
+#define VER_DEBUG 0
+#endif
+
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION     @rocblas_VERSION_MAJOR@,@rocblas_VERSION_MINOR@,@rocblas_VERSION_PATCH@,0
+PRODUCTVERSION  @rocblas_VERSION_MAJOR@,@rocblas_VERSION_MINOR@,@rocblas_VERSION_PATCH@,0
+FILEFLAGSMASK   VS_FFI_FILEFLAGSMASK
+FILEFLAGS       VER_DEBUG
+FILEOS          VOS__WINDOWS32
+FILETYPE        VFT_DLL
+FILESUBTYPE     VFT2_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904B0"
+        BEGIN
+            VALUE "CompanyName",      "Advanced Micro Devices, Inc."
+            VALUE "FileDescription",  "AMD rocBLAS - BLAS Library for ROCm"
+            VALUE "FileVersion",      "@rocblas_VERSION_MAJOR@.@rocblas_VERSION_MINOR@.@rocblas_VERSION_PATCH@.0"
+            VALUE "InternalName",     "rocblas"
+            VALUE "LegalCopyright",   "Copyright (C) @ROCBLAS_COPYRIGHT_YEAR@ Advanced Micro Devices, Inc."
+            VALUE "OriginalFilename", "rocblas.dll"
+            VALUE "ProductName",      "AMD ROCm rocBLAS @rocblas_VERSION_MAJOR@.@rocblas_VERSION_MINOR@ (@rocblas_VERSION_TWEAK@)"
+            VALUE "ProductVersion",   "@rocblas_VERSION_MAJOR@.@rocblas_VERSION_MINOR@.@rocblas_VERSION_PATCH@.0"
+            VALUE "Comments",         "Git commit: @rocblas_VERSION_COMMIT_ID@"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END


### PR DESCRIPTION
This pull request adds Windows version resource support to both the hipBLAS and rocBLAS libraries. The main goal is to embed version information and metadata into the generated DLLs on Windows, which improves integration with Windows tooling and provides clear versioning details in the library binaries.

The most important changes are:

**Windows Version Resource Integration:**

* Added generation of a Windows version resource file (`version.rc`) during the CMake configuration step for both hipBLAS and rocBLAS. This file includes version information, copyright, product details, and the current Git commit. 
* Updated the build scripts to include the generated `version.rc` as a private source for the shared library targets when building on Windows, ensuring the DLLs contain the embedded metadata.

**Resource Template Files:**

* Introduced new template files `version.rc.in` for both `hipblas` and `rocblas`, which are processed by CMake to produce the final resource files with the correct version and copyright information.