### PR TITLE
hipblaslt install.sh fix for Minimum Cmake version

### DIFF
--- a/projects/hipblaslt/install.sh
+++ b/projects/hipblaslt/install.sh
@@ -229,7 +229,7 @@ install_packages( )
   fi
 
   # wget and openssl are needed for cmake
-  if [ -z "$CMAKE_VERSION" ] || $(dpkg --compare-versions $CMAKE_VERSION lt 3.16.8); then
+  if [ -z "$CMAKE_VERSION" ] || $(dpkg --compare-versions $CMAKE_VERSION lt 3.25.2); then
     if $update_cmake == true; then
       library_dependencies_ubuntu+=("wget" "libssl-dev")
       library_dependencies_centos+=("wget" "openssl-devel")
@@ -679,7 +679,7 @@ if [[ "${install_dependencies}" == true ]]; then
   install_packages
 
   CMAKE_VERSION=$(cmake --version | grep -oP '(?<=version )[^ ]*' )
-  if [ -z "$CMAKE_VERSION" ] || $(dpkg --compare-versions $CMAKE_VERSION lt 3.22); then
+  if [ -z "$CMAKE_VERSION" ] || $(dpkg --compare-versions $CMAKE_VERSION lt 3.25.2); then
       if $update_cmake == true; then
         pushd
         printf "\033[32mBuilding \033[33mcmake\033[32m from source; installing into \033[33m/usr/local\033[0m\n"
@@ -694,7 +694,7 @@ if [[ "${install_dependencies}" == true ]]; then
         sudo make install
         popd
       else
-          echo "hipBLASLt requires CMake version >= 3.22 and CMake version ${CMAKE_VERSION} is installed. Run install.sh again with --cmake_install flag and CMake version 3.25.2 will be installed to /usr/local"
+          echo "hipBLASLt requires CMake version >= 3.25.2 and CMake version ${CMAKE_VERSION} is installed. Run install.sh again with --cmake_install flag and CMake version 3.25.2 will be installed to /usr/local"
           exit 2
       fi
   fi


### PR DESCRIPTION
the CMakeLists.txt in hipblaslt specifies the minimum version as 3.25.2 Hence update the install.sh also accordingly

## Motivation

the install.sh does not have the correct checks for minimum cmake version

## Technical Details

CMakeLists.txt has minimum version specified. install.sh was ok even if older version was installed. fix such that if an older version is present, update to newer version

## Test Plan

with older version of cmake, the install.sh prints error now
## Test Result

with older version of cmake, the install.sh prints error now

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
