### PR TITLE
hipDNN: Warn when clang-tidy checks are disabled

### DIFF
--- a/projects/hipdnn/CMakeLists.txt
+++ b/projects/hipdnn/CMakeLists.txt
@@ -148,11 +148,16 @@ option(BUILD_THREAD_SANITIZER "Build with Thread Sanitizer enabled" OFF)
 option(ENABLE_CLANG_FORMAT "Enable Clang-Format checks" ON)
 if(WIN32)
     option(ENABLE_CLANG_TIDY "Enable Clang-Tidy checks" OFF)
-    if(ENABLE_CLANG_TIDY)
+else()
+    option(ENABLE_CLANG_TIDY "Enable Clang-Tidy checks" ON)
+endif()
+
+if(ENABLE_CLANG_TIDY)
+    if(WIN32)
         message(WARNING "Clang-Tidy enabled on Windows - this significantly increases build time.")
     endif()
 else()
-    option(ENABLE_CLANG_TIDY "Enable Clang-Tidy checks" ON)
+    message(WARNING "Clang-Tidy is disabled - some build issues may be missed.")
 endif()
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE CACHE BOOL


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This PR resolves issue #3761 by adding a CMake warning when Clang-Tidy checks are disabled. The warning informs users that disabling these checks may result in missed build issues.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

- Added a CMake warning that is shown whenever `ENABLE_CLANG_TIDY` is set to `OFF`.
- The warning applies to both Windows and Linux platforms.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Testing was performed during the CMake configure phase.

## Test Result

<!-- Briefly summarize test outcomes. -->

CMake warnings are correctly emitted when Clang-Tidy is disabled and existing warnings for enabled Clang-Tidy on Windows are preserved. The behavior matches expectations on both Linux and Windows platforms.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
