### PR TITLE
Fix lapack dependency guard in install.sh in hipblaslt

### DIFF
--- a/projects/hipblaslt/install.sh
+++ b/projects/hipblaslt/install.sh
@@ -710,7 +710,7 @@ if [[ "${install_dependencies}" == true ]]; then
 
   # The following builds googletest from source, installs into cmake default /usr/local
   build_lapack="ON"
-  if [ "${use_system_packages}" == true || "${cpu_ref_lib}" == "blis" ]; then
+  if [[ "${use_system_packages}" == true || "${cpu_ref_lib}" == "blis" ]]; then
     build_lapack="OFF"
   fi
   pushd .


### PR DESCRIPTION
## Motivation

install.sh -d command prints an error message saying 

```Requirement already satisfied: wheel in /usr/lib/python3/dist-packages (0.37.1)
./install.sh: line 713: [: missing `]'
./install.sh: line 713: blis: command not found
~/gh/rocm-libraries/projects/hipblaslt ~/gh/rocm-libraries/projects/hipblaslt
```

## Technical Details

correct fix is to replace [ with [[ 
## Test Plan

run 'install.sh -d' after the change

## Test Result

error message is gone.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
