### PR TITLE
[hipfft-test] Do not exclude some options if a token is used

### DIFF
--- a/projects/hipfft/clients/tests/gtest_main.cpp
+++ b/projects/hipfft/clients/tests/gtest_main.cpp
@@ -473,17 +473,16 @@ int main(int argc, char* argv[])
         ->default_val(0);
     non_token->add_option("--ioffset", manual_params.ioffset, "Input offset");
     non_token->add_option("--ooffset", manual_params.ooffset, "Output offset");
-    non_token->add_option("--isize", manual_params.isize, "Logical size of input buffer");
-    non_token->add_option("--osize", manual_params.osize, "Logical size of output buffer");
-    non_token->add_option(
-        "--scalefactor", manual_params.scale_factor, "Scale factor to apply to output");
+    app.add_option("--isize", manual_params.isize, "Logical size of input buffer");
+    app.add_option("--osize", manual_params.osize, "Logical size of output buffer");
     // Default value is set in fft_params.h based on if device-side PRNG was enabled.
-    non_token->add_option("-g, --inputGen",
-                          manual_params.igen,
-                          "Input data generation:\n0) PRNG sequence (device)\n"
-                          "1) PRNG sequence (host)\n"
-                          "2) linearly-spaced sequence (device)\n"
-                          "3) linearly-spaced sequence (host)");
+    app.add_option("-g, --inputGen",
+                   manual_params.igen,
+                   "Input data generation:\n0) PRNG sequence (device)\n"
+                   "1) PRNG sequence (host)\n"
+                   "2) linearly-spaced sequence (device)\n"
+                   "3) linearly-spaced sequence (host)");
+    app.add_option("--scalefactor", manual_params.scale_factor, "Scale factor to apply to output");
     const auto* opt_version = app.add_flag(
         "--version",
         "Print queryable version information from the hipfft library's backend (and return)");


### PR DESCRIPTION
## Motivation

Some `hipfft-test` options are currently inaccessible if a token is used, making them almost irrelevant since they do not apply to tests that aren't defined manually.

## Technical Details

Self-explanatory changes.

## Test Plan

Verified manually that the modified options can indeed be used with user-provided tokens with the suggested changes.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
