### PR TITLE
[CK] [CK Tile] Improved ci_safety_check in smart-build infrastructure

### DIFF
--- a/projects/composablekernel/script/dependency-parser/ci_safety_check.sh
+++ b/projects/composablekernel/script/dependency-parser/ci_safety_check.sh
@@ -18,8 +18,8 @@
 #   CHANGE_TARGET - Base branch for PR builds (set by Jenkins Multibranch Pipeline)
 #
 # Note: CHANGE_ID may not be set even for PR builds if Jenkins job is not
-# configured as Multibranch Pipeline. Script uses three-dot git diff syntax
-# to correctly detect PR changes regardless of CHANGE_ID availability.
+# configured as Multibranch Pipeline. Script uses two-dot git diff syntax
+# to detect PR changes regardless of CHANGE_ID availability.
 #
 # Manual override (set by developer/admin if needed):
 #   DISABLE_SMART_BUILD - Set to "true" to force full build
@@ -48,15 +48,9 @@ fi
 
 # 3. Force full build if CMakeLists.txt or cmake/ configuration changed
 # Always compare against base branch (not consecutive commits) to avoid false positives from merge commits
-# Three-dot syntax (...) only shows changes actually made in the PR, not changes from merged develop branch
-if [ -n "$CHANGE_ID" ]; then
-    # This is a PR build (CHANGE_ID set by Jenkins Multibranch Pipeline)
-    CHANGED_FILES=$(git diff --name-only origin/${BASE_BRANCH}..HEAD 2>/dev/null || echo "")
-else
-    # Fallback: Works for both branch builds and PRs without CHANGE_ID
-    # Use two-dot syntax to get all files that differ between develop and the branch
-    CHANGED_FILES=$(git diff --name-only origin/${BASE_BRANCH}..HEAD 2>/dev/null || echo "")
-fi
+# Two-dot syntax (..) compares current state against base branch
+# Note: This includes merged changes from develop, which is conservative but safe (catches all potentially affected files)
+CHANGED_FILES=$(git diff --name-only origin/${BASE_BRANCH}..HEAD 2>/dev/null || echo "")
 
 # Comprehensive pattern for build/infrastructure files that require full build:
 # - CMake: CMakeLists.txt, *.cmake, *.cmake.in, CMakePresets.json

--- a/projects/composablekernel/script/dependency-parser/ci_safety_check.sh
+++ b/projects/composablekernel/script/dependency-parser/ci_safety_check.sh
@@ -51,14 +51,14 @@ fi
 # Three-dot syntax (...) only shows changes actually made in the PR, not changes from merged develop branch
 if [ -n "$CHANGE_ID" ]; then
     # This is a PR build (CHANGE_ID set by Jenkins Multibranch Pipeline)
-    CHANGED_FILES=$(git diff --name-only origin/${BASE_BRANCH}...HEAD 2>/dev/null || echo "")
+    CHANGED_FILES=$(git diff --name-only origin/${BASE_BRANCH}..HEAD 2>/dev/null || echo "")
 else
     # Fallback: Works for both branch builds and PRs without CHANGE_ID
     # Use three-dot syntax to avoid including merge commit changes from develop
-    CHANGED_FILES=$(git diff --name-only origin/${BASE_BRANCH}...HEAD 2>/dev/null || echo "")
+    CHANGED_FILES=$(git diff --name-only origin/${BASE_BRANCH}..HEAD 2>/dev/null || echo "")
 fi
 
-if echo "$CHANGED_FILES" | grep -qE "(CMakeLists\.txt|cmake/.*\.cmake)"; then
+if echo "$CHANGED_FILES" | grep -qE "(CMakeLists\.txt|cmake/.*\.cmake|Dockerfile|Jenkinsfile|CMakePresets\.json|script/dependency-parser/)"; then
     FORCE_FULL_BUILD=true
     REASON="build system configuration changed (CMakeLists.txt or cmake/*.cmake)"
 fi

--- a/projects/composablekernel/script/dependency-parser/ci_safety_check.sh
+++ b/projects/composablekernel/script/dependency-parser/ci_safety_check.sh
@@ -58,9 +58,25 @@ else
     CHANGED_FILES=$(git diff --name-only origin/${BASE_BRANCH}..HEAD 2>/dev/null || echo "")
 fi
 
-if echo "$CHANGED_FILES" | grep -qE "(CMakeLists\.txt|cmake/.*\.cmake|Dockerfile|Jenkinsfile|CMakePresets\.json|script/dependency-parser/)"; then
+# Comprehensive pattern for build/infrastructure files that require full build:
+# - CMake: CMakeLists.txt, *.cmake, *.cmake.in, CMakePresets.json
+# - Docker: Dockerfile*, docker-compose*
+# - CI/CD: Jenkinsfile, .github/, .gitlab-ci.yml, .pre-commit-config.yaml, .readthedocs.yaml
+# - Scripts: script/ directory (cmake, dependency-parser, build utilities)
+# - Compiler: .clang-format, .clang-tidy
+# - Python: setup.py, pyproject.toml, requirements*.txt
+BUILD_INFRA_PATTERN="(CMakeLists\.txt"
+BUILD_INFRA_PATTERN="${BUILD_INFRA_PATTERN}|\.cmake$|\.cmake\.in$|CMakePresets\.json"
+BUILD_INFRA_PATTERN="${BUILD_INFRA_PATTERN}|Dockerfile|docker-compose"
+BUILD_INFRA_PATTERN="${BUILD_INFRA_PATTERN}|Jenkinsfile|\.github/|\.gitlab-ci\.yml"
+BUILD_INFRA_PATTERN="${BUILD_INFRA_PATTERN}|\.pre-commit-config\.yaml|\.readthedocs\.yaml"
+BUILD_INFRA_PATTERN="${BUILD_INFRA_PATTERN}|script/"
+BUILD_INFRA_PATTERN="${BUILD_INFRA_PATTERN}|\.clang-format|\.clang-tidy"
+BUILD_INFRA_PATTERN="${BUILD_INFRA_PATTERN}|setup\.py|pyproject\.toml|requirements.*\.txt)"
+
+if echo "$CHANGED_FILES" | grep -qE "${BUILD_INFRA_PATTERN}"; then
     FORCE_FULL_BUILD=true
-    REASON="build system configuration changed (CMakeLists.txt or cmake/*.cmake)"
+    REASON="build system configuration changed"
 fi
 
 # 4. Force full build if dependency cache is older than 7 days

--- a/projects/composablekernel/script/dependency-parser/ci_safety_check.sh
+++ b/projects/composablekernel/script/dependency-parser/ci_safety_check.sh
@@ -54,7 +54,7 @@ if [ -n "$CHANGE_ID" ]; then
     CHANGED_FILES=$(git diff --name-only origin/${BASE_BRANCH}..HEAD 2>/dev/null || echo "")
 else
     # Fallback: Works for both branch builds and PRs without CHANGE_ID
-    # Use three-dot syntax to avoid including merge commit changes from develop
+    # Use two-dot syntax to get all files that differ between develop and the branch
     CHANGED_FILES=$(git diff --name-only origin/${BASE_BRANCH}..HEAD 2>/dev/null || echo "")
 fi
 

--- a/projects/composablekernel/script/dependency-parser/validate_pr.sh
+++ b/projects/composablekernel/script/dependency-parser/validate_pr.sh
@@ -189,7 +189,7 @@ git log --oneline -5
 
 log_section "Step 3: Analyze Changed Files"
 log_info "Files changed vs $BASE_BRANCH:"
-CHANGED_FILES=$(git diff --name-only ${BASE_BRANCH}...HEAD -- projects/composablekernel)
+CHANGED_FILES=$(git diff --name-only ${BASE_BRANCH}..HEAD -- projects/composablekernel)
 NUM_FILES=$(echo "$CHANGED_FILES" | wc -l)
 echo "$CHANGED_FILES" | head -20
 if [ "$NUM_FILES" -gt 20 ]; then


### PR DESCRIPTION
## Motivation
The two-dot syntax (origin/develop..HEAD) is more conservative and catches a broader set of changes when PRs merge develop branch. While three-dot syntax shows only PR-specific changes, two-dot ensures we don't miss any files that differ between develop and the PR branch, including files modified in both the PR and merged develop commits.

This conservative approach prioritizes catching all potential issues over CI efficiency, which is appropriate for build system change detection.

# Technical Details:
- Switched to two-dot (..) syntax in ci_safety_check.sh
- Update comments to clarify the intentional use of two-dot syntax
- Maintain consistency across both CHANGE_ID branches
- Trigger full build when any of the following changes 
   - `Dockerfile|Jenkinsfile|CMakePresets\.json|script/dependency-parser/`


## Test Plan

Tested with PR 6200 which has multiple merge-commits.

## Test Result

It detects 43 new tests compared to 3-dot scheme.

## Submission Checklist

- [x ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
