### PR TITLE
Improve supported kernels and add kernel name

### DIFF
--- a/projects/hipblaslt/library/src/amd_detail/hipblaslt-ext.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/hipblaslt-ext.cpp
@@ -1419,22 +1419,12 @@ namespace hipblaslt_ext
 
     std::string getSolutionNameFromAlgo(hipblasLtHandle_t handle, hipblasLtMatmulAlgo_t& algo)
     {
-        int* algo_ptr = (int*)algo.data;
-        if(*algo_ptr < 0)
-        {
-            return "";
-        }
         auto rocalgo = reinterpret_cast<const rocblaslt_matmul_algo*>(&algo);
         return rocblaslt_get_solution_name_from_algo((rocblaslt_handle)handle, *rocalgo);
     }
 
     std::string getKernelNameFromAlgo(hipblasLtHandle_t handle, hipblasLtMatmulAlgo_t& algo)
     {
-        int* algo_ptr = (int*)algo.data;
-        if(*algo_ptr < 0)
-        {
-            return "";
-        }
         auto rocalgo = reinterpret_cast<const rocblaslt_matmul_algo*>(&algo);
         return rocblaslt_get_kernel_name_from_algo((rocblaslt_handle)handle, *rocalgo);
     }

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/custom_kernels.cpp
@@ -345,7 +345,7 @@ void preloadCustomKernels(SolutionCache& cache)
                     params.workgroupTile,
                     getCoPath() / "rr_custom_kernels.co"));            
 
-            params.workgroupTile    = {128, 256, 256};
+            /*params.workgroupTile    = {128, 256, 256};
             cache.addKernel(
                 mxfp4Kernel,
                 params,
@@ -353,7 +353,7 @@ void preloadCustomKernels(SolutionCache& cache)
                     getKernelName("f4gemm_bf16_per1x32Fp4_BpreShuffle_128x256", nonTemporalA, nonTemporalB),
                     mxfp4Kernel,
                     params.workgroupTile,
-                    getCoPath() / "rr_custom_kernels.co"));
+                    getCoPath() / "rr_custom_kernels.co"));*/
 
             params.workgroupTile    = {128, 384, 256};
             cache.addKernel(
@@ -726,7 +726,15 @@ size_t AssemblyStoreRowOrderGemm::workspaceRequired(const RocblasltContractionPr
 bool AssemblyStoreRowOrderGemm::isSupportedProblem(const RocblasltContractionProblem& prob)
 {
     const auto& wgt = params->workgroupTile;
-    return (prob.m % wgt.m == 0 && prob.n % wgt.n == 0 && prob.k % wgt.k == 0);
+
+    if ((wgt.m == 192 && wgt.n == 256) || (wgt.m == 224 && wgt.n == 256) || (wgt.m == 128 && wgt.n == 512))
+    {
+        return (prob.m % wgt.m == 0 && prob.n % wgt.n == 0 && prob.k % wgt.k == 0);
+    }
+    else
+    {
+        return (prob.m % 32 == 0 && prob.n % 32 == 0 && prob.k % wgt.k == 0);
+    }
 }
 
 rocblaslt_status AssemblyStoreRowOrderGemm::run(const RocblasltContractionProblem& prob)

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/include/rocroller_host.hpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/include/rocroller_host.hpp
@@ -15,6 +15,11 @@
 
 #include "rocblaslt.h"
 
+#include <string>
+
+/** rr_… label from packed rocRoller solution index (negative int); uses shortRocRollerKernelNameFromSolutionIndex. */
+std::string rocRollerShortKernelNameFromEncodedSolutionIndex(int encodedSolutionIndex);
+
 void rocroller_destroy_handle(void* handle);
 
 void rocroller_create_handle(void** handle);

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/include/solution_selection.hpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/include/solution_selection.hpp
@@ -76,6 +76,12 @@ struct SolutionIndexParameters
 int                     parametersToIndex(const SolutionIndexParameters& params);
 SolutionIndexParameters indexToParameters(int index);
 
+/**
+ * Compact kernel label for rocRoller algo indices (negative signed int, bit 31 set).
+ * Format: rr_<M>x<N>x<K> with optional _wgm, _sk, _notl, _ntA, _ntB suffixes.
+ */
+std::string shortRocRollerKernelNameFromSolutionIndex(const SolutionIndexParameters& params);
+
 size_t maxNumberSolutions();
 
 /**

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/rocroller_host.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/rocroller_host.cpp
@@ -20,6 +20,11 @@
 
 using namespace rocRoller;
 
+std::string rocRollerShortKernelNameFromEncodedSolutionIndex(int encodedSolutionIndex)
+{
+    return shortRocRollerKernelNameFromSolutionIndex(indexToParameters(encodedSolutionIndex));
+}
+
 /**
  * @brief RocRollerHandle
  *
@@ -514,19 +519,6 @@ rocblaslt_status
             break;
 
         index = parametersToIndex(solutionIndexParameter);
-        
-        // Validate problem dimensions match kernel tile requirements before generating kernel
-        // to avoid ocRoller expression evaluation with invalid dimensions
-        if(solutionIndexParameter.workgroupTile.m > 0 && solutionIndexParameter.workgroupTile.n > 0
-           && solutionIndexParameter.workgroupTile.k > 0)
-        {
-            if(prob.m % solutionIndexParameter.workgroupTile.m != 0
-               || prob.n % solutionIndexParameter.workgroupTile.n != 0
-               || prob.k % solutionIndexParameter.workgroupTile.k != 0)
-            {
-                continue;  // Skip this solution entirely
-            }
-        }
 
         auto existingSolution = rocroller_handle->cache.getKernel(
             kernelType, solutionIndexParameter, ProblemDims{prob.m, prob.n, prob.k});
@@ -534,6 +526,19 @@ rocblaslt_status
         // If kernel doesn't already exist, generate it
         if(!existingSolution)
         {
+            // Validate problem dimensions match kernel tile requirements before generating kernel
+            // to avoid rocRoller expression evaluation with invalid dimensions
+            if(solutionIndexParameter.workgroupTile.m > 0 && solutionIndexParameter.workgroupTile.n > 0
+                && solutionIndexParameter.workgroupTile.k > 0)
+            {
+                if(prob.m % solutionIndexParameter.workgroupTile.m != 0
+                    || prob.n % solutionIndexParameter.workgroupTile.n != 0
+                    || prob.k % solutionIndexParameter.workgroupTile.k != 0)
+                {
+                    continue;  // Skip this solution entirely
+                }
+            }
+
             auto status = genKernelFromSolutionIndexParameters(
                 rocroller_handle, kernelType, solutionIndexParameter, index, kernel);
             if(status != rocblaslt_status_success)
@@ -542,6 +547,11 @@ rocblaslt_status
         else
         {
             kernel = *existingSolution;
+        }
+
+        if (!kernel->isSupportedProblem(prob))
+        {
+            continue;
         }
 
         // Fill out heuristicResultsArray

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/solution_selection.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/solution_selection.cpp
@@ -8,6 +8,8 @@
 
 #include "origami/origami.hpp"
 
+#include <sstream>
+
 const int MAX_BITS_WORKGROUPTILE_M     = 8;
 const int MAX_BITS_WORKGROUPTILE_N     = 8;
 const int MAX_BITS_WORKGROUPTILE_K     = 7;
@@ -32,7 +34,7 @@ constexpr std::array<WorkGroupTileSize, possibleTileSizesCount> possibleTileSize
         {32, 32, 128},   {32, 32, 64},    {16, 256, 128},  {64, 16, 128},   {16, 64, 128},
         {32, 16, 128},   {16, 32, 128},   {16, 16, 128},   {16, 16, 256},   {16, 64, 256}}};
 
-constexpr size_t possibleSwizzleTileSizesCount = 38;
+constexpr size_t possibleSwizzleTileSizesCount = 37;
 
 constexpr std::array<WorkGroupTileSize, possibleSwizzleTileSizesCount> possibleSwizzleTileSizes
     = {{{32,32,128}, {64, 32, 128}, {64, 64, 128}, {128, 32, 128},
@@ -40,7 +42,7 @@ constexpr std::array<WorkGroupTileSize, possibleSwizzleTileSizesCount> possibleS
         {32, 768, 128},  {32, 896, 128},  {32, 1024, 128}, {64, 128, 128},  {64, 256, 128},
         {64, 384, 128},  {64, 512, 128},  {64, 640, 128},  {64, 768, 128},  {64, 896, 128},
         {64, 1024, 128}, {96, 128, 128},  {96, 256, 128},  {96, 384, 128},  {96, 512, 128},
-        {96, 640, 128},  {128, 128, 128}, {128, 256, 128}, {128, 384, 128}, {128, 512, 128},
+        {96, 640, 128},  {128, 128, 128}, {128, 256, 128}, {128, 384, 128},
         {160, 128, 128}, {160, 256, 128}, {160, 384, 128}, {192, 128, 128}, {192, 256, 128},
         {224, 128, 128}, {224, 256, 128}, {256, 128, 128}, {256, 256, 128}}};
 
@@ -257,109 +259,105 @@ std::vector<SolutionIndexParameters> chooseSolutionIndexParameters(
         int unrollAmount = preferredUnrolling(kernelType.typeA, kernelType.typeB, wgt, hasPreSwizzle, hasPreTile);
         wgt.k /= unrollAmount;
 
-        if((requestedAlgoCount == -1)
-           || (prob.m % wgt.m == 0 && prob.n % wgt.n == 0 && prob.k % wgt.k == 0))
+        // FP8 kernels run out of registers with larger tile sizes
+        if((kernelType.typeA == rocRoller::DataType::FP8
+            || kernelType.typeA == rocRoller::DataType::BF8
+            || kernelType.typeB == rocRoller::DataType::FP8
+            || kernelType.typeB == rocRoller::DataType::BF8)
+            && (wgt.m == 192 || wgt.n == 192))
+            continue;
+
+        // 6bit datatypes only work with power of 2 tile sizes
+        if((kernelType.typeA == rocRoller::DataType::FP6
+            || kernelType.typeA == rocRoller::DataType::BF6
+            || kernelType.typeB == rocRoller::DataType::FP6
+            || kernelType.typeB == rocRoller::DataType::BF6)
+            && (!std::has_single_bit(static_cast<uint>(wgt.m))
+                || !std::has_single_bit(static_cast<uint>(wgt.n))))
+            continue;
+
+        // check if this size is valid for pre-swizzled data
+        if (hasPreSwizzle)
         {
-            // FP8 kernels run out of registers with larger tile sizes
-            if((kernelType.typeA == rocRoller::DataType::FP8
-                || kernelType.typeA == rocRoller::DataType::BF8
-                || kernelType.typeB == rocRoller::DataType::FP8
-                || kernelType.typeB == rocRoller::DataType::BF8)
-               && (wgt.m == 192 || wgt.n == 192))
+            if (kernelType.typeA != rocRoller::DataType::FP4 ||
+                kernelType.typeB != rocRoller::DataType::FP4)
                 continue;
-
-            // 6bit datatypes only work with power of 2 tile sizes
-            if((kernelType.typeA == rocRoller::DataType::FP6
-                || kernelType.typeA == rocRoller::DataType::BF6
-                || kernelType.typeB == rocRoller::DataType::FP6
-                || kernelType.typeB == rocRoller::DataType::BF6)
-               && (!std::has_single_bit(static_cast<uint>(wgt.m))
-                   || !std::has_single_bit(static_cast<uint>(wgt.n))))
+            if (wgt.m % 32 != 0 || wgt.n % 32 != 0)
                 continue;
-
-            // check if this size is valid for pre-swizzled data
-            if (hasPreSwizzle)
-            {
-                if (kernelType.typeA != rocRoller::DataType::FP4 ||
-                    kernelType.typeB != rocRoller::DataType::FP4)
-                    continue;
-                if (wgt.m % 32 != 0 || wgt.n % 32 != 0)
-                    continue;
-            }
-
-            // wgt.k has to be at least 256 when scale data is pre-swizzled
-            if(kernelType.scaleTypeA.preSwizzleTile.size() == 3
-               && kernelType.scaleTypeB.preSwizzleTile.size() == 3 && wgt.k < 256)
-                continue;
-
-            // {256, 256, 256} tile size is only supported for FP4 data types with preSwizzled and preTiled scale data
-            bool isFP4 = (kernelType.typeA == rocRoller::DataType::FP4
-                          && kernelType.typeB == rocRoller::DataType::FP4);
-
-            bool is256Tile = (wgt.m == 256 && wgt.n == 256 && wgt.k == 256);
-
-            // Only allow 256x256x256 for FP4 with preSwizzled and preTiled scale data
-            if(is256Tile && !(isFP4))
-                continue;
-
-            bool useTailLoops = true;
-
-            
-
-            bool useWorkgroupMapping = true;
-            if(prob.k < USE_WORKGROUP_MAPPING_K_SIZE)
-            {
-                useWorkgroupMapping = false;
-            }
-
-            // Enable StreamK when:
-            // 1. Number of output tiles < number of CUs
-            // 2. There are enough K iterations per tile (itersPerTile >= 16) to
-            //    amortize StreamK overhead. Threshold is derived from origami's
-            //    MinItersPerCU (8) applied to the smallest useful split factor (2).
-            // 3. Data type is not f6 (unsupported) or large f8 (register pressure).
-            // 4. Not the 256x256x256 FP4 pre-swizzled tile.
-            bool useStreamK = false;
-            size_t numTilesM    = prob.m / wgt.m;
-            size_t numTilesN    = prob.n / wgt.n;
-            size_t numTiles     = numTilesM * numTilesN * prob.batch_count;
-            size_t itersPerTile = prob.k / wgt.k;
-            auto   isF6         = (kernelType.typeA == rocRoller::DataType::FP6
-                         || kernelType.typeA == rocRoller::DataType::BF6
-                         || kernelType.typeB == rocRoller::DataType::FP6
-                         || kernelType.typeB == rocRoller::DataType::BF6);
-            auto isLargeF8 = ((kernelType.typeA == rocRoller::DataType::FP8
-                || kernelType.typeA == rocRoller::DataType::BF8
-                || kernelType.typeB == rocRoller::DataType::FP8
-                || kernelType.typeB == rocRoller::DataType::BF8)
-               && wgt.m + wgt.n > 256);
-            int cu_multiplier = 1;
-            if(kernelType.swizzleA)
-                cu_multiplier = 4;
-            if(numTiles * cu_multiplier < analytical_hardware.N_CU && itersPerTile >= 16
-               && !isF6 && !isLargeF8)
-            {
-                useStreamK = true;
-            }
-
-            // Heuristics:
-            // 64x256 performs poorly for StreamK
-            if(useStreamK && wgt.m == 64 && wgt.n == 256)
-                continue;
-
-            // Extract nontemporal hints from the config
-            bool useNonTemporalA = (result.config.cache_hints_a != 0);
-            bool useNonTemporalB = (result.config.cache_hints_b != 0);
-
-            // Prefer assembly kernels for swizzleA
-            if(kernelType.swizzleA && !useStreamK && ((wgt.m == 32 && wgt.n == 32) ||
-                                                      (wgt.m == 64 && wgt.n == 32) ||
-                                                      (wgt.m == 64 && wgt.n == 64) ||
-                                                      (wgt.m == 128 && wgt.n == 32)))
-                lastParams.push_back({wgt, useWorkgroupMapping, useStreamK, useTailLoops, useNonTemporalA, useNonTemporalB});
-            else
-                params.push_back({wgt, useWorkgroupMapping, useStreamK, useTailLoops, useNonTemporalA, useNonTemporalB});
         }
+
+        // wgt.k has to be at least 256 when scale data is pre-swizzled
+        if(kernelType.scaleTypeA.preSwizzleTile.size() == 3
+            && kernelType.scaleTypeB.preSwizzleTile.size() == 3 && wgt.k < 256)
+            continue;
+
+        // {256, 256, 256} tile size is only supported for FP4 data types with preSwizzled and preTiled scale data
+        bool isFP4 = (kernelType.typeA == rocRoller::DataType::FP4
+                        && kernelType.typeB == rocRoller::DataType::FP4);
+
+        bool is256Tile = (wgt.m == 256 && wgt.n == 256 && wgt.k == 256);
+
+        // Only allow 256x256x256 for FP4 with preSwizzled and preTiled scale data
+        if(is256Tile && !(isFP4))
+            continue;
+
+        bool useTailLoops = true;
+
+        
+
+        bool useWorkgroupMapping = true;
+        if(prob.k < USE_WORKGROUP_MAPPING_K_SIZE)
+        {
+            useWorkgroupMapping = false;
+        }
+
+        // Enable StreamK when:
+        // 1. Number of output tiles < number of CUs
+        // 2. There are enough K iterations per tile (itersPerTile >= 16) to
+        //    amortize StreamK overhead. Threshold is derived from origami's
+        //    MinItersPerCU (8) applied to the smallest useful split factor (2).
+        // 3. Data type is not f6 (unsupported) or large f8 (register pressure).
+        // 4. Not the 256x256x256 FP4 pre-swizzled tile.
+        bool useStreamK = false;
+        size_t numTilesM    = prob.m / wgt.m;
+        size_t numTilesN    = prob.n / wgt.n;
+        size_t numTiles     = numTilesM * numTilesN * prob.batch_count;
+        size_t itersPerTile = prob.k / wgt.k;
+        auto   isF6         = (kernelType.typeA == rocRoller::DataType::FP6
+                        || kernelType.typeA == rocRoller::DataType::BF6
+                        || kernelType.typeB == rocRoller::DataType::FP6
+                        || kernelType.typeB == rocRoller::DataType::BF6);
+        auto isLargeF8 = ((kernelType.typeA == rocRoller::DataType::FP8
+            || kernelType.typeA == rocRoller::DataType::BF8
+            || kernelType.typeB == rocRoller::DataType::FP8
+            || kernelType.typeB == rocRoller::DataType::BF8)
+            && wgt.m + wgt.n > 256);
+        int cu_multiplier = 1;
+        if(kernelType.swizzleA)
+            cu_multiplier = 4;
+        if(numTiles * cu_multiplier < analytical_hardware.N_CU && itersPerTile >= 16
+            && !isF6 && !isLargeF8)
+        {
+            useStreamK = true;
+        }
+
+        // Heuristics:
+        // 64x256 performs poorly for StreamK
+        if(useStreamK && wgt.m == 64 && wgt.n == 256)
+            continue;
+
+        // Extract nontemporal hints from the config
+        bool useNonTemporalA = (result.config.cache_hints_a != 0);
+        bool useNonTemporalB = (result.config.cache_hints_b != 0);
+
+        // Prefer assembly kernels for swizzleA
+        if(kernelType.swizzleA && !useStreamK && ((wgt.m == 32 && wgt.n == 32) ||
+                                                    (wgt.m == 64 && wgt.n == 32) ||
+                                                    (wgt.m == 64 && wgt.n == 64) ||
+                                                    (wgt.m == 128 && wgt.n == 32)))
+            lastParams.push_back({wgt, useWorkgroupMapping, useStreamK, useTailLoops, useNonTemporalA, useNonTemporalB});
+        else
+            params.push_back({wgt, useWorkgroupMapping, useStreamK, useTailLoops, useNonTemporalA, useNonTemporalB});
     }
 
     // Append lastParams to params so that assembly kernel tile sizes are included as fallback options
@@ -427,4 +425,19 @@ SolutionIndexParameters indexToParameters(int index)
     result.nonTemporalB = (index >> pos) & 1;
 
     return result;
+}
+
+std::string shortRocRollerKernelNameFromSolutionIndex(const SolutionIndexParameters& p)
+{
+    std::ostringstream o;
+    o << "rr_" << p.workgroupTile.m << "x" << p.workgroupTile.n << "x" << p.workgroupTile.k;
+    if(p.workgroupMapping)
+        o << "_wgm";
+    if(p.streamK)
+        o << "_sk";
+    if(p.nonTemporalA)
+        o << "_ntA";
+    if(p.nonTemporalB)
+        o << "_ntB";
+    return o.str();
 }

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -4377,6 +4377,15 @@ std::string getSolutionNameFromData(rocblaslt_handle             handle,
 
 std::string getKernelNameFromAlgoIndex(rocblaslt_handle handle, const rocblaslt_matmul_algo& algo)
 {
+    int* solutionIndex = (int*)algo.data;
+
+#ifdef HIPBLASLT_USE_ROCROLLER
+    if(*solutionIndex < 0)
+    {
+        return rocRollerShortKernelNameFromEncodedSolutionIndex(*solutionIndex);
+    }
+#endif
+
     std::shared_ptr<TensileLite::MasterSolutionLibrary<TensileLite::ContractionProblemGemm>>
                                      library;
     std::shared_ptr<hipDeviceProp_t> deviceProp;
@@ -4390,13 +4399,21 @@ std::string getKernelNameFromAlgoIndex(rocblaslt_handle handle, const rocblaslt_
         return std::string();
     }
 
-    int* solutionIndex = (int*)algo.data;
-    auto solution      = library->getSolutionByIndex(*hardware, *solutionIndex);
+    auto solution = library->getSolutionByIndex(*hardware, *solutionIndex);
     return solution->kernelName;
 }
 
 std::string getSolutionNameFromAlgoIndex(rocblaslt_handle handle, const rocblaslt_matmul_algo& algo)
 {
+    int* solutionIndex = (int*)algo.data;
+ 
+#ifdef HIPBLASLT_USE_ROCROLLER
+    if(*solutionIndex < 0)
+    {
+        return rocRollerShortKernelNameFromEncodedSolutionIndex(*solutionIndex);
+    }
+#endif
+
     std::shared_ptr<TensileLite::MasterSolutionLibrary<TensileLite::ContractionProblemGemm>>
                                      library;
     std::shared_ptr<hipDeviceProp_t> deviceProp;
@@ -4410,8 +4427,7 @@ std::string getSolutionNameFromAlgoIndex(rocblaslt_handle handle, const rocblasl
         return std::string();
     }
 
-    int* solutionIndex = (int*)algo.data;
-    auto solution      = library->getSolutionByIndex(*hardware, *solutionIndex);
+    auto solution = library->getSolutionByIndex(*hardware, *solutionIndex);
     return solution->solutionName;
 }
 


### PR DESCRIPTION
## Motivation

Allow custom kernels in the rocRoller path to have different isSupportedProblem function.

Removed a custom kernel that was giving incorrect results.

Prints out kernel names when using rocRoller path of hipBLASLt.

## Technical Details

Some of the custom kernels that were previously added don't need as restrictive of a isSupportedProblem function as the rocRoller kernels. This PR makes isSupportedProblem a virtual function of a GemmKernel and lets the custom kernels use their own filtering method.

## Test Plan

Running existing tests and benchmarking.

## Test Result

Tests pass and benchmarks show improvements in many cases.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
