### PR TITLE
[Tensile] Allow specifying GPU architecture with flag to Tensile.py

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Tensile.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tensile.py
@@ -631,10 +631,10 @@ def Tensile(userArgs):
         for arch in args.gpuTargets.split(";"):
             arch = arch.strip()
             if not arch:
-                continue
+                raise ValueError(f"Invalid GPU target: '{arch}'")
             isa = gfxToIsa(arch)
             if isa is None:
-                printExit(f"Unrecognized GPU target: '{arch}'")
+                raise ValueError(f"Unrecognized GPU target: '{arch}'")
             isaList.append(isa)
     elif "ISA" in config["GlobalParameters"]:
         isaList = [IsaVersion(isa[0], isa[1], isa[2]) for isa in config["GlobalParameters"]["ISA"]]

--- a/projects/hipblaslt/tensilelite/Tensile/Tensile.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tensile.py
@@ -500,6 +500,9 @@ def Tensile(userArgs):
                  "First run using this flag, then rerun with --use-cache.")
     argParser.add_argument("--restore-from-log", type=str, dest="RestoreLog",
             help="A log file captured in previous tuning. ONLY RELIABLE when configs yaml not changes")
+    argParser.add_argument("--gpu-targets", dest="gpuTargets", default=None,
+            help="Semicolon-separated GPU targets (e.g. gfx942). "
+                 "Overrides ISA auto-detection and YAML config ISA.")
 
     addCommonArguments(argParser)
     args = argParser.parse_args(userArgs)
@@ -602,11 +605,15 @@ def Tensile(userArgs):
 
     cxxCompiler, \
     cCompiler, \
-    offloadBundler, \
-    enumerator = validateToolchain(args.CxxCompiler,
-                                   args.CCompiler,
-                                   args.OffloadBundler,
-                                   ToolchainDefaults.DEVICE_ENUMERATOR if args.rocm_agent_enumerator is None else args.rocm_agent_enumerator)
+    offloadBundler = validateToolchain(args.CxxCompiler,
+                                       args.CCompiler,
+                                       args.OffloadBundler)
+
+    if args.gpuTargets:
+        enumerator = None  # not needed — ISA comes from --gpu-targets
+    else:
+        enumerator = validateToolchain(ToolchainDefaults.DEVICE_ENUMERATOR if args.rocm_agent_enumerator is None else args.rocm_agent_enumerator)
+
     asmToolchain = makeAssemblyToolchain(
         cxxCompiler,
         offloadBundler,
@@ -618,7 +625,18 @@ def Tensile(userArgs):
         offloadBundler,
     )
 
-    if "ISA" in config["GlobalParameters"]:
+    if args.gpuTargets:
+        from Tensile.Common.Architectures import gfxToIsa
+        isaList = []
+        for arch in args.gpuTargets.split(";"):
+            arch = arch.strip()
+            if not arch:
+                continue
+            isa = gfxToIsa(arch)
+            if isa is None:
+                printExit(f"Unrecognized GPU target: '{arch}'")
+            isaList.append(isa)
+    elif "ISA" in config["GlobalParameters"]:
         isaList = [IsaVersion(isa[0], isa[1], isa[2]) for isa in config["GlobalParameters"]["ISA"]]
 
     else:


### PR DESCRIPTION
## Motivation

Allow explicit ISA specification via semicolon-separated GPU targets (e.g. gfx942), bypassing hardware auto-detection.
Useful for cross-compilation on machines without the target GPU.
Required for splitting CIs across cpu-compile nodes and gpu-run nodes.

## Technical Details

Add new flag which bypass the automatic architecture finding code.

## Test Plan

Run existing tests.

## Test Result

Passes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
