### PR TITLE
Properly address unescaped chars in PR title

### DIFF
--- a/.github/scripts/notify_teams.py
+++ b/.github/scripts/notify_teams.py
@@ -366,7 +366,7 @@ def main():
         "--pr-number", default="", help="Pull request number (optional)"
     )
     parser.add_argument(
-        "--pr-title", nargs='*', default=[], help="Pull request title (optional)"
+        "--pr-title", nargs="*", default=[], help="Pull request title (optional)"
     )
     parser.add_argument(
         "--job-name", default="", help="Job/test name (optional, for test failures)"

--- a/.github/scripts/notify_teams.py
+++ b/.github/scripts/notify_teams.py
@@ -365,7 +365,9 @@ def main():
     parser.add_argument(
         "--pr-number", default="", help="Pull request number (optional)"
     )
-    parser.add_argument("--pr-title", nargs='*', default=[], help="Pull request title (optional)")
+    parser.add_argument(
+        "--pr-title", nargs='*', default=[], help="Pull request title (optional)"
+    )
     parser.add_argument(
         "--job-name", default="", help="Job/test name (optional, for test failures)"
     )

--- a/.github/scripts/notify_teams.py
+++ b/.github/scripts/notify_teams.py
@@ -365,7 +365,7 @@ def main():
     parser.add_argument(
         "--pr-number", default="", help="Pull request number (optional)"
     )
-    parser.add_argument("--pr-title", default="", help="Pull request title (optional)")
+    parser.add_argument("--pr-title", nargs='*', default=[], help="Pull request title (optional)")
     parser.add_argument(
         "--job-name", default="", help="Job/test name (optional, for test failures)"
     )
@@ -393,6 +393,9 @@ def main():
     extractor = ErrorExtractor(args.log_path, args.failure_stage)
     error_context, issue_type = extractor.extract()
 
+    # Handle pr_title which may be a list due to nargs='*'
+    pr_title = " ".join(args.pr_title) if args.pr_title else None
+
     # Send notification
     notifier = TeamsNotifier(args.webhook_url, args.dry_run)
     success = notifier.send_notification(
@@ -403,7 +406,7 @@ def main():
         error_context=error_context,
         issue_type=issue_type,
         pr_number=args.pr_number if args.pr_number else None,
-        pr_title=args.pr_title if args.pr_title else None,
+        pr_title=pr_title,
         job_name=args.job_name if args.job_name else None,
     )
 


### PR DESCRIPTION
## Motivation

For PR titles with quotes such as `revert "..."` the script doesn't escape properly and fails.

## Technical Details

The fix makes the script resilient to shell quoting issues without requiring changes to the GitHub Actions workflow files.   

## Test Plan

Test PRs with characters " and []

## Test Result

Message sent correctly:
<img width="334" height="181" alt="image" src="https://github.com/user-attachments/assets/21d8f354-670d-4f34-b731-edb3e593ade9" />

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
