### PR TITLE
[hipTensor] Fix compiling backend crash  problem when HIPTENSOR_INLINE_UNARY_OPS is OFF

### DIFF
--- a/projects/hiptensor/library/src/include/hiptensor_element_wise_operation.hpp
+++ b/projects/hiptensor/library/src/include/hiptensor_element_wise_operation.hpp
@@ -52,122 +52,122 @@ namespace ck
             using DoubleFunctionPtr = void (*)(double& y, double const& x);
 
             template <typename T>
-            __host__ __device__ static void hiptensor_identity(T& y, T const& x)
+            __host__ __device__ HIPTENSOR_UNARY_INLINE static void hiptensor_identity(T& y, T const& x)
             {
                 y = x;
             };
             template <typename T>
-            __host__ __device__ static void hiptensor_sqrt(T& y, T const& x)
+            __host__ __device__ HIPTENSOR_UNARY_INLINE static void hiptensor_sqrt(T& y, T const& x)
             {
                 y = std::sqrt(x);
             };
             template <typename T>
-            __host__ __device__ static void hiptensor_relu(T& y, T const& x)
+            __host__ __device__ HIPTENSOR_UNARY_INLINE static void hiptensor_relu(T& y, T const& x)
             {
                 y = x > 0 ? x : 0;
             };
             template <typename T>
-            __host__ __device__ static void hiptensor_conj(T& y, T const& x)
+            __host__ __device__ HIPTENSOR_UNARY_INLINE static void hiptensor_conj(T& y, T const& x)
             {
                 y = x;
             };
             template <typename T>
-            __host__ __device__ static void hiptensor_rcp(T& y, T const& x)
+            __host__ __device__ HIPTENSOR_UNARY_INLINE static void hiptensor_rcp(T& y, T const& x)
             {
                 y = 1 / x;
             }
             template <typename T>
-            __host__ __device__ static void hiptensor_sigmoid(T& y, T const& x)
+            __host__ __device__ HIPTENSOR_UNARY_INLINE static void hiptensor_sigmoid(T& y, T const& x)
             {
                 y = 1 / (1 + std::exp(-x));
             }
             template <typename T>
-            __host__ __device__ static void hiptensor_tanh(T& y, T const& x)
+            __host__ __device__ HIPTENSOR_UNARY_INLINE static void hiptensor_tanh(T& y, T const& x)
             {
                 y = std::tanh(x);
             }
             template <typename T>
-            __host__ __device__ static void hiptensor_exp(T& y, T const& x)
+            __host__ __device__ HIPTENSOR_UNARY_INLINE static void hiptensor_exp(T& y, T const& x)
             {
                 y = std::exp(x);
             }
             template <typename T>
-            __host__ __device__ static void hiptensor_log(T& y, T const& x)
+            __host__ __device__ HIPTENSOR_UNARY_INLINE static void hiptensor_log(T& y, T const& x)
             {
                 y = std::log(x);
             }
             template <typename T>
-            __host__ __device__ static void hiptensor_abs(T& y, T const& x)
+            __host__ __device__ HIPTENSOR_UNARY_INLINE static void hiptensor_abs(T& y, T const& x)
             {
                 y = std::abs(x);
             }
             template <typename T>
-            __host__ __device__ static void hiptensor_neg(T& y, T const& x)
+            __host__ __device__ HIPTENSOR_UNARY_INLINE static void hiptensor_neg(T& y, T const& x)
             {
                 y = -x;
             }
             template <typename T>
-            __host__ __device__ static void hiptensor_sin(T& y, T const& x)
+            __host__ __device__ HIPTENSOR_UNARY_INLINE static void hiptensor_sin(T& y, T const& x)
             {
                 y = std::sin(x);
             }
             template <typename T>
-            __host__ __device__ static void hiptensor_cos(T& y, T const& x)
+            __host__ __device__ HIPTENSOR_UNARY_INLINE static void hiptensor_cos(T& y, T const& x)
             {
                 y = std::cos(x);
             }
             template <typename T>
-            __host__ __device__ static void hiptensor_tan(T& y, T const& x)
+            __host__ __device__ HIPTENSOR_UNARY_INLINE static void hiptensor_tan(T& y, T const& x)
             {
                 y = std::tan(x);
             }
             template <typename T>
-            __host__ __device__ static void hiptensor_sinh(T& y, T const& x)
+            __host__ __device__ HIPTENSOR_UNARY_INLINE static void hiptensor_sinh(T& y, T const& x)
             {
                 y = std::sinh(x);
             }
             template <typename T>
-            __host__ __device__ static void hiptensor_cosh(T& y, T const& x)
+            __host__ __device__ HIPTENSOR_UNARY_INLINE static void hiptensor_cosh(T& y, T const& x)
             {
                 y = std::cosh(x);
             }
             template <typename T>
-            __host__ __device__ static void hiptensor_asin(T& y, T const& x)
+            __host__ __device__ HIPTENSOR_UNARY_INLINE static void hiptensor_asin(T& y, T const& x)
             {
                 y = std::asin(x);
             }
             template <typename T>
-            __host__ __device__ static void hiptensor_acos(T& y, T const& x)
+            __host__ __device__ HIPTENSOR_UNARY_INLINE static void hiptensor_acos(T& y, T const& x)
             {
                 y = std::acos(x);
             }
             template <typename T>
-            __host__ __device__ static void hiptensor_atan(T& y, T const& x)
+            __host__ __device__ HIPTENSOR_UNARY_INLINE static void hiptensor_atan(T& y, T const& x)
             {
                 y = std::atan(x);
             }
             template <typename T>
-            __host__ __device__ static void hiptensor_asinh(T& y, T const& x)
+            __host__ __device__ HIPTENSOR_UNARY_INLINE static void hiptensor_asinh(T& y, T const& x)
             {
                 y = std::asinh(x);
             }
             template <typename T>
-            __host__ __device__ static void hiptensor_acosh(T& y, T const& x)
+            __host__ __device__ HIPTENSOR_UNARY_INLINE static void hiptensor_acosh(T& y, T const& x)
             {
                 y = std::acosh(x);
             }
             template <typename T>
-            __host__ __device__ static void hiptensor_atanh(T& y, T const& x)
+            __host__ __device__ HIPTENSOR_UNARY_INLINE static void hiptensor_atanh(T& y, T const& x)
             {
                 y = std::atanh(x);
             }
             template <typename T>
-            __host__ __device__ static void hiptensor_ceil(T& y, T const& x)
+            __host__ __device__ HIPTENSOR_UNARY_INLINE static void hiptensor_ceil(T& y, T const& x)
             {
                 y = std::ceil(x);
             }
             template <typename T>
-            __host__ __device__ static void hiptensor_floor(T& y, T const& x)
+            __host__ __device__ HIPTENSOR_UNARY_INLINE static void hiptensor_floor(T& y, T const& x)
             {
                 y = std::floor(x);
             }
@@ -185,7 +185,7 @@ namespace ck
                     = default;
 
                 template <typename T>
-                __host__ __device__ HIPTENSOR_UNARY_INLINE void switch_op(T& y, T const& x) const
+                __host__ __device__ void switch_op(T& y, T const& x) const
                 {
                     switch(op_type)
                     {


### PR DESCRIPTION
## Motivation

When HIPTENSOR_INLINE_UNARY_OPS is OFF, it may cause AMDGPU compiler backend crash problem.

## Technical Details

Instead of only apply HIPTENSOR_UNARY_INLINE on function switch_op,  apply HIPTENSOR_UNARY_INLINE to the individual hiptensor_* helper functions. 

## Test Plan

Test compiling in different docker images.
Run normal tests.

## Test Result

All tests passed.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
