### PR TITLE
[fusilli-provider] Fix null graph name segfault in fusilli plugin with hash fallback

### DIFF
--- a/dnn-providers/fusilli-provider/include/graph_import.h
+++ b/dnn-providers/fusilli-provider/include/graph_import.h
@@ -26,8 +26,10 @@
 #include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
 
 #include <format>
+#include <functional>
 #include <memory>
 #include <optional>
+#include <string_view>
 #include <unordered_map>
 
 #include "custom_ops.h"
@@ -109,8 +111,19 @@ private:
   // Helper class for reading from flatbuffer.
   hipdnn_plugin_sdk::GraphWrapper opGraphWrapper;
 
+  // Hash of the serialized FlatBuffer bytes, used as a fallback graph name
+  // when the hipDNN graph has no name set. This ensures a unique compile cache
+  // key per distinct graph structure.
+  std::string serializedGraphHash;
+
   GraphImport(const hipdnnPluginConstData_t *opGraph)
-      : opGraphWrapper(opGraph->ptr, opGraph->size) {}
+      : opGraphWrapper(opGraph->ptr, opGraph->size) {
+    std::hash<std::string_view> hasher;
+    size_t hash = hasher(std::string_view(
+        static_cast<const char *>(opGraph->ptr), opGraph->size));
+    // 016x: zero-pad to 16 hex digits (full 64-bit size_t, 64/4 = 16).
+    serializedGraphHash = std::format("hipdnn_{:016x}", hash);
+  }
 
   fusilli::ErrorObject importGraph() {
     const hipdnn_data_sdk::data_objects::Graph &hipDnnGraph =
@@ -128,7 +141,9 @@ private:
     FUSILLI_ASSIGN_OR_RETURN(
         computeDataType,
         hipDnnDataTypeToFusilliDataType(hipDnnGraph.compute_data_type()));
-    fusilliGraph.setName(hipDnnGraph.name()->str())
+    std::string graphName =
+        hipDnnGraph.name() ? hipDnnGraph.name()->str() : serializedGraphHash;
+    fusilliGraph.setName(graphName)
         .setIODataType(ioDataType)
         .setIntermediateDataType(intermediateDataType)
         .setComputeDataType(computeDataType);

--- a/dnn-providers/fusilli-provider/test/test_graph_import.cpp
+++ b/dnn-providers/fusilli-provider/test/test_graph_import.cpp
@@ -11,6 +11,51 @@
 #include <gtest/gtest.h>
 #include <hipdnn_data_sdk/data_objects/data_types_generated.h>
 
+namespace {
+
+// Build a minimal valid conv graph with no name field set (nullptr).
+flatbuffers::FlatBufferBuilder buildUnnamedValidGraph() {
+  namespace sdk = hipdnn_data_sdk::data_objects;
+
+  flatbuffers::FlatBufferBuilder builder;
+
+  std::vector<int64_t> xDims = {1, 1, 2, 2};
+  std::vector<int64_t> xStrides = {4, 4, 2, 1};
+  std::vector<int64_t> wDims = {1, 1, 1, 1};
+  std::vector<int64_t> wStrides = {1, 1, 1, 1};
+  std::vector<int64_t> yDims = {1, 1, 2, 2};
+  std::vector<int64_t> yStrides = {4, 4, 2, 1};
+
+  std::vector<flatbuffers::Offset<sdk::TensorAttributes>> tensors;
+  tensors.push_back(sdk::CreateTensorAttributesDirect(
+      builder, 1, "x", sdk::DataType::FLOAT, &xStrides, &xDims));
+  tensors.push_back(sdk::CreateTensorAttributesDirect(
+      builder, 2, "w", sdk::DataType::FLOAT, &wStrides, &wDims));
+  tensors.push_back(sdk::CreateTensorAttributesDirect(
+      builder, 3, "y", sdk::DataType::FLOAT, &yStrides, &yDims));
+
+  std::vector<int64_t> padding = {0, 0};
+  std::vector<int64_t> stride = {1, 1};
+  std::vector<int64_t> dilation = {1, 1};
+  auto convAttr = sdk::CreateConvolutionFwdAttributesDirect(
+      builder, 1, 2, 3, &padding, &padding, &stride, &dilation,
+      sdk::ConvMode::CROSS_CORRELATION);
+
+  std::vector<flatbuffers::Offset<sdk::Node>> nodes;
+  nodes.push_back(sdk::CreateNodeDirect(
+      builder, "conv", sdk::DataType::FLOAT,
+      sdk::NodeAttributes::ConvolutionFwdAttributes, convAttr.Union()));
+
+  auto graph =
+      sdk::CreateGraphDirect(builder, nullptr, // no name
+                             sdk::DataType::FLOAT, sdk::DataType::FLOAT,
+                             sdk::DataType::FLOAT, &tensors, &nodes);
+  builder.Finish(graph);
+  return builder;
+}
+
+} // namespace
+
 TEST(TestGraphImport, ConvertHipDnnToFusilli) {
   FUSILLI_PLUGIN_EXPECT_OR_ASSIGN(
       auto halfDt, hipDnnDataTypeToFusilliDataType(
@@ -48,4 +93,18 @@ TEST(TestGraphImport, ConvertHipDnnToFusilli) {
   auto invalidResult = hipDnnDataTypeToFusilliDataType(
       static_cast<hipdnn_data_sdk::data_objects::DataType>(42));
   EXPECT_TRUE(isError(invalidResult));
+}
+
+TEST(TestGraphImport, UnnamedGraphGetsHashBasedName) {
+  auto builder = buildUnnamedValidGraph();
+
+  hipdnnPluginConstData_t opGraph;
+  opGraph.ptr = builder.GetBufferPointer();
+  opGraph.size = builder.GetSize();
+
+  FUSILLI_PLUGIN_EXPECT_OR_ASSIGN(auto ctx, importGraph(&opGraph));
+  // Graph name should be a hash fallback, not empty or null.
+  std::string name = ctx.graph.getName();
+  EXPECT_TRUE(name.starts_with("hipdnn_"));
+  EXPECT_EQ(name.size(), 7 + 16); // "hipdnn_" + 16 hex digits
 }


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Create unique name for fusilli graph import in the case where a hipDNN graph doesn't have a name set. The issue came up because one of the tests from `hipdnn_integration_tests` doesn't set a graph name, leading to a segfault on `hipDnnGraph.name()->str()`  in `GraphImport::importGraph()`. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

-  In the case where a graph name is not set we can hash the flatbuffer, the name should be unique and therefore avoid thrashing the compile cache.
   - Hash created with `std::hash<std::string_view>` available in C++ 17

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Test added

## Test Result

<!-- Briefly summarize test outcomes. -->

- Test passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
