### PR TITLE
rocfft: update doc + samples to check/alloc/set per-device work buffers

### DIFF
--- a/projects/rocfft/clients/samples/multi_gpu/mgpu_complex.cpp
+++ b/projects/rocfft/clients/samples/multi_gpu/mgpu_complex.cpp
@@ -244,22 +244,25 @@ int main(int argc, char* argv[])
     if(fftrc != rocfft_status_success)
         throw std::runtime_error("failed to create plan");
 
-    // Get execution information and allocate work buffer
-    rocfft_execution_info planinfo      = nullptr;
-    size_t                work_buf_size = 0;
-    if(rocfft_plan_get_work_buffer_size(gpu_plan, &work_buf_size) != rocfft_status_success)
-        throw std::runtime_error("rocfft_plan_get_work_buffer_size failed.");
-    void* work_buf = nullptr;
-
-    if(work_buf_size)
+    // Get execution information and allocate work buffer for each device
+    rocfft_execution_info planinfo = nullptr;
+    std::vector<void*>    work_bufs(nDevices);
+    for(int device = 0; device < nDevices; ++device)
     {
-        if(rocfft_execution_info_create(&planinfo) != rocfft_status_success)
-            throw std::runtime_error("failed to create execution info");
-        if(hipMalloc(&work_buf, work_buf_size) != hipSuccess)
-            throw std::runtime_error("hipMalloc failed");
-        if(rocfft_execution_info_set_work_buffer(planinfo, work_buf, work_buf_size)
-           != rocfft_status_success)
-            throw std::runtime_error("rocfft_execution_info_set_work_buffer failed.");
+        size_t work_buf_size = 0;
+        if(rocfft_plan_get_work_buffer_size(gpu_plan, &work_buf_size) != rocfft_status_success)
+            throw std::runtime_error("rocfft_plan_get_work_buffer_size failed.");
+
+        if(work_buf_size)
+        {
+            if(rocfft_execution_info_create(&planinfo) != rocfft_status_success)
+                throw std::runtime_error("failed to create execution info");
+            if(hipMalloc(&work_bufs[device], work_buf_size) != hipSuccess)
+                throw std::runtime_error("hipMalloc failed");
+            if(rocfft_execution_info_set_work_buffer(planinfo, work_bufs[device], work_buf_size)
+               != rocfft_status_success)
+                throw std::runtime_error("rocfft_execution_info_set_work_buffer failed.");
+        }
     }
 
     // Execute plan:
@@ -311,13 +314,18 @@ int main(int argc, char* argv[])
     if(rocfft_cleanup() != rocfft_status_success)
         throw std::runtime_error("rocfft_cleanup failed.");
 
-    for(size_t idx = 0; idx < gpu_in.size(); ++idx)
+    for(auto buf : work_bufs)
     {
-        (void)hipFree(gpu_in[idx]);
+        if(buf)
+            (void)hipFree(buf);
     }
-    for(size_t idx = 0; idx < gpu_out.size(); ++idx)
+    for(auto buf : gpu_in)
     {
-        (void)hipFree(gpu_out[idx]);
+        (void)hipFree(buf);
+    }
+    for(auto buf : gpu_out)
+    {
+        (void)hipFree(buf);
     }
 
     return 0;

--- a/projects/rocfft/clients/samples/multi_gpu/mgpu_complex.cpp
+++ b/projects/rocfft/clients/samples/multi_gpu/mgpu_complex.cpp
@@ -249,13 +249,14 @@ int main(int argc, char* argv[])
     std::vector<void*>    work_bufs(nDevices);
     for(int device = 0; device < nDevices; ++device)
     {
+        (void)hipSetDevice(device);
         size_t work_buf_size = 0;
         if(rocfft_plan_get_work_buffer_size(gpu_plan, &work_buf_size) != rocfft_status_success)
             throw std::runtime_error("rocfft_plan_get_work_buffer_size failed.");
 
         if(work_buf_size)
         {
-            if(rocfft_execution_info_create(&planinfo) != rocfft_status_success)
+            if(!planinfo && rocfft_execution_info_create(&planinfo) != rocfft_status_success)
                 throw std::runtime_error("failed to create execution info");
             if(hipMalloc(&work_bufs[device], work_buf_size) != hipSuccess)
                 throw std::runtime_error("hipMalloc failed");
@@ -264,6 +265,9 @@ int main(int argc, char* argv[])
                 throw std::runtime_error("rocfft_execution_info_set_work_buffer failed.");
         }
     }
+
+    // Reset the device back to where the plan was created before execution
+    (void)hipSetDevice(devices[0]);
 
     // Execute plan:
     fftrc = rocfft_execute(gpu_plan, (void**)gpu_in.data(), (void**)gpu_out.data(), planinfo);
@@ -314,18 +318,18 @@ int main(int argc, char* argv[])
     if(rocfft_cleanup() != rocfft_status_success)
         throw std::runtime_error("rocfft_cleanup failed.");
 
-    for(auto buf : work_bufs)
+    for(int device = 0; device < nDevices; ++device)
     {
-        if(buf)
-            (void)hipFree(buf);
+        (void)hipSetDevice(device);
+        if(work_bufs[device])
+            (void)hipFree(work_bufs[device]);
     }
-    for(auto buf : gpu_in)
+
+    for(const auto device : devices)
     {
-        (void)hipFree(buf);
-    }
-    for(auto buf : gpu_out)
-    {
-        (void)hipFree(buf);
+        (void)hipSetDevice(device);
+        (void)hipFree(gpu_in[device]);
+        (void)hipFree(gpu_out[device]);
     }
 
     return 0;

--- a/projects/rocfft/docs/how-to/working-with-rocfft.rst
+++ b/projects/rocfft/docs/how-to/working-with-rocfft.rst
@@ -79,7 +79,7 @@ Example
            // Create HIP device buffer
            float2 *x;
            hipMalloc(&x, Nbytes);
-   
+
            // Initialize data
            std::vector<float2> cx(N);
            for (size_t i = 0; i < N; i++)
@@ -87,10 +87,10 @@ Example
                    cx[i].x = 1;
                    cx[i].y = -1;
            }
-   
+
            //  Copy data to device
            hipMemcpy(x, cx.data(), Nbytes, hipMemcpyHostToDevice);
-   
+
            // Create rocFFT plan
            rocfft_plan plan = nullptr;
            size_t length = N;
@@ -98,18 +98,18 @@ Example
                 rocfft_transform_type_complex_forward, rocfft_precision_single,
                 1, &length, 1, nullptr);
 
-	   // Check if the plan requires a work buffer
-	   size_t work_buf_size = 0;
+           // Check if the plan requires a work buffer
+           size_t work_buf_size = 0;
            // This is a single-device plan that uses the current HIP device,
            // so any work buffer would be on that device.
-	   rocfft_plan_get_work_buffer_size(plan, &work_buf_size);
-	   void* work_buf = nullptr;
-	   rocfft_execution_info info = nullptr;
-	   if(work_buf_size)
+           rocfft_plan_get_work_buffer_size(plan, &work_buf_size);
+           void* work_buf = nullptr;
+           rocfft_execution_info info = nullptr;
+           if(work_buf_size)
            {
                    rocfft_execution_info_create(&info);
-		   hipMalloc(&work_buf, work_buf_size);
-		   rocfft_execution_info_set_work_buffer(info, work_buf, work_buf_size);
+                   hipMalloc(&work_buf, work_buf_size);
+                   rocfft_execution_info_set_work_buffer(info, work_buf, work_buf_size);
            }
    
            // Execute plan
@@ -118,12 +118,12 @@ Example
            // Wait for execution to finish
            hipDeviceSynchronize();
 
-	   // Clean up work buffer
-	   if(work_buf_size)
-	   {
-	           hipFree(work_buf);
-		   rocfft_execution_info_destroy(info);
-	   }
+           // Clean up work buffer
+           if(work_buf_size)
+           {
+                   hipFree(work_buf);
+                   rocfft_execution_info_destroy(info);
+           }
 
            // Destroy plan
            rocfft_plan_destroy(plan);
@@ -192,23 +192,28 @@ The :cpp:func:`rocfft_plan_get_work_buffer_size` and
 set work buffers for the current HIP device.  By default, rocFFT
 plans run on the HIP device that is current when
 :cpp:func:`rocfft_plan_create` is called, and work buffers may only
-be required on the same device.
+be required on the same device.  Any supplied work buffer for a device must be accessible 
 
 .. _multi_device_work_mem:
 
 If the plan uses multiple HIP devices by decomposing the input or
 output into :ref:`fields<input_output_fields>`, work memory may be
-required on any of the devices used by the input or output fields.
-In this case, the steps to query and set work buffers need to be
-repeated for each HIP device, as illustrated by the following code fragment:
+required on any of the devices used by the input or output fields as
+well as the current HIP device when the plan was created.  In this
+case, the steps to query and set work buffers need to be repeated for
+each HIP device, as illustrated by the following code fragment:
 
 .. code-block:: c++
 
   rocfft_plan plan = nullptr;
   rocfft_execution_info info = nullptr;
 
-  // For brevity, the steps to create the plan and execution info have been omitted
+  // For brevity, error checking and the steps to create the plan and
+  // execution info have been omitted
 
+  // Start on device 0
+  hipSetDevice(0);
+  
   // Get the number of HIP devices
   int ndevices = 0;
   hipGetDeviceCount(&ndevices);
@@ -229,6 +234,9 @@ repeated for each HIP device, as illustrated by the following code fragment:
       }
   }
 
+  // Return to device 0
+  hipSetDevice(0);
+  
   // Execution of the plan with the execution info would happen here
 
   // Free the work buffers that were allocated
@@ -240,6 +248,9 @@ repeated for each HIP device, as illustrated by the following code fragment:
           hipFree(workbufs[device]);
       }
   }
+
+  // Return to device 0
+  hipSetDevice(0);
 
 Transform and array types 
 =========================

--- a/projects/rocfft/docs/how-to/working-with-rocfft.rst
+++ b/projects/rocfft/docs/how-to/working-with-rocfft.rst
@@ -37,6 +37,7 @@ To perform a transform, follow these steps:
 
       * Create an execution info object using :cpp:func:`rocfft_execution_info_create`.
       * Allocate a buffer using ``hipMalloc`` and pass the allocated buffer to :cpp:func:`rocfft_execution_info_set_work_buffer`.
+   *  If the plan uses multiple HIP devices for input or output, :ref:`repeat the above steps<multi_device_work_mem>` for each HIP device.
 
 #. Execute the plan:
 
@@ -99,6 +100,8 @@ Example
 
 	   // Check if the plan requires a work buffer
 	   size_t work_buf_size = 0;
+           // This is a single-device plan that uses the current HIP device,
+           // so any work buffer would be on that device.
 	   rocfft_plan_get_work_buffer_size(plan, &work_buf_size);
 	   void* work_buf = nullptr;
 	   rocfft_execution_info info = nullptr;
@@ -183,6 +186,60 @@ memory regions on the device, it expects you to manage the work buffers. The siz
 :cpp:func:`rocfft_plan_get_work_buffer_size`. After allocation, it can be passed to the library using
 :cpp:func:`rocfft_execution_info_set_work_buffer`. The `GitHub repository <https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocfft/clients/samples>`_
 provide some samples and examples.
+
+The :cpp:func:`rocfft_plan_get_work_buffer_size` and
+:cpp:func:`rocfft_execution_info_set_work_buffer` functions query and
+set work buffers for the current HIP device.  By default, rocFFT
+plans run on the HIP device that is current when
+:cpp:func:`rocfft_plan_create` is called, and work buffers may only
+be required on the same device.
+
+.. _multi_device_work_mem:
+
+If the plan uses multiple HIP devices by decomposing the input or
+output into :ref:`fields<input_output_fields>`, work memory may be
+required on any of the devices used by the input or output fields.
+In this case, the steps to query and set work buffers need to be
+repeated for each HIP device, as illustrated by the following code fragment:
+
+.. code-block:: c++
+
+  rocfft_plan plan = nullptr;
+  rocfft_execution_info info = nullptr;
+
+  // For brevity, the steps to create the plan and execution info have been omitted
+
+  // Get the number of HIP devices
+  int ndevices = 0;
+  hipGetDeviceCount(&ndevices);
+
+  // Loop over each device, checking work memory requirements for each one
+  std::vector<void*> workbufs(ndevices);
+  for(int device = 0; device < ndevices; ++device)
+  {
+      hipSetDevice(device);
+      size_t worksize = 0;
+      // Get work memory size required for the current device
+      rocfft_plan_get_work_buffer_size(plan, &worksize);
+      if(worksize)
+      {
+          // Allocate and set the work buffer for the current device
+          hipMalloc(&workbufs[device], worksize);
+          rocfft_execution_info_set_work_buffer(info, workbufs[device], worksize);
+      }
+  }
+
+  // Execution of the plan with the execution info would happen here
+
+  // Free the work buffers that were allocated
+  for(int device = 0; device < ndevices; ++device)
+  {
+      if(workbufs[device])
+      {
+          hipSetDevice(device);
+          hipFree(workbufs[device]);
+      }
+  }
 
 Transform and array types 
 =========================

--- a/projects/rocfft/library/include/rocfft/rocfft.h
+++ b/projects/rocfft/library/include/rocfft/rocfft.h
@@ -431,8 +431,15 @@ ROCFFT_EXPORT rocfft_status rocfft_plan_description_add_infield(rocfft_plan_desc
 ROCFFT_EXPORT rocfft_status
     rocfft_plan_description_add_outfield(rocfft_plan_description description, rocfft_field field);
 
-/*! @brief Get work buffer size
- *  @details Get the work buffer size required for a plan.
+/*! @brief Get work buffer size on current HIP device
+ *  @details Get the work buffer size required for a plan on the current HIP device.
+ *
+ *  Work memory may be required on any device(s) with input or output
+ *  data for the transform.  If the FFT plan uses multiple devices
+ *  then this function can be called repeatedly with each of those
+ *  devices as the current HIP device, to know the complete work
+ *  memory requirements for all devices.
+ *
  *  @param[in] plan plan handle
  *  @param[out] size_in_bytes size of needed work buffer in bytes
  *  */
@@ -475,12 +482,18 @@ ROCFFT_EXPORT rocfft_status rocfft_execution_info_create(rocfft_execution_info* 
  *  */
 ROCFFT_EXPORT rocfft_status rocfft_execution_info_destroy(rocfft_execution_info info);
 
-/*! @brief Set work buffer in execution info
+/*! @brief Set work buffer in execution info for the current HIP device
  *
  *  @details This is one of the execution info functions to specify
  *  optional additional information to control execution.  This API
  *  provides a work buffer for the transform. It must be called
  *  before ::rocfft_execute.
+ *
+ *  Work memory may be required on any device(s) with input or output
+ *  data for the transform.  If the FFT plan uses multiple devices
+ *  then this function can be called repeatedly with each of those
+ *  devices as the current HIP device, to set work memory for all
+ *  devices.
  *
  *  When a non-zero value is obtained from
  *  ::rocfft_plan_get_work_buffer_size, that means the library needs a

--- a/projects/rocfft/library/include/rocfft/rocfft.h
+++ b/projects/rocfft/library/include/rocfft/rocfft.h
@@ -435,10 +435,11 @@ ROCFFT_EXPORT rocfft_status
  *  @details Get the work buffer size required for a plan on the current HIP device.
  *
  *  Work memory may be required on any device(s) with input or output
- *  data for the transform.  If the FFT plan uses multiple devices
- *  then this function can be called repeatedly with each of those
- *  devices as the current HIP device, to know the complete work
- *  memory requirements for all devices.
+ *  data for the transform, and also the current device when the plan
+ *  was created.  If the FFT plan uses multiple devices then this
+ *  function can be called repeatedly with each of those devices as
+ *  the current HIP device, to know the complete work memory
+ *  requirements for all devices.
  *
  *  @param[in] plan plan handle
  *  @param[out] size_in_bytes size of needed work buffer in bytes
@@ -490,10 +491,10 @@ ROCFFT_EXPORT rocfft_status rocfft_execution_info_destroy(rocfft_execution_info 
  *  before ::rocfft_execute.
  *
  *  Work memory may be required on any device(s) with input or output
- *  data for the transform.  If the FFT plan uses multiple devices
- *  then this function can be called repeatedly with each of those
- *  devices as the current HIP device, to set work memory for all
- *  devices.
+ *  data for the transform, and also the current device when the plan
+ *  was created.  If the FFT plan uses multiple devices then this
+ *  function can be called repeatedly with each of those devices as
+ *  the current HIP device, to set work memory for all devices.
  *
  *  When a non-zero value is obtained from
  *  ::rocfft_plan_get_work_buffer_size, that means the library needs a


### PR DESCRIPTION
## Motivation

Update documentation and samples to check, allocate, and set work buffer memory on each device for multi-device transforms.

## Technical Details

No functional change except to sample program.

## Test Plan

Ran multi-GPU sample program manually plus regular automated tests.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
