### PR TITLE
[fft shared] Use a RAII wrapper for FFTW cpu plans

### DIFF
--- a/projects/hipfft/clients/tests/hipfftw_test.cpp
+++ b/projects/hipfft/clients/tests/hipfftw_test.cpp
@@ -21,6 +21,7 @@
 #include "../hipfftw_helper.h"
 
 #include "../../shared/environment.h"
+#include "../../shared/fftw_transform.h"
 #include "../../shared/gpubuf.h"
 #include "../../shared/hostbuf.h"
 #include "../../shared/params_gen.h"
@@ -2755,10 +2756,7 @@ namespace
             execution_results_on_host.clear();
             host_io_buffer.clear();
             gpu_io_buffer.clear();
-            if constexpr(prec == fft_precision_single)
-                fftwf_destroy_plan(reference_plan);
-            else
-                fftw_destroy_plan(reference_plan);
+            reference_plan.clear();
             this->GetParam().plan_helper.release_plan();
         }
         // verification buffers (set_input and other common routines require std::vector's of size 1 for these)
@@ -2770,7 +2768,7 @@ namespace
         // possible nonhost buffers (may be current/other device or runtime-managed)
         std::map<std::pair<hipfftw_step, fft_io>, gpubuf> gpu_io_buffer;
         // reference plan
-        hipfftw_plan_t<prec> reference_plan = nullptr;
+        fftw_plan_wrapper<hipfftw_real_t<prec>> reference_plan;
 
         void functional_test() const
         {
@@ -2876,10 +2874,7 @@ namespace
                 }
 
                 std::shared_future<void> reference_cpu_dft = std::async(std::launch::async, [&]() {
-                    if constexpr(prec == fft_precision_single)
-                        fftwf_execute(reference_plan);
-                    else
-                        fftw_execute(reference_plan);
+                    fftw_execute_type<hipfftw_real_t<prec>>(reference_plan);
                 });
                 hipfftw_exception_logger exception_logger;
 

--- a/projects/hipfft/clients/tests/hipfftw_test.cpp
+++ b/projects/hipfft/clients/tests/hipfftw_test.cpp
@@ -2722,11 +2722,12 @@ namespace
                                                          params.get_contiguous_istrides(),
                                                          params.get_contiguous_idist());
                 // create the reference plan (systematically using the most general guru64 creation)
-                reference_plan = params.plan_helper.get_reference_plan(
-                    verification_input[0].data(),
-                    params.get_placement() == fft_placement_inplace
-                        ? verification_input[0].data()
-                        : verification_output[0].data());
+                reference_plan = fftw_trait<hipfftw_real_t<prec>>::make_wrapper(
+                    params.plan_helper.get_reference_plan(verification_input[0].data(),
+                                                          params.get_placement()
+                                                                  == fft_placement_inplace
+                                                              ? verification_input[0].data()
+                                                              : verification_output[0].data()));
 
                 if(!reference_plan)
                 {
@@ -2756,7 +2757,7 @@ namespace
             execution_results_on_host.clear();
             host_io_buffer.clear();
             gpu_io_buffer.clear();
-            reference_plan.clear();
+            reference_plan.reset();
             this->GetParam().plan_helper.release_plan();
         }
         // verification buffers (set_input and other common routines require std::vector's of size 1 for these)
@@ -2768,7 +2769,8 @@ namespace
         // possible nonhost buffers (may be current/other device or runtime-managed)
         std::map<std::pair<hipfftw_step, fft_io>, gpubuf> gpu_io_buffer;
         // reference plan
-        fftw_plan_wrapper<hipfftw_real_t<prec>> reference_plan;
+        fftw_plan_wrapper_t<hipfftw_real_t<prec>> reference_plan
+            = fftw_trait<hipfftw_real_t<prec>>::make_wrapper(nullptr);
 
         void functional_test() const
         {

--- a/projects/hipfft/clients/tests/simple_test.cpp
+++ b/projects/hipfft/clients/tests/simple_test.cpp
@@ -621,8 +621,9 @@ TEST(hipfftTest, RunR2C)
     fftw_complex* ref_out;
 
     ref_out = (fftw_complex*)fftw_malloc(sizeof(fftw_complex) * (N / 2 + 1));
-    fftw_plan_wrapper<double> ref_p(fftw_plan_dft_r2c_1d(N, ref_in, ref_out, FFTW_ESTIMATE));
-    fftw_execute(ref_p);
+    fftw_plan_wrapper_t<double> ref_p
+        = fftw_trait<double>::make_wrapper(fftw_plan_dft_r2c_1d(N, ref_in, ref_out, FFTW_ESTIMATE));
+    fftw_execute_type<double>(ref_p);
 
     double maxv  = 0;
     double nrmse = 0; // normalized root mean square error
@@ -696,9 +697,10 @@ TEST(hipfftTest, OutplaceOnly)
 
     fftw_complex* ref_out;
 
-    ref_out = (fftw_complex*)fftw_malloc(sizeof(fftw_complex) * N_out);
-    fftw_plan_wrapper<double> ref_p(fftw_plan_dft_r2c_1d(N_in, ref_in, ref_out, FFTW_ESTIMATE));
-    fftw_execute(ref_p);
+    ref_out                           = (fftw_complex*)fftw_malloc(sizeof(fftw_complex) * N_out);
+    fftw_plan_wrapper_t<double> ref_p = fftw_trait<double>::make_wrapper(
+        fftw_plan_dft_r2c_1d(N_in, ref_in, ref_out, FFTW_ESTIMATE));
+    fftw_execute_type<double>(ref_p);
 
     double maxv  = 0;
     double nrmse = 0; // normalized root mean square error

--- a/projects/hipfft/clients/tests/simple_test.cpp
+++ b/projects/hipfft/clients/tests/simple_test.cpp
@@ -26,6 +26,7 @@
 #include <random>
 #include <vector>
 
+#include "../../shared/fftw_transform.h"
 #include "../hipfft_params.h"
 
 DISABLE_WARNING_PUSH
@@ -618,10 +619,9 @@ TEST(hipfftTest, RunR2C)
         ref_in[i] = in[i];
 
     fftw_complex* ref_out;
-    fftw_plan     ref_p;
 
     ref_out = (fftw_complex*)fftw_malloc(sizeof(fftw_complex) * (N / 2 + 1));
-    ref_p   = fftw_plan_dft_r2c_1d(N, ref_in, ref_out, FFTW_ESTIMATE);
+    fftw_plan_wrapper<double> ref_p(fftw_plan_dft_r2c_1d(N, ref_in, ref_out, FFTW_ESTIMATE));
     fftw_execute(ref_p);
 
     double maxv  = 0;
@@ -640,9 +640,8 @@ TEST(hipfftTest, RunR2C)
     nrmse = sqrt(nrmse);
     nrmse /= maxv;
 
-    EXPECT_LT(nrmse, type_epsilon_simple<double>());
-    fftw_destroy_plan(ref_p);
     fftw_free(ref_out);
+    EXPECT_LT(nrmse, type_epsilon_simple<double>());
 }
 
 // ask for a transform whose parameters are only valid out-of-place.
@@ -696,10 +695,9 @@ TEST(hipfftTest, OutplaceOnly)
         ref_in[i] = in[i];
 
     fftw_complex* ref_out;
-    fftw_plan     ref_p;
 
     ref_out = (fftw_complex*)fftw_malloc(sizeof(fftw_complex) * N_out);
-    ref_p   = fftw_plan_dft_r2c_1d(N_in, ref_in, ref_out, FFTW_ESTIMATE);
+    fftw_plan_wrapper<double> ref_p(fftw_plan_dft_r2c_1d(N_in, ref_in, ref_out, FFTW_ESTIMATE));
     fftw_execute(ref_p);
 
     double maxv  = 0;
@@ -718,9 +716,8 @@ TEST(hipfftTest, OutplaceOnly)
     nrmse = sqrt(nrmse);
     nrmse /= maxv;
 
-    ASSERT_LT(nrmse, type_epsilon_simple<double>());
-    fftw_destroy_plan(ref_p);
     fftw_free(ref_out);
+    ASSERT_LT(nrmse, type_epsilon_simple<double>());
 }
 
 static constexpr int absurd_version_or_property = std::numeric_limits<int>::min();

--- a/projects/hipfft/shared/accuracy_test.h
+++ b/projects/hipfft/shared/accuracy_test.h
@@ -135,7 +135,7 @@ inline void check_problem_fits_device_memory(Tparams& params, const int verbose)
 }
 
 template <typename Tfloat>
-bool fftw_plan_uses_bluestein(const typename fftw_trait<Tfloat>::fftw_plan_type& cpu_plan)
+bool fftw_plan_uses_bluestein(const fftw_plan_wrapper_t<Tfloat>& cpu_plan)
 {
 #ifdef FFTW_HAVE_SPRINT_PLAN
     char*       print_plan_c_str = fftw_sprint_plan<Tfloat>(cpu_plan);
@@ -174,11 +174,11 @@ static auto allocate_cpu_fft_buffer(const fft_precision        precision,
 }
 
 template <typename Tfloat>
-inline void execute_cpu_fft(fft_params&                params,
-                            fft_params&                contiguous_params,
-                            fftw_plan_wrapper<Tfloat>& cpu_plan,
-                            std::vector<hostbuf>&      cpu_input,
-                            std::vector<hostbuf>&      cpu_output)
+inline void execute_cpu_fft(fft_params&                  params,
+                            fft_params&                  contiguous_params,
+                            fftw_plan_wrapper_t<Tfloat>& cpu_plan,
+                            std::vector<hostbuf>&        cpu_input,
+                            std::vector<hostbuf>&        cpu_output)
 {
     // CPU output might not be allocated already for us, if FFTW never
     // needed an output buffer during planning
@@ -205,7 +205,7 @@ inline void execute_cpu_fft(fft_params&                params,
     params.apply_host_load_ops(*input_ptr);
     fftw_run<Tfloat>(contiguous_params.transform_type, cpu_plan, *input_ptr, cpu_output);
     // ask FFTW to fully clean up, since it tries to cache plan details
-    cpu_plan.clear();
+    cpu_plan.reset();
     fftw_cleanup();
     params.apply_host_store_ops(cpu_output);
     apply_store_callback(params, cpu_output);
@@ -861,7 +861,7 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
 
     // Create FFTW plan - this may write to input, but that's fine
     // since there's nothing in there right now
-    fftw_plan_wrapper<Tfloat> cpu_plan;
+    fftw_plan_wrapper_t<Tfloat> cpu_plan = fftw_trait<Tfloat>::make_wrapper(nullptr);
 
     if(run_fftw)
     {

--- a/projects/hipfft/shared/accuracy_test.h
+++ b/projects/hipfft/shared/accuracy_test.h
@@ -174,11 +174,11 @@ static auto allocate_cpu_fft_buffer(const fft_precision        precision,
 }
 
 template <typename Tfloat>
-inline void execute_cpu_fft(fft_params&                                  params,
-                            fft_params&                                  contiguous_params,
-                            typename fftw_trait<Tfloat>::fftw_plan_type& cpu_plan,
-                            std::vector<hostbuf>&                        cpu_input,
-                            std::vector<hostbuf>&                        cpu_output)
+inline void execute_cpu_fft(fft_params&                params,
+                            fft_params&                contiguous_params,
+                            fftw_plan_wrapper<Tfloat>& cpu_plan,
+                            std::vector<hostbuf>&      cpu_input,
+                            std::vector<hostbuf>&      cpu_output)
 {
     // CPU output might not be allocated already for us, if FFTW never
     // needed an output buffer during planning
@@ -204,11 +204,9 @@ inline void execute_cpu_fft(fft_params&                                  params,
     apply_load_callback(params, *input_ptr);
     params.apply_host_load_ops(*input_ptr);
     fftw_run<Tfloat>(contiguous_params.transform_type, cpu_plan, *input_ptr, cpu_output);
-    // clean up
-    fftw_destroy_plan_type(cpu_plan);
     // ask FFTW to fully clean up, since it tries to cache plan details
+    cpu_plan.clear();
     fftw_cleanup();
-    cpu_plan = nullptr;
     params.apply_host_store_ops(cpu_output);
     apply_store_callback(params, cpu_output);
 }
@@ -863,7 +861,8 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
 
     // Create FFTW plan - this may write to input, but that's fine
     // since there's nothing in there right now
-    typename fftw_trait<Tfloat>::fftw_plan_type cpu_plan = nullptr;
+    fftw_plan_wrapper<Tfloat> cpu_plan;
+
     if(run_fftw)
     {
         // Normally, we would want to defer allocation of CPU output

--- a/projects/hipfft/shared/fftw_transform.h
+++ b/projects/hipfft/shared/fftw_transform.h
@@ -75,78 +75,52 @@ static constexpr double default_double_epsilon()
     return 1e-15;
 }
 
-// C++ traits to translate float->fftwf_complex and
-// double->fftw_complex.
-// The correct FFTW complex type can be accessed via, for example,
-// using complex_t = typename fftw_complex_trait<Tfloat>::complex_t;
-template <typename Tfloat>
-struct fftw_trait;
-template <>
-struct fftw_trait<rocfft_fp16>
+// C++ traits to simplify type selection for FFTW plans, complex and/or real
+// FFTW types, based on the base real type of the floating-point arithmetic of
+// interest. The correct FFTW complex type can be accessed via, for example,
+// using complex_t = fftw_complex_trait<Tfloat>::complex_t;
+// NOTE: FFTW does not natively support half-precision, single-precision,
+// members of fftw_trait<rocfft_fp16> are made equivalent to the members of fftw_trait<float>.
+template <typename Tfloat,
+          std::enable_if_t<std::is_same<Tfloat, double>::value || std::is_same<Tfloat, float>::value
+                               || std::is_same<Tfloat, rocfft_fp16>::value,
+                           bool> = true>
+struct fftw_trait
 {
-    // fftw does not support half precision, so use single precision and convert
-    using fftw_complex_type = fftwf_complex;
-    using fftw_plan_type    = fftwf_plan;
-};
-template <>
-struct fftw_trait<float>
-{
-    using fftw_complex_type = fftwf_complex;
-    using fftw_plan_type    = fftwf_plan;
-};
-template <>
-struct fftw_trait<double>
-{
-    using fftw_complex_type = fftw_complex;
-    using fftw_plan_type    = fftw_plan;
-};
-
-template <typename Tfloat>
-struct fftw_plan_wrapper
-{
-    fftw_plan_wrapper(typename fftw_trait<Tfloat>::fftw_plan_type raw_plan_ptr = nullptr)
-        : plan_ptr(raw_plan_ptr)
-    {
-    }
-    // default moves are fine
-    fftw_plan_wrapper(fftw_plan_wrapper&&) = default;
-    fftw_plan_wrapper& operator=(fftw_plan_wrapper&&) = default;
-    // disable copies
-    fftw_plan_wrapper(const fftw_plan_wrapper&) = delete;
-    fftw_plan_wrapper& operator=(const fftw_plan_wrapper& other) = delete;
-    // copy assignment from raw pointer
-    fftw_plan_wrapper& operator=(typename fftw_trait<Tfloat>::fftw_plan_type raw_plan_ptr)
-    {
-        clear();
-        plan_ptr = raw_plan_ptr;
-        return *this;
-    }
-
-    // conversion to raw pointer
-    operator typename fftw_trait<Tfloat>::fftw_plan_type() const
-    {
-        return plan_ptr;
-    }
-
-    void clear()
-    {
-        if(plan_ptr)
-        {
-            if constexpr(std::is_same_v<Tfloat, double>)
-                fftw_destroy_plan(plan_ptr);
-            else
-                fftwf_destroy_plan(plan_ptr);
-            plan_ptr = nullptr;
-        }
-    }
-    ~fftw_plan_wrapper()
-    {
-        clear();
-    }
 
 private:
-    typename fftw_trait<Tfloat>::fftw_plan_type plan_ptr;
+    using raw_fftw_plan_type = std::conditional_t<std::is_same_v<Tfloat, double>,
+                                                  std::remove_pointer<fftw_plan>::type,
+                                                  std::remove_pointer<fftwf_plan>::type>;
+    static void plan_deleter(raw_fftw_plan_type* plan_ptr)
+    {
+        static_assert(
+            std::is_same<raw_fftw_plan_type, std::remove_pointer<fftw_plan>::type>::value
+            || std::is_same<raw_fftw_plan_type, std::remove_pointer<fftwf_plan>::type>::value);
+        if constexpr(std::is_same<raw_fftw_plan_type, std::remove_pointer<fftw_plan>::type>::value)
+            fftw_destroy_plan(plan_ptr);
+        else
+            fftwf_destroy_plan(plan_ptr);
+    }
+
+public:
+    using real_t = std::conditional_t<std::is_same<Tfloat, double>::value, double, float>;
+    using complex_t
+        = std::conditional_t<std::is_same<Tfloat, double>::value, fftw_complex, fftwf_complex>;
+    using plan_wrapper_t = std::unique_ptr<raw_fftw_plan_type, decltype(&plan_deleter)>;
+
+    static plan_wrapper_t make_wrapper(raw_fftw_plan_type* raw_plan_ptr)
+    {
+        return plan_wrapper_t{raw_plan_ptr, plan_deleter};
+    }
 };
+// External alias templates to avoid verbose syntax thereafter
+template <typename T>
+using fftw_plan_wrapper_t = typename fftw_trait<T>::plan_wrapper_t;
+template <typename T>
+using fftw_complex_t = typename fftw_trait<T>::complex_t;
+template <typename T>
+using fftw_real_t = typename fftw_trait<T>::real_t;
 
 // Copies the half-precision input buffer to a single-precision
 // buffer.  Note that the input buffer is already sized like it's a
@@ -195,14 +169,14 @@ inline double* fftw_alloc_real_type<double>(size_t n)
 
 // Template wrappers for complex-valued FFTW allocators:
 template <typename Tfloat>
-inline typename fftw_trait<Tfloat>::fftw_complex_type* fftw_alloc_complex_type(size_t n);
+inline fftw_complex_t<Tfloat>* fftw_alloc_complex_type(size_t n);
 template <>
-inline typename fftw_trait<float>::fftw_complex_type* fftw_alloc_complex_type<float>(size_t n)
+inline fftw_complex_t<float>* fftw_alloc_complex_type<float>(size_t n)
 {
     return fftwf_alloc_complex(n);
 }
 template <>
-inline typename fftw_trait<double>::fftw_complex_type* fftw_alloc_complex_type<double>(size_t n)
+inline fftw_complex_t<double>* fftw_alloc_complex_type<double>(size_t n)
 {
     return fftw_alloc_complex(n);
 }
@@ -242,279 +216,275 @@ inline rocfft_complex<double>* fftw_alloc_type<rocfft_complex<double>>(size_t n)
 
 // Template wrappers for FFTW plan executors:
 template <typename Tfloat>
-inline void fftw_execute_type(typename fftw_trait<Tfloat>::fftw_plan_type plan);
+inline void fftw_execute_type(const fftw_plan_wrapper_t<Tfloat>& plan);
 template <>
-inline void fftw_execute_type<float>(typename fftw_trait<float>::fftw_plan_type plan)
+inline void fftw_execute_type<float>(const fftw_plan_wrapper_t<float>& plan)
 {
-    return fftwf_execute(plan);
+    return fftwf_execute(plan.get());
 }
 template <>
-inline void fftw_execute_type<double>(typename fftw_trait<double>::fftw_plan_type plan)
+inline void fftw_execute_type<double>(const fftw_plan_wrapper_t<double>& plan)
 {
-    return fftw_execute(plan);
+    return fftw_execute(plan.get());
 }
 
 // Template wrappers for FFTW c2c planners:
 template <typename Tfloat>
-inline typename fftw_trait<Tfloat>::fftw_plan_type
-    fftw_plan_guru64_dft(int                                             rank,
-                         const fftw_iodim64*                             dims,
-                         int                                             howmany_rank,
-                         const fftw_iodim64*                             howmany_dims,
-                         typename fftw_trait<Tfloat>::fftw_complex_type* in,
-                         typename fftw_trait<Tfloat>::fftw_complex_type* out,
-                         int                                             sign,
-                         unsigned                                        flags);
+inline fftw_plan_wrapper_t<Tfloat> fftw_plan_guru64_dft(int                     rank,
+                                                        const fftw_iodim64*     dims,
+                                                        int                     howmany_rank,
+                                                        const fftw_iodim64*     howmany_dims,
+                                                        fftw_complex_t<Tfloat>* in,
+                                                        fftw_complex_t<Tfloat>* out,
+                                                        int                     sign,
+                                                        unsigned                flags);
 
 template <>
-inline typename fftw_trait<rocfft_fp16>::fftw_plan_type
-    fftw_plan_guru64_dft<rocfft_fp16>(int                 rank,
-                                      const fftw_iodim64* dims,
-                                      int                 howmany_rank,
-                                      const fftw_iodim64* howmany_dims,
-                                      typename fftw_trait<rocfft_fp16>::fftw_complex_type* in,
-                                      typename fftw_trait<rocfft_fp16>::fftw_complex_type* out,
-                                      int                                                  sign,
-                                      unsigned                                             flags)
+inline fftw_plan_wrapper_t<rocfft_fp16>
+    fftw_plan_guru64_dft<rocfft_fp16>(int                          rank,
+                                      const fftw_iodim64*          dims,
+                                      int                          howmany_rank,
+                                      const fftw_iodim64*          howmany_dims,
+                                      fftw_complex_t<rocfft_fp16>* in,
+                                      fftw_complex_t<rocfft_fp16>* out,
+                                      int                          sign,
+                                      unsigned                     flags)
 {
-    return fftwf_plan_guru64_dft(rank, dims, howmany_rank, howmany_dims, in, out, sign, flags);
+    return fftw_trait<rocfft_fp16>::make_wrapper(
+        fftwf_plan_guru64_dft(rank, dims, howmany_rank, howmany_dims, in, out, sign, flags));
 }
 
 template <>
-inline typename fftw_trait<float>::fftw_plan_type
-    fftw_plan_guru64_dft<float>(int                                            rank,
-                                const fftw_iodim64*                            dims,
-                                int                                            howmany_rank,
-                                const fftw_iodim64*                            howmany_dims,
-                                typename fftw_trait<float>::fftw_complex_type* in,
-                                typename fftw_trait<float>::fftw_complex_type* out,
-                                int                                            sign,
-                                unsigned                                       flags)
+inline fftw_plan_wrapper_t<float> fftw_plan_guru64_dft<float>(int                    rank,
+                                                              const fftw_iodim64*    dims,
+                                                              int                    howmany_rank,
+                                                              const fftw_iodim64*    howmany_dims,
+                                                              fftw_complex_t<float>* in,
+                                                              fftw_complex_t<float>* out,
+                                                              int                    sign,
+                                                              unsigned               flags)
 {
-    return fftwf_plan_guru64_dft(rank, dims, howmany_rank, howmany_dims, in, out, sign, flags);
+    return fftw_trait<float>::make_wrapper(
+        fftwf_plan_guru64_dft(rank, dims, howmany_rank, howmany_dims, in, out, sign, flags));
 }
 
 template <>
-inline typename fftw_trait<double>::fftw_plan_type
-    fftw_plan_guru64_dft<double>(int                                             rank,
-                                 const fftw_iodim64*                             dims,
-                                 int                                             howmany_rank,
-                                 const fftw_iodim64*                             howmany_dims,
-                                 typename fftw_trait<double>::fftw_complex_type* in,
-                                 typename fftw_trait<double>::fftw_complex_type* out,
-                                 int                                             sign,
-                                 unsigned                                        flags)
+inline fftw_plan_wrapper_t<double> fftw_plan_guru64_dft<double>(int                 rank,
+                                                                const fftw_iodim64* dims,
+                                                                int                 howmany_rank,
+                                                                const fftw_iodim64* howmany_dims,
+                                                                fftw_complex_t<double>* in,
+                                                                fftw_complex_t<double>* out,
+                                                                int                     sign,
+                                                                unsigned                flags)
 {
-    return fftw_plan_guru64_dft(rank, dims, howmany_rank, howmany_dims, in, out, sign, flags);
+    return fftw_trait<double>::make_wrapper(
+        fftw_plan_guru64_dft(rank, dims, howmany_rank, howmany_dims, in, out, sign, flags));
 }
 
 // Template wrappers for FFTW c2c executors:
 template <typename Tfloat>
-inline void fftw_plan_execute_c2c(typename fftw_trait<Tfloat>::fftw_plan_type plan,
-                                  std::vector<hostbuf>&                       in,
-                                  std::vector<hostbuf>&                       out);
-
+inline void fftw_plan_execute_c2c(const fftw_plan_wrapper_t<Tfloat>& plan,
+                                  std::vector<hostbuf>&              in,
+                                  std::vector<hostbuf>&              out);
 template <>
-inline void
-    fftw_plan_execute_c2c<rocfft_fp16>(typename fftw_trait<rocfft_fp16>::fftw_plan_type plan,
-                                       std::vector<hostbuf>&                            in,
-                                       std::vector<hostbuf>&                            out)
+inline void fftw_plan_execute_c2c<rocfft_fp16>(const fftw_plan_wrapper_t<rocfft_fp16>& plan,
+                                               std::vector<hostbuf>&                   in,
+                                               std::vector<hostbuf>&                   out)
 {
     // since FFTW does not natively support half precision, convert
     // input to single, execute, then convert output back to half
     auto in_single = half_to_single_copy(in.front());
-    fftwf_execute_dft(plan,
+    fftwf_execute_dft(plan.get(),
                       reinterpret_cast<fftwf_complex*>(in_single.data()),
                       reinterpret_cast<fftwf_complex*>(out.front().data()));
     single_to_half_inplace(out.front());
 }
 
 template <>
-inline void fftw_plan_execute_c2c<float>(typename fftw_trait<float>::fftw_plan_type plan,
-                                         std::vector<hostbuf>&                      in,
-                                         std::vector<hostbuf>&                      out)
+inline void fftw_plan_execute_c2c<float>(const fftw_plan_wrapper_t<float>& plan,
+                                         std::vector<hostbuf>&             in,
+                                         std::vector<hostbuf>&             out)
 {
-    fftwf_execute_dft(plan,
+    fftwf_execute_dft(plan.get(),
                       reinterpret_cast<fftwf_complex*>(in.front().data()),
                       reinterpret_cast<fftwf_complex*>(out.front().data()));
 }
 
 template <>
-inline void fftw_plan_execute_c2c<double>(typename fftw_trait<double>::fftw_plan_type plan,
-                                          std::vector<hostbuf>&                       in,
-                                          std::vector<hostbuf>&                       out)
+inline void fftw_plan_execute_c2c<double>(const fftw_plan_wrapper_t<double>& plan,
+                                          std::vector<hostbuf>&              in,
+                                          std::vector<hostbuf>&              out)
 {
-    fftw_execute_dft(plan,
+    fftw_execute_dft(plan.get(),
                      reinterpret_cast<fftw_complex*>(in.front().data()),
                      reinterpret_cast<fftw_complex*>(out.front().data()));
 }
 
 // Template wrappers for FFTW r2c planners:
 template <typename Tfloat>
-inline typename fftw_trait<Tfloat>::fftw_plan_type
-    fftw_plan_guru64_r2c(int                                             rank,
-                         const fftw_iodim64*                             dims,
-                         int                                             howmany_rank,
-                         const fftw_iodim64*                             howmany_dims,
-                         Tfloat*                                         in,
-                         typename fftw_trait<Tfloat>::fftw_complex_type* out,
-                         unsigned                                        flags);
+inline fftw_plan_wrapper_t<Tfloat> fftw_plan_guru64_r2c(int                     rank,
+                                                        const fftw_iodim64*     dims,
+                                                        int                     howmany_rank,
+                                                        const fftw_iodim64*     howmany_dims,
+                                                        Tfloat*                 in,
+                                                        fftw_complex_t<Tfloat>* out,
+                                                        unsigned                flags);
 template <>
-inline typename fftw_trait<rocfft_fp16>::fftw_plan_type
-    fftw_plan_guru64_r2c<rocfft_fp16>(int                 rank,
-                                      const fftw_iodim64* dims,
-                                      int                 howmany_rank,
-                                      const fftw_iodim64* howmany_dims,
-                                      rocfft_fp16*        in,
-                                      typename fftw_trait<rocfft_fp16>::fftw_complex_type* out,
-                                      unsigned                                             flags)
+inline fftw_plan_wrapper_t<rocfft_fp16>
+    fftw_plan_guru64_r2c<rocfft_fp16>(int                          rank,
+                                      const fftw_iodim64*          dims,
+                                      int                          howmany_rank,
+                                      const fftw_iodim64*          howmany_dims,
+                                      rocfft_fp16*                 in,
+                                      fftw_complex_t<rocfft_fp16>* out,
+                                      unsigned                     flags)
 {
-    return fftwf_plan_guru64_dft_r2c(
-        rank, dims, howmany_rank, howmany_dims, reinterpret_cast<float*>(in), out, flags);
+    return fftw_trait<rocfft_fp16>::make_wrapper(fftwf_plan_guru64_dft_r2c(
+        rank, dims, howmany_rank, howmany_dims, reinterpret_cast<float*>(in), out, flags));
 }
 template <>
-inline typename fftw_trait<float>::fftw_plan_type
-    fftw_plan_guru64_r2c<float>(int                                            rank,
-                                const fftw_iodim64*                            dims,
-                                int                                            howmany_rank,
-                                const fftw_iodim64*                            howmany_dims,
-                                float*                                         in,
-                                typename fftw_trait<float>::fftw_complex_type* out,
-                                unsigned                                       flags)
+inline fftw_plan_wrapper_t<float> fftw_plan_guru64_r2c<float>(int                    rank,
+                                                              const fftw_iodim64*    dims,
+                                                              int                    howmany_rank,
+                                                              const fftw_iodim64*    howmany_dims,
+                                                              float*                 in,
+                                                              fftw_complex_t<float>* out,
+                                                              unsigned               flags)
 {
-    return fftwf_plan_guru64_dft_r2c(rank, dims, howmany_rank, howmany_dims, in, out, flags);
+    return fftw_trait<float>::make_wrapper(
+        fftwf_plan_guru64_dft_r2c(rank, dims, howmany_rank, howmany_dims, in, out, flags));
 }
 template <>
-inline typename fftw_trait<double>::fftw_plan_type
-    fftw_plan_guru64_r2c<double>(int                                             rank,
-                                 const fftw_iodim64*                             dims,
-                                 int                                             howmany_rank,
-                                 const fftw_iodim64*                             howmany_dims,
-                                 double*                                         in,
-                                 typename fftw_trait<double>::fftw_complex_type* out,
-                                 unsigned                                        flags)
+inline fftw_plan_wrapper_t<double> fftw_plan_guru64_r2c<double>(int                 rank,
+                                                                const fftw_iodim64* dims,
+                                                                int                 howmany_rank,
+                                                                const fftw_iodim64* howmany_dims,
+                                                                double*             in,
+                                                                fftw_complex_t<double>* out,
+                                                                unsigned                flags)
 {
-    return fftw_plan_guru64_dft_r2c(rank, dims, howmany_rank, howmany_dims, in, out, flags);
+    return fftw_trait<double>::make_wrapper(
+        fftw_plan_guru64_dft_r2c(rank, dims, howmany_rank, howmany_dims, in, out, flags));
 }
 
 // Template wrappers for FFTW r2c executors:
 template <typename Tfloat>
-inline void fftw_plan_execute_r2c(typename fftw_trait<Tfloat>::fftw_plan_type plan,
-                                  std::vector<hostbuf>&                       in,
-                                  std::vector<hostbuf>&                       out);
+inline void fftw_plan_execute_r2c(const fftw_plan_wrapper_t<Tfloat>& plan,
+                                  std::vector<hostbuf>&              in,
+                                  std::vector<hostbuf>&              out);
 template <>
-inline void fftw_plan_execute_r2c<rocfft_fp16>(typename fftw_trait<float>::fftw_plan_type plan,
-                                               std::vector<hostbuf>&                      in,
-                                               std::vector<hostbuf>&                      out)
+inline void fftw_plan_execute_r2c<rocfft_fp16>(const fftw_plan_wrapper_t<rocfft_fp16>& plan,
+                                               std::vector<hostbuf>&                   in,
+                                               std::vector<hostbuf>&                   out)
 {
     // since FFTW does not natively support half precision, convert
     // input to single, execute, then convert output back to half
     auto in_single = half_to_single_copy(in.front());
-    fftwf_execute_dft_r2c(plan,
+    fftwf_execute_dft_r2c(plan.get(),
                           reinterpret_cast<float*>(in_single.data()),
                           reinterpret_cast<fftwf_complex*>(out.front().data()));
     single_to_half_inplace(out.front());
 }
 template <>
-inline void fftw_plan_execute_r2c<float>(typename fftw_trait<float>::fftw_plan_type plan,
-                                         std::vector<hostbuf>&                      in,
-                                         std::vector<hostbuf>&                      out)
+inline void fftw_plan_execute_r2c<float>(const fftw_plan_wrapper_t<float>& plan,
+                                         std::vector<hostbuf>&             in,
+                                         std::vector<hostbuf>&             out)
 {
-    fftwf_execute_dft_r2c(plan,
+    fftwf_execute_dft_r2c(plan.get(),
                           reinterpret_cast<float*>(in.front().data()),
                           reinterpret_cast<fftwf_complex*>(out.front().data()));
 }
 template <>
-inline void fftw_plan_execute_r2c<double>(typename fftw_trait<double>::fftw_plan_type plan,
-                                          std::vector<hostbuf>&                       in,
-                                          std::vector<hostbuf>&                       out)
+inline void fftw_plan_execute_r2c<double>(const fftw_plan_wrapper_t<double>& plan,
+                                          std::vector<hostbuf>&              in,
+                                          std::vector<hostbuf>&              out)
 {
-    fftw_execute_dft_r2c(plan,
+    fftw_execute_dft_r2c(plan.get(),
                          reinterpret_cast<double*>(in.front().data()),
                          reinterpret_cast<fftw_complex*>(out.front().data()));
 }
 
 // Template wrappers for FFTW c2r planners:
 template <typename Tfloat>
-inline typename fftw_trait<Tfloat>::fftw_plan_type
-    fftw_plan_guru64_c2r(int                                             rank,
-                         const fftw_iodim64*                             dims,
-                         int                                             howmany_rank,
-                         const fftw_iodim64*                             howmany_dims,
-                         typename fftw_trait<Tfloat>::fftw_complex_type* in,
-                         Tfloat*                                         out,
-                         unsigned                                        flags);
+inline fftw_plan_wrapper_t<Tfloat> fftw_plan_guru64_c2r(int                     rank,
+                                                        const fftw_iodim64*     dims,
+                                                        int                     howmany_rank,
+                                                        const fftw_iodim64*     howmany_dims,
+                                                        fftw_complex_t<Tfloat>* in,
+                                                        Tfloat*                 out,
+                                                        unsigned                flags);
 template <>
-inline typename fftw_trait<rocfft_fp16>::fftw_plan_type
-    fftw_plan_guru64_c2r<rocfft_fp16>(int                 rank,
-                                      const fftw_iodim64* dims,
-                                      int                 howmany_rank,
-                                      const fftw_iodim64* howmany_dims,
-                                      typename fftw_trait<rocfft_fp16>::fftw_complex_type* in,
-                                      rocfft_fp16*                                         out,
-                                      unsigned                                             flags)
+inline fftw_plan_wrapper_t<rocfft_fp16>
+    fftw_plan_guru64_c2r<rocfft_fp16>(int                          rank,
+                                      const fftw_iodim64*          dims,
+                                      int                          howmany_rank,
+                                      const fftw_iodim64*          howmany_dims,
+                                      fftw_complex_t<rocfft_fp16>* in,
+                                      rocfft_fp16*                 out,
+                                      unsigned                     flags)
 {
-    return fftwf_plan_guru64_dft_c2r(
-        rank, dims, howmany_rank, howmany_dims, in, reinterpret_cast<float*>(out), flags);
+    return fftw_trait<rocfft_fp16>::make_wrapper(fftwf_plan_guru64_dft_c2r(
+        rank, dims, howmany_rank, howmany_dims, in, reinterpret_cast<float*>(out), flags));
 }
 template <>
-inline typename fftw_trait<float>::fftw_plan_type
-    fftw_plan_guru64_c2r<float>(int                                            rank,
-                                const fftw_iodim64*                            dims,
-                                int                                            howmany_rank,
-                                const fftw_iodim64*                            howmany_dims,
-                                typename fftw_trait<float>::fftw_complex_type* in,
-                                float*                                         out,
-                                unsigned                                       flags)
+inline fftw_plan_wrapper_t<float> fftw_plan_guru64_c2r<float>(int                    rank,
+                                                              const fftw_iodim64*    dims,
+                                                              int                    howmany_rank,
+                                                              const fftw_iodim64*    howmany_dims,
+                                                              fftw_complex_t<float>* in,
+                                                              float*                 out,
+                                                              unsigned               flags)
 {
-    return fftwf_plan_guru64_dft_c2r(rank, dims, howmany_rank, howmany_dims, in, out, flags);
+    return fftw_trait<float>::make_wrapper(
+        fftwf_plan_guru64_dft_c2r(rank, dims, howmany_rank, howmany_dims, in, out, flags));
 }
 template <>
-inline typename fftw_trait<double>::fftw_plan_type
-    fftw_plan_guru64_c2r<double>(int                                             rank,
-                                 const fftw_iodim64*                             dims,
-                                 int                                             howmany_rank,
-                                 const fftw_iodim64*                             howmany_dims,
-                                 typename fftw_trait<double>::fftw_complex_type* in,
-                                 double*                                         out,
-                                 unsigned                                        flags)
+inline fftw_plan_wrapper_t<double> fftw_plan_guru64_c2r<double>(int                 rank,
+                                                                const fftw_iodim64* dims,
+                                                                int                 howmany_rank,
+                                                                const fftw_iodim64* howmany_dims,
+                                                                fftw_complex_t<double>* in,
+                                                                double*                 out,
+                                                                unsigned                flags)
 {
-    return fftw_plan_guru64_dft_c2r(rank, dims, howmany_rank, howmany_dims, in, out, flags);
+    return fftw_trait<double>::make_wrapper(
+        fftw_plan_guru64_dft_c2r(rank, dims, howmany_rank, howmany_dims, in, out, flags));
 }
 
 // Template wrappers for FFTW c2r executors:
 template <typename Tfloat>
-inline void fftw_plan_execute_c2r(typename fftw_trait<Tfloat>::fftw_plan_type plan,
-                                  std::vector<hostbuf>&                       in,
-                                  std::vector<hostbuf>&                       out);
+inline void fftw_plan_execute_c2r(const fftw_plan_wrapper_t<Tfloat>& plan,
+                                  std::vector<hostbuf>&              in,
+                                  std::vector<hostbuf>&              out);
 template <>
-inline void fftw_plan_execute_c2r<rocfft_fp16>(typename fftw_trait<float>::fftw_plan_type plan,
-                                               std::vector<hostbuf>&                      in,
-                                               std::vector<hostbuf>&                      out)
+inline void fftw_plan_execute_c2r<rocfft_fp16>(const fftw_plan_wrapper_t<rocfft_fp16>& plan,
+                                               std::vector<hostbuf>&                   in,
+                                               std::vector<hostbuf>&                   out)
 {
     // since FFTW does not natively support half precision, convert
     // input to single, execute, then convert output back to half
     auto in_single = half_to_single_copy(in.front());
-    fftwf_execute_dft_c2r(plan,
+    fftwf_execute_dft_c2r(plan.get(),
                           reinterpret_cast<fftwf_complex*>(in_single.data()),
                           reinterpret_cast<float*>(out.front().data()));
     single_to_half_inplace(out.front());
 }
 template <>
-inline void fftw_plan_execute_c2r<float>(typename fftw_trait<float>::fftw_plan_type plan,
-                                         std::vector<hostbuf>&                      in,
-                                         std::vector<hostbuf>&                      out)
+inline void fftw_plan_execute_c2r<float>(const fftw_plan_wrapper_t<float>& plan,
+                                         std::vector<hostbuf>&             in,
+                                         std::vector<hostbuf>&             out)
 {
-    fftwf_execute_dft_c2r(plan,
+    fftwf_execute_dft_c2r(plan.get(),
                           reinterpret_cast<fftwf_complex*>(in.front().data()),
                           reinterpret_cast<float*>(out.front().data()));
 }
 template <>
-inline void fftw_plan_execute_c2r<double>(typename fftw_trait<double>::fftw_plan_type plan,
-                                          std::vector<hostbuf>&                       in,
-                                          std::vector<hostbuf>&                       out)
+inline void fftw_plan_execute_c2r<double>(const fftw_plan_wrapper_t<double>& plan,
+                                          std::vector<hostbuf>&              in,
+                                          std::vector<hostbuf>&              out)
 {
-    fftw_execute_dft_c2r(plan,
+    fftw_execute_dft_c2r(plan.get(),
                          reinterpret_cast<fftw_complex*>(in.front().data()),
                          reinterpret_cast<double*>(out.front().data()));
 }
@@ -522,22 +492,21 @@ inline void fftw_plan_execute_c2r<double>(typename fftw_trait<double>::fftw_plan
 #ifdef FFTW_HAVE_SPRINT_PLAN
 // Template wrappers for FFTW print plan:
 template <typename Tfloat>
-inline char* fftw_sprint_plan(const typename fftw_trait<Tfloat>::fftw_plan_type plan);
+inline char* fftw_sprint_plan(const fftw_plan_wrapper_t<Tfloat>& plan);
 template <>
-inline char*
-    fftw_sprint_plan<rocfft_fp16>(const typename fftw_trait<rocfft_fp16>::fftw_plan_type plan)
+inline char* fftw_sprint_plan<rocfft_fp16>(const fftw_plan_wrapper_t<rocfft_fp16>& plan)
 {
-    return fftwf_sprint_plan(plan);
+    return fftwf_sprint_plan(plan.get());
 }
 template <>
-inline char* fftw_sprint_plan<float>(const typename fftw_trait<float>::fftw_plan_type plan)
+inline char* fftw_sprint_plan<float>(const fftw_plan_wrapper_t<float>& plan)
 {
-    return fftwf_sprint_plan(plan);
+    return fftwf_sprint_plan(plan.get());
 }
 template <>
-inline char* fftw_sprint_plan<double>(const typename fftw_trait<double>::fftw_plan_type plan)
+inline char* fftw_sprint_plan<double>(const fftw_plan_wrapper_t<double>& plan)
 {
-    return fftw_sprint_plan(plan);
+    return fftw_sprint_plan(plan.get());
 }
 #endif
 

--- a/projects/hipfft/shared/fftw_transform.h
+++ b/projects/hipfft/shared/fftw_transform.h
@@ -78,9 +78,9 @@ static constexpr double default_double_epsilon()
 // C++ traits to simplify type selection for FFTW plans, complex and/or real
 // FFTW types, based on the base real type of the floating-point arithmetic of
 // interest. The correct FFTW complex type can be accessed via, for example,
-// using complex_t = fftw_complex_trait<Tfloat>::complex_t;
-// NOTE: FFTW does not natively support half-precision, single-precision,
-// members of fftw_trait<rocfft_fp16> are made equivalent to the members of fftw_trait<float>.
+// using complex_t = typename fftw_complex_trait<Tfloat>::complex_t;
+// NOTE: FFTW does not support half-precision: members of fftw_trait<rocfft_fp16>
+// are made equivalent to the members of fftw_trait<float>.
 template <typename Tfloat,
           std::enable_if_t<std::is_same<Tfloat, double>::value || std::is_same<Tfloat, float>::value
                                || std::is_same<Tfloat, rocfft_fp16>::value,

--- a/projects/hipfft/shared/fftw_transform.h
+++ b/projects/hipfft/shared/fftw_transform.h
@@ -101,6 +101,53 @@ struct fftw_trait<double>
     using fftw_plan_type    = fftw_plan;
 };
 
+template <typename Tfloat>
+struct fftw_plan_wrapper
+{
+    fftw_plan_wrapper(typename fftw_trait<Tfloat>::fftw_plan_type raw_plan_ptr = nullptr)
+        : plan_ptr(raw_plan_ptr)
+    {
+    }
+    // default moves are fine
+    fftw_plan_wrapper(fftw_plan_wrapper&&) = default;
+    fftw_plan_wrapper& operator=(fftw_plan_wrapper&&) = default;
+    // disable copies
+    fftw_plan_wrapper(const fftw_plan_wrapper&) = delete;
+    fftw_plan_wrapper& operator=(const fftw_plan_wrapper& other) = delete;
+    // copy assignment from raw pointer
+    fftw_plan_wrapper& operator=(typename fftw_trait<Tfloat>::fftw_plan_type raw_plan_ptr)
+    {
+        clear();
+        plan_ptr = raw_plan_ptr;
+        return *this;
+    }
+
+    // conversion to raw pointer
+    operator typename fftw_trait<Tfloat>::fftw_plan_type() const
+    {
+        return plan_ptr;
+    }
+
+    void clear()
+    {
+        if(plan_ptr)
+        {
+            if constexpr(std::is_same_v<Tfloat, double>)
+                fftw_destroy_plan(plan_ptr);
+            else
+                fftwf_destroy_plan(plan_ptr);
+            plan_ptr = nullptr;
+        }
+    }
+    ~fftw_plan_wrapper()
+    {
+        clear();
+    }
+
+private:
+    typename fftw_trait<Tfloat>::fftw_plan_type plan_ptr;
+};
+
 // Copies the half-precision input buffer to a single-precision
 // buffer.  Note that the input buffer is already sized like it's a
 // single-precision buffer (but only half of it is filled), because
@@ -205,20 +252,6 @@ template <>
 inline void fftw_execute_type<double>(typename fftw_trait<double>::fftw_plan_type plan)
 {
     return fftw_execute(plan);
-}
-
-// Template wrappers for FFTW plan destroyers:
-template <typename Tfftw_plan>
-inline void fftw_destroy_plan_type(Tfftw_plan plan);
-template <>
-inline void fftw_destroy_plan_type<fftwf_plan>(fftwf_plan plan)
-{
-    return fftwf_destroy_plan(plan);
-}
-template <>
-inline void fftw_destroy_plan_type<fftw_plan>(fftw_plan plan)
-{
-    return fftw_destroy_plan(plan);
 }
 
 // Template wrappers for FFTW c2c planners:

--- a/projects/hipfft/shared/mpi_worker.h
+++ b/projects/hipfft/shared/mpi_worker.h
@@ -462,15 +462,15 @@ static void
 template <typename Tfloat>
 void execute_reference_fft(const fft_params& params, std::vector<hostbuf>& input)
 {
-    fftw_plan_wrapper<Tfloat> cpu_plan = fftw_plan_via_rocfft<Tfloat>(params.length,
-                                                                      params.istride,
-                                                                      params.ostride,
-                                                                      params.nbatch,
-                                                                      params.idist,
-                                                                      params.odist,
-                                                                      params.transform_type,
-                                                                      input,
-                                                                      input);
+    fftw_plan_wrapper_t<Tfloat> cpu_plan = fftw_plan_via_rocfft<Tfloat>(params.length,
+                                                                        params.istride,
+                                                                        params.ostride,
+                                                                        params.nbatch,
+                                                                        params.idist,
+                                                                        params.odist,
+                                                                        params.transform_type,
+                                                                        input,
+                                                                        input);
 
     fftw_run<Tfloat>(params.transform_type, cpu_plan, input, input);
 }

--- a/projects/hipfft/shared/mpi_worker.h
+++ b/projects/hipfft/shared/mpi_worker.h
@@ -462,19 +462,17 @@ static void
 template <typename Tfloat>
 void execute_reference_fft(const fft_params& params, std::vector<hostbuf>& input)
 {
-    auto cpu_plan = fftw_plan_via_rocfft<Tfloat>(params.length,
-                                                 params.istride,
-                                                 params.ostride,
-                                                 params.nbatch,
-                                                 params.idist,
-                                                 params.odist,
-                                                 params.transform_type,
-                                                 input,
-                                                 input);
+    fftw_plan_wrapper<Tfloat> cpu_plan = fftw_plan_via_rocfft<Tfloat>(params.length,
+                                                                      params.istride,
+                                                                      params.ostride,
+                                                                      params.nbatch,
+                                                                      params.idist,
+                                                                      params.odist,
+                                                                      params.transform_type,
+                                                                      input,
+                                                                      input);
 
     fftw_run<Tfloat>(params.transform_type, cpu_plan, input, input);
-
-    fftw_destroy_plan_type(cpu_plan);
 }
 
 bool   use_fftw_wisdom = false;

--- a/projects/hipfft/shared/rocfft_against_fftw.h
+++ b/projects/hipfft/shared/rocfft_against_fftw.h
@@ -48,7 +48,7 @@ extern bool use_fftw_wisdom;
 // precision, and dimensions.  cpu_out is required if we're using
 // wisdom, which runs actual FFTs to work out the best plan.
 template <typename Tfloat>
-static typename fftw_trait<Tfloat>::fftw_plan_type
+static fftw_plan_wrapper_t<Tfloat>
     fftw_plan_with_precision(const std::vector<fftw_iodim64>& dims,
                              const std::vector<fftw_iodim64>& howmany_dims,
                              const fft_transform_type         transformType,
@@ -56,8 +56,6 @@ static typename fftw_trait<Tfloat>::fftw_plan_type
                              void*                            cpu_in,
                              void*                            cpu_out)
 {
-    using fftw_complex_type = typename fftw_trait<Tfloat>::fftw_complex_type;
-
     // NB: Using FFTW_MEASURE implies that the input buffer's data
     // may be destroyed during plan creation.  But if we're wanting
     // to run FFTW in the first place, we must have just created an
@@ -70,8 +68,8 @@ static typename fftw_trait<Tfloat>::fftw_plan_type
                                             dims.data(),
                                             howmany_dims.size(),
                                             howmany_dims.data(),
-                                            reinterpret_cast<fftw_complex_type*>(cpu_in),
-                                            reinterpret_cast<fftw_complex_type*>(cpu_out),
+                                            reinterpret_cast<fftw_complex_t<Tfloat>*>(cpu_in),
+                                            reinterpret_cast<fftw_complex_t<Tfloat>*>(cpu_out),
                                             -1,
                                             use_fftw_wisdom ? FFTW_MEASURE : FFTW_ESTIMATE);
     case fft_transform_type_complex_inverse:
@@ -79,8 +77,8 @@ static typename fftw_trait<Tfloat>::fftw_plan_type
                                             dims.data(),
                                             howmany_dims.size(),
                                             howmany_dims.data(),
-                                            reinterpret_cast<fftw_complex_type*>(cpu_in),
-                                            reinterpret_cast<fftw_complex_type*>(cpu_out),
+                                            reinterpret_cast<fftw_complex_t<Tfloat>*>(cpu_in),
+                                            reinterpret_cast<fftw_complex_t<Tfloat>*>(cpu_out),
                                             1,
                                             use_fftw_wisdom ? FFTW_MEASURE : FFTW_ESTIMATE);
     case fft_transform_type_real_forward:
@@ -89,14 +87,14 @@ static typename fftw_trait<Tfloat>::fftw_plan_type
                                             howmany_dims.size(),
                                             howmany_dims.data(),
                                             reinterpret_cast<Tfloat*>(cpu_in),
-                                            reinterpret_cast<fftw_complex_type*>(cpu_out),
+                                            reinterpret_cast<fftw_complex_t<Tfloat>*>(cpu_out),
                                             use_fftw_wisdom ? FFTW_MEASURE : FFTW_ESTIMATE);
     case fft_transform_type_real_inverse:
         return fftw_plan_guru64_c2r<Tfloat>(dims.size(),
                                             dims.data(),
                                             howmany_dims.size(),
                                             howmany_dims.data(),
-                                            reinterpret_cast<fftw_complex_type*>(cpu_in),
+                                            reinterpret_cast<fftw_complex_t<Tfloat>*>(cpu_in),
                                             reinterpret_cast<Tfloat*>(cpu_out),
                                             use_fftw_wisdom ? FFTW_MEASURE : FFTW_ESTIMATE);
     default:
@@ -107,16 +105,15 @@ static typename fftw_trait<Tfloat>::fftw_plan_type
 // construct an FFTW plan, given rocFFT parameters.  output is
 // required if planning with wisdom.
 template <typename Tfloat>
-static typename fftw_trait<Tfloat>::fftw_plan_type
-    fftw_plan_via_rocfft(const std::vector<size_t>& length,
-                         const std::vector<size_t>& istride,
-                         const std::vector<size_t>& ostride,
-                         const size_t               nbatch,
-                         const size_t               idist,
-                         const size_t               odist,
-                         const fft_transform_type   transformType,
-                         std::vector<hostbuf>&      input,
-                         std::vector<hostbuf>&      output)
+static fftw_plan_wrapper_t<Tfloat> fftw_plan_via_rocfft(const std::vector<size_t>& length,
+                                                        const std::vector<size_t>& istride,
+                                                        const std::vector<size_t>& ostride,
+                                                        const size_t               nbatch,
+                                                        const size_t               idist,
+                                                        const size_t               odist,
+                                                        const fft_transform_type   transformType,
+                                                        std::vector<hostbuf>&      input,
+                                                        std::vector<hostbuf>&      output)
 {
     // Dimension configuration:
     std::vector<fftw_iodim64> dims(length.size());
@@ -142,10 +139,10 @@ static typename fftw_trait<Tfloat>::fftw_plan_type
 }
 
 template <typename Tfloat>
-void fftw_run(fft_transform_type                          transformType,
-              typename fftw_trait<Tfloat>::fftw_plan_type cpu_plan,
-              std::vector<hostbuf>&                       cpu_in,
-              std::vector<hostbuf>&                       cpu_out)
+void fftw_run(fft_transform_type                 transformType,
+              const fftw_plan_wrapper_t<Tfloat>& cpu_plan,
+              std::vector<hostbuf>&              cpu_in,
+              std::vector<hostbuf>&              cpu_out)
 {
     switch(transformType)
     {

--- a/projects/rocfft/shared/accuracy_test.h
+++ b/projects/rocfft/shared/accuracy_test.h
@@ -135,7 +135,7 @@ inline void check_problem_fits_device_memory(Tparams& params, const int verbose)
 }
 
 template <typename Tfloat>
-bool fftw_plan_uses_bluestein(const typename fftw_trait<Tfloat>::fftw_plan_type& cpu_plan)
+bool fftw_plan_uses_bluestein(const fftw_plan_wrapper_t<Tfloat>& cpu_plan)
 {
 #ifdef FFTW_HAVE_SPRINT_PLAN
     char*       print_plan_c_str = fftw_sprint_plan<Tfloat>(cpu_plan);
@@ -174,11 +174,11 @@ static auto allocate_cpu_fft_buffer(const fft_precision        precision,
 }
 
 template <typename Tfloat>
-inline void execute_cpu_fft(fft_params&                params,
-                            fft_params&                contiguous_params,
-                            fftw_plan_wrapper<Tfloat>& cpu_plan,
-                            std::vector<hostbuf>&      cpu_input,
-                            std::vector<hostbuf>&      cpu_output)
+inline void execute_cpu_fft(fft_params&                  params,
+                            fft_params&                  contiguous_params,
+                            fftw_plan_wrapper_t<Tfloat>& cpu_plan,
+                            std::vector<hostbuf>&        cpu_input,
+                            std::vector<hostbuf>&        cpu_output)
 {
     // CPU output might not be allocated already for us, if FFTW never
     // needed an output buffer during planning
@@ -205,7 +205,7 @@ inline void execute_cpu_fft(fft_params&                params,
     params.apply_host_load_ops(*input_ptr);
     fftw_run<Tfloat>(contiguous_params.transform_type, cpu_plan, *input_ptr, cpu_output);
     // ask FFTW to fully clean up, since it tries to cache plan details
-    cpu_plan.clear();
+    cpu_plan.reset();
     fftw_cleanup();
     params.apply_host_store_ops(cpu_output);
     apply_store_callback(params, cpu_output);
@@ -861,7 +861,7 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
 
     // Create FFTW plan - this may write to input, but that's fine
     // since there's nothing in there right now
-    fftw_plan_wrapper<Tfloat> cpu_plan;
+    fftw_plan_wrapper_t<Tfloat> cpu_plan = fftw_trait<Tfloat>::make_wrapper(nullptr);
 
     if(run_fftw)
     {

--- a/projects/rocfft/shared/accuracy_test.h
+++ b/projects/rocfft/shared/accuracy_test.h
@@ -174,11 +174,11 @@ static auto allocate_cpu_fft_buffer(const fft_precision        precision,
 }
 
 template <typename Tfloat>
-inline void execute_cpu_fft(fft_params&                                  params,
-                            fft_params&                                  contiguous_params,
-                            typename fftw_trait<Tfloat>::fftw_plan_type& cpu_plan,
-                            std::vector<hostbuf>&                        cpu_input,
-                            std::vector<hostbuf>&                        cpu_output)
+inline void execute_cpu_fft(fft_params&                params,
+                            fft_params&                contiguous_params,
+                            fftw_plan_wrapper<Tfloat>& cpu_plan,
+                            std::vector<hostbuf>&      cpu_input,
+                            std::vector<hostbuf>&      cpu_output)
 {
     // CPU output might not be allocated already for us, if FFTW never
     // needed an output buffer during planning
@@ -204,11 +204,9 @@ inline void execute_cpu_fft(fft_params&                                  params,
     apply_load_callback(params, *input_ptr);
     params.apply_host_load_ops(*input_ptr);
     fftw_run<Tfloat>(contiguous_params.transform_type, cpu_plan, *input_ptr, cpu_output);
-    // clean up
-    fftw_destroy_plan_type(cpu_plan);
     // ask FFTW to fully clean up, since it tries to cache plan details
+    cpu_plan.clear();
     fftw_cleanup();
-    cpu_plan = nullptr;
     params.apply_host_store_ops(cpu_output);
     apply_store_callback(params, cpu_output);
 }
@@ -863,7 +861,8 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
 
     // Create FFTW plan - this may write to input, but that's fine
     // since there's nothing in there right now
-    typename fftw_trait<Tfloat>::fftw_plan_type cpu_plan = nullptr;
+    fftw_plan_wrapper<Tfloat> cpu_plan;
+
     if(run_fftw)
     {
         // Normally, we would want to defer allocation of CPU output

--- a/projects/rocfft/shared/fftw_transform.h
+++ b/projects/rocfft/shared/fftw_transform.h
@@ -75,78 +75,52 @@ static constexpr double default_double_epsilon()
     return 1e-15;
 }
 
-// C++ traits to translate float->fftwf_complex and
-// double->fftw_complex.
-// The correct FFTW complex type can be accessed via, for example,
-// using complex_t = typename fftw_complex_trait<Tfloat>::complex_t;
-template <typename Tfloat>
-struct fftw_trait;
-template <>
-struct fftw_trait<rocfft_fp16>
+// C++ traits to simplify type selection for FFTW plans, complex and/or real
+// FFTW types, based on the base real type of the floating-point arithmetic of
+// interest. The correct FFTW complex type can be accessed via, for example,
+// using complex_t = fftw_complex_trait<Tfloat>::complex_t;
+// NOTE: FFTW does not natively support half-precision, single-precision,
+// members of fftw_trait<rocfft_fp16> are made equivalent to the members of fftw_trait<float>.
+template <typename Tfloat,
+          std::enable_if_t<std::is_same<Tfloat, double>::value || std::is_same<Tfloat, float>::value
+                               || std::is_same<Tfloat, rocfft_fp16>::value,
+                           bool> = true>
+struct fftw_trait
 {
-    // fftw does not support half precision, so use single precision and convert
-    using fftw_complex_type = fftwf_complex;
-    using fftw_plan_type    = fftwf_plan;
-};
-template <>
-struct fftw_trait<float>
-{
-    using fftw_complex_type = fftwf_complex;
-    using fftw_plan_type    = fftwf_plan;
-};
-template <>
-struct fftw_trait<double>
-{
-    using fftw_complex_type = fftw_complex;
-    using fftw_plan_type    = fftw_plan;
-};
-
-template <typename Tfloat>
-struct fftw_plan_wrapper
-{
-    fftw_plan_wrapper(typename fftw_trait<Tfloat>::fftw_plan_type raw_plan_ptr = nullptr)
-        : plan_ptr(raw_plan_ptr)
-    {
-    }
-    // default moves are fine
-    fftw_plan_wrapper(fftw_plan_wrapper&&) = default;
-    fftw_plan_wrapper& operator=(fftw_plan_wrapper&&) = default;
-    // disable copies
-    fftw_plan_wrapper(const fftw_plan_wrapper&) = delete;
-    fftw_plan_wrapper& operator=(const fftw_plan_wrapper& other) = delete;
-    // copy assignment from raw pointer
-    fftw_plan_wrapper& operator=(typename fftw_trait<Tfloat>::fftw_plan_type raw_plan_ptr)
-    {
-        clear();
-        plan_ptr = raw_plan_ptr;
-        return *this;
-    }
-
-    // conversion to raw pointer
-    operator typename fftw_trait<Tfloat>::fftw_plan_type() const
-    {
-        return plan_ptr;
-    }
-
-    void clear()
-    {
-        if(plan_ptr)
-        {
-            if constexpr(std::is_same_v<Tfloat, double>)
-                fftw_destroy_plan(plan_ptr);
-            else
-                fftwf_destroy_plan(plan_ptr);
-            plan_ptr = nullptr;
-        }
-    }
-    ~fftw_plan_wrapper()
-    {
-        clear();
-    }
 
 private:
-    typename fftw_trait<Tfloat>::fftw_plan_type plan_ptr;
+    using raw_fftw_plan_type = std::conditional_t<std::is_same_v<Tfloat, double>,
+                                                  std::remove_pointer<fftw_plan>::type,
+                                                  std::remove_pointer<fftwf_plan>::type>;
+    static void plan_deleter(raw_fftw_plan_type* plan_ptr)
+    {
+        static_assert(
+            std::is_same<raw_fftw_plan_type, std::remove_pointer<fftw_plan>::type>::value
+            || std::is_same<raw_fftw_plan_type, std::remove_pointer<fftwf_plan>::type>::value);
+        if constexpr(std::is_same<raw_fftw_plan_type, std::remove_pointer<fftw_plan>::type>::value)
+            fftw_destroy_plan(plan_ptr);
+        else
+            fftwf_destroy_plan(plan_ptr);
+    }
+
+public:
+    using real_t = std::conditional_t<std::is_same<Tfloat, double>::value, double, float>;
+    using complex_t
+        = std::conditional_t<std::is_same<Tfloat, double>::value, fftw_complex, fftwf_complex>;
+    using plan_wrapper_t = std::unique_ptr<raw_fftw_plan_type, decltype(&plan_deleter)>;
+
+    static plan_wrapper_t make_wrapper(raw_fftw_plan_type* raw_plan_ptr)
+    {
+        return plan_wrapper_t{raw_plan_ptr, plan_deleter};
+    }
 };
+// External alias templates to avoid verbose syntax thereafter
+template <typename T>
+using fftw_plan_wrapper_t = typename fftw_trait<T>::plan_wrapper_t;
+template <typename T>
+using fftw_complex_t = typename fftw_trait<T>::complex_t;
+template <typename T>
+using fftw_real_t = typename fftw_trait<T>::real_t;
 
 // Copies the half-precision input buffer to a single-precision
 // buffer.  Note that the input buffer is already sized like it's a
@@ -195,14 +169,14 @@ inline double* fftw_alloc_real_type<double>(size_t n)
 
 // Template wrappers for complex-valued FFTW allocators:
 template <typename Tfloat>
-inline typename fftw_trait<Tfloat>::fftw_complex_type* fftw_alloc_complex_type(size_t n);
+inline fftw_complex_t<Tfloat>* fftw_alloc_complex_type(size_t n);
 template <>
-inline typename fftw_trait<float>::fftw_complex_type* fftw_alloc_complex_type<float>(size_t n)
+inline fftw_complex_t<float>* fftw_alloc_complex_type<float>(size_t n)
 {
     return fftwf_alloc_complex(n);
 }
 template <>
-inline typename fftw_trait<double>::fftw_complex_type* fftw_alloc_complex_type<double>(size_t n)
+inline fftw_complex_t<double>* fftw_alloc_complex_type<double>(size_t n)
 {
     return fftw_alloc_complex(n);
 }
@@ -242,279 +216,275 @@ inline rocfft_complex<double>* fftw_alloc_type<rocfft_complex<double>>(size_t n)
 
 // Template wrappers for FFTW plan executors:
 template <typename Tfloat>
-inline void fftw_execute_type(typename fftw_trait<Tfloat>::fftw_plan_type plan);
+inline void fftw_execute_type(const fftw_plan_wrapper_t<Tfloat>& plan);
 template <>
-inline void fftw_execute_type<float>(typename fftw_trait<float>::fftw_plan_type plan)
+inline void fftw_execute_type<float>(const fftw_plan_wrapper_t<float>& plan)
 {
-    return fftwf_execute(plan);
+    return fftwf_execute(plan.get());
 }
 template <>
-inline void fftw_execute_type<double>(typename fftw_trait<double>::fftw_plan_type plan)
+inline void fftw_execute_type<double>(const fftw_plan_wrapper_t<double>& plan)
 {
-    return fftw_execute(plan);
+    return fftw_execute(plan.get());
 }
 
 // Template wrappers for FFTW c2c planners:
 template <typename Tfloat>
-inline typename fftw_trait<Tfloat>::fftw_plan_type
-    fftw_plan_guru64_dft(int                                             rank,
-                         const fftw_iodim64*                             dims,
-                         int                                             howmany_rank,
-                         const fftw_iodim64*                             howmany_dims,
-                         typename fftw_trait<Tfloat>::fftw_complex_type* in,
-                         typename fftw_trait<Tfloat>::fftw_complex_type* out,
-                         int                                             sign,
-                         unsigned                                        flags);
+inline fftw_plan_wrapper_t<Tfloat> fftw_plan_guru64_dft(int                     rank,
+                                                        const fftw_iodim64*     dims,
+                                                        int                     howmany_rank,
+                                                        const fftw_iodim64*     howmany_dims,
+                                                        fftw_complex_t<Tfloat>* in,
+                                                        fftw_complex_t<Tfloat>* out,
+                                                        int                     sign,
+                                                        unsigned                flags);
 
 template <>
-inline typename fftw_trait<rocfft_fp16>::fftw_plan_type
-    fftw_plan_guru64_dft<rocfft_fp16>(int                 rank,
-                                      const fftw_iodim64* dims,
-                                      int                 howmany_rank,
-                                      const fftw_iodim64* howmany_dims,
-                                      typename fftw_trait<rocfft_fp16>::fftw_complex_type* in,
-                                      typename fftw_trait<rocfft_fp16>::fftw_complex_type* out,
-                                      int                                                  sign,
-                                      unsigned                                             flags)
+inline fftw_plan_wrapper_t<rocfft_fp16>
+    fftw_plan_guru64_dft<rocfft_fp16>(int                          rank,
+                                      const fftw_iodim64*          dims,
+                                      int                          howmany_rank,
+                                      const fftw_iodim64*          howmany_dims,
+                                      fftw_complex_t<rocfft_fp16>* in,
+                                      fftw_complex_t<rocfft_fp16>* out,
+                                      int                          sign,
+                                      unsigned                     flags)
 {
-    return fftwf_plan_guru64_dft(rank, dims, howmany_rank, howmany_dims, in, out, sign, flags);
+    return fftw_trait<rocfft_fp16>::make_wrapper(
+        fftwf_plan_guru64_dft(rank, dims, howmany_rank, howmany_dims, in, out, sign, flags));
 }
 
 template <>
-inline typename fftw_trait<float>::fftw_plan_type
-    fftw_plan_guru64_dft<float>(int                                            rank,
-                                const fftw_iodim64*                            dims,
-                                int                                            howmany_rank,
-                                const fftw_iodim64*                            howmany_dims,
-                                typename fftw_trait<float>::fftw_complex_type* in,
-                                typename fftw_trait<float>::fftw_complex_type* out,
-                                int                                            sign,
-                                unsigned                                       flags)
+inline fftw_plan_wrapper_t<float> fftw_plan_guru64_dft<float>(int                    rank,
+                                                              const fftw_iodim64*    dims,
+                                                              int                    howmany_rank,
+                                                              const fftw_iodim64*    howmany_dims,
+                                                              fftw_complex_t<float>* in,
+                                                              fftw_complex_t<float>* out,
+                                                              int                    sign,
+                                                              unsigned               flags)
 {
-    return fftwf_plan_guru64_dft(rank, dims, howmany_rank, howmany_dims, in, out, sign, flags);
+    return fftw_trait<float>::make_wrapper(
+        fftwf_plan_guru64_dft(rank, dims, howmany_rank, howmany_dims, in, out, sign, flags));
 }
 
 template <>
-inline typename fftw_trait<double>::fftw_plan_type
-    fftw_plan_guru64_dft<double>(int                                             rank,
-                                 const fftw_iodim64*                             dims,
-                                 int                                             howmany_rank,
-                                 const fftw_iodim64*                             howmany_dims,
-                                 typename fftw_trait<double>::fftw_complex_type* in,
-                                 typename fftw_trait<double>::fftw_complex_type* out,
-                                 int                                             sign,
-                                 unsigned                                        flags)
+inline fftw_plan_wrapper_t<double> fftw_plan_guru64_dft<double>(int                 rank,
+                                                                const fftw_iodim64* dims,
+                                                                int                 howmany_rank,
+                                                                const fftw_iodim64* howmany_dims,
+                                                                fftw_complex_t<double>* in,
+                                                                fftw_complex_t<double>* out,
+                                                                int                     sign,
+                                                                unsigned                flags)
 {
-    return fftw_plan_guru64_dft(rank, dims, howmany_rank, howmany_dims, in, out, sign, flags);
+    return fftw_trait<double>::make_wrapper(
+        fftw_plan_guru64_dft(rank, dims, howmany_rank, howmany_dims, in, out, sign, flags));
 }
 
 // Template wrappers for FFTW c2c executors:
 template <typename Tfloat>
-inline void fftw_plan_execute_c2c(typename fftw_trait<Tfloat>::fftw_plan_type plan,
-                                  std::vector<hostbuf>&                       in,
-                                  std::vector<hostbuf>&                       out);
-
+inline void fftw_plan_execute_c2c(const fftw_plan_wrapper_t<Tfloat>& plan,
+                                  std::vector<hostbuf>&              in,
+                                  std::vector<hostbuf>&              out);
 template <>
-inline void
-    fftw_plan_execute_c2c<rocfft_fp16>(typename fftw_trait<rocfft_fp16>::fftw_plan_type plan,
-                                       std::vector<hostbuf>&                            in,
-                                       std::vector<hostbuf>&                            out)
+inline void fftw_plan_execute_c2c<rocfft_fp16>(const fftw_plan_wrapper_t<rocfft_fp16>& plan,
+                                               std::vector<hostbuf>&                   in,
+                                               std::vector<hostbuf>&                   out)
 {
     // since FFTW does not natively support half precision, convert
     // input to single, execute, then convert output back to half
     auto in_single = half_to_single_copy(in.front());
-    fftwf_execute_dft(plan,
+    fftwf_execute_dft(plan.get(),
                       reinterpret_cast<fftwf_complex*>(in_single.data()),
                       reinterpret_cast<fftwf_complex*>(out.front().data()));
     single_to_half_inplace(out.front());
 }
 
 template <>
-inline void fftw_plan_execute_c2c<float>(typename fftw_trait<float>::fftw_plan_type plan,
-                                         std::vector<hostbuf>&                      in,
-                                         std::vector<hostbuf>&                      out)
+inline void fftw_plan_execute_c2c<float>(const fftw_plan_wrapper_t<float>& plan,
+                                         std::vector<hostbuf>&             in,
+                                         std::vector<hostbuf>&             out)
 {
-    fftwf_execute_dft(plan,
+    fftwf_execute_dft(plan.get(),
                       reinterpret_cast<fftwf_complex*>(in.front().data()),
                       reinterpret_cast<fftwf_complex*>(out.front().data()));
 }
 
 template <>
-inline void fftw_plan_execute_c2c<double>(typename fftw_trait<double>::fftw_plan_type plan,
-                                          std::vector<hostbuf>&                       in,
-                                          std::vector<hostbuf>&                       out)
+inline void fftw_plan_execute_c2c<double>(const fftw_plan_wrapper_t<double>& plan,
+                                          std::vector<hostbuf>&              in,
+                                          std::vector<hostbuf>&              out)
 {
-    fftw_execute_dft(plan,
+    fftw_execute_dft(plan.get(),
                      reinterpret_cast<fftw_complex*>(in.front().data()),
                      reinterpret_cast<fftw_complex*>(out.front().data()));
 }
 
 // Template wrappers for FFTW r2c planners:
 template <typename Tfloat>
-inline typename fftw_trait<Tfloat>::fftw_plan_type
-    fftw_plan_guru64_r2c(int                                             rank,
-                         const fftw_iodim64*                             dims,
-                         int                                             howmany_rank,
-                         const fftw_iodim64*                             howmany_dims,
-                         Tfloat*                                         in,
-                         typename fftw_trait<Tfloat>::fftw_complex_type* out,
-                         unsigned                                        flags);
+inline fftw_plan_wrapper_t<Tfloat> fftw_plan_guru64_r2c(int                     rank,
+                                                        const fftw_iodim64*     dims,
+                                                        int                     howmany_rank,
+                                                        const fftw_iodim64*     howmany_dims,
+                                                        Tfloat*                 in,
+                                                        fftw_complex_t<Tfloat>* out,
+                                                        unsigned                flags);
 template <>
-inline typename fftw_trait<rocfft_fp16>::fftw_plan_type
-    fftw_plan_guru64_r2c<rocfft_fp16>(int                 rank,
-                                      const fftw_iodim64* dims,
-                                      int                 howmany_rank,
-                                      const fftw_iodim64* howmany_dims,
-                                      rocfft_fp16*        in,
-                                      typename fftw_trait<rocfft_fp16>::fftw_complex_type* out,
-                                      unsigned                                             flags)
+inline fftw_plan_wrapper_t<rocfft_fp16>
+    fftw_plan_guru64_r2c<rocfft_fp16>(int                          rank,
+                                      const fftw_iodim64*          dims,
+                                      int                          howmany_rank,
+                                      const fftw_iodim64*          howmany_dims,
+                                      rocfft_fp16*                 in,
+                                      fftw_complex_t<rocfft_fp16>* out,
+                                      unsigned                     flags)
 {
-    return fftwf_plan_guru64_dft_r2c(
-        rank, dims, howmany_rank, howmany_dims, reinterpret_cast<float*>(in), out, flags);
+    return fftw_trait<rocfft_fp16>::make_wrapper(fftwf_plan_guru64_dft_r2c(
+        rank, dims, howmany_rank, howmany_dims, reinterpret_cast<float*>(in), out, flags));
 }
 template <>
-inline typename fftw_trait<float>::fftw_plan_type
-    fftw_plan_guru64_r2c<float>(int                                            rank,
-                                const fftw_iodim64*                            dims,
-                                int                                            howmany_rank,
-                                const fftw_iodim64*                            howmany_dims,
-                                float*                                         in,
-                                typename fftw_trait<float>::fftw_complex_type* out,
-                                unsigned                                       flags)
+inline fftw_plan_wrapper_t<float> fftw_plan_guru64_r2c<float>(int                    rank,
+                                                              const fftw_iodim64*    dims,
+                                                              int                    howmany_rank,
+                                                              const fftw_iodim64*    howmany_dims,
+                                                              float*                 in,
+                                                              fftw_complex_t<float>* out,
+                                                              unsigned               flags)
 {
-    return fftwf_plan_guru64_dft_r2c(rank, dims, howmany_rank, howmany_dims, in, out, flags);
+    return fftw_trait<float>::make_wrapper(
+        fftwf_plan_guru64_dft_r2c(rank, dims, howmany_rank, howmany_dims, in, out, flags));
 }
 template <>
-inline typename fftw_trait<double>::fftw_plan_type
-    fftw_plan_guru64_r2c<double>(int                                             rank,
-                                 const fftw_iodim64*                             dims,
-                                 int                                             howmany_rank,
-                                 const fftw_iodim64*                             howmany_dims,
-                                 double*                                         in,
-                                 typename fftw_trait<double>::fftw_complex_type* out,
-                                 unsigned                                        flags)
+inline fftw_plan_wrapper_t<double> fftw_plan_guru64_r2c<double>(int                 rank,
+                                                                const fftw_iodim64* dims,
+                                                                int                 howmany_rank,
+                                                                const fftw_iodim64* howmany_dims,
+                                                                double*             in,
+                                                                fftw_complex_t<double>* out,
+                                                                unsigned                flags)
 {
-    return fftw_plan_guru64_dft_r2c(rank, dims, howmany_rank, howmany_dims, in, out, flags);
+    return fftw_trait<double>::make_wrapper(
+        fftw_plan_guru64_dft_r2c(rank, dims, howmany_rank, howmany_dims, in, out, flags));
 }
 
 // Template wrappers for FFTW r2c executors:
 template <typename Tfloat>
-inline void fftw_plan_execute_r2c(typename fftw_trait<Tfloat>::fftw_plan_type plan,
-                                  std::vector<hostbuf>&                       in,
-                                  std::vector<hostbuf>&                       out);
+inline void fftw_plan_execute_r2c(const fftw_plan_wrapper_t<Tfloat>& plan,
+                                  std::vector<hostbuf>&              in,
+                                  std::vector<hostbuf>&              out);
 template <>
-inline void fftw_plan_execute_r2c<rocfft_fp16>(typename fftw_trait<float>::fftw_plan_type plan,
-                                               std::vector<hostbuf>&                      in,
-                                               std::vector<hostbuf>&                      out)
+inline void fftw_plan_execute_r2c<rocfft_fp16>(const fftw_plan_wrapper_t<rocfft_fp16>& plan,
+                                               std::vector<hostbuf>&                   in,
+                                               std::vector<hostbuf>&                   out)
 {
     // since FFTW does not natively support half precision, convert
     // input to single, execute, then convert output back to half
     auto in_single = half_to_single_copy(in.front());
-    fftwf_execute_dft_r2c(plan,
+    fftwf_execute_dft_r2c(plan.get(),
                           reinterpret_cast<float*>(in_single.data()),
                           reinterpret_cast<fftwf_complex*>(out.front().data()));
     single_to_half_inplace(out.front());
 }
 template <>
-inline void fftw_plan_execute_r2c<float>(typename fftw_trait<float>::fftw_plan_type plan,
-                                         std::vector<hostbuf>&                      in,
-                                         std::vector<hostbuf>&                      out)
+inline void fftw_plan_execute_r2c<float>(const fftw_plan_wrapper_t<float>& plan,
+                                         std::vector<hostbuf>&             in,
+                                         std::vector<hostbuf>&             out)
 {
-    fftwf_execute_dft_r2c(plan,
+    fftwf_execute_dft_r2c(plan.get(),
                           reinterpret_cast<float*>(in.front().data()),
                           reinterpret_cast<fftwf_complex*>(out.front().data()));
 }
 template <>
-inline void fftw_plan_execute_r2c<double>(typename fftw_trait<double>::fftw_plan_type plan,
-                                          std::vector<hostbuf>&                       in,
-                                          std::vector<hostbuf>&                       out)
+inline void fftw_plan_execute_r2c<double>(const fftw_plan_wrapper_t<double>& plan,
+                                          std::vector<hostbuf>&              in,
+                                          std::vector<hostbuf>&              out)
 {
-    fftw_execute_dft_r2c(plan,
+    fftw_execute_dft_r2c(plan.get(),
                          reinterpret_cast<double*>(in.front().data()),
                          reinterpret_cast<fftw_complex*>(out.front().data()));
 }
 
 // Template wrappers for FFTW c2r planners:
 template <typename Tfloat>
-inline typename fftw_trait<Tfloat>::fftw_plan_type
-    fftw_plan_guru64_c2r(int                                             rank,
-                         const fftw_iodim64*                             dims,
-                         int                                             howmany_rank,
-                         const fftw_iodim64*                             howmany_dims,
-                         typename fftw_trait<Tfloat>::fftw_complex_type* in,
-                         Tfloat*                                         out,
-                         unsigned                                        flags);
+inline fftw_plan_wrapper_t<Tfloat> fftw_plan_guru64_c2r(int                     rank,
+                                                        const fftw_iodim64*     dims,
+                                                        int                     howmany_rank,
+                                                        const fftw_iodim64*     howmany_dims,
+                                                        fftw_complex_t<Tfloat>* in,
+                                                        Tfloat*                 out,
+                                                        unsigned                flags);
 template <>
-inline typename fftw_trait<rocfft_fp16>::fftw_plan_type
-    fftw_plan_guru64_c2r<rocfft_fp16>(int                 rank,
-                                      const fftw_iodim64* dims,
-                                      int                 howmany_rank,
-                                      const fftw_iodim64* howmany_dims,
-                                      typename fftw_trait<rocfft_fp16>::fftw_complex_type* in,
-                                      rocfft_fp16*                                         out,
-                                      unsigned                                             flags)
+inline fftw_plan_wrapper_t<rocfft_fp16>
+    fftw_plan_guru64_c2r<rocfft_fp16>(int                          rank,
+                                      const fftw_iodim64*          dims,
+                                      int                          howmany_rank,
+                                      const fftw_iodim64*          howmany_dims,
+                                      fftw_complex_t<rocfft_fp16>* in,
+                                      rocfft_fp16*                 out,
+                                      unsigned                     flags)
 {
-    return fftwf_plan_guru64_dft_c2r(
-        rank, dims, howmany_rank, howmany_dims, in, reinterpret_cast<float*>(out), flags);
+    return fftw_trait<rocfft_fp16>::make_wrapper(fftwf_plan_guru64_dft_c2r(
+        rank, dims, howmany_rank, howmany_dims, in, reinterpret_cast<float*>(out), flags));
 }
 template <>
-inline typename fftw_trait<float>::fftw_plan_type
-    fftw_plan_guru64_c2r<float>(int                                            rank,
-                                const fftw_iodim64*                            dims,
-                                int                                            howmany_rank,
-                                const fftw_iodim64*                            howmany_dims,
-                                typename fftw_trait<float>::fftw_complex_type* in,
-                                float*                                         out,
-                                unsigned                                       flags)
+inline fftw_plan_wrapper_t<float> fftw_plan_guru64_c2r<float>(int                    rank,
+                                                              const fftw_iodim64*    dims,
+                                                              int                    howmany_rank,
+                                                              const fftw_iodim64*    howmany_dims,
+                                                              fftw_complex_t<float>* in,
+                                                              float*                 out,
+                                                              unsigned               flags)
 {
-    return fftwf_plan_guru64_dft_c2r(rank, dims, howmany_rank, howmany_dims, in, out, flags);
+    return fftw_trait<float>::make_wrapper(
+        fftwf_plan_guru64_dft_c2r(rank, dims, howmany_rank, howmany_dims, in, out, flags));
 }
 template <>
-inline typename fftw_trait<double>::fftw_plan_type
-    fftw_plan_guru64_c2r<double>(int                                             rank,
-                                 const fftw_iodim64*                             dims,
-                                 int                                             howmany_rank,
-                                 const fftw_iodim64*                             howmany_dims,
-                                 typename fftw_trait<double>::fftw_complex_type* in,
-                                 double*                                         out,
-                                 unsigned                                        flags)
+inline fftw_plan_wrapper_t<double> fftw_plan_guru64_c2r<double>(int                 rank,
+                                                                const fftw_iodim64* dims,
+                                                                int                 howmany_rank,
+                                                                const fftw_iodim64* howmany_dims,
+                                                                fftw_complex_t<double>* in,
+                                                                double*                 out,
+                                                                unsigned                flags)
 {
-    return fftw_plan_guru64_dft_c2r(rank, dims, howmany_rank, howmany_dims, in, out, flags);
+    return fftw_trait<double>::make_wrapper(
+        fftw_plan_guru64_dft_c2r(rank, dims, howmany_rank, howmany_dims, in, out, flags));
 }
 
 // Template wrappers for FFTW c2r executors:
 template <typename Tfloat>
-inline void fftw_plan_execute_c2r(typename fftw_trait<Tfloat>::fftw_plan_type plan,
-                                  std::vector<hostbuf>&                       in,
-                                  std::vector<hostbuf>&                       out);
+inline void fftw_plan_execute_c2r(const fftw_plan_wrapper_t<Tfloat>& plan,
+                                  std::vector<hostbuf>&              in,
+                                  std::vector<hostbuf>&              out);
 template <>
-inline void fftw_plan_execute_c2r<rocfft_fp16>(typename fftw_trait<float>::fftw_plan_type plan,
-                                               std::vector<hostbuf>&                      in,
-                                               std::vector<hostbuf>&                      out)
+inline void fftw_plan_execute_c2r<rocfft_fp16>(const fftw_plan_wrapper_t<rocfft_fp16>& plan,
+                                               std::vector<hostbuf>&                   in,
+                                               std::vector<hostbuf>&                   out)
 {
     // since FFTW does not natively support half precision, convert
     // input to single, execute, then convert output back to half
     auto in_single = half_to_single_copy(in.front());
-    fftwf_execute_dft_c2r(plan,
+    fftwf_execute_dft_c2r(plan.get(),
                           reinterpret_cast<fftwf_complex*>(in_single.data()),
                           reinterpret_cast<float*>(out.front().data()));
     single_to_half_inplace(out.front());
 }
 template <>
-inline void fftw_plan_execute_c2r<float>(typename fftw_trait<float>::fftw_plan_type plan,
-                                         std::vector<hostbuf>&                      in,
-                                         std::vector<hostbuf>&                      out)
+inline void fftw_plan_execute_c2r<float>(const fftw_plan_wrapper_t<float>& plan,
+                                         std::vector<hostbuf>&             in,
+                                         std::vector<hostbuf>&             out)
 {
-    fftwf_execute_dft_c2r(plan,
+    fftwf_execute_dft_c2r(plan.get(),
                           reinterpret_cast<fftwf_complex*>(in.front().data()),
                           reinterpret_cast<float*>(out.front().data()));
 }
 template <>
-inline void fftw_plan_execute_c2r<double>(typename fftw_trait<double>::fftw_plan_type plan,
-                                          std::vector<hostbuf>&                       in,
-                                          std::vector<hostbuf>&                       out)
+inline void fftw_plan_execute_c2r<double>(const fftw_plan_wrapper_t<double>& plan,
+                                          std::vector<hostbuf>&              in,
+                                          std::vector<hostbuf>&              out)
 {
-    fftw_execute_dft_c2r(plan,
+    fftw_execute_dft_c2r(plan.get(),
                          reinterpret_cast<fftw_complex*>(in.front().data()),
                          reinterpret_cast<double*>(out.front().data()));
 }
@@ -522,22 +492,21 @@ inline void fftw_plan_execute_c2r<double>(typename fftw_trait<double>::fftw_plan
 #ifdef FFTW_HAVE_SPRINT_PLAN
 // Template wrappers for FFTW print plan:
 template <typename Tfloat>
-inline char* fftw_sprint_plan(const typename fftw_trait<Tfloat>::fftw_plan_type plan);
+inline char* fftw_sprint_plan(const fftw_plan_wrapper_t<Tfloat>& plan);
 template <>
-inline char*
-    fftw_sprint_plan<rocfft_fp16>(const typename fftw_trait<rocfft_fp16>::fftw_plan_type plan)
+inline char* fftw_sprint_plan<rocfft_fp16>(const fftw_plan_wrapper_t<rocfft_fp16>& plan)
 {
-    return fftwf_sprint_plan(plan);
+    return fftwf_sprint_plan(plan.get());
 }
 template <>
-inline char* fftw_sprint_plan<float>(const typename fftw_trait<float>::fftw_plan_type plan)
+inline char* fftw_sprint_plan<float>(const fftw_plan_wrapper_t<float>& plan)
 {
-    return fftwf_sprint_plan(plan);
+    return fftwf_sprint_plan(plan.get());
 }
 template <>
-inline char* fftw_sprint_plan<double>(const typename fftw_trait<double>::fftw_plan_type plan)
+inline char* fftw_sprint_plan<double>(const fftw_plan_wrapper_t<double>& plan)
 {
-    return fftw_sprint_plan(plan);
+    return fftw_sprint_plan(plan.get());
 }
 #endif
 

--- a/projects/rocfft/shared/fftw_transform.h
+++ b/projects/rocfft/shared/fftw_transform.h
@@ -78,9 +78,9 @@ static constexpr double default_double_epsilon()
 // C++ traits to simplify type selection for FFTW plans, complex and/or real
 // FFTW types, based on the base real type of the floating-point arithmetic of
 // interest. The correct FFTW complex type can be accessed via, for example,
-// using complex_t = fftw_complex_trait<Tfloat>::complex_t;
-// NOTE: FFTW does not natively support half-precision, single-precision,
-// members of fftw_trait<rocfft_fp16> are made equivalent to the members of fftw_trait<float>.
+// using complex_t = typename fftw_complex_trait<Tfloat>::complex_t;
+// NOTE: FFTW does not support half-precision: members of fftw_trait<rocfft_fp16>
+// are made equivalent to the members of fftw_trait<float>.
 template <typename Tfloat,
           std::enable_if_t<std::is_same<Tfloat, double>::value || std::is_same<Tfloat, float>::value
                                || std::is_same<Tfloat, rocfft_fp16>::value,

--- a/projects/rocfft/shared/fftw_transform.h
+++ b/projects/rocfft/shared/fftw_transform.h
@@ -101,6 +101,53 @@ struct fftw_trait<double>
     using fftw_plan_type    = fftw_plan;
 };
 
+template <typename Tfloat>
+struct fftw_plan_wrapper
+{
+    fftw_plan_wrapper(typename fftw_trait<Tfloat>::fftw_plan_type raw_plan_ptr = nullptr)
+        : plan_ptr(raw_plan_ptr)
+    {
+    }
+    // default moves are fine
+    fftw_plan_wrapper(fftw_plan_wrapper&&) = default;
+    fftw_plan_wrapper& operator=(fftw_plan_wrapper&&) = default;
+    // disable copies
+    fftw_plan_wrapper(const fftw_plan_wrapper&) = delete;
+    fftw_plan_wrapper& operator=(const fftw_plan_wrapper& other) = delete;
+    // copy assignment from raw pointer
+    fftw_plan_wrapper& operator=(typename fftw_trait<Tfloat>::fftw_plan_type raw_plan_ptr)
+    {
+        clear();
+        plan_ptr = raw_plan_ptr;
+        return *this;
+    }
+
+    // conversion to raw pointer
+    operator typename fftw_trait<Tfloat>::fftw_plan_type() const
+    {
+        return plan_ptr;
+    }
+
+    void clear()
+    {
+        if(plan_ptr)
+        {
+            if constexpr(std::is_same_v<Tfloat, double>)
+                fftw_destroy_plan(plan_ptr);
+            else
+                fftwf_destroy_plan(plan_ptr);
+            plan_ptr = nullptr;
+        }
+    }
+    ~fftw_plan_wrapper()
+    {
+        clear();
+    }
+
+private:
+    typename fftw_trait<Tfloat>::fftw_plan_type plan_ptr;
+};
+
 // Copies the half-precision input buffer to a single-precision
 // buffer.  Note that the input buffer is already sized like it's a
 // single-precision buffer (but only half of it is filled), because
@@ -205,20 +252,6 @@ template <>
 inline void fftw_execute_type<double>(typename fftw_trait<double>::fftw_plan_type plan)
 {
     return fftw_execute(plan);
-}
-
-// Template wrappers for FFTW plan destroyers:
-template <typename Tfftw_plan>
-inline void fftw_destroy_plan_type(Tfftw_plan plan);
-template <>
-inline void fftw_destroy_plan_type<fftwf_plan>(fftwf_plan plan)
-{
-    return fftwf_destroy_plan(plan);
-}
-template <>
-inline void fftw_destroy_plan_type<fftw_plan>(fftw_plan plan)
-{
-    return fftw_destroy_plan(plan);
 }
 
 // Template wrappers for FFTW c2c planners:

--- a/projects/rocfft/shared/mpi_worker.h
+++ b/projects/rocfft/shared/mpi_worker.h
@@ -462,15 +462,15 @@ static void
 template <typename Tfloat>
 void execute_reference_fft(const fft_params& params, std::vector<hostbuf>& input)
 {
-    fftw_plan_wrapper<Tfloat> cpu_plan = fftw_plan_via_rocfft<Tfloat>(params.length,
-                                                                      params.istride,
-                                                                      params.ostride,
-                                                                      params.nbatch,
-                                                                      params.idist,
-                                                                      params.odist,
-                                                                      params.transform_type,
-                                                                      input,
-                                                                      input);
+    fftw_plan_wrapper_t<Tfloat> cpu_plan = fftw_plan_via_rocfft<Tfloat>(params.length,
+                                                                        params.istride,
+                                                                        params.ostride,
+                                                                        params.nbatch,
+                                                                        params.idist,
+                                                                        params.odist,
+                                                                        params.transform_type,
+                                                                        input,
+                                                                        input);
 
     fftw_run<Tfloat>(params.transform_type, cpu_plan, input, input);
 }

--- a/projects/rocfft/shared/mpi_worker.h
+++ b/projects/rocfft/shared/mpi_worker.h
@@ -462,19 +462,17 @@ static void
 template <typename Tfloat>
 void execute_reference_fft(const fft_params& params, std::vector<hostbuf>& input)
 {
-    auto cpu_plan = fftw_plan_via_rocfft<Tfloat>(params.length,
-                                                 params.istride,
-                                                 params.ostride,
-                                                 params.nbatch,
-                                                 params.idist,
-                                                 params.odist,
-                                                 params.transform_type,
-                                                 input,
-                                                 input);
+    fftw_plan_wrapper<Tfloat> cpu_plan = fftw_plan_via_rocfft<Tfloat>(params.length,
+                                                                      params.istride,
+                                                                      params.ostride,
+                                                                      params.nbatch,
+                                                                      params.idist,
+                                                                      params.odist,
+                                                                      params.transform_type,
+                                                                      input,
+                                                                      input);
 
     fftw_run<Tfloat>(params.transform_type, cpu_plan, input, input);
-
-    fftw_destroy_plan_type(cpu_plan);
 }
 
 bool   use_fftw_wisdom = false;

--- a/projects/rocfft/shared/rocfft_against_fftw.h
+++ b/projects/rocfft/shared/rocfft_against_fftw.h
@@ -48,7 +48,7 @@ extern bool use_fftw_wisdom;
 // precision, and dimensions.  cpu_out is required if we're using
 // wisdom, which runs actual FFTs to work out the best plan.
 template <typename Tfloat>
-static typename fftw_trait<Tfloat>::fftw_plan_type
+static fftw_plan_wrapper_t<Tfloat>
     fftw_plan_with_precision(const std::vector<fftw_iodim64>& dims,
                              const std::vector<fftw_iodim64>& howmany_dims,
                              const fft_transform_type         transformType,
@@ -56,8 +56,6 @@ static typename fftw_trait<Tfloat>::fftw_plan_type
                              void*                            cpu_in,
                              void*                            cpu_out)
 {
-    using fftw_complex_type = typename fftw_trait<Tfloat>::fftw_complex_type;
-
     // NB: Using FFTW_MEASURE implies that the input buffer's data
     // may be destroyed during plan creation.  But if we're wanting
     // to run FFTW in the first place, we must have just created an
@@ -70,8 +68,8 @@ static typename fftw_trait<Tfloat>::fftw_plan_type
                                             dims.data(),
                                             howmany_dims.size(),
                                             howmany_dims.data(),
-                                            reinterpret_cast<fftw_complex_type*>(cpu_in),
-                                            reinterpret_cast<fftw_complex_type*>(cpu_out),
+                                            reinterpret_cast<fftw_complex_t<Tfloat>*>(cpu_in),
+                                            reinterpret_cast<fftw_complex_t<Tfloat>*>(cpu_out),
                                             -1,
                                             use_fftw_wisdom ? FFTW_MEASURE : FFTW_ESTIMATE);
     case fft_transform_type_complex_inverse:
@@ -79,8 +77,8 @@ static typename fftw_trait<Tfloat>::fftw_plan_type
                                             dims.data(),
                                             howmany_dims.size(),
                                             howmany_dims.data(),
-                                            reinterpret_cast<fftw_complex_type*>(cpu_in),
-                                            reinterpret_cast<fftw_complex_type*>(cpu_out),
+                                            reinterpret_cast<fftw_complex_t<Tfloat>*>(cpu_in),
+                                            reinterpret_cast<fftw_complex_t<Tfloat>*>(cpu_out),
                                             1,
                                             use_fftw_wisdom ? FFTW_MEASURE : FFTW_ESTIMATE);
     case fft_transform_type_real_forward:
@@ -89,14 +87,14 @@ static typename fftw_trait<Tfloat>::fftw_plan_type
                                             howmany_dims.size(),
                                             howmany_dims.data(),
                                             reinterpret_cast<Tfloat*>(cpu_in),
-                                            reinterpret_cast<fftw_complex_type*>(cpu_out),
+                                            reinterpret_cast<fftw_complex_t<Tfloat>*>(cpu_out),
                                             use_fftw_wisdom ? FFTW_MEASURE : FFTW_ESTIMATE);
     case fft_transform_type_real_inverse:
         return fftw_plan_guru64_c2r<Tfloat>(dims.size(),
                                             dims.data(),
                                             howmany_dims.size(),
                                             howmany_dims.data(),
-                                            reinterpret_cast<fftw_complex_type*>(cpu_in),
+                                            reinterpret_cast<fftw_complex_t<Tfloat>*>(cpu_in),
                                             reinterpret_cast<Tfloat*>(cpu_out),
                                             use_fftw_wisdom ? FFTW_MEASURE : FFTW_ESTIMATE);
     default:
@@ -107,16 +105,15 @@ static typename fftw_trait<Tfloat>::fftw_plan_type
 // construct an FFTW plan, given rocFFT parameters.  output is
 // required if planning with wisdom.
 template <typename Tfloat>
-static typename fftw_trait<Tfloat>::fftw_plan_type
-    fftw_plan_via_rocfft(const std::vector<size_t>& length,
-                         const std::vector<size_t>& istride,
-                         const std::vector<size_t>& ostride,
-                         const size_t               nbatch,
-                         const size_t               idist,
-                         const size_t               odist,
-                         const fft_transform_type   transformType,
-                         std::vector<hostbuf>&      input,
-                         std::vector<hostbuf>&      output)
+static fftw_plan_wrapper_t<Tfloat> fftw_plan_via_rocfft(const std::vector<size_t>& length,
+                                                        const std::vector<size_t>& istride,
+                                                        const std::vector<size_t>& ostride,
+                                                        const size_t               nbatch,
+                                                        const size_t               idist,
+                                                        const size_t               odist,
+                                                        const fft_transform_type   transformType,
+                                                        std::vector<hostbuf>&      input,
+                                                        std::vector<hostbuf>&      output)
 {
     // Dimension configuration:
     std::vector<fftw_iodim64> dims(length.size());
@@ -142,10 +139,10 @@ static typename fftw_trait<Tfloat>::fftw_plan_type
 }
 
 template <typename Tfloat>
-void fftw_run(fft_transform_type                          transformType,
-              typename fftw_trait<Tfloat>::fftw_plan_type cpu_plan,
-              std::vector<hostbuf>&                       cpu_in,
-              std::vector<hostbuf>&                       cpu_out)
+void fftw_run(fft_transform_type                 transformType,
+              const fftw_plan_wrapper_t<Tfloat>& cpu_plan,
+              std::vector<hostbuf>&              cpu_in,
+              std::vector<hostbuf>&              cpu_out)
 {
     switch(transformType)
     {


### PR DESCRIPTION
## Motivation

FFT accuracy tests maintain a raw pointer to the reference FFTW plan which may result in leaking of the latter, when test scopes are exited before plan execution.

## Technical Details

Introducing a RAII wrapper for FFTW plan and enforcing usage thereof throughout FFT projects.

## Test Plan

Current tests suffice.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
