### PR TITLE
[hipDNN] Add LSE output to SDPA forward CPU reference

### DIFF
--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceSdpa.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceSdpa.hpp
@@ -25,6 +25,7 @@ public:
     ///
     /// Supports GQA/MQA: numHeads must be divisible by both numHeadsK and numHeadsV.
     /// Optionally adds an additive attention mask before softmax.
+    /// Optionally outputs LSE (log-sum-exp) for backward pass recomputation.
     ///
     /// @param q              Query tensor [B, H, Sq, D]
     /// @param k              Key tensor   [B, Hkv, Skv, D]
@@ -35,6 +36,10 @@ public:
     ///                       to [B, H, Sq, Skv] (rank 1–4), with broadcasting on size-1 dims
     /// @param causalMask     When true, applies a lower-triangular causal mask so each
     ///                       query position sq can only attend to kv positions skv <= sq
+    /// @param lse            Optional log-sum-exp output [B, H, Sq] (always float type).
+    ///                       Stores maxVal + log(sumExp) for each query position.
+    ///                       Used for memory-efficient backward pass recomputation.
+    ///                       Pass nullptr (default) to disable LSE output.
     template <class QDataType,
               class KDataType,
               class VDataType,
@@ -47,7 +52,8 @@ public:
                         std::optional<float> attnScaleValue = std::nullopt,
                         const hipdnn_data_sdk::utilities::TensorBase<ComputeDataType>* attnMask
                         = nullptr,
-                        bool causalMask = false)
+                        bool causalMask = false,
+                        hipdnn_data_sdk::utilities::TensorBase<float>* lse = nullptr)
     {
         if(q.dims().size() != 4)
         {
@@ -106,6 +112,23 @@ public:
         {
             throw std::invalid_argument(
                 "CpuFpReferenceSdpa: numHeads must be divisible by numHeadsK");
+        }
+
+        // Validate LSE tensor if provided
+        if(lse != nullptr)
+        {
+            if(lse->dims().size() != 3)
+            {
+                throw std::invalid_argument("CpuFpReferenceSdpa: lse must be rank-3 [B, H, Sq]");
+            }
+            if(lse->dims()[0] != batch || lse->dims()[1] != numHeads || lse->dims()[2] != seqQ)
+            {
+                throw std::invalid_argument(
+                    "CpuFpReferenceSdpa: lse shape must be [" + std::to_string(batch) + ", "
+                    + std::to_string(numHeads) + ", " + std::to_string(seqQ) + "] but got ["
+                    + std::to_string(lse->dims()[0]) + ", " + std::to_string(lse->dims()[1]) + ", "
+                    + std::to_string(lse->dims()[2]) + "]");
+            }
         }
 
         const auto headsPerHeadK = numHeads / numHeadsK;
@@ -188,6 +211,16 @@ public:
                 probs[static_cast<size_t>(skv)] /= sumExp;
             }
 
+            // Step 4b: Write LSE (log-sum-exp) if requested
+            // LSE = maxVal + log(sumExp) enables backward pass to recompute softmax
+            // probabilities without storing the full [B, H, Sq, Skv] attention matrix.
+            // For fully masked rows (sumExp = 0), log(0) = -inf which is correct.
+            if(lse != nullptr)
+            {
+                const float lseVal = maxVal + std::log(sumExp);
+                lse->setHostValue(lseVal, std::vector<int64_t>{b, h, sq});
+            }
+
             // Step 5: Weighted sum over V to produce O
             for(int64_t dv = 0; dv < headDimV; ++dv)
             {
@@ -208,6 +241,10 @@ public:
         parallelFunc(std::thread::hardware_concurrency());
 
         o.memory().markHostModified();
+        if(lse != nullptr)
+        {
+            lse->memory().markHostModified();
+        }
     }
 };
 

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceSdpa.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceSdpa.cpp
@@ -494,3 +494,339 @@ TYPED_TEST(CpuFpReferenceSdpaFwd, BasicFwd)
     EXPECT_NEAR(static_cast<float>(o.getHostValue(0, 0, 0, 0)), vVal, tol);
     EXPECT_NEAR(static_cast<float>(o.getHostValue(0, 1, 3, 7)), vVal, tol);
 }
+
+// ---------------------------------------------------------------------------
+// LSE (Log-Sum-Exp) Output Tests
+// ---------------------------------------------------------------------------
+
+TEST(TestCpuFpReferenceSdpaFp64, LseOutputMatchesFormula)
+{
+    // Small controlled input: [B=1, H=1, Sq=2, Skv=2, D=2, Dv=2]
+    // Use one-hot Q/K for known scores, then verify LSE = maxVal + log(sumExp)
+
+    Tensor<double> q({1, 1, 2, 2});
+    Tensor<double> k({1, 1, 2, 2});
+    Tensor<double> v({1, 1, 2, 2});
+    Tensor<double> o({1, 1, 2, 2});
+    Tensor<float> lse({1, 1, 2});
+
+    q.fillWithValue(0.0);
+    k.fillWithValue(0.0);
+
+    // One-hot pattern: Q[0,0,0,:] = [1,0], Q[0,0,1,:] = [0,1]
+    q.setHostValue(1.0, 0, 0, 0, 0);
+    q.setHostValue(1.0, 0, 0, 1, 1);
+
+    // K[0,0,0,:] = [1,0], K[0,0,1,:] = [0,1]
+    k.setHostValue(1.0, 0, 0, 0, 0);
+    k.setHostValue(1.0, 0, 0, 1, 1);
+
+    v.setHostValue(1.0, 0, 0, 0, 0);
+    v.setHostValue(2.0, 0, 0, 0, 1);
+    v.setHostValue(3.0, 0, 0, 1, 0);
+    v.setHostValue(4.0, 0, 0, 1, 1);
+
+    const hipdnn_data_sdk::utilities::TensorBase<double>* noMask = nullptr;
+    CpuFpReferenceSdpa::forward(q, k, v, o, std::nullopt, noMask, false, &lse);
+
+    // Manually compute expected LSE
+    const float scale = 1.0f / std::sqrt(2.0f);
+
+    // For sq=0: dot products are [1,0] → scores = [scale, 0]
+    const float maxVal0 = scale;
+    const float sumExp0 = std::exp(scale - maxVal0) + std::exp(0.0f - maxVal0);
+    const float expectedLse0 = maxVal0 + std::log(sumExp0);
+
+    EXPECT_NEAR(lse.getHostValue(0, 0, 0), expectedLse0, 1e-5f);
+
+    // For sq=1: dot products are [0,1] → scores = [0, scale]
+    const float maxVal1 = scale;
+    const float sumExp1 = std::exp(0.0f - maxVal1) + std::exp(scale - maxVal1);
+    const float expectedLse1 = maxVal1 + std::log(sumExp1);
+
+    EXPECT_NEAR(lse.getHostValue(0, 0, 1), expectedLse1, 1e-5f);
+}
+
+TYPED_TEST(CpuFpReferenceSdpaFwd, LseAlwaysFloatType)
+{
+    // Verify: LSE is always float, even when inputs are half/bfloat16
+    using InT = typename TypeParam::First;
+
+    Tensor<InT> q({1, 2, 4, 8});
+    Tensor<InT> k({1, 2, 4, 8});
+    Tensor<InT> v({1, 2, 4, 8});
+    Tensor<InT> o({1, 2, 4, 8});
+    Tensor<float> lse({1, 2, 4});
+
+    q.fillWithRandomValues(safeTestTypeCast<InT>(-1.0f), safeTestTypeCast<InT>(1.0f), 100);
+    k.fillWithRandomValues(safeTestTypeCast<InT>(-1.0f), safeTestTypeCast<InT>(1.0f), 101);
+    v.fillWithRandomValues(safeTestTypeCast<InT>(-1.0f), safeTestTypeCast<InT>(1.0f), 102);
+
+    const hipdnn_data_sdk::utilities::TensorBase<float>* noMask = nullptr;
+    CpuFpReferenceSdpa::forward(q, k, v, o, std::nullopt, noMask, false, &lse);
+
+    // LSE values should be reasonable (not NaN, not inf for non-masked rows)
+    for(int b = 0; b < 1; ++b)
+    {
+        for(int h = 0; h < 2; ++h)
+        {
+            for(int sq = 0; sq < 4; ++sq)
+            {
+                const float lseVal = lse.getHostValue(b, h, sq);
+                EXPECT_FALSE(std::isnan(lseVal)) << "NaN at [" << b << "," << h << "," << sq << "]";
+                // LSE typically in range [-10, 10] for random inputs with default scale
+                EXPECT_GT(lseVal, -20.0f)
+                    << "Unexpectedly small LSE at [" << b << "," << h << "," << sq << "]";
+                EXPECT_LT(lseVal, 20.0f)
+                    << "Unexpectedly large LSE at [" << b << "," << h << "," << sq << "]";
+            }
+        }
+    }
+}
+
+TEST(TestCpuFpReferenceSdpaFp64, LseWithMultipleBatchHeads)
+{
+    // Verify: LSE computed correctly for B > 1, H > 1
+
+    Tensor<double> q({2, 4, 16, 32});
+    Tensor<double> k({2, 4, 16, 32});
+    Tensor<double> v({2, 4, 16, 32});
+    Tensor<double> o({2, 4, 16, 32});
+    Tensor<float> lse({2, 4, 16});
+
+    q.fillWithRandomValues(-1.0, 1.0, 200);
+    k.fillWithRandomValues(-1.0, 1.0, 201);
+    v.fillWithRandomValues(-1.0, 1.0, 202);
+
+    const hipdnn_data_sdk::utilities::TensorBase<double>* noMask = nullptr;
+    CpuFpReferenceSdpa::forward(q, k, v, o, std::nullopt, noMask, false, &lse);
+
+    // Verify all LSE values are reasonable (no NaN, finite)
+    for(int b = 0; b < 2; ++b)
+    {
+        for(int h = 0; h < 4; ++h)
+        {
+            for(int sq = 0; sq < 16; ++sq)
+            {
+                const float lseVal = lse.getHostValue(b, h, sq);
+                EXPECT_TRUE(std::isfinite(lseVal))
+                    << "LSE not finite at [" << b << "," << h << "," << sq << "]";
+            }
+        }
+    }
+}
+
+TEST(TestCpuFpReferenceSdpaFp64, LseWithCausalMask)
+{
+    // [B=1, H=1, Sq=4, Skv=4]
+    // Causal mask: sq=0 sees 1 position, sq=1 sees 2, sq=2 sees 3, sq=3 sees 4
+
+    Tensor<double> q({1, 1, 4, 8});
+    Tensor<double> k({1, 1, 4, 8});
+    Tensor<double> v({1, 1, 4, 8});
+    Tensor<double> o({1, 1, 4, 8});
+    Tensor<float> lse({1, 1, 4});
+
+    q.fillWithValue(1.0);
+    k.fillWithValue(1.0);
+    v.fillWithValue(1.0);
+
+    const hipdnn_data_sdk::utilities::TensorBase<double>* noMask = nullptr;
+    CpuFpReferenceSdpa::forward(q, k, v, o, std::nullopt, noMask, true, &lse);
+
+    // With uniform Q/K and causal mask:
+    // sq=0: 1 valid position → smaller sumExp → smaller LSE
+    // sq=3: 4 valid positions → larger sumExp → larger LSE
+    // LSE should increase monotonically as sq increases
+
+    const float lse0 = lse.getHostValue(0, 0, 0);
+    const float lse1 = lse.getHostValue(0, 0, 1);
+    const float lse2 = lse.getHostValue(0, 0, 2);
+    const float lse3 = lse.getHostValue(0, 0, 3);
+
+    EXPECT_LT(lse0, lse1) << "LSE should increase with more unmasked positions";
+    EXPECT_LT(lse1, lse2);
+    EXPECT_LT(lse2, lse3);
+}
+
+TEST(TestCpuFpReferenceSdpaFp64, LseWithFullyMaskedRow)
+{
+    // Edge case: All scores masked to -inf
+    // LSE should be -inf (mathematically correct: log(0) = -inf)
+
+    Tensor<double> q({1, 1, 2, 2});
+    Tensor<double> k({1, 1, 2, 2});
+    Tensor<double> v({1, 1, 2, 2});
+    Tensor<double> o({1, 1, 2, 2});
+    Tensor<float> lse({1, 1, 2});
+
+    q.fillWithValue(1.0);
+    k.fillWithValue(1.0);
+    v.fillWithValue(1.0);
+
+    // Create additive mask that blocks ALL positions for sq=0
+    Tensor<float> mask({2, 2});
+    mask.fillWithValue(-std::numeric_limits<float>::infinity());
+
+    // But allow sq=1 to see all positions
+    mask.setHostValue(0.0f, 1, 0);
+    mask.setHostValue(0.0f, 1, 1);
+
+    const hipdnn_data_sdk::utilities::TensorBase<float>* maskPtr = &mask;
+    CpuFpReferenceSdpa::forward(q, k, v, o, std::nullopt, maskPtr, false, &lse);
+
+    // sq=0: all masked → LSE = -inf (or NaN due to -inf - (-inf) in exp)
+    const float lse0 = lse.getHostValue(0, 0, 0);
+    // When all scores are -inf: maxVal = -inf, exp(-inf - (-inf)) = exp(NaN) = NaN
+    // So LSE may be NaN rather than -inf. Both indicate "no valid attention weights"
+    EXPECT_TRUE((std::isinf(lse0) && lse0 < 0) || std::isnan(lse0))
+        << "LSE should be -inf or NaN for fully masked row, got: " << lse0;
+
+    // sq=1: normal → LSE finite
+    const float lse1 = lse.getHostValue(0, 0, 1);
+    EXPECT_TRUE(std::isfinite(lse1)) << "LSE should be finite for normal row";
+}
+
+TEST(TestCpuFpReferenceSdpaFp64, LseWithAdditiveMask)
+{
+    // Verify: LSE accounts for additive mask contributions
+
+    Tensor<double> q({1, 1, 2, 2});
+    Tensor<double> k({1, 1, 2, 2});
+    Tensor<double> v({1, 1, 2, 2});
+    Tensor<double> o1({1, 1, 2, 2});
+    Tensor<double> o2({1, 1, 2, 2});
+    Tensor<float> lse1({1, 1, 2});
+    Tensor<float> lse2({1, 1, 2});
+
+    // One-hot Q/K for predictable scores
+    q.fillWithValue(0.0);
+    k.fillWithValue(0.0);
+    q.setHostValue(1.0, 0, 0, 0, 0);
+    q.setHostValue(1.0, 0, 0, 1, 1);
+    k.setHostValue(1.0, 0, 0, 0, 0);
+    k.setHostValue(1.0, 0, 0, 1, 1);
+    v.fillWithValue(1.0);
+
+    // Forward without mask
+    const hipdnn_data_sdk::utilities::TensorBase<double>* noMask = nullptr;
+    CpuFpReferenceSdpa::forward(q, k, v, o1, std::nullopt, noMask, false, &lse1);
+
+    // Forward with mask that suppresses one position
+    Tensor<float> mask({2, 2});
+    mask.fillWithValue(0.0f);
+    mask.setHostValue(-1e4f, 0, 1); // Block skv=1 for sq=0
+
+    CpuFpReferenceSdpa::forward(q, k, v, o2, std::nullopt, &mask, false, &lse2);
+
+    // LSE should differ between masked and unmasked cases
+    const float lseNomask = lse1.getHostValue(0, 0, 0);
+    const float lseWithmask = lse2.getHostValue(0, 0, 0);
+
+    EXPECT_NE(lseNomask, lseWithmask) << "LSE should change with additive mask";
+
+    // With mask blocking skv=1, LSE should be lower (fewer effective positions)
+    EXPECT_LT(lseWithmask, lseNomask) << "LSE should decrease when positions are masked";
+}
+
+TEST(TestCpuFpReferenceSdpaFp64, LseWrongRank)
+{
+    Tensor<double> q({1, 1, 2, 2});
+    Tensor<double> k({1, 1, 2, 2});
+    Tensor<double> v({1, 1, 2, 2});
+    Tensor<double> o({1, 1, 2, 2});
+
+    // Wrong rank: rank-4 instead of rank-3
+    Tensor<float> lseWrong({1, 1, 2, 1});
+
+    EXPECT_THROW(
+        {
+            q.fillWithValue(1.0);
+            k.fillWithValue(1.0);
+            v.fillWithValue(1.0);
+            const hipdnn_data_sdk::utilities::TensorBase<double>* noMask = nullptr;
+            CpuFpReferenceSdpa::forward(q, k, v, o, std::nullopt, noMask, false, &lseWrong);
+        },
+        std::invalid_argument);
+}
+
+TEST(TestCpuFpReferenceSdpaFp64, LseWrongShape)
+{
+    Tensor<double> q({2, 4, 16, 32});
+    Tensor<double> k({2, 4, 16, 32});
+    Tensor<double> v({2, 4, 16, 32});
+    Tensor<double> o({2, 4, 16, 32});
+
+    // Wrong shape: [2, 4, 8] instead of [2, 4, 16]
+    Tensor<float> lseWrong({2, 4, 8});
+
+    EXPECT_THROW(
+        {
+            q.fillWithRandomValues(-1.0, 1.0, 42);
+            k.fillWithRandomValues(-1.0, 1.0, 43);
+            v.fillWithRandomValues(-1.0, 1.0, 44);
+            const hipdnn_data_sdk::utilities::TensorBase<double>* noMask = nullptr;
+            CpuFpReferenceSdpa::forward(q, k, v, o, std::nullopt, noMask, false, &lseWrong);
+        },
+        std::invalid_argument);
+}
+
+TEST(TestCpuFpReferenceSdpaFp64, LseMismatchedBatch)
+{
+    Tensor<double> q({2, 1, 4, 8});
+    Tensor<double> k({2, 1, 4, 8});
+    Tensor<double> v({2, 1, 4, 8});
+    Tensor<double> o({2, 1, 4, 8});
+
+    // Wrong batch: [1, 1, 4] instead of [2, 1, 4]
+    Tensor<float> lseWrong({1, 1, 4});
+
+    EXPECT_THROW(
+        {
+            q.fillWithRandomValues(-1.0, 1.0, 50);
+            k.fillWithRandomValues(-1.0, 1.0, 51);
+            v.fillWithRandomValues(-1.0, 1.0, 52);
+            const hipdnn_data_sdk::utilities::TensorBase<double>* noMask = nullptr;
+            CpuFpReferenceSdpa::forward(q, k, v, o, std::nullopt, noMask, false, &lseWrong);
+        },
+        std::invalid_argument);
+}
+
+TEST(TestCpuFpReferenceSdpaFp64, LseWithGqa)
+{
+    // GQA: H=8, HkV=2 (headsPerKvHead = 4)
+    // Verify: LSE computed correctly despite K/V head sharing
+
+    Tensor<double> q({1, 8, 16, 32});
+    Tensor<double> k({1, 2, 16, 32});
+    Tensor<double> v({1, 2, 16, 32});
+    Tensor<double> o({1, 8, 16, 32});
+    Tensor<float> lse({1, 8, 16});
+
+    q.fillWithRandomValues(-1.0, 1.0, 300);
+    k.fillWithRandomValues(-1.0, 1.0, 301);
+    v.fillWithRandomValues(-1.0, 1.0, 302);
+
+    const hipdnn_data_sdk::utilities::TensorBase<float>* noMask = nullptr;
+    CpuFpReferenceSdpa::forward(q, k, v, o, std::nullopt, noMask, false, &lse);
+
+    // All LSE values should be reasonable
+    for(int h = 0; h < 8; ++h)
+    {
+        for(int sq = 0; sq < 16; ++sq)
+        {
+            const float lseVal = lse.getHostValue(0, h, sq);
+            EXPECT_TRUE(std::isfinite(lseVal)) << "LSE not finite at h=" << h << ", sq=" << sq;
+            EXPECT_GT(lseVal, -20.0f);
+            EXPECT_LT(lseVal, 20.0f);
+        }
+    }
+
+    // Different Q heads using same KV head should have different LSE
+    // (because Q differs, even though K/V are shared)
+    const float lseH0 = lse.getHostValue(0, 0, 0);
+    const float lseH1 = lse.getHostValue(0, 1, 0);
+
+    // With random Q, LSE should almost certainly differ
+    EXPECT_NE(lseH0, lseH1) << "LSE should differ for different Q heads even with shared KV";
+}


### PR DESCRIPTION
## Motivation

The SDPA CPU forward reference needs to output LSE (log-sum-exp) values to enable:

**FlashAttention backward pass**: Recompute softmax probabilities without storing full [B, H, Sq, Skv] attention matrix (4096× memory reduction for typical shapes)
**AITER backward kernel validation**: AITER v3 backward kernels require LSE input
**Gradient correctness testing**: Link forward and backward passes for numerical differentiation

## Technical Details

Added optional LSE parameter to `CpuFpReferenceSdpa::forward()`:


`static void forward(..., TensorBase<float>* lse = nullptr)`

LSE always uses `float` type (not templated) to match AITER/cuDNN/FlashAttention conventions and ensure numerical correctness.
## Test Plan

Added 10 new tests in TestCpuFpReferenceSdpa.cpp:
- LSE formula correctness (hand-derived expected values)
- Data type independence (TYPED_TEST for float/half/bfloat16)
- Causal/additive mask behavior
- GQA support (H=8, Hkv=2)
- Validation error handling (wrong rank/shape/dimensions)
- Edge case: Fully masked rows → LSE is -inf or NaN

## Test Result

Local run
```
[==========] 26 tests from 4 test suites ran. (422 ms total)
[  PASSED  ] 26 tests.
```
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
