### PR TITLE
[hipcub] Fix a few memory leaks reported by the ASAN build

### DIFF
--- a/projects/hipcub/test/hipcub/test_hipcub_block_radix_rank.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_block_radix_rank.cpp
@@ -2,7 +2,7 @@
 /******************************************************************************
 * Copyright (c) 2011, Duane Merrill.  All rights reserved.
 * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
-* Modifications Copyright (c) 2021-2025, Advanced Micro Devices, Inc.  All rights reserved.
+* Modifications Copyright (c) 2021-2026, Advanced Micro Devices, Inc.  All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions are met:
@@ -790,6 +790,7 @@ void test_radix_rank_with_prefix_sum_output()
 
             HIP_CHECK(hipFree(d_keys_input));
             HIP_CHECK(hipFree(d_ranks_output));
+            HIP_CHECK(hipFree(d_prefix_sum_output));
         }
     }
 }

--- a/projects/hipcub/test/hipcub/test_hipcub_block_shuffle.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_block_shuffle.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -431,6 +431,7 @@ TYPED_TEST(HipcubBlockShuffleTests, BlockUpWithSuffix)
         delete[] host_block_suffix;
         HIP_CHECK(hipFree(device_input));
         HIP_CHECK(hipFree(device_output));
+        HIP_CHECK(hipFree(device_suffix));
     }
 }
 
@@ -626,5 +627,6 @@ TYPED_TEST(HipcubBlockShuffleTests, BlockDownWithSuffix)
         delete[] host_block_prefix;
         HIP_CHECK(hipFree(device_input));
         HIP_CHECK(hipFree(device_output));
+        HIP_CHECK(hipFree(device_prefix));
     }
 }

--- a/projects/hipcub/test/hipcub/test_hipcub_caching_device_allocator.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_caching_device_allocator.cpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  * Copyright (c) 2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2019-2025, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2019-2026, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -40,6 +40,17 @@
     #define HAS_VALGRIND_H 0
 #endif
 
+#if defined(__SANITIZE_ADDRESS__)
+    #define IS_ASAN_BUILD 1
+#elif defined(__has_feature)
+    #if __has_feature(address_sanitizer)
+        #define IS_ASAN_BUILD 1
+    #endif
+#endif
+#ifndef IS_ASAN_BUILD
+    #define IS_ASAN_BUILD 0
+#endif
+
 __global__
 void EmptyKernel()
 {}
@@ -49,14 +60,18 @@ void EmptyKernel()
 TEST(HipcubCachingDeviceAllocatorTests, Test1)
 {
 
-#if HAS_VALGRIND_H
-    // This test is very timing sensitive. Valgrind significantly slows down
+    // This test is very timing sensitive. Valgrind and ASAN slow down
     // kernel execution and therefore messes up the timing of the test. 
-    // If valgrind is being used we should disable this test otherwise it will fail
+    // If valgrind or ASAN is being used we disable this test otherwise
+    // it will fail.
+#if HAS_VALGRIND_H
     if (RUNNING_ON_VALGRIND) {
         GTEST_SKIP() << "Skipping test under Valgrind";
     }
 #endif //HAS_VALGRIND_H
+#if IS_ASAN_BUILD
+    GTEST_SKIP() << "Skipping test under ASAN";
+#endif
 
     // Get number of GPUs and current GPU
     int num_gpus;

--- a/projects/hipcub/test/hipcub/test_hipcub_device_transform.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_device_transform.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -164,6 +164,9 @@ TYPED_TEST(HipcubDeviceTransformTests, Transform)
             {
                 ASSERT_EQ(unary_op{}(h_input[i]), h_output[i]);
             }
+
+            HIP_CHECK(hipFree(d_input));
+            HIP_CHECK(hipFree(d_output));
         }
     }
 }
@@ -222,6 +225,9 @@ TYPED_TEST(HipcubDeviceTransformTests, TransformAddrStableNonCopyable)
             {
                 ASSERT_EQ(unary_op{}(h_input[i]), h_output[i]);
             }
+
+            HIP_CHECK(hipFree(d_input));
+            HIP_CHECK(hipFree(d_output));
         }
     }
 }
@@ -279,6 +285,9 @@ TYPED_TEST(HipcubDeviceTransformTests, TransformAddrStablePointerDiff)
             {
                 ASSERT_EQ(i, h_output[i]);
             }
+
+            HIP_CHECK(hipFree(d_input));
+            HIP_CHECK(hipFree(d_output));
         }
     }
 }


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This PR fixes a few memory leaks in the hipcub tests.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
The ASAN build reported a few memory leaks in hipcub tests. They are fixed by this PR. This PR also disables the `caching_device_allocator` test in ASAN build since this test is sensitive to running time and in the ASAN build assumptions about the caching behaviour of the tested allocator no longer hold - it was already disabled by Valgrind due to the same reason.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
No more memory leaks reported by the ASAN build from these tests.

## Test Result

<!-- Briefly summarize test outcomes. -->
The tests pass in the ASAN build with no memory leaks reported.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
