### PR TITLE
Convert 4 CK fusion solvers to dlopen runtime loading

### DIFF
--- a/projects/miopen/src/ck_impl/CMakeLists.txt
+++ b/projects/miopen/src/ck_impl/CMakeLists.txt
@@ -17,6 +17,10 @@ set(CK_IMPL_SOURCES
     ck_grouped_conv_3d_fwd_impl.cpp
     ck_grouped_conv_3d_bwd_impl.cpp
     ck_grouped_conv_3d_wrw_impl.cpp
+    ck_fused_bias_activ_impl.cpp
+    ck_fused_bias_res_add_activ_impl.cpp
+    ck_fused_grp_activ_impl.cpp
+    ck_fused_grp_bias_activ_impl.cpp
 )
 
 # Strip target features (e.g. ":sramecc+:xnack-") to get the base arch name.

--- a/projects/miopen/src/ck_impl/ck_fused_bias_activ_impl.cpp
+++ b/projects/miopen/src/ck_impl/ck_fused_bias_activ_impl.cpp
@@ -20,11 +20,10 @@
 // CK type aliases and instance function for Conv+Bias+ReLU fusion (FP16)
 // ---------------------------------------------------------------------------
 
-using DeviceConvFwdBiasReluPtr =
-    ck::tensor_operation::device::DeviceConvFwdBiasActivationPtr<
-        ck::tensor_operation::element_wise::PassThrough,
-        ck::tensor_operation::element_wise::PassThrough,
-        ck::tensor_operation::element_wise::AddRelu>;
+using DeviceConvFwdBiasReluPtr = ck::tensor_operation::device::DeviceConvFwdBiasActivationPtr<
+    ck::tensor_operation::element_wise::PassThrough,
+    ck::tensor_operation::element_wise::PassThrough,
+    ck::tensor_operation::element_wise::AddRelu>;
 
 // Forward-declare CK's explicit instance population function.
 namespace ck {
@@ -104,8 +103,8 @@ std::vector<DeviceConvFwdBiasReluPtr> GetConvInstances()
 
 std::vector<std::string> FillValidKernels(const ProblemDescription& problem)
 {
-    const auto args      = CKArgs{problem};
-    auto conv_ptrs       = GetConvInstances();
+    const auto args = CKArgs{problem};
+    auto conv_ptrs  = GetConvInstances();
     std::vector<std::string> valid_kernels;
     valid_kernels.reserve(conv_ptrs.size());
     for(const auto& it : conv_ptrs)
@@ -173,22 +172,22 @@ bool CheckIsArgSupported(const ProblemDescription& problem, const std::string& k
         if(conv_ptrs[i]->GetTypeString() == kernel_id)
         {
             auto argument_ptr = conv_ptrs[i]->MakeArgumentPointer(nullptr,
-                                                                   nullptr,
-                                                                   nullptr,
-                                                                   nullptr,
-                                                                   args.N,
-                                                                   args.K,
-                                                                   args.C,
-                                                                   args.input,
-                                                                   args.filter,
-                                                                   args.output,
-                                                                   args.strides,
-                                                                   args.dilation,
-                                                                   args.lPadding,
-                                                                   args.rPadding,
-                                                                   {},
-                                                                   {},
-                                                                   {});
+                                                                  nullptr,
+                                                                  nullptr,
+                                                                  nullptr,
+                                                                  args.N,
+                                                                  args.K,
+                                                                  args.C,
+                                                                  args.input,
+                                                                  args.filter,
+                                                                  args.output,
+                                                                  args.strides,
+                                                                  args.dilation,
+                                                                  args.lPadding,
+                                                                  args.rPadding,
+                                                                  {},
+                                                                  {},
+                                                                  {});
             return conv_ptrs[i]->IsSupportedArgument(argument_ptr.get());
         }
     }
@@ -202,9 +201,7 @@ bool CheckIsArgSupported(const ProblemDescription& problem, const std::string& k
 // ===========================================================================
 
 extern "C" CKKernelListHandle* ckgrpconv_fused_bias_activ_fill_valid_kernels(
-    const miopen::conv::ProblemDescription* problem,
-    miopenDataType_t data_type,
-    bool /*use_tf32*/)
+    const miopen::conv::ProblemDescription* problem, miopenDataType_t data_type, bool /*use_tf32*/)
 {
     try
     {
@@ -220,10 +217,8 @@ extern "C" CKKernelListHandle* ckgrpconv_fused_bias_activ_fill_valid_kernels(
     }
 }
 
-extern "C" bool
-ckgrpconv_fused_bias_activ_is_applicable(const miopen::conv::ProblemDescription* problem,
-                                         miopenDataType_t data_type,
-                                         bool /*use_tf32*/)
+extern "C" bool ckgrpconv_fused_bias_activ_is_applicable(
+    const miopen::conv::ProblemDescription* problem, miopenDataType_t data_type, bool /*use_tf32*/)
 {
     try
     {
@@ -278,70 +273,68 @@ ckgrpconv_fused_bias_activ_get_solution(const miopen::ExecutionContext* ctx,
         std::string kid(kernel_id);
 
         miopen::solver::ConvSolution solution;
-        solution.invoker_factory =
-            [kid, conv_problem = *problem](const std::vector<miopen::Kernel>& kernels) {
-                std::ignore = kernels;
-                return [kid, conv_problem](const miopen::Handle& handle,
-                                           const miopen::AnyInvokeParams& primitive_parameters) {
-                    const auto args = CKArgs{conv_problem};
-                    auto conv_ptrs  = GetConvInstances();
+        solution.invoker_factory = [kid, conv_problem = *problem](
+                                       const std::vector<miopen::Kernel>& kernels) {
+            std::ignore = kernels;
+            return [kid, conv_problem](const miopen::Handle& handle,
+                                       const miopen::AnyInvokeParams& primitive_parameters) {
+                const auto args = CKArgs{conv_problem};
+                auto conv_ptrs  = GetConvInstances();
 
-                    // Find the instance matching the kernel_id.
-                    size_t id = 0;
-                    for(; id < conv_ptrs.size(); ++id)
-                    {
-                        if(conv_ptrs[id]->GetTypeString() == kid)
-                            break;
-                    }
-                    assert(id < conv_ptrs.size());
-                    auto& conv_ck = conv_ptrs.at(id);
+                // Find the instance matching the kernel_id.
+                size_t id = 0;
+                for(; id < conv_ptrs.size(); ++id)
+                {
+                    if(conv_ptrs[id]->GetTypeString() == kid)
+                        break;
+                }
+                assert(id < conv_ptrs.size());
+                auto& conv_ck = conv_ptrs.at(id);
 
-                    // Extract tensors from FusionInvokeParams.
-                    const auto& invoke_ctx =
-                        primitive_parameters.CastTo<miopen::fusion::FusionInvokeParams>();
-                    const auto& wei_buf =
-                        dynamic_cast<miopen::fusion::ConvolutionOpInvokeParam&>(
-                            *invoke_ctx.op_args.params[0])
-                            .weights;
-                    const auto& bias_buf =
-                        dynamic_cast<miopen::fusion::BiasOpInvokeParam&>(
-                            *invoke_ctx.op_args.params[1])
-                            .bdata;
+                // Extract tensors from FusionInvokeParams.
+                const auto& invoke_ctx =
+                    primitive_parameters.CastTo<miopen::fusion::FusionInvokeParams>();
+                const auto& wei_buf = dynamic_cast<miopen::fusion::ConvolutionOpInvokeParam&>(
+                                          *invoke_ctx.op_args.params[0])
+                                          .weights;
+                const auto& bias_buf =
+                    dynamic_cast<miopen::fusion::BiasOpInvokeParam&>(*invoke_ctx.op_args.params[1])
+                        .bdata;
 
-                    auto argument_ptr = conv_ck->MakeArgumentPointer(
-                        const_cast<void*>( // NOLINT (cppcoreguidelines-pro-type-const-cast)
-                            static_cast<const void*>(invoke_ctx.in)),
-                        const_cast<void*>( // NOLINT (cppcoreguidelines-pro-type-const-cast)
-                            static_cast<const void*>(wei_buf)),
-                        invoke_ctx.out,
-                        const_cast<void*>( // NOLINT (cppcoreguidelines-pro-type-const-cast)
-                            static_cast<const void*>(bias_buf)),
-                        args.N,
-                        args.K,
-                        args.C,
-                        args.input,
-                        args.filter,
-                        args.output,
-                        args.strides,
-                        args.dilation,
-                        args.lPadding,
-                        args.rPadding,
-                        {},
-                        {},
-                        {});
+                auto argument_ptr = conv_ck->MakeArgumentPointer(
+                    const_cast<void*>( // NOLINT (cppcoreguidelines-pro-type-const-cast)
+                        static_cast<const void*>(invoke_ctx.in)),
+                    const_cast<void*>( // NOLINT (cppcoreguidelines-pro-type-const-cast)
+                        static_cast<const void*>(wei_buf)),
+                    invoke_ctx.out,
+                    const_cast<void*>( // NOLINT (cppcoreguidelines-pro-type-const-cast)
+                        static_cast<const void*>(bias_buf)),
+                    args.N,
+                    args.K,
+                    args.C,
+                    args.input,
+                    args.filter,
+                    args.output,
+                    args.strides,
+                    args.dilation,
+                    args.lPadding,
+                    args.rPadding,
+                    {},
+                    {},
+                    {});
 
-                    auto invoker_ptr            = conv_ck->MakeInvokerPointer();
-                    const auto enable_profiling = handle.IsProfilingEnabled();
+                auto invoker_ptr            = conv_ck->MakeInvokerPointer();
+                const auto enable_profiling = handle.IsProfilingEnabled();
 
-                    float elapsed_time =
-                        invoker_ptr->Run(argument_ptr.get(), {handle.GetStream(), enable_profiling});
-                    if(enable_profiling)
-                    {
-                        handle.ResetKernelTime();
-                        handle.AccumKernelTime(elapsed_time);
-                    }
-                };
+                float elapsed_time =
+                    invoker_ptr->Run(argument_ptr.get(), {handle.GetStream(), enable_profiling});
+                if(enable_profiling)
+                {
+                    handle.ResetKernelTime();
+                    handle.AccumKernelTime(elapsed_time);
+                }
             };
+        };
 
         return new miopen::solver::ConvSolution(std::move(solution));
     }

--- a/projects/miopen/src/ck_impl/ck_fused_bias_activ_impl.cpp
+++ b/projects/miopen/src/ck_impl/ck_fused_bias_activ_impl.cpp
@@ -1,0 +1,352 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include <vector>
+#include <cstdint>
+#include <string>
+#include <memory>
+#include <cassert>
+
+#include "ck_grouped_conv_common.hpp"
+#include <miopen/conv_solution.hpp>
+#include <miopen/solver/ck_grouped_conv_interface.hpp>
+#include <miopen/conv/problem_description.hpp>
+#include <miopen/execution_context.hpp>
+#include <miopen/fusion/fusion_invoke_params.hpp>
+#include <miopen/solver/implicitgemm_ck_util.hpp>
+#include <ck/tensor_operation/gpu/device/device_conv_fwd_bias_activation.hpp>
+
+// ---------------------------------------------------------------------------
+// CK type aliases and instance function for Conv+Bias+ReLU fusion (FP16)
+// ---------------------------------------------------------------------------
+
+using DeviceConvFwdBiasReluPtr =
+    ck::tensor_operation::device::DeviceConvFwdBiasActivationPtr<
+        ck::tensor_operation::element_wise::PassThrough,
+        ck::tensor_operation::element_wise::PassThrough,
+        ck::tensor_operation::element_wise::AddRelu>;
+
+// Forward-declare CK's explicit instance population function.
+namespace ck {
+namespace tensor_operation {
+namespace device {
+namespace instance {
+
+void add_device_conv2d_fwd_xdl_c_shuffle_bias_relu_nhwc_kyxc_nhwk_f16_instances(
+    std::vector<DeviceConvFwdBiasReluPtr>&);
+
+} // namespace instance
+} // namespace device
+} // namespace tensor_operation
+} // namespace ck
+
+namespace {
+
+using ProblemDescription = miopen::conv::ProblemDescription;
+using miopen::solver::ProblemInterpreter;
+
+// ---------------------------------------------------------------------------
+// CKArgs -- 2D fused Conv+Bias+ReLU (older CK API, std::vector-based).
+// ---------------------------------------------------------------------------
+
+struct CKArgs
+{
+    CKArgs(const ProblemDescription& problem)
+    {
+        N        = ProblemInterpreter::GetBatchN(problem);
+        K        = ProblemInterpreter::GetOutputChannelK(problem);
+        C        = ProblemInterpreter::GetInputChannelC(problem);
+        input    = {ProblemInterpreter::GetInputHeightHi(problem),
+                    ProblemInterpreter::GetInputWidthWi(problem)};
+        output   = {ProblemInterpreter::GetOutputHeightHo(problem),
+                    ProblemInterpreter::GetOutputWidthWo(problem)};
+        filter   = {ProblemInterpreter::GetFilterHeightY(problem),
+                    ProblemInterpreter::GetFilterWidthX(problem)};
+        strides  = {ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
+                    ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
+        dilation = {ProblemInterpreter::GetAdjustedConvolutionDilationH(problem),
+                    ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
+        lPadding = {ProblemInterpreter::GetInputLeftPadH(problem),
+                    ProblemInterpreter::GetInputLeftPadW(problem)};
+        rPadding = {ProblemInterpreter::GetAdjustedInputRightPadH(problem),
+                    ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
+    }
+
+    int N;
+    int K;
+    int C;
+    std::vector<int> input;
+    std::vector<int> output;
+    std::vector<int> filter;
+    std::vector<int> strides;
+    std::vector<int> dilation;
+    std::vector<int> lPadding;
+    std::vector<int> rPadding;
+};
+
+// ---------------------------------------------------------------------------
+// Helper: get the populated list of CK device operator instances.
+// ---------------------------------------------------------------------------
+
+std::vector<DeviceConvFwdBiasReluPtr> GetConvInstances()
+{
+    std::vector<DeviceConvFwdBiasReluPtr> conv_ptrs;
+    ck::tensor_operation::device::instance::
+        add_device_conv2d_fwd_xdl_c_shuffle_bias_relu_nhwc_kyxc_nhwk_f16_instances(conv_ptrs);
+    return conv_ptrs;
+}
+
+// ---------------------------------------------------------------------------
+// Template-free helpers for fill/applicable/args_supported.
+// These replicate the logic from the solver but operate directly on the
+// explicit instance list (no DeviceOperationInstanceFactory).
+// ---------------------------------------------------------------------------
+
+std::vector<std::string> FillValidKernels(const ProblemDescription& problem)
+{
+    const auto args      = CKArgs{problem};
+    auto conv_ptrs       = GetConvInstances();
+    std::vector<std::string> valid_kernels;
+    valid_kernels.reserve(conv_ptrs.size());
+    for(const auto& it : conv_ptrs)
+    {
+        auto argument_ptr = it->MakeArgumentPointer(nullptr,
+                                                    nullptr,
+                                                    nullptr,
+                                                    nullptr,
+                                                    args.N,
+                                                    args.K,
+                                                    args.C,
+                                                    args.input,
+                                                    args.filter,
+                                                    args.output,
+                                                    args.strides,
+                                                    args.dilation,
+                                                    args.lPadding,
+                                                    args.rPadding,
+                                                    {},
+                                                    {},
+                                                    {});
+        if(it->IsSupportedArgument(argument_ptr.get()))
+        {
+            valid_kernels.push_back(it->GetTypeString());
+        }
+    }
+    return valid_kernels;
+}
+
+bool CheckCKApplicability(const ProblemDescription& problem)
+{
+    const auto args = CKArgs{problem};
+    auto conv_ptrs  = GetConvInstances();
+    for(const auto& it : conv_ptrs)
+    {
+        auto argument_ptr = it->MakeArgumentPointer(nullptr,
+                                                    nullptr,
+                                                    nullptr,
+                                                    nullptr,
+                                                    args.N,
+                                                    args.K,
+                                                    args.C,
+                                                    args.input,
+                                                    args.filter,
+                                                    args.output,
+                                                    args.strides,
+                                                    args.dilation,
+                                                    args.lPadding,
+                                                    args.rPadding,
+                                                    {},
+                                                    {},
+                                                    {});
+        if(it->IsSupportedArgument(argument_ptr.get()))
+            return true;
+    }
+    return false;
+}
+
+bool CheckIsArgSupported(const ProblemDescription& problem, const std::string& kernel_id)
+{
+    const auto args = CKArgs{problem};
+    auto conv_ptrs  = GetConvInstances();
+    for(size_t i = 0; i < conv_ptrs.size(); ++i)
+    {
+        if(conv_ptrs[i]->GetTypeString() == kernel_id)
+        {
+            auto argument_ptr = conv_ptrs[i]->MakeArgumentPointer(nullptr,
+                                                                   nullptr,
+                                                                   nullptr,
+                                                                   nullptr,
+                                                                   args.N,
+                                                                   args.K,
+                                                                   args.C,
+                                                                   args.input,
+                                                                   args.filter,
+                                                                   args.output,
+                                                                   args.strides,
+                                                                   args.dilation,
+                                                                   args.lPadding,
+                                                                   args.rPadding,
+                                                                   {},
+                                                                   {},
+                                                                   {});
+            return conv_ptrs[i]->IsSupportedArgument(argument_ptr.get());
+        }
+    }
+    return false;
+}
+
+} // anonymous namespace
+
+// ===========================================================================
+// Fused Conv+Bias+ReLU extern "C" functions
+// ===========================================================================
+
+extern "C" CKKernelListHandle* ckgrpconv_fused_bias_activ_fill_valid_kernels(
+    const miopen::conv::ProblemDescription* problem,
+    miopenDataType_t data_type,
+    bool /*use_tf32*/)
+{
+    try
+    {
+        if(!problem || data_type != miopenHalf)
+            return nullptr;
+        auto result     = std::make_unique<CKKernelListHandle>();
+        result->kernels = FillValidKernels(*problem);
+        return result.release();
+    }
+    catch(...)
+    {
+        return nullptr;
+    }
+}
+
+extern "C" bool
+ckgrpconv_fused_bias_activ_is_applicable(const miopen::conv::ProblemDescription* problem,
+                                         miopenDataType_t data_type,
+                                         bool /*use_tf32*/)
+{
+    try
+    {
+        if(!problem || data_type != miopenHalf)
+            return false;
+        return CheckCKApplicability(*problem);
+    }
+    catch(...)
+    {
+        return false;
+    }
+}
+
+extern "C" bool
+ckgrpconv_fused_bias_activ_is_args_supported(const miopen::conv::ProblemDescription* problem,
+                                             const char* kernel_id,
+                                             miopenDataType_t data_type,
+                                             bool /*use_tf32*/)
+{
+    try
+    {
+        if(!problem || !kernel_id || data_type != miopenHalf)
+            return false;
+        std::string kid(kernel_id);
+        return CheckIsArgSupported(*problem, kid);
+    }
+    catch(...)
+    {
+        return false;
+    }
+}
+
+extern "C" size_t
+ckgrpconv_fused_bias_activ_get_workspace_size(const miopen::conv::ProblemDescription* /*problem*/,
+                                              miopenDataType_t /*data_type*/,
+                                              bool /*use_tf32*/)
+{
+    return 0;
+}
+
+extern "C" miopen::solver::ConvSolution*
+ckgrpconv_fused_bias_activ_get_solution(const miopen::ExecutionContext* ctx,
+                                        const miopen::conv::ProblemDescription* problem,
+                                        const char* kernel_id,
+                                        bool /*use_tf32*/)
+{
+    try
+    {
+        if(!ctx || !problem || !kernel_id)
+            return nullptr;
+
+        std::string kid(kernel_id);
+
+        miopen::solver::ConvSolution solution;
+        solution.invoker_factory =
+            [kid, conv_problem = *problem](const std::vector<miopen::Kernel>& kernels) {
+                std::ignore = kernels;
+                return [kid, conv_problem](const miopen::Handle& handle,
+                                           const miopen::AnyInvokeParams& primitive_parameters) {
+                    const auto args = CKArgs{conv_problem};
+                    auto conv_ptrs  = GetConvInstances();
+
+                    // Find the instance matching the kernel_id.
+                    size_t id = 0;
+                    for(; id < conv_ptrs.size(); ++id)
+                    {
+                        if(conv_ptrs[id]->GetTypeString() == kid)
+                            break;
+                    }
+                    assert(id < conv_ptrs.size());
+                    auto& conv_ck = conv_ptrs.at(id);
+
+                    // Extract tensors from FusionInvokeParams.
+                    const auto& invoke_ctx =
+                        primitive_parameters.CastTo<miopen::fusion::FusionInvokeParams>();
+                    const auto& wei_buf =
+                        dynamic_cast<miopen::fusion::ConvolutionOpInvokeParam&>(
+                            *invoke_ctx.op_args.params[0])
+                            .weights;
+                    const auto& bias_buf =
+                        dynamic_cast<miopen::fusion::BiasOpInvokeParam&>(
+                            *invoke_ctx.op_args.params[1])
+                            .bdata;
+
+                    auto argument_ptr = conv_ck->MakeArgumentPointer(
+                        const_cast<void*>( // NOLINT (cppcoreguidelines-pro-type-const-cast)
+                            static_cast<const void*>(invoke_ctx.in)),
+                        const_cast<void*>( // NOLINT (cppcoreguidelines-pro-type-const-cast)
+                            static_cast<const void*>(wei_buf)),
+                        invoke_ctx.out,
+                        const_cast<void*>( // NOLINT (cppcoreguidelines-pro-type-const-cast)
+                            static_cast<const void*>(bias_buf)),
+                        args.N,
+                        args.K,
+                        args.C,
+                        args.input,
+                        args.filter,
+                        args.output,
+                        args.strides,
+                        args.dilation,
+                        args.lPadding,
+                        args.rPadding,
+                        {},
+                        {},
+                        {});
+
+                    auto invoker_ptr            = conv_ck->MakeInvokerPointer();
+                    const auto enable_profiling = handle.IsProfilingEnabled();
+
+                    float elapsed_time =
+                        invoker_ptr->Run(argument_ptr.get(), {handle.GetStream(), enable_profiling});
+                    if(enable_profiling)
+                    {
+                        handle.ResetKernelTime();
+                        handle.AccumKernelTime(elapsed_time);
+                    }
+                };
+            };
+
+        return new miopen::solver::ConvSolution(std::move(solution));
+    }
+    catch(...)
+    {
+        return nullptr;
+    }
+}

--- a/projects/miopen/src/ck_impl/ck_fused_bias_res_add_activ_impl.cpp
+++ b/projects/miopen/src/ck_impl/ck_fused_bias_res_add_activ_impl.cpp
@@ -226,8 +226,8 @@ bool CheckCKApplicability(const ProblemDescription& problem)
 template <typename DataType, typename AccumDataType>
 bool CheckIsArgSupported(const ProblemDescription& problem, const std::string& kernel_id)
 {
-    return miopen::solver::IsCKArgsSupported<DeviceOp<DataType, AccumDataType>, CKArgs>(
-        problem, kernel_id);
+    return miopen::solver::IsCKArgsSupported<DeviceOp<DataType, AccumDataType>, CKArgs>(problem,
+                                                                                        kernel_id);
 }
 
 // ---------------------------------------------------------------------------
@@ -351,9 +351,8 @@ ckgrpconv_fused_bias_res_add_activ_get_solution(const miopen::ExecutionContext* 
                 InitAnyInvokerFactory<DeviceOp<float, float>, CKArgs, ParamType>(*problem, kid);
             break;
         case miopenBFloat16:
-            solution =
-                InitAnyInvokerFactory<DeviceOp<ck::bhalf_t, ck::bhalf_t>, CKArgs, ParamType>(
-                    *problem, kid);
+            solution = InitAnyInvokerFactory<DeviceOp<ck::bhalf_t, ck::bhalf_t>, CKArgs, ParamType>(
+                *problem, kid);
             break;
         default: return nullptr;
         }

--- a/projects/miopen/src/ck_impl/ck_fused_bias_res_add_activ_impl.cpp
+++ b/projects/miopen/src/ck_impl/ck_fused_bias_res_add_activ_impl.cpp
@@ -1,0 +1,367 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include <vector>
+#include <cstdint>
+#include <string>
+#include <memory>
+
+#include "ck_grouped_conv_common.hpp"
+#include <miopen/conv_solution.hpp>
+#include <miopen/solver/ck_grouped_conv_interface.hpp>
+#include <miopen/conv/problem_description.hpp>
+#include <miopen/execution_context.hpp>
+#include <miopen/fusion/fusion_invoke_params.hpp>
+#include <miopen/solver/ck_utility_common.hpp>
+#include <miopen/solver/implicitgemm_ck_util.hpp>
+#include <miopen/solver/problem_description_interpreter.hpp>
+#include <ck/tensor_operation/gpu/device/device_conv_fwd_bias_activation.hpp>
+#include <ck/library/tensor_operation_instance/gpu/grouped_convolution_forward_scaleadd_scaleadd_relu.hpp>
+
+// ---------------------------------------------------------------------------
+// CK type aliases for fused Conv+ScaleAdd+Bias+ReLU
+// ---------------------------------------------------------------------------
+
+namespace {
+
+using ProblemDescription = miopen::conv::ProblemDescription;
+using miopen::solver::ProblemInterpreter;
+
+using CK_OutLayout = ck::tensor_layout::convolution::NDHWGK;
+
+// DataType also applies to weights
+// AccumDataType also applies to added z & bias tensors
+template <typename DataType, typename AccumDataType = DataType>
+using DeviceOp = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
+    ck::tensor_operation::device::DeviceGroupedConvFwdMultipleABD<
+        3,
+        ck::tensor_layout::convolution::NDHWGC,
+        ck::tensor_layout::convolution::GKZYXC,
+        ck::Tuple<CK_OutLayout, ck::tensor_layout::convolution::G_K>,
+        CK_OutLayout,
+        DataType,                                // in data type
+        DataType,                                // wei data type
+        ck::Tuple<AccumDataType, AccumDataType>, // z & bias tensors data type
+        DataType,                                // out data type
+        ck::tensor_operation::element_wise::PassThrough,
+        ck::tensor_operation::element_wise::PassThrough,
+        ck::tensor_operation::element_wise::
+            ScaleAddScaleAddRelu>>; // end DeviceOperationInstanceFactory
+
+// ---------------------------------------------------------------------------
+// CKArgs -- fused Conv+ScaleAdd+Bias+ReLU (from solver lines 74-235).
+// ---------------------------------------------------------------------------
+
+struct CKArgs
+{
+    CKArgs(const miopen::conv::ProblemDescription& problem)
+    {
+        G  = ProblemInterpreter::GetGroupCountG(problem);
+        N  = ProblemInterpreter::GetBatchN(problem);
+        K1 = ProblemInterpreter::GetOutputChannelK(problem);
+        C1 = ProblemInterpreter::GetInputChannelC(problem);
+        C  = C1 / G; // Number of input Channel per group
+        K  = K1 / G; // Number of output Channel per group
+        Hi = ProblemInterpreter::GetInputHeightHi(problem);
+        Wi = ProblemInterpreter::GetInputWidthWi(problem);
+        Ho = ProblemInterpreter::GetOutputHeightHo(problem);
+        Wo = ProblemInterpreter::GetOutputWidthWo(problem);
+        Y  = ProblemInterpreter::GetFilterHeightY(problem);
+        X  = ProblemInterpreter::GetFilterWidthX(problem);
+        Di = ProblemInterpreter::GetInputDepthDi(problem);
+        Do = ProblemInterpreter::GetOutputDepthDo(problem);
+        Z  = ProblemInterpreter::GetFilterDepthZ(problem);
+
+        in_lens      = {G, N, C, Di, Hi, Wi};
+        out_lens     = {G, N, K, Do, Ho, Wo};
+        wei_lens     = {G, K, C, Z, Y, X};
+        bias_lens    = {G, 1, K, 1, 1, 1};
+        bias_strides = {K, 0, 1, 0, 0, 0};
+
+        // miopen filter_stride to CK filter_stride
+        auto miopen_in_strides  = problem.GetIn().GetStrides();
+        auto miopen_out_strides = problem.GetOut().GetStrides();
+        auto miopen_wei_strides = problem.GetWeights().GetStrides();
+        miopen_in_strides.insert(miopen_in_strides.begin(), C);
+        miopen_out_strides.insert(miopen_out_strides.begin(), K);
+        miopen_wei_strides.insert(miopen_wei_strides.begin(), K * miopen_wei_strides[0]);
+        std::copy(miopen_in_strides.begin(), miopen_in_strides.end(), in_strides.begin());
+        std::copy(miopen_out_strides.begin(), miopen_out_strides.end(), out_strides.begin());
+        std::copy(miopen_wei_strides.begin(), miopen_wei_strides.end(), wei_strides.begin());
+
+        filter_stride   = {ProblemInterpreter::GetAdjustedConvolutionStrideD(problem),
+                           ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
+                           ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
+        filter_dilation = {ProblemInterpreter::GetAdjustedConvolutionDilationD(problem),
+                           ProblemInterpreter::GetAdjustedConvolutionDilationH(problem),
+                           ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
+        lPadding        = {ProblemInterpreter::GetInputLeftPadD(problem),
+                           ProblemInterpreter::GetInputLeftPadH(problem),
+                           ProblemInterpreter::GetInputLeftPadW(problem)};
+        rPadding        = {ProblemInterpreter::GetAdjustedInputRightPadD(problem),
+                           ProblemInterpreter::GetAdjustedInputRightPadH(problem),
+                           ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
+    }
+
+    CKArgs(const CKArgs&)            = default;
+    CKArgs(CKArgs&&)                 = default;
+    CKArgs& operator=(const CKArgs&) = default;
+
+    template <typename DevOpPtr>
+    auto MakeArgPtr(const DevOpPtr& op_ptr,
+                    ConstData_t in_buf,
+                    ConstData_t wei_buf,
+                    Data_t out_buf,
+                    ConstData_t z_buf,
+                    ConstData_t bias_buf,
+                    float alpha1,
+                    float alpha2) const
+    {
+        using ScaleAddScaleAddRelu = ck::tensor_operation::element_wise::ScaleAddScaleAddRelu;
+        return op_ptr->MakeArgumentPointer(in_buf,
+                                           wei_buf,
+                                           {z_buf, bias_buf},
+                                           out_buf,
+                                           in_lens,
+                                           in_strides,
+                                           wei_lens,
+                                           wei_strides,
+                                           {out_lens, bias_lens},
+                                           {out_strides, bias_strides},
+                                           out_lens,
+                                           out_strides,
+                                           filter_stride,
+                                           filter_dilation,
+                                           lPadding,
+                                           rPadding,
+                                           {}, // PassThrough
+                                           {}, // PassThrough
+                                           ScaleAddScaleAddRelu{alpha1, alpha2});
+    }
+
+    template <typename DevOpPtr>
+    auto MakeArgPtr(const DevOpPtr& op_ptr,
+                    const miopen::fusion::FusionInvokeParams& data_ctx) const
+    {
+        const auto& conv_param =
+            dynamic_cast<miopen::fusion::ConvolutionOpInvokeParam&>(*data_ctx.op_args.params[0]);
+        assert(&conv_param);
+
+        const auto& z_param =
+            dynamic_cast<miopen::fusion::TensorScaleAddOpInvokeParam&>(*data_ctx.op_args.params[1]);
+        assert(&z_param);
+
+        const auto& bias_param =
+            dynamic_cast<miopen::fusion::BiasOpInvokeParam&>(*data_ctx.op_args.params[2]);
+        assert(&bias_param);
+
+        /// \todo: Support general activation functions.
+        /// only relu activation supported and hardcoded for now
+        [[maybe_unused]] const auto& activ_param =
+            dynamic_cast<miopen::fusion::ActivationOpInvokeParam&>(*data_ctx.op_args.params[3]);
+        assert(&activ_param);
+
+        return MakeArgPtr(op_ptr,
+                          data_ctx.in,
+                          conv_param.weights,
+                          data_ctx.out,
+                          z_param.tensor_ptr,
+                          bias_param.bdata,
+                          conv_param.alpha,
+                          z_param.alpha);
+    }
+
+    template <typename DevOpPtr>
+    bool IsSupportedBy(const DevOpPtr& op_ptr) const
+    {
+        auto arg_ptr = MakeArgPtr(op_ptr, nullptr, nullptr, nullptr, nullptr, nullptr, 1.0, 1.0);
+        return op_ptr->IsSupportedArgument(arg_ptr.get());
+    }
+
+    int G;
+    int N;
+    int K;
+    int C;
+    int C1;
+    int K1;
+    int Hi;
+    int Wi;
+    int Di;
+    int Ho;
+    int Wo;
+    int Do;
+    int Y;
+    int X;
+    int Z;
+    std::array<ck::index_t, 6> in_lens;
+    std::array<ck::index_t, 6> in_strides;
+    std::array<ck::index_t, 6> out_lens;
+    std::array<ck::index_t, 6> out_strides;
+    std::array<ck::index_t, 6> wei_lens;
+    std::array<ck::index_t, 6> wei_strides;
+    std::array<ck::index_t, 6> bias_lens;
+    std::array<ck::index_t, 6> bias_strides;
+    std::array<ck::index_t, 3> filter_stride;
+    std::array<ck::index_t, 3> filter_dilation;
+    std::array<ck::index_t, 3> lPadding;
+    std::array<ck::index_t, 3> rPadding;
+};
+
+// ---------------------------------------------------------------------------
+// Template helpers
+// ---------------------------------------------------------------------------
+
+template <typename DataType, typename AccumDataType>
+std::vector<std::string> FillValidKernels(const ProblemDescription& problem)
+{
+    return miopen::solver::FillValidKernelsIDs<DeviceOp<DataType, AccumDataType>, CKArgs>(problem);
+}
+
+template <typename DataType, typename AccumDataType>
+bool CheckCKApplicability(const ProblemDescription& problem)
+{
+    return miopen::solver::IsCKApplicable<DeviceOp<DataType, AccumDataType>, CKArgs>(problem);
+}
+
+template <typename DataType, typename AccumDataType>
+bool CheckIsArgSupported(const ProblemDescription& problem, const std::string& kernel_id)
+{
+    return miopen::solver::IsCKArgsSupported<DeviceOp<DataType, AccumDataType>, CKArgs>(
+        problem, kernel_id);
+}
+
+// ---------------------------------------------------------------------------
+// Data-type dispatch helpers.
+//
+// This solver supports int8_t with float accumulation, so the standard
+// DispatchByDataType (which maps int8_t to int8_t AccumDataType) cannot
+// be reused directly.  Instead, we dispatch manually with the correct
+// (DataType, AccumDataType) pairs.
+// ---------------------------------------------------------------------------
+
+template <typename Fn>
+auto DispatchFusedByDataType(miopenDataType_t dtype, Fn&& fn)
+{
+    switch(dtype)
+    {
+    case miopenHalf: return fn(ck::half_t{}, ck::half_t{});
+    case miopenBFloat16: return fn(ck::bhalf_t{}, ck::bhalf_t{});
+    case miopenInt8: return fn(int8_t{}, float{});
+    default: return fn(float{}, float{});
+    }
+}
+
+} // anonymous namespace
+
+// ===========================================================================
+// Fused Conv+ScaleAdd+Bias+ReLU extern "C" functions
+// ===========================================================================
+
+using miopen::solver::InitAnyInvokerFactory;
+
+extern "C" CKKernelListHandle* ckgrpconv_fused_bias_res_add_activ_fill_valid_kernels(
+    const miopen::conv::ProblemDescription* problem, miopenDataType_t data_type, bool /*use_tf32*/)
+{
+    try
+    {
+        auto result     = std::make_unique<CKKernelListHandle>();
+        result->kernels = DispatchFusedByDataType(data_type, [&](auto data_val, auto accum_val) {
+            return FillValidKernels<decltype(data_val), decltype(accum_val)>(*problem);
+        });
+        return result.release();
+    }
+    catch(...)
+    {
+        return nullptr;
+    }
+}
+
+extern "C" bool ckgrpconv_fused_bias_res_add_activ_is_applicable(
+    const miopen::conv::ProblemDescription* problem, miopenDataType_t data_type, bool /*use_tf32*/)
+{
+    try
+    {
+        return DispatchFusedByDataType(data_type, [&](auto data_val, auto accum_val) {
+            return CheckCKApplicability<decltype(data_val), decltype(accum_val)>(*problem);
+        });
+    }
+    catch(...)
+    {
+        return false;
+    }
+}
+
+extern "C" bool ckgrpconv_fused_bias_res_add_activ_is_args_supported(
+    const miopen::conv::ProblemDescription* problem,
+    const char* kernel_id,
+    miopenDataType_t data_type,
+    bool /*use_tf32*/)
+{
+    try
+    {
+        if(!kernel_id)
+            return false;
+        std::string kid(kernel_id);
+        return DispatchFusedByDataType(data_type, [&](auto data_val, auto accum_val) {
+            return CheckIsArgSupported<decltype(data_val), decltype(accum_val)>(*problem, kid);
+        });
+    }
+    catch(...)
+    {
+        return false;
+    }
+}
+
+extern "C" size_t ckgrpconv_fused_bias_res_add_activ_get_workspace_size(
+    const miopen::conv::ProblemDescription* /*problem*/,
+    miopenDataType_t /*data_type*/,
+    bool /*use_tf32*/)
+{
+    // Fused Conv+ScaleAdd+Bias+ReLU CK kernels do not require CK-level workspace.
+    return 0;
+}
+
+extern "C" miopen::solver::ConvSolution*
+ckgrpconv_fused_bias_res_add_activ_get_solution(const miopen::ExecutionContext* /*ctx*/,
+                                                const miopen::conv::ProblemDescription* problem,
+                                                const char* kernel_id,
+                                                bool /*use_tf32*/)
+{
+    try
+    {
+        if(!problem || !kernel_id)
+            return nullptr;
+        std::string kid(kernel_id);
+
+        using ParamType = miopen::fusion::FusionInvokeParams;
+
+        miopen::solver::ConvSolution solution;
+        switch(problem->GetInDataType())
+        {
+        case miopenInt8:
+            solution =
+                InitAnyInvokerFactory<DeviceOp<int8_t, float>, CKArgs, ParamType>(*problem, kid);
+            break;
+        case miopenHalf:
+            solution = InitAnyInvokerFactory<DeviceOp<ck::half_t, ck::half_t>, CKArgs, ParamType>(
+                *problem, kid);
+            break;
+        case miopenFloat:
+            solution =
+                InitAnyInvokerFactory<DeviceOp<float, float>, CKArgs, ParamType>(*problem, kid);
+            break;
+        case miopenBFloat16:
+            solution =
+                InitAnyInvokerFactory<DeviceOp<ck::bhalf_t, ck::bhalf_t>, CKArgs, ParamType>(
+                    *problem, kid);
+            break;
+        default: return nullptr;
+        }
+
+        return new miopen::solver::ConvSolution(std::move(solution));
+    }
+    catch(...)
+    {
+        return nullptr;
+    }
+}

--- a/projects/miopen/src/ck_impl/ck_fused_grp_activ_impl.cpp
+++ b/projects/miopen/src/ck_impl/ck_fused_grp_activ_impl.cpp
@@ -57,28 +57,6 @@ struct LayoutsSelector<3>
     using OutLayout = ck::tensor_layout::convolution::NDHWGK;
 };
 
-inline auto Get2DLayouts()
-{
-    struct Layouts
-    {
-        using InLayout  = ck::tensor_layout::convolution::NHWGC;
-        using WeiLayout = ck::tensor_layout::convolution::GKYXC;
-        using OutLayout = ck::tensor_layout::convolution::NHWGK;
-    };
-    return Layouts{};
-}
-
-inline auto Get3DLayouts()
-{
-    struct Layouts
-    {
-        using InLayout  = ck::tensor_layout::convolution::NDHWGC;
-        using WeiLayout = ck::tensor_layout::convolution::GKZYXC;
-        using OutLayout = ck::tensor_layout::convolution::NDHWGK;
-    };
-    return Layouts{};
-}
-
 // ---------------------------------------------------------------------------
 // DeviceOp template aliases (same as in solver)
 // ---------------------------------------------------------------------------

--- a/projects/miopen/src/ck_impl/ck_fused_grp_activ_impl.cpp
+++ b/projects/miopen/src/ck_impl/ck_fused_grp_activ_impl.cpp
@@ -92,21 +92,20 @@ template <ck::index_t NumDimSpatial,
           typename InLayout     = ck::tensor_layout::convolution::NHWGC,
           typename WeiLayout    = ck::tensor_layout::convolution::GKYXC,
           typename OutLayout    = ck::tensor_layout::convolution::NHWGK>
-using DeviceOpGFwdAct =
-    ck::tensor_operation::device::DeviceGroupedConvFwdMultipleABD<NumDimSpatial,
-                                                                  InLayout,
-                                                                  WeiLayout,
-                                                                  ck::Tuple<>,
-                                                                  OutLayout,
-                                                                  InDataType,
-                                                                  WeiDataType,
-                                                                  ck::Tuple<>,
-                                                                  OutDataType,
-                                                                  InElementOp,
-                                                                  WeiElementOp,
-                                                                  OutElementOp,
-                                                                  AComputeType,
-                                                                  BComputeType>;
+using DeviceOpGFwdAct = ck::tensor_operation::device::DeviceGroupedConvFwdMultipleABD<NumDimSpatial,
+                                                                                      InLayout,
+                                                                                      WeiLayout,
+                                                                                      ck::Tuple<>,
+                                                                                      OutLayout,
+                                                                                      InDataType,
+                                                                                      WeiDataType,
+                                                                                      ck::Tuple<>,
+                                                                                      OutDataType,
+                                                                                      InElementOp,
+                                                                                      WeiElementOp,
+                                                                                      OutElementOp,
+                                                                                      AComputeType,
+                                                                                      BComputeType>;
 
 template <ck::index_t NumDimSpatial,
           typename DataType,
@@ -368,39 +367,36 @@ template <int NDim, typename DataType>
 std::vector<std::string> FillValidKernels(const ProblemDescription& problem)
 {
     using Layouts = LayoutsSelector<NDim>;
-    return miopen::solver::FillValidKernelsIDs<
-        DeviceOpGFwdActPtrs<NDim,
-                            DataType,
-                            typename Layouts::InLayout,
-                            typename Layouts::WeiLayout,
-                            typename Layouts::OutLayout>,
-        CKArgs<NDim, DataType>>(problem);
+    return miopen::solver::FillValidKernelsIDs<DeviceOpGFwdActPtrs<NDim,
+                                                                   DataType,
+                                                                   typename Layouts::InLayout,
+                                                                   typename Layouts::WeiLayout,
+                                                                   typename Layouts::OutLayout>,
+                                               CKArgs<NDim, DataType>>(problem);
 }
 
 template <int NDim, typename DataType>
 bool CheckCKApplicability(const ProblemDescription& problem)
 {
     using Layouts = LayoutsSelector<NDim>;
-    return miopen::solver::IsCKApplicable<
-        DeviceOpGFwdActPtrs<NDim,
-                            DataType,
-                            typename Layouts::InLayout,
-                            typename Layouts::WeiLayout,
-                            typename Layouts::OutLayout>,
-        CKArgs<NDim, DataType>>(problem);
+    return miopen::solver::IsCKApplicable<DeviceOpGFwdActPtrs<NDim,
+                                                              DataType,
+                                                              typename Layouts::InLayout,
+                                                              typename Layouts::WeiLayout,
+                                                              typename Layouts::OutLayout>,
+                                          CKArgs<NDim, DataType>>(problem);
 }
 
 template <int NDim, typename DataType>
 bool CheckIsArgSupported(const ProblemDescription& problem, const std::string& kernel_id)
 {
     using Layouts = LayoutsSelector<NDim>;
-    return miopen::solver::IsCKArgsSupported<
-        DeviceOpGFwdActPtrs<NDim,
-                            DataType,
-                            typename Layouts::InLayout,
-                            typename Layouts::WeiLayout,
-                            typename Layouts::OutLayout>,
-        CKArgs<NDim, DataType>>(problem, kernel_id);
+    return miopen::solver::IsCKArgsSupported<DeviceOpGFwdActPtrs<NDim,
+                                                                 DataType,
+                                                                 typename Layouts::InLayout,
+                                                                 typename Layouts::WeiLayout,
+                                                                 typename Layouts::OutLayout>,
+                                             CKArgs<NDim, DataType>>(problem, kernel_id);
 }
 
 // ---------------------------------------------------------------------------
@@ -532,16 +528,16 @@ ckgrpconv_fused_grp_activ_get_solution(const miopen::ExecutionContext* ctx,
                 [&](auto data_type_val, [[maybe_unused]] auto compute_type_val) {
                     (void)data_type_val;
                     using T = decltype(data_type_val);
-                    return InitInvokerFactoryFwdNCHW<NDim,
-                                                     false,
-                                                     DeviceOpGFwdActPtrs<NDim,
-                                                                         T,
-                                                                         typename Layouts::InLayout,
-                                                                         typename Layouts::WeiLayout,
-                                                                         typename Layouts::OutLayout>,
-                                                     CKArgs<NDim, T>,
-                                                     miopen::fusion::FusionInvokeParams>(
-                        *ctx, *problem, kid);
+                    return InitInvokerFactoryFwdNCHW<
+                        NDim,
+                        false,
+                        DeviceOpGFwdActPtrs<NDim,
+                                            T,
+                                            typename Layouts::InLayout,
+                                            typename Layouts::WeiLayout,
+                                            typename Layouts::OutLayout>,
+                        CKArgs<NDim, T>,
+                        miopen::fusion::FusionInvokeParams>(*ctx, *problem, kid);
                 },
                 [&](auto data_type_val, [[maybe_unused]] auto compute_type_val) {
                     (void)data_type_val;

--- a/projects/miopen/src/ck_impl/ck_fused_grp_activ_impl.cpp
+++ b/projects/miopen/src/ck_impl/ck_fused_grp_activ_impl.cpp
@@ -1,0 +1,573 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include <vector>
+#include <cstdint>
+#include <string>
+#include <memory>
+
+#include "ck_grouped_conv_common.hpp"
+#include "ck_grouped_conv_impl_helpers.hpp"
+#include <miopen/conv_solution.hpp>
+#include <miopen/solver/ck_grouped_conv_interface.hpp>
+#include <miopen/conv/problem_description.hpp>
+#include <miopen/execution_context.hpp>
+#include <miopen/conv/data_invoke_params.hpp>
+#include <miopen/fusion/fusion_invoke_params.hpp>
+#include <miopen/solver/ck_utility_common.hpp>
+#include <miopen/solver/implicitgemm_ck_util.hpp>
+#include <ck/library/tensor_operation_instance/gpu/grouped_convolution_forward_clamp.hpp>
+
+// ---------------------------------------------------------------------------
+// CK type aliases for fused grouped conv + activation (Clamp)
+// ---------------------------------------------------------------------------
+
+namespace {
+
+using ProblemDescription = miopen::conv::ProblemDescription;
+using miopen::solver::ProblemInterpreter;
+
+using InElementOp  = ck::tensor_operation::element_wise::PassThrough;
+using WeiElementOp = ck::tensor_operation::element_wise::PassThrough;
+using OutElementOp = ck::tensor_operation::element_wise::Clamp;
+
+const auto in_element_op  = InElementOp{};
+const auto wei_element_op = WeiElementOp{};
+
+// ---------------------------------------------------------------------------
+// Layout selectors for 2D and 3D
+// ---------------------------------------------------------------------------
+
+template <ck::index_t NDimSpatial>
+struct LayoutsSelector;
+
+template <>
+struct LayoutsSelector<2>
+{
+    using InLayout  = ck::tensor_layout::convolution::NHWGC;
+    using WeiLayout = ck::tensor_layout::convolution::GKYXC;
+    using OutLayout = ck::tensor_layout::convolution::NHWGK;
+};
+
+template <>
+struct LayoutsSelector<3>
+{
+    using InLayout  = ck::tensor_layout::convolution::NDHWGC;
+    using WeiLayout = ck::tensor_layout::convolution::GKZYXC;
+    using OutLayout = ck::tensor_layout::convolution::NDHWGK;
+};
+
+inline auto Get2DLayouts()
+{
+    struct Layouts
+    {
+        using InLayout  = ck::tensor_layout::convolution::NHWGC;
+        using WeiLayout = ck::tensor_layout::convolution::GKYXC;
+        using OutLayout = ck::tensor_layout::convolution::NHWGK;
+    };
+    return Layouts{};
+}
+
+inline auto Get3DLayouts()
+{
+    struct Layouts
+    {
+        using InLayout  = ck::tensor_layout::convolution::NDHWGC;
+        using WeiLayout = ck::tensor_layout::convolution::GKZYXC;
+        using OutLayout = ck::tensor_layout::convolution::NDHWGK;
+    };
+    return Layouts{};
+}
+
+// ---------------------------------------------------------------------------
+// DeviceOp template aliases (same as in solver)
+// ---------------------------------------------------------------------------
+
+template <ck::index_t NumDimSpatial,
+          typename InDataType,
+          typename WeiDataType,
+          typename OutDataType,
+          typename AComputeType = InDataType,
+          typename BComputeType = AComputeType,
+          typename InLayout     = ck::tensor_layout::convolution::NHWGC,
+          typename WeiLayout    = ck::tensor_layout::convolution::GKYXC,
+          typename OutLayout    = ck::tensor_layout::convolution::NHWGK>
+using DeviceOpGFwdAct =
+    ck::tensor_operation::device::DeviceGroupedConvFwdMultipleABD<NumDimSpatial,
+                                                                  InLayout,
+                                                                  WeiLayout,
+                                                                  ck::Tuple<>,
+                                                                  OutLayout,
+                                                                  InDataType,
+                                                                  WeiDataType,
+                                                                  ck::Tuple<>,
+                                                                  OutDataType,
+                                                                  InElementOp,
+                                                                  WeiElementOp,
+                                                                  OutElementOp,
+                                                                  AComputeType,
+                                                                  BComputeType>;
+
+template <ck::index_t NumDimSpatial,
+          typename DataType,
+          typename InLayout,
+          typename WeiLayout,
+          typename OutLayout>
+using DeviceOpGFwdActPtrs = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
+    DeviceOpGFwdAct<NumDimSpatial,
+                    DataType,
+                    DataType,
+                    DataType,
+                    DataType,
+                    DataType,
+                    InLayout,
+                    WeiLayout,
+                    OutLayout>>;
+
+// ---------------------------------------------------------------------------
+// CKArgs<NDimSpatial, DataType> — handles 2D/3D via runtime check
+// ---------------------------------------------------------------------------
+
+template <int NDimSpatial, typename DataType>
+struct CKArgs
+{
+    using OutputElementOpType = OutElementOp;
+    using OutputDataType      = DataType;
+
+    CKArgs(const ProblemDescription& problem)
+    {
+        G  = ProblemInterpreter::GetGroupCountG(problem);
+        N  = ProblemInterpreter::GetBatchN(problem);
+        K1 = ProblemInterpreter::GetOutputChannelK(problem);
+        C1 = ProblemInterpreter::GetInputChannelC(problem);
+        C  = C1 / G;
+        K  = K1 / G;
+
+        if(problem.Is3d())
+        {
+            Di = ProblemInterpreter::GetInputDepthDi(problem);
+            Do = ProblemInterpreter::GetOutputDepthDo(problem);
+            Z  = ProblemInterpreter::GetFilterDepthZ(problem);
+            Hi = ProblemInterpreter::GetInputHeightHi(problem);
+            Wi = ProblemInterpreter::GetInputWidthWi(problem);
+            Ho = ProblemInterpreter::GetOutputHeightHo(problem);
+            Wo = ProblemInterpreter::GetOutputWidthWo(problem);
+            Y  = ProblemInterpreter::GetFilterHeightY(problem);
+            X  = ProblemInterpreter::GetFilterWidthX(problem);
+
+            in_lens  = {G, N, C, Di, Hi, Wi};
+            out_lens = {G, N, K, Do, Ho, Wo};
+            wei_lens = {G, K, C, Z, Y, X};
+
+            in_strides  = {C, Di * Hi * Wi * G * C, 1, Hi * Wi * G * C, Wi * G * C, G * C};
+            out_strides = {K, Do * Ho * Wo * G * K, 1, Ho * Wo * G * K, Wo * G * K, G * K};
+            wei_strides = {K * Z * Y * X * C, Z * Y * X * C, 1, Y * X * C, X * C, C};
+
+            filter_stride   = {ProblemInterpreter::GetAdjustedConvolutionStrideD(problem),
+                               ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
+                               ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
+            filter_dilation = {ProblemInterpreter::GetAdjustedConvolutionDilationD(problem),
+                               ProblemInterpreter::GetAdjustedConvolutionDilationH(problem),
+                               ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
+            lPadding        = {ProblemInterpreter::GetInputLeftPadD(problem),
+                               ProblemInterpreter::GetInputLeftPadH(problem),
+                               ProblemInterpreter::GetInputLeftPadW(problem)};
+            rPadding        = {ProblemInterpreter::GetAdjustedInputRightPadD(problem),
+                               ProblemInterpreter::GetAdjustedInputRightPadH(problem),
+                               ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
+        }
+        else
+        {
+
+            Hi = ProblemInterpreter::GetInputHeightHi(problem);
+            Wi = ProblemInterpreter::GetInputWidthWi(problem);
+            Ho = ProblemInterpreter::GetOutputHeightHo(problem);
+            Wo = ProblemInterpreter::GetOutputWidthWo(problem);
+            Y  = ProblemInterpreter::GetFilterHeightY(problem);
+            X  = ProblemInterpreter::GetFilterWidthX(problem);
+
+            in_lens  = {G, N, C, Hi, Wi};
+            out_lens = {G, N, K, Ho, Wo};
+            wei_lens = {G, K, C, Y, X};
+
+            in_strides  = {C, Hi * Wi * G * C, 1, Wi * G * C, G * C};
+            out_strides = {K, Ho * Wo * G * K, 1, Wo * G * K, G * K};
+            wei_strides = {K * Y * X * C, Y * X * C, 1, X * C, C};
+
+            filter_stride   = {ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
+                               ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
+            filter_dilation = {ProblemInterpreter::GetAdjustedConvolutionDilationH(problem),
+                               ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
+            lPadding        = {ProblemInterpreter::GetInputLeftPadH(problem),
+                               ProblemInterpreter::GetInputLeftPadW(problem)};
+            rPadding        = {ProblemInterpreter::GetAdjustedInputRightPadH(problem),
+                               ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
+        }
+    }
+
+    CKArgs(const CKArgs&)            = default;
+    CKArgs(CKArgs&&)                 = default;
+    CKArgs& operator=(const CKArgs&) = default;
+
+    template <typename ConvPtr>
+    auto MakeArgPtr(const ConvPtr& conv_ptr,
+                    ConstData_t in,
+                    ConstData_t w,
+                    ConstData_t bias,
+                    Data_t out,
+                    float alpha,
+                    float beta,
+                    OutElementOp clampOp) const
+    {
+        (void)alpha;
+        (void)beta;
+        (void)bias;
+        constexpr bool is3DConv = (NDimSpatial == 3);
+
+        if constexpr(is3DConv)
+        {
+            return conv_ptr->MakeArgumentPointer(in,
+                                                 w,
+                                                 {},
+                                                 out,
+                                                 in_lens,
+                                                 in_strides,
+                                                 wei_lens,
+                                                 wei_strides,
+                                                 {},
+                                                 {},
+                                                 out_lens,
+                                                 out_strides,
+                                                 filter_stride,
+                                                 filter_dilation,
+                                                 lPadding,
+                                                 rPadding,
+                                                 in_element_op,
+                                                 wei_element_op,
+                                                 clampOp);
+        }
+        else
+        {
+            std::array<ck::index_t, 5> adjusted_in_lens{};
+            std::array<ck::index_t, 5> adjusted_out_lens{};
+            std::array<ck::index_t, 5> adjusted_wei_lens{};
+
+            std::copy(in_lens.begin(), in_lens.begin() + 5, adjusted_in_lens.begin());
+            std::copy(out_lens.begin(), out_lens.begin() + 5, adjusted_out_lens.begin());
+            std::copy(wei_lens.begin(), wei_lens.begin() + 5, adjusted_wei_lens.begin());
+
+            std::array<ck::index_t, 5> adjusted_in_strides{};
+            std::array<ck::index_t, 5> adjusted_out_strides{};
+            std::array<ck::index_t, 5> adjusted_wei_strides{};
+            std::copy(in_strides.begin(), in_strides.begin() + 5, adjusted_in_strides.begin());
+            std::copy(out_strides.begin(), out_strides.begin() + 5, adjusted_out_strides.begin());
+            std::copy(wei_strides.begin(), wei_strides.begin() + 5, adjusted_wei_strides.begin());
+
+            std::array<ck::index_t, 2> adjusted_filter_stride{};
+            std::array<ck::index_t, 2> adjusted_filter_dilation{};
+            std::array<ck::index_t, 2> adjusted_lPadding{};
+            std::array<ck::index_t, 2> adjusted_rPadding{};
+
+            std::copy(
+                filter_stride.begin(), filter_stride.begin() + 2, adjusted_filter_stride.begin());
+            std::copy(filter_dilation.begin(),
+                      filter_dilation.begin() + 2,
+                      adjusted_filter_dilation.begin());
+            std::copy(lPadding.begin(), lPadding.begin() + 2, adjusted_lPadding.begin());
+            std::copy(rPadding.begin(), rPadding.begin() + 2, adjusted_rPadding.begin());
+
+            return conv_ptr->MakeArgumentPointer(in,
+                                                 w,
+                                                 {},
+                                                 out,
+                                                 adjusted_in_lens,
+                                                 adjusted_in_strides,
+                                                 adjusted_wei_lens,
+                                                 adjusted_wei_strides,
+                                                 {},
+                                                 {},
+                                                 adjusted_out_lens,
+                                                 adjusted_out_strides,
+                                                 adjusted_filter_stride,
+                                                 adjusted_filter_dilation,
+                                                 adjusted_lPadding,
+                                                 adjusted_rPadding,
+                                                 in_element_op,
+                                                 wei_element_op,
+                                                 clampOp);
+        }
+    }
+
+    template <typename DevOpPtr>
+    auto MakeArgPtr(const DevOpPtr& op_ptr,
+                    const miopen::fusion::FusionInvokeParams& data_ctx) const
+    {
+        const auto& conv_param =
+            dynamic_cast<miopen::fusion::ConvolutionOpInvokeParam&>(*data_ctx.op_args.params[0]);
+        assert(&conv_param);
+
+        const auto& activ_param =
+            dynamic_cast<miopen::fusion::ActivationOpInvokeParam&>(*data_ctx.op_args.params[1]);
+
+        return MakeArgPtr(op_ptr,
+                          data_ctx.in,
+                          conv_param.weights,
+                          nullptr,
+                          data_ctx.out,
+                          conv_param.alpha,
+                          conv_param.beta,
+                          miopen::solver::GetOutElementOp<DataType, OutElementOp>(activ_param));
+    }
+
+    template <typename ConvPtr>
+    bool IsSupportedBy(const ConvPtr& conv_ptr) const
+    {
+        auto arg_ptr = MakeArgPtr(conv_ptr,
+                                  nullptr,
+                                  nullptr,
+                                  nullptr,
+                                  nullptr,
+                                  1.0f,
+                                  0.0f,
+                                  OutElementOp{0, ck::NumericLimits<DataType>::Max()});
+        return conv_ptr->IsSupportedArgument(arg_ptr.get());
+    }
+
+    int G;
+    int N;
+    int K1;
+    int C1;
+    int K;
+    int C;
+    int Hi;
+    int Wi;
+    int Ho;
+    int Wo;
+    int Y;
+    int X;
+    int Di = 0;
+    int Do = 0;
+    int Z  = 0;
+    std::array<ck::index_t, 6> in_lens;
+    std::array<ck::index_t, 6> in_strides;
+    std::array<ck::index_t, 6> out_lens;
+    std::array<ck::index_t, 6> out_strides;
+    std::array<ck::index_t, 6> wei_lens;
+    std::array<ck::index_t, 6> wei_strides;
+    std::array<ck::index_t, 3> filter_stride;
+    std::array<ck::index_t, 3> filter_dilation;
+    std::array<ck::index_t, 3> lPadding;
+    std::array<ck::index_t, 3> rPadding;
+};
+
+// ---------------------------------------------------------------------------
+// Template helpers
+// ---------------------------------------------------------------------------
+
+template <int NDim, typename DataType>
+std::vector<std::string> FillValidKernels(const ProblemDescription& problem)
+{
+    using Layouts = LayoutsSelector<NDim>;
+    return miopen::solver::FillValidKernelsIDs<
+        DeviceOpGFwdActPtrs<NDim,
+                            DataType,
+                            typename Layouts::InLayout,
+                            typename Layouts::WeiLayout,
+                            typename Layouts::OutLayout>,
+        CKArgs<NDim, DataType>>(problem);
+}
+
+template <int NDim, typename DataType>
+bool CheckCKApplicability(const ProblemDescription& problem)
+{
+    using Layouts = LayoutsSelector<NDim>;
+    return miopen::solver::IsCKApplicable<
+        DeviceOpGFwdActPtrs<NDim,
+                            DataType,
+                            typename Layouts::InLayout,
+                            typename Layouts::WeiLayout,
+                            typename Layouts::OutLayout>,
+        CKArgs<NDim, DataType>>(problem);
+}
+
+template <int NDim, typename DataType>
+bool CheckIsArgSupported(const ProblemDescription& problem, const std::string& kernel_id)
+{
+    using Layouts = LayoutsSelector<NDim>;
+    return miopen::solver::IsCKArgsSupported<
+        DeviceOpGFwdActPtrs<NDim,
+                            DataType,
+                            typename Layouts::InLayout,
+                            typename Layouts::WeiLayout,
+                            typename Layouts::OutLayout>,
+        CKArgs<NDim, DataType>>(problem, kernel_id);
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch helpers that select 2D or 3D based on problem->Is3d()
+// ---------------------------------------------------------------------------
+
+template <typename DataType>
+std::vector<std::string> FillValidKernelsForDim(const ProblemDescription& problem)
+{
+    if(problem.Is3d())
+        return FillValidKernels<3, DataType>(problem);
+    else
+        return FillValidKernels<2, DataType>(problem);
+}
+
+template <typename DataType>
+bool CheckCKApplicabilityForDim(const ProblemDescription& problem)
+{
+    if(problem.Is3d())
+        return CheckCKApplicability<3, DataType>(problem);
+    else
+        return CheckCKApplicability<2, DataType>(problem);
+}
+
+template <typename DataType>
+bool CheckIsArgSupportedForDim(const ProblemDescription& problem, const std::string& kernel_id)
+{
+    if(problem.Is3d())
+        return CheckIsArgSupported<3, DataType>(problem, kernel_id);
+    else
+        return CheckIsArgSupported<2, DataType>(problem, kernel_id);
+}
+
+} // anonymous namespace
+
+// ===========================================================================
+// Fused grouped conv + activation (Clamp) extern "C" functions
+// ===========================================================================
+
+using miopen::solver::InitInvokerFactoryFwdNCHW;
+using miopen::solver::InitInvokerFactoryNHWC;
+using miopen::solver::MakeSolutionGroupConvImplicitGemmXdlops;
+
+extern "C" CKKernelListHandle* ckgrpconv_fused_grp_activ_fill_valid_kernels(
+    const miopen::conv::ProblemDescription* problem, miopenDataType_t data_type, bool /*use_tf32*/)
+{
+    try
+    {
+        auto result     = std::make_unique<CKKernelListHandle>();
+        result->kernels = DispatchByDataType(data_type, [&](auto type_val) {
+            return FillValidKernelsForDim<decltype(type_val)>(*problem);
+        });
+        return result.release();
+    }
+    catch(...)
+    {
+        return nullptr;
+    }
+}
+
+extern "C" bool ckgrpconv_fused_grp_activ_is_applicable(
+    const miopen::conv::ProblemDescription* problem, miopenDataType_t data_type, bool /*use_tf32*/)
+{
+    try
+    {
+        return DispatchByDataType(data_type, [&](auto type_val) {
+            return CheckCKApplicabilityForDim<decltype(type_val)>(*problem);
+        });
+    }
+    catch(...)
+    {
+        return false;
+    }
+}
+
+extern "C" bool
+ckgrpconv_fused_grp_activ_is_args_supported(const miopen::conv::ProblemDescription* problem,
+                                            const char* kernel_id,
+                                            miopenDataType_t data_type,
+                                            bool /*use_tf32*/)
+{
+    try
+    {
+        if(!kernel_id)
+            return false;
+        std::string kid(kernel_id);
+        return DispatchByDataType(data_type, [&](auto type_val) {
+            return CheckIsArgSupportedForDim<decltype(type_val)>(*problem, kid);
+        });
+    }
+    catch(...)
+    {
+        return false;
+    }
+}
+
+extern "C" size_t
+ckgrpconv_fused_grp_activ_get_workspace_size(const miopen::conv::ProblemDescription* problem,
+                                             miopenDataType_t /*data_type*/,
+                                             bool /*use_tf32*/)
+{
+    try
+    {
+        return miopen::solver::GetWorkspaceSizeLayoutTransformConv(*problem);
+    }
+    catch(...)
+    {
+        return 0;
+    }
+}
+
+extern "C" miopen::solver::ConvSolution*
+ckgrpconv_fused_grp_activ_get_solution(const miopen::ExecutionContext* ctx,
+                                       const miopen::conv::ProblemDescription* problem,
+                                       const char* kernel_id,
+                                       bool /*use_tf32*/)
+{
+    try
+    {
+        if(!ctx || !problem || !kernel_id)
+            return nullptr;
+        std::string kid(kernel_id);
+
+        auto make_solution = [&](auto ndim_constant) {
+            constexpr int NDim = decltype(ndim_constant)::value;
+            using Layouts      = LayoutsSelector<NDim>;
+            return MakeSolutionGroupConvImplicitGemmXdlops(
+                *problem,
+                [&](auto data_type_val, [[maybe_unused]] auto compute_type_val) {
+                    (void)data_type_val;
+                    using T = decltype(data_type_val);
+                    return InitInvokerFactoryFwdNCHW<NDim,
+                                                     false,
+                                                     DeviceOpGFwdActPtrs<NDim,
+                                                                         T,
+                                                                         typename Layouts::InLayout,
+                                                                         typename Layouts::WeiLayout,
+                                                                         typename Layouts::OutLayout>,
+                                                     CKArgs<NDim, T>,
+                                                     miopen::fusion::FusionInvokeParams>(
+                        *ctx, *problem, kid);
+                },
+                [&](auto data_type_val, [[maybe_unused]] auto compute_type_val) {
+                    (void)data_type_val;
+                    using T = decltype(data_type_val);
+                    return InitInvokerFactoryNHWC<false,
+                                                  DeviceOpGFwdActPtrs<NDim,
+                                                                      T,
+                                                                      typename Layouts::InLayout,
+                                                                      typename Layouts::WeiLayout,
+                                                                      typename Layouts::OutLayout>,
+                                                  CKArgs<NDim, T>,
+                                                  miopen::fusion::FusionInvokeParams>(
+                        *ctx, *problem, kid);
+                });
+        };
+
+        miopen::solver::ConvSolution solution;
+        if(problem->Is3d())
+            solution = make_solution(std::integral_constant<int, 3>{});
+        else
+            solution = make_solution(std::integral_constant<int, 2>{});
+
+        return new miopen::solver::ConvSolution(std::move(solution));
+    }
+    catch(...)
+    {
+        return nullptr;
+    }
+}

--- a/projects/miopen/src/ck_impl/ck_fused_grp_bias_activ_impl.cpp
+++ b/projects/miopen/src/ck_impl/ck_fused_grp_bias_activ_impl.cpp
@@ -5,7 +5,6 @@
 #include <cstdint>
 #include <string>
 #include <memory>
-#include <limits>
 
 #include "ck_grouped_conv_common.hpp"
 #include "ck_grouped_conv_impl_helpers.hpp"
@@ -311,7 +310,7 @@ struct CKArgs
                                   nullptr,
                                   1.0f,
                                   0.0f,
-                                  OutElementOp{0, std::numeric_limits<DataType>::max()});
+                                  OutElementOp{0, ck::NumericLimits<DataType>::Max()});
         return conv_ptr->IsSupportedArgument(arg_ptr.get());
     }
 

--- a/projects/miopen/src/ck_impl/ck_fused_grp_bias_activ_impl.cpp
+++ b/projects/miopen/src/ck_impl/ck_fused_grp_bias_activ_impl.cpp
@@ -1,0 +1,546 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include <vector>
+#include <cstdint>
+#include <string>
+#include <memory>
+#include <limits>
+
+#include "ck_grouped_conv_common.hpp"
+#include "ck_grouped_conv_impl_helpers.hpp"
+#include <miopen/conv_solution.hpp>
+#include <miopen/solver/ck_grouped_conv_interface.hpp>
+#include <miopen/conv/problem_description.hpp>
+#include <miopen/execution_context.hpp>
+#include <miopen/conv/data_invoke_params.hpp>
+#include <miopen/solver/ck_utility_common.hpp>
+#include <miopen/solver/implicitgemm_ck_util.hpp>
+#include <ck/library/tensor_operation_instance/gpu/grouped_convolution_forward_bias_clamp.hpp>
+
+// ---------------------------------------------------------------------------
+// CK type aliases for fused grouped Conv+Bias+Activation(AddClamp)
+// ---------------------------------------------------------------------------
+
+namespace {
+
+using ProblemDescription = miopen::conv::ProblemDescription;
+using miopen::solver::ProblemInterpreter;
+
+using InElementOp  = ck::tensor_operation::element_wise::PassThrough;
+using WeiElementOp = ck::tensor_operation::element_wise::PassThrough;
+using OutElementOp = ck::tensor_operation::element_wise::AddClamp;
+
+const auto in_element_op  = InElementOp{};
+const auto wei_element_op = WeiElementOp{};
+
+template <ck::index_t NDimSpatial>
+struct LayoutsSelector;
+
+template <>
+struct LayoutsSelector<2>
+{
+    using InLayout  = ck::tensor_layout::convolution::NHWGC;
+    using WeiLayout = ck::tensor_layout::convolution::GKYXC;
+    using OutLayout = ck::tensor_layout::convolution::NHWGK;
+};
+
+template <>
+struct LayoutsSelector<3>
+{
+    using InLayout  = ck::tensor_layout::convolution::NDHWGC;
+    using WeiLayout = ck::tensor_layout::convolution::GKZYXC;
+    using OutLayout = ck::tensor_layout::convolution::NDHWGK;
+};
+
+template <ck::index_t NumDimSpatial,
+          typename InDataType,
+          typename WeiDataType,
+          typename OutDataType,
+          typename AComputeType = InDataType,
+          typename BComputeType = AComputeType,
+          typename InLayout     = typename LayoutsSelector<NumDimSpatial>::InLayout,
+          typename WeiLayout    = typename LayoutsSelector<NumDimSpatial>::WeiLayout,
+          typename OutLayout    = typename LayoutsSelector<NumDimSpatial>::OutLayout>
+using DeviceOpGFwdBiasActiv =
+    ck::tensor_operation::device::DeviceGroupedConvFwdMultipleABD<NumDimSpatial,
+                                                                  InLayout,
+                                                                  WeiLayout,
+                                                                  ck::Tuple<OutLayout>,
+                                                                  OutLayout,
+                                                                  InDataType,
+                                                                  WeiDataType,
+                                                                  ck::Tuple<OutDataType>,
+                                                                  OutDataType,
+                                                                  InElementOp,
+                                                                  WeiElementOp,
+                                                                  OutElementOp,
+                                                                  AComputeType,
+                                                                  BComputeType>;
+
+template <ck::index_t NumDimSpatial,
+          typename DataType,
+          typename InLayout  = typename LayoutsSelector<NumDimSpatial>::InLayout,
+          typename WeiLayout = typename LayoutsSelector<NumDimSpatial>::WeiLayout,
+          typename OutLayout = typename LayoutsSelector<NumDimSpatial>::OutLayout>
+using DeviceOpGFwdBiasActivPtrs =
+    ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
+        DeviceOpGFwdBiasActiv<NumDimSpatial,
+                              DataType,
+                              DataType,
+                              DataType,
+                              DataType,
+                              DataType,
+                              InLayout,
+                              WeiLayout,
+                              OutLayout>>;
+
+// ---------------------------------------------------------------------------
+// CKArgs -- fused grouped Conv+Bias+Activation, templated on NDimSpatial
+// and DataType.  Handles both 2D and 3D cases with bias_strides.
+// ---------------------------------------------------------------------------
+
+template <int NDimSpatial, typename DataType>
+struct CKArgs
+{
+    using OutputElementOpType = OutElementOp;
+    using OutputDataType      = DataType;
+
+    CKArgs(const ProblemDescription& problem)
+    {
+        G  = ProblemInterpreter::GetGroupCountG(problem);
+        N  = ProblemInterpreter::GetBatchN(problem);
+        K1 = ProblemInterpreter::GetOutputChannelK(problem);
+        C1 = ProblemInterpreter::GetInputChannelC(problem);
+        C  = C1 / G;
+        K  = K1 / G;
+
+        if(problem.Is3d())
+        {
+            Di = ProblemInterpreter::GetInputDepthDi(problem);
+            Do = ProblemInterpreter::GetOutputDepthDo(problem);
+            Z  = ProblemInterpreter::GetFilterDepthZ(problem);
+            Hi = ProblemInterpreter::GetInputHeightHi(problem);
+            Wi = ProblemInterpreter::GetInputWidthWi(problem);
+            Ho = ProblemInterpreter::GetOutputHeightHo(problem);
+            Wo = ProblemInterpreter::GetOutputWidthWo(problem);
+            Y  = ProblemInterpreter::GetFilterHeightY(problem);
+            X  = ProblemInterpreter::GetFilterWidthX(problem);
+
+            in_lens  = {G, N, C, Di, Hi, Wi};
+            out_lens = {G, N, K, Do, Ho, Wo};
+            wei_lens = {G, K, C, Z, Y, X};
+
+            in_strides  = {C, Di * Hi * Wi * G * C, 1, Hi * Wi * G * C, Wi * G * C, G * C};
+            out_strides = {K, Do * Ho * Wo * G * K, 1, Ho * Wo * G * K, Wo * G * K, G * K};
+            wei_strides = {K * Z * Y * X * C, Z * Y * X * C, 1, Y * X * C, X * C, C};
+
+            bias_strides = {K, 0, 1, 0, 0, 0};
+
+            filter_stride   = {ProblemInterpreter::GetAdjustedConvolutionStrideD(problem),
+                               ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
+                               ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
+            filter_dilation = {ProblemInterpreter::GetAdjustedConvolutionDilationD(problem),
+                               ProblemInterpreter::GetAdjustedConvolutionDilationH(problem),
+                               ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
+            lPadding        = {ProblemInterpreter::GetInputLeftPadD(problem),
+                               ProblemInterpreter::GetInputLeftPadH(problem),
+                               ProblemInterpreter::GetInputLeftPadW(problem)};
+            rPadding        = {ProblemInterpreter::GetAdjustedInputRightPadD(problem),
+                               ProblemInterpreter::GetAdjustedInputRightPadH(problem),
+                               ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
+        }
+        else
+        {
+            Hi = ProblemInterpreter::GetInputHeightHi(problem);
+            Wi = ProblemInterpreter::GetInputWidthWi(problem);
+            Ho = ProblemInterpreter::GetOutputHeightHo(problem);
+            Wo = ProblemInterpreter::GetOutputWidthWo(problem);
+            Y  = ProblemInterpreter::GetFilterHeightY(problem);
+            X  = ProblemInterpreter::GetFilterWidthX(problem);
+
+            in_lens  = {G, N, C, Hi, Wi};
+            out_lens = {G, N, K, Ho, Wo};
+            wei_lens = {G, K, C, Y, X};
+
+            in_strides  = {C, Hi * Wi * G * C, 1, Wi * G * C, G * C};
+            out_strides = {K, Ho * Wo * G * K, 1, Wo * G * K, G * K};
+            wei_strides = {K * Y * X * C, Y * X * C, 1, X * C, C};
+
+            bias_strides = {K, 0, 1, 0, 0};
+
+            filter_stride   = {ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
+                               ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
+            filter_dilation = {ProblemInterpreter::GetAdjustedConvolutionDilationH(problem),
+                               ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
+            lPadding        = {ProblemInterpreter::GetInputLeftPadH(problem),
+                               ProblemInterpreter::GetInputLeftPadW(problem)};
+            rPadding        = {ProblemInterpreter::GetAdjustedInputRightPadH(problem),
+                               ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
+        }
+    }
+
+    CKArgs(const CKArgs&)            = default;
+    CKArgs(CKArgs&&)                 = default;
+    CKArgs& operator=(const CKArgs&) = default;
+
+    template <typename ConvPtr>
+    auto MakeArgPtr(const ConvPtr& conv_ptr,
+                    ConstData_t in_buf,
+                    ConstData_t w_buf,
+                    ConstData_t bias_buf,
+                    Data_t out_buf,
+                    float alpha,
+                    float beta,
+                    OutElementOp clampOp) const
+    {
+        (void)alpha;
+        (void)beta;
+        constexpr bool is3DConv = (NDimSpatial == 3);
+
+        if constexpr(is3DConv)
+        {
+            return conv_ptr->MakeArgumentPointer(
+                in_buf,
+                w_buf,
+                {bias_buf},
+                out_buf,
+                in_lens,
+                in_strides,
+                wei_lens,
+                wei_strides,
+                {out_lens}, // hack CK's is applicable check: use output_len instead of bias_len
+                {bias_strides},
+                out_lens,
+                out_strides,
+                filter_stride,
+                filter_dilation,
+                lPadding,
+                rPadding,
+                in_element_op,
+                wei_element_op,
+                clampOp);
+        }
+        else
+        {
+            std::array<ck::index_t, 5> adjusted_in_lens{};
+            std::array<ck::index_t, 5> adjusted_out_lens{};
+            std::array<ck::index_t, 5> adjusted_wei_lens{};
+
+            std::copy(in_lens.begin(), in_lens.begin() + 5, adjusted_in_lens.begin());
+            std::copy(out_lens.begin(), out_lens.begin() + 5, adjusted_out_lens.begin());
+            std::copy(wei_lens.begin(), wei_lens.begin() + 5, adjusted_wei_lens.begin());
+
+            std::array<ck::index_t, 5> adjusted_in_strides{};
+            std::array<ck::index_t, 5> adjusted_out_strides{};
+            std::array<ck::index_t, 5> adjusted_wei_strides{};
+            std::array<ck::index_t, 5> adjusted_bias_strides{K, 0, 1, 0, 0};
+            std::copy(in_strides.begin(), in_strides.begin() + 5, adjusted_in_strides.begin());
+            std::copy(out_strides.begin(), out_strides.begin() + 5, adjusted_out_strides.begin());
+            std::copy(wei_strides.begin(), wei_strides.begin() + 5, adjusted_wei_strides.begin());
+
+            std::array<ck::index_t, 2> adjusted_filter_stride{};
+            std::array<ck::index_t, 2> adjusted_filter_dilation{};
+            std::array<ck::index_t, 2> adjusted_lPadding{};
+            std::array<ck::index_t, 2> adjusted_rPadding{};
+
+            std::copy(
+                filter_stride.begin(), filter_stride.begin() + 2, adjusted_filter_stride.begin());
+            std::copy(filter_dilation.begin(),
+                      filter_dilation.begin() + 2,
+                      adjusted_filter_dilation.begin());
+            std::copy(lPadding.begin(), lPadding.begin() + 2, adjusted_lPadding.begin());
+            std::copy(rPadding.begin(), rPadding.begin() + 2, adjusted_rPadding.begin());
+
+            return conv_ptr->MakeArgumentPointer(
+                in_buf,
+                w_buf,
+                {bias_buf},
+                out_buf,
+                adjusted_in_lens,
+                adjusted_in_strides,
+                adjusted_wei_lens,
+                adjusted_wei_strides,
+                {adjusted_out_lens}, // hack CK's is applicable check: use output_len instead of
+                                     // bias_len
+                {adjusted_bias_strides},
+                adjusted_out_lens,
+                adjusted_out_strides,
+                adjusted_filter_stride,
+                adjusted_filter_dilation,
+                adjusted_lPadding,
+                adjusted_rPadding,
+                in_element_op,
+                wei_element_op,
+                clampOp);
+        }
+    }
+
+    template <typename DevOpPtr>
+    auto MakeArgPtr(const DevOpPtr& op_ptr,
+                    const miopen::fusion::FusionInvokeParams& data_ctx) const
+    {
+        const auto& conv_param =
+            dynamic_cast<miopen::fusion::ConvolutionOpInvokeParam&>(*data_ctx.op_args.params[0]);
+        assert(&conv_param);
+
+        const auto& bias_param =
+            dynamic_cast<miopen::fusion::BiasOpInvokeParam&>(*data_ctx.op_args.params[1]);
+        assert(&bias_param);
+
+        const auto& activ_param =
+            dynamic_cast<miopen::fusion::ActivationOpInvokeParam&>(*data_ctx.op_args.params[2]);
+
+        return MakeArgPtr(op_ptr,
+                          data_ctx.in,
+                          conv_param.weights,
+                          bias_param.bdata,
+                          data_ctx.out,
+                          conv_param.alpha,
+                          conv_param.beta,
+                          miopen::solver::GetOutElementOp<DataType, OutElementOp>(activ_param));
+    }
+
+    template <typename ConvPtr>
+    bool IsSupportedBy(const ConvPtr& conv_ptr) const
+    {
+        auto arg_ptr = MakeArgPtr(conv_ptr,
+                                  nullptr,
+                                  nullptr,
+                                  nullptr,
+                                  nullptr,
+                                  1.0f,
+                                  0.0f,
+                                  OutElementOp{0, std::numeric_limits<DataType>::max()});
+        return conv_ptr->IsSupportedArgument(arg_ptr.get());
+    }
+
+    int G;
+    int N;
+    int K1;
+    int C1;
+    int K;
+    int C;
+    int Hi;
+    int Wi;
+    int Ho;
+    int Wo;
+    int Y;
+    int X;
+    int Di = 0;
+    int Do = 0;
+    int Z  = 0;
+    std::array<ck::index_t, 6> in_lens;
+    std::array<ck::index_t, 6> in_strides;
+    std::array<ck::index_t, 6> out_lens;
+    std::array<ck::index_t, 6> out_strides;
+    std::array<ck::index_t, 6> wei_lens;
+    std::array<ck::index_t, 6> wei_strides;
+    std::array<ck::index_t, 6> bias_strides;
+    std::array<ck::index_t, 3> filter_stride;
+    std::array<ck::index_t, 3> filter_dilation;
+    std::array<ck::index_t, 3> lPadding;
+    std::array<ck::index_t, 3> rPadding;
+};
+
+// ---------------------------------------------------------------------------
+// Template helpers — dispatch by dimensionality and data type
+// ---------------------------------------------------------------------------
+
+template <ck::index_t NDimSpatial, typename DataType>
+std::vector<std::string> FillValidKernelsForDim(const ProblemDescription& problem)
+{
+    return miopen::solver::FillValidKernelsIDs<DeviceOpGFwdBiasActivPtrs<NDimSpatial, DataType>,
+                                               CKArgs<NDimSpatial, DataType>>(problem);
+}
+
+template <ck::index_t NDimSpatial, typename DataType>
+bool CheckCKApplicabilityForDim(const ProblemDescription& problem)
+{
+    return miopen::solver::IsCKApplicable<DeviceOpGFwdBiasActivPtrs<NDimSpatial, DataType>,
+                                          CKArgs<NDimSpatial, DataType>>(problem);
+}
+
+template <ck::index_t NDimSpatial, typename DataType>
+bool CheckIsArgSupportedForDim(const ProblemDescription& problem, const std::string& kernel_id)
+{
+    return miopen::solver::IsCKArgsSupported<DeviceOpGFwdBiasActivPtrs<NDimSpatial, DataType>,
+                                             CKArgs<NDimSpatial, DataType>>(problem, kernel_id);
+}
+
+// ---------------------------------------------------------------------------
+// Top-level dispatch: first by 2D/3D, then by data type
+// ---------------------------------------------------------------------------
+
+template <typename DataType>
+std::vector<std::string> FillValidKernels(const ProblemDescription& problem)
+{
+    if(problem.Is3d())
+        return FillValidKernelsForDim<3, DataType>(problem);
+    else
+        return FillValidKernelsForDim<2, DataType>(problem);
+}
+
+template <typename DataType>
+bool CheckCKApplicability(const ProblemDescription& problem)
+{
+    if(problem.Is3d())
+        return CheckCKApplicabilityForDim<3, DataType>(problem);
+    else
+        return CheckCKApplicabilityForDim<2, DataType>(problem);
+}
+
+template <typename DataType>
+bool CheckIsArgSupported(const ProblemDescription& problem, const std::string& kernel_id)
+{
+    if(problem.Is3d())
+        return CheckIsArgSupportedForDim<3, DataType>(problem, kernel_id);
+    else
+        return CheckIsArgSupportedForDim<2, DataType>(problem, kernel_id);
+}
+
+} // anonymous namespace
+
+// ===========================================================================
+// Fused grouped Conv+Bias+Activation extern "C" functions
+// ===========================================================================
+
+using miopen::solver::GetWorkspaceSizeLayoutTransformConv;
+using miopen::solver::InitInvokerFactoryFwdNCHW;
+using miopen::solver::InitInvokerFactoryNHWC;
+using miopen::solver::MakeSolutionGroupConvImplicitGemmXdlops;
+
+extern "C" CKKernelListHandle* ckgrpconv_fused_grp_bias_activ_fill_valid_kernels(
+    const miopen::conv::ProblemDescription* problem, miopenDataType_t data_type, bool /*use_tf32*/)
+{
+    try
+    {
+        auto result     = std::make_unique<CKKernelListHandle>();
+        result->kernels = DispatchByDataType(data_type, [&](auto type_val) {
+            return FillValidKernels<decltype(type_val)>(*problem);
+        });
+        return result.release();
+    }
+    catch(...)
+    {
+        return nullptr;
+    }
+}
+
+extern "C" bool ckgrpconv_fused_grp_bias_activ_is_applicable(
+    const miopen::conv::ProblemDescription* problem, miopenDataType_t data_type, bool /*use_tf32*/)
+{
+    try
+    {
+        return DispatchByDataType(data_type, [&](auto type_val) {
+            return CheckCKApplicability<decltype(type_val)>(*problem);
+        });
+    }
+    catch(...)
+    {
+        return false;
+    }
+}
+
+extern "C" bool ckgrpconv_fused_grp_bias_activ_is_args_supported(
+    const miopen::conv::ProblemDescription* problem,
+    const char* kernel_id,
+    miopenDataType_t data_type,
+    bool /*use_tf32*/)
+{
+    try
+    {
+        if(!kernel_id)
+            return false;
+        std::string kid(kernel_id);
+        return DispatchByDataType(data_type, [&](auto type_val) {
+            return CheckIsArgSupported<decltype(type_val)>(*problem, kid);
+        });
+    }
+    catch(...)
+    {
+        return false;
+    }
+}
+
+extern "C" size_t ckgrpconv_fused_grp_bias_activ_get_workspace_size(
+    const miopen::conv::ProblemDescription* problem,
+    miopenDataType_t /*data_type*/,
+    bool /*use_tf32*/)
+{
+    try
+    {
+        return GetWorkspaceSizeLayoutTransformConv(*problem);
+    }
+    catch(...)
+    {
+        return 0;
+    }
+}
+
+extern "C" miopen::solver::ConvSolution*
+ckgrpconv_fused_grp_bias_activ_get_solution(const miopen::ExecutionContext* ctx,
+                                            const miopen::conv::ProblemDescription* problem,
+                                            const char* kernel_id,
+                                            bool /*use_tf32*/)
+{
+    try
+    {
+        if(!ctx || !problem || !kernel_id)
+            return nullptr;
+        std::string kid(kernel_id);
+
+        auto get_ndim = [&]() -> ck::index_t { return problem->Is3d() ? 3 : 2; };
+
+        auto solution = MakeSolutionGroupConvImplicitGemmXdlops(
+            *problem,
+            [&](auto data_type_val, [[maybe_unused]] auto compute_type_val) {
+                using T = decltype(data_type_val);
+                auto ndim = get_ndim();
+                if(ndim == 3)
+                {
+                    return InitInvokerFactoryFwdNCHW<3,
+                                                     false,
+                                                     DeviceOpGFwdBiasActivPtrs<3, T>,
+                                                     CKArgs<3, T>,
+                                                     miopen::fusion::FusionInvokeParams>(
+                        *ctx, *problem, kid);
+                }
+                else
+                {
+                    return InitInvokerFactoryFwdNCHW<2,
+                                                     false,
+                                                     DeviceOpGFwdBiasActivPtrs<2, T>,
+                                                     CKArgs<2, T>,
+                                                     miopen::fusion::FusionInvokeParams>(
+                        *ctx, *problem, kid);
+                }
+            },
+            [&](auto data_type_val, [[maybe_unused]] auto compute_type_val) {
+                using T = decltype(data_type_val);
+                auto ndim = get_ndim();
+                if(ndim == 3)
+                {
+                    return InitInvokerFactoryNHWC<false,
+                                                  DeviceOpGFwdBiasActivPtrs<3, T>,
+                                                  CKArgs<3, T>,
+                                                  miopen::fusion::FusionInvokeParams>(
+                        *ctx, *problem, kid);
+                }
+                else
+                {
+                    return InitInvokerFactoryNHWC<false,
+                                                  DeviceOpGFwdBiasActivPtrs<2, T>,
+                                                  CKArgs<2, T>,
+                                                  miopen::fusion::FusionInvokeParams>(
+                        *ctx, *problem, kid);
+                }
+            });
+
+        return new miopen::solver::ConvSolution(std::move(solution));
+    }
+    catch(...)
+    {
+        return nullptr;
+    }
+}

--- a/projects/miopen/src/ck_impl/ck_fused_grp_bias_activ_impl.cpp
+++ b/projects/miopen/src/ck_impl/ck_fused_grp_bias_activ_impl.cpp
@@ -442,11 +442,11 @@ extern "C" bool ckgrpconv_fused_grp_bias_activ_is_applicable(
     }
 }
 
-extern "C" bool ckgrpconv_fused_grp_bias_activ_is_args_supported(
-    const miopen::conv::ProblemDescription* problem,
-    const char* kernel_id,
-    miopenDataType_t data_type,
-    bool /*use_tf32*/)
+extern "C" bool
+ckgrpconv_fused_grp_bias_activ_is_args_supported(const miopen::conv::ProblemDescription* problem,
+                                                 const char* kernel_id,
+                                                 miopenDataType_t data_type,
+                                                 bool /*use_tf32*/)
 {
     try
     {
@@ -463,10 +463,10 @@ extern "C" bool ckgrpconv_fused_grp_bias_activ_is_args_supported(
     }
 }
 
-extern "C" size_t ckgrpconv_fused_grp_bias_activ_get_workspace_size(
-    const miopen::conv::ProblemDescription* problem,
-    miopenDataType_t /*data_type*/,
-    bool /*use_tf32*/)
+extern "C" size_t
+ckgrpconv_fused_grp_bias_activ_get_workspace_size(const miopen::conv::ProblemDescription* problem,
+                                                  miopenDataType_t /*data_type*/,
+                                                  bool /*use_tf32*/)
 {
     try
     {
@@ -495,7 +495,7 @@ ckgrpconv_fused_grp_bias_activ_get_solution(const miopen::ExecutionContext* ctx,
         auto solution = MakeSolutionGroupConvImplicitGemmXdlops(
             *problem,
             [&](auto data_type_val, [[maybe_unused]] auto compute_type_val) {
-                using T = decltype(data_type_val);
+                using T   = decltype(data_type_val);
                 auto ndim = get_ndim();
                 if(ndim == 3)
                 {
@@ -517,7 +517,7 @@ ckgrpconv_fused_grp_bias_activ_get_solution(const miopen::ExecutionContext* ctx,
                 }
             },
             [&](auto data_type_val, [[maybe_unused]] auto compute_type_val) {
-                using T = decltype(data_type_val);
+                using T   = decltype(data_type_val);
                 auto ndim = get_ndim();
                 if(ndim == 3)
                 {

--- a/projects/miopen/src/include/miopen/solver/ck_grouped_conv_interface.hpp
+++ b/projects/miopen/src/include/miopen/solver/ck_grouped_conv_interface.hpp
@@ -26,7 +26,7 @@ struct ConvSolution;
 
 /// API version constant. Bump when the set of extern "C" symbols or their
 /// semantics change.  The loader checks this at dlopen time.
-#define CK_GROUPED_CONV_API_VERSION 2
+#define CK_GROUPED_CONV_API_VERSION 3
 
 /// Opaque handle wrapping a list of valid kernel ID strings.
 /// Allocated by the impl library, freed by the caller via
@@ -206,6 +206,98 @@ ckgrpconv_3d_wrw_get_solution(const miopen::ExecutionContext* ctx,
                               const miopen::conv::ProblemDescription* problem,
                               const char* kernel_id,
                               bool use_tf32);
+
+// -- Fused Conv+Bias+ReLU (non-grouped, FP16) ---------------------------------
+
+CK_GROUPED_CONV_API CKKernelListHandle* ckgrpconv_fused_bias_activ_fill_valid_kernels(
+    const miopen::conv::ProblemDescription* problem, miopenDataType_t data_type, bool use_tf32);
+
+CK_GROUPED_CONV_API bool ckgrpconv_fused_bias_activ_is_applicable(
+    const miopen::conv::ProblemDescription* problem, miopenDataType_t data_type, bool use_tf32);
+
+CK_GROUPED_CONV_API bool
+ckgrpconv_fused_bias_activ_is_args_supported(const miopen::conv::ProblemDescription* problem,
+                                             const char* kernel_id,
+                                             miopenDataType_t data_type,
+                                             bool use_tf32);
+
+CK_GROUPED_CONV_API size_t ckgrpconv_fused_bias_activ_get_workspace_size(
+    const miopen::conv::ProblemDescription* problem, miopenDataType_t data_type, bool use_tf32);
+
+CK_GROUPED_CONV_API miopen::solver::ConvSolution*
+ckgrpconv_fused_bias_activ_get_solution(const miopen::ExecutionContext* ctx,
+                                        const miopen::conv::ProblemDescription* problem,
+                                        const char* kernel_id,
+                                        bool use_tf32);
+
+// -- Fused Conv+ScaleAdd+Bias+ReLU --------------------------------------------
+
+CK_GROUPED_CONV_API CKKernelListHandle* ckgrpconv_fused_bias_res_add_activ_fill_valid_kernels(
+    const miopen::conv::ProblemDescription* problem, miopenDataType_t data_type, bool use_tf32);
+
+CK_GROUPED_CONV_API bool ckgrpconv_fused_bias_res_add_activ_is_applicable(
+    const miopen::conv::ProblemDescription* problem, miopenDataType_t data_type, bool use_tf32);
+
+CK_GROUPED_CONV_API bool
+ckgrpconv_fused_bias_res_add_activ_is_args_supported(const miopen::conv::ProblemDescription* problem,
+                                                     const char* kernel_id,
+                                                     miopenDataType_t data_type,
+                                                     bool use_tf32);
+
+CK_GROUPED_CONV_API size_t ckgrpconv_fused_bias_res_add_activ_get_workspace_size(
+    const miopen::conv::ProblemDescription* problem, miopenDataType_t data_type, bool use_tf32);
+
+CK_GROUPED_CONV_API miopen::solver::ConvSolution*
+ckgrpconv_fused_bias_res_add_activ_get_solution(const miopen::ExecutionContext* ctx,
+                                                const miopen::conv::ProblemDescription* problem,
+                                                const char* kernel_id,
+                                                bool use_tf32);
+
+// -- Fused Grouped Conv+Activation(Clamp) -------------------------------------
+
+CK_GROUPED_CONV_API CKKernelListHandle* ckgrpconv_fused_grp_activ_fill_valid_kernels(
+    const miopen::conv::ProblemDescription* problem, miopenDataType_t data_type, bool use_tf32);
+
+CK_GROUPED_CONV_API bool ckgrpconv_fused_grp_activ_is_applicable(
+    const miopen::conv::ProblemDescription* problem, miopenDataType_t data_type, bool use_tf32);
+
+CK_GROUPED_CONV_API bool
+ckgrpconv_fused_grp_activ_is_args_supported(const miopen::conv::ProblemDescription* problem,
+                                            const char* kernel_id,
+                                            miopenDataType_t data_type,
+                                            bool use_tf32);
+
+CK_GROUPED_CONV_API size_t ckgrpconv_fused_grp_activ_get_workspace_size(
+    const miopen::conv::ProblemDescription* problem, miopenDataType_t data_type, bool use_tf32);
+
+CK_GROUPED_CONV_API miopen::solver::ConvSolution*
+ckgrpconv_fused_grp_activ_get_solution(const miopen::ExecutionContext* ctx,
+                                       const miopen::conv::ProblemDescription* problem,
+                                       const char* kernel_id,
+                                       bool use_tf32);
+
+// -- Fused Grouped Conv+Bias+Activation(AddClamp) -----------------------------
+
+CK_GROUPED_CONV_API CKKernelListHandle* ckgrpconv_fused_grp_bias_activ_fill_valid_kernels(
+    const miopen::conv::ProblemDescription* problem, miopenDataType_t data_type, bool use_tf32);
+
+CK_GROUPED_CONV_API bool ckgrpconv_fused_grp_bias_activ_is_applicable(
+    const miopen::conv::ProblemDescription* problem, miopenDataType_t data_type, bool use_tf32);
+
+CK_GROUPED_CONV_API bool
+ckgrpconv_fused_grp_bias_activ_is_args_supported(const miopen::conv::ProblemDescription* problem,
+                                                  const char* kernel_id,
+                                                  miopenDataType_t data_type,
+                                                  bool use_tf32);
+
+CK_GROUPED_CONV_API size_t ckgrpconv_fused_grp_bias_activ_get_workspace_size(
+    const miopen::conv::ProblemDescription* problem, miopenDataType_t data_type, bool use_tf32);
+
+CK_GROUPED_CONV_API miopen::solver::ConvSolution*
+ckgrpconv_fused_grp_bias_activ_get_solution(const miopen::ExecutionContext* ctx,
+                                            const miopen::conv::ProblemDescription* problem,
+                                            const char* kernel_id,
+                                            bool use_tf32);
 
 // -- Get all kernel type strings (for test/metadata validation) -----------------
 

--- a/projects/miopen/src/include/miopen/solver/ck_grouped_conv_interface.hpp
+++ b/projects/miopen/src/include/miopen/solver/ck_grouped_conv_interface.hpp
@@ -238,11 +238,11 @@ CK_GROUPED_CONV_API CKKernelListHandle* ckgrpconv_fused_bias_res_add_activ_fill_
 CK_GROUPED_CONV_API bool ckgrpconv_fused_bias_res_add_activ_is_applicable(
     const miopen::conv::ProblemDescription* problem, miopenDataType_t data_type, bool use_tf32);
 
-CK_GROUPED_CONV_API bool
-ckgrpconv_fused_bias_res_add_activ_is_args_supported(const miopen::conv::ProblemDescription* problem,
-                                                     const char* kernel_id,
-                                                     miopenDataType_t data_type,
-                                                     bool use_tf32);
+CK_GROUPED_CONV_API bool ckgrpconv_fused_bias_res_add_activ_is_args_supported(
+    const miopen::conv::ProblemDescription* problem,
+    const char* kernel_id,
+    miopenDataType_t data_type,
+    bool use_tf32);
 
 CK_GROUPED_CONV_API size_t ckgrpconv_fused_bias_res_add_activ_get_workspace_size(
     const miopen::conv::ProblemDescription* problem, miopenDataType_t data_type, bool use_tf32);
@@ -286,9 +286,9 @@ CK_GROUPED_CONV_API bool ckgrpconv_fused_grp_bias_activ_is_applicable(
 
 CK_GROUPED_CONV_API bool
 ckgrpconv_fused_grp_bias_activ_is_args_supported(const miopen::conv::ProblemDescription* problem,
-                                                  const char* kernel_id,
-                                                  miopenDataType_t data_type,
-                                                  bool use_tf32);
+                                                 const char* kernel_id,
+                                                 miopenDataType_t data_type,
+                                                 bool use_tf32);
 
 CK_GROUPED_CONV_API size_t ckgrpconv_fused_grp_bias_activ_get_workspace_size(
     const miopen::conv::ProblemDescription* problem, miopenDataType_t data_type, bool use_tf32);

--- a/projects/miopen/src/include/miopen/solver/ck_grouped_conv_lib_loader.hpp
+++ b/projects/miopen/src/include/miopen/solver/ck_grouped_conv_lib_loader.hpp
@@ -30,13 +30,17 @@ struct ConvSolution;
 
 enum class CKSolverType
 {
-    GrpConvFwd   = 0,
-    GrpConvBwd   = 1,
-    GrpConvWrw   = 2,
-    GrpConv3dFwd = 3,
-    GrpConv3dBwd = 4,
-    GrpConv3dWrw = 5,
-    Count        = 6
+    GrpConvFwd            = 0,
+    GrpConvBwd            = 1,
+    GrpConvWrw            = 2,
+    GrpConv3dFwd          = 3,
+    GrpConv3dBwd          = 4,
+    GrpConv3dWrw          = 5,
+    FusedBiasActiv        = 6,
+    FusedBiasResAddActiv  = 7,
+    FusedGrpActiv         = 8,
+    FusedGrpBiasActiv     = 9,
+    Count                 = 10
 };
 
 /// Query the HIP runtime for the current device's architecture name.

--- a/projects/miopen/src/include/miopen/solver/ck_grouped_conv_lib_loader.hpp
+++ b/projects/miopen/src/include/miopen/solver/ck_grouped_conv_lib_loader.hpp
@@ -30,17 +30,17 @@ struct ConvSolution;
 
 enum class CKSolverType
 {
-    GrpConvFwd            = 0,
-    GrpConvBwd            = 1,
-    GrpConvWrw            = 2,
-    GrpConv3dFwd          = 3,
-    GrpConv3dBwd          = 4,
-    GrpConv3dWrw          = 5,
-    FusedBiasActiv        = 6,
-    FusedBiasResAddActiv  = 7,
-    FusedGrpActiv         = 8,
-    FusedGrpBiasActiv     = 9,
-    Count                 = 10
+    GrpConvFwd           = 0,
+    GrpConvBwd           = 1,
+    GrpConvWrw           = 2,
+    GrpConv3dFwd         = 3,
+    GrpConv3dBwd         = 4,
+    GrpConv3dWrw         = 5,
+    FusedBiasActiv       = 6,
+    FusedBiasResAddActiv = 7,
+    FusedGrpActiv        = 8,
+    FusedGrpBiasActiv    = 9,
+    Count                = 10
 };
 
 /// Query the HIP runtime for the current device's architecture name.

--- a/projects/miopen/src/solver/ck_grouped_conv_lib_loader.cpp
+++ b/projects/miopen/src/solver/ck_grouped_conv_lib_loader.cpp
@@ -128,7 +128,7 @@ std::string GetDynamicLoadError()
 #else
     // NOLINTNEXTLINE(concurrency-mt-unsafe)
     const char* err = dlerror();
-    return err ? err : "unknown error";
+    return err != nullptr ? err : "unknown error";
 #endif
 }
 

--- a/projects/miopen/src/solver/ck_grouped_conv_lib_loader.cpp
+++ b/projects/miopen/src/solver/ck_grouped_conv_lib_loader.cpp
@@ -342,7 +342,11 @@ bool CKGroupedConvLibLoader::LoadSymbols()
         {CKSolverType::GrpConvWrw, "wrw"},
         {CKSolverType::GrpConv3dFwd, "3d_fwd"},
         {CKSolverType::GrpConv3dBwd, "3d_bwd"},
-        {CKSolverType::GrpConv3dWrw, "3d_wrw"}};
+        {CKSolverType::GrpConv3dWrw, "3d_wrw"},
+        {CKSolverType::FusedBiasActiv, "fused_bias_activ"},
+        {CKSolverType::FusedBiasResAddActiv, "fused_bias_res_add_activ"},
+        {CKSolverType::FusedGrpActiv, "fused_grp_activ"},
+        {CKSolverType::FusedGrpBiasActiv, "fused_grp_bias_activ"}};
 
     for(const auto& binding : solver_bindings)
         BindSolverSymbols(binding.solver, binding.prefix, missing);

--- a/projects/miopen/src/solver/conv_ck_igemm_fwd_bias_activ_fused.cpp
+++ b/projects/miopen/src/solver/conv_ck_igemm_fwd_bias_activ_fused.cpp
@@ -28,296 +28,46 @@
 #include <vector>
 #include <cstdint>
 
-#include <miopen/check_numerics.hpp>
 #include <miopen/env.hpp>
 #include <miopen/fusion/solvers.hpp>
 #include <miopen/generic_search.hpp>
 #include <miopen/conv/data_invoke_params.hpp>
-#include <miopen/solver/problem_description_interpreter.hpp>
-#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
-#include <ck/tensor_operation/gpu/device/device_conv_fwd_bias_activation.hpp>
-#endif
+#include <miopen/solver/ck_grouped_conv_lib_loader.hpp>
+
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_CONV_CK_IGEMM_FWD_BIAS_ACTIV)
-
-#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
-// Forward declare CK's function.
-namespace ck {
-namespace tensor_operation {
-namespace device {
-using DeviceConvFwdBiasReluPtr = ck::tensor_operation::device::DeviceConvFwdBiasActivationPtr<
-    ck::tensor_operation::element_wise::PassThrough,
-    ck::tensor_operation::element_wise::PassThrough,
-    ck::tensor_operation::element_wise::AddRelu>;
-
-namespace instance {
-
-void add_device_conv2d_fwd_xdl_c_shuffle_bias_relu_nhwc_kyxc_nhwk_f16_instances(
-    std::vector<DeviceConvFwdBiasReluPtr>&);
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
-#endif
 
 namespace miopen {
 namespace solver {
 namespace fusion {
 
-#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
-namespace {
-
-struct CKArgs
-{
-    CKArgs(const miopen::conv::ProblemDescription& problem)
-    {
-        N        = ProblemInterpreter::GetBatchN(problem);
-        K        = ProblemInterpreter::GetOutputChannelK(problem);
-        C        = ProblemInterpreter::GetInputChannelC(problem);
-        input    = {ProblemInterpreter::GetInputHeightHi(problem),
-                    ProblemInterpreter::GetInputWidthWi(problem)};
-        output   = {ProblemInterpreter::GetOutputHeightHo(problem),
-                    ProblemInterpreter::GetOutputWidthWo(problem)};
-        filter   = {ProblemInterpreter::GetFilterHeightY(problem),
-                    ProblemInterpreter::GetFilterWidthX(problem)};
-        strides  = {ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
-                    ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
-        dilation = {ProblemInterpreter::GetAdjustedConvolutionDilationH(problem),
-                    ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
-        lPadding = {ProblemInterpreter::GetInputLeftPadH(problem),
-                    ProblemInterpreter::GetInputLeftPadW(problem)};
-        rPadding = {ProblemInterpreter::GetAdjustedInputRightPadH(problem),
-                    ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
-    }
-    int N;
-    int K;
-    int C;
-    std::vector<int> input;
-    std::vector<int> output;
-    std::vector<int> filter;
-    std::vector<int> strides;
-    std::vector<int> dilation;
-    std::vector<int> lPadding;
-    std::vector<int> rPadding;
-};
-
-} // namespace
-
-template <typename DataType>
-void PerformanceConfigConvCKIgemmFwdBiasActivFused::Init(
-    const miopen::conv::ProblemDescription& problem)
-{
-    const auto& args = CKArgs{problem};
-    std::vector<ck::tensor_operation::device::DeviceConvFwdBiasReluPtr> conv_ptrs;
-    ck::tensor_operation::device::instance::
-        add_device_conv2d_fwd_xdl_c_shuffle_bias_relu_nhwc_kyxc_nhwk_f16_instances(conv_ptrs);
-    assert(!conv_ptrs.empty());
-    for(const auto& it : conv_ptrs)
-    {
-        auto argument_ptr = it->MakeArgumentPointer(nullptr,
-                                                    nullptr,
-                                                    nullptr,
-                                                    nullptr,
-                                                    args.N,
-                                                    args.K,
-                                                    args.C,
-                                                    args.input,
-                                                    args.filter,
-                                                    args.output,
-                                                    args.strides,
-                                                    args.dilation,
-                                                    args.lPadding,
-                                                    args.rPadding,
-                                                    {},
-                                                    {},
-                                                    {});
-        if(it->IsSupportedArgument(argument_ptr.get()))
-        {
-            valid_kernels.push_back(it->GetTypeString());
-        }
-    }
-
-    assert(!valid_kernels.empty());
-    this->index     = 0;
-    this->kernel_id = valid_kernels[0];
-}
-
-template <typename DataType>
-bool PerformanceConfigConvCKIgemmFwdBiasActivFused::CheckIsSupportCKArgs(
-    const miopen::conv::ProblemDescription& problem) const
-{
-    const auto& args = CKArgs{problem};
-    std::vector<ck::tensor_operation::device::DeviceConvFwdBiasReluPtr> conv_ptrs;
-    ck::tensor_operation::device::instance::
-        add_device_conv2d_fwd_xdl_c_shuffle_bias_relu_nhwc_kyxc_nhwk_f16_instances(conv_ptrs);
-
-    int i = 0;
-    for(; i < conv_ptrs.size(); i++)
-    {
-        if(conv_ptrs[i]->GetTypeString() == this->kernel_id)
-        {
-            break;
-        }
-    }
-    if(i == valid_kernels.size())
-    {
-        return false;
-    }
-    auto argument_ptr = conv_ptrs[i]->MakeArgumentPointer(nullptr,
-                                                          nullptr,
-                                                          nullptr,
-                                                          nullptr,
-                                                          args.N,
-                                                          args.K,
-                                                          args.C,
-                                                          args.input,
-                                                          args.filter,
-                                                          args.output,
-                                                          args.strides,
-                                                          args.dilation,
-                                                          args.lPadding,
-                                                          args.rPadding,
-                                                          {},
-                                                          {},
-                                                          {});
-    return conv_ptrs[i]->IsSupportedArgument(argument_ptr.get());
-}
-
-template <typename DataType>
-bool ConvCKIgemmFwdBiasActivFused::CheckCKApplicability(
-    const miopen::conv::ProblemDescription& problem) const
-{
-    std::vector<ck::tensor_operation::device::DeviceConvFwdBiasReluPtr> conv_ptrs;
-    ck::tensor_operation::device::instance::
-        add_device_conv2d_fwd_xdl_c_shuffle_bias_relu_nhwc_kyxc_nhwk_f16_instances(conv_ptrs);
-    assert(!conv_ptrs.empty());
-    const auto& args = CKArgs{problem};
-    for(const auto& it : conv_ptrs)
-    {
-        auto argument_ptr = it->MakeArgumentPointer(nullptr,
-                                                    nullptr,
-                                                    nullptr,
-                                                    nullptr,
-                                                    args.N,
-                                                    args.K,
-                                                    args.C,
-                                                    args.input,
-                                                    args.filter,
-                                                    args.output,
-                                                    args.strides,
-                                                    args.dilation,
-                                                    args.lPadding,
-                                                    args.rPadding,
-                                                    {},
-                                                    {},
-                                                    {});
-        if(it->IsSupportedArgument(argument_ptr.get()))
-            return true;
-    }
-    return false;
-}
-
-namespace {
-
-template <typename DataType>
-void RunCKSolution(const Handle& handle,
-                   const AnyInvokeParams& primitive_parameters,
-                   const miopen::conv::ProblemDescription& problem,
-                   const PerformanceConfigConvCKIgemmFwdBiasActivFused& config)
-{
-    const auto& args = CKArgs{problem};
-    std::vector<ck::tensor_operation::device::DeviceConvFwdBiasReluPtr> conv_ptrs;
-    ck::tensor_operation::device::instance::
-        add_device_conv2d_fwd_xdl_c_shuffle_bias_relu_nhwc_kyxc_nhwk_f16_instances(conv_ptrs);
-
-    int id = 0;
-    for(; id < conv_ptrs.size(); id++)
-    {
-        if(conv_ptrs[id]->GetTypeString() == config.kernel_id)
-        {
-            break;
-        }
-    }
-    assert(id < conv_ptrs.size());
-    auto& conv_ck          = conv_ptrs.at(id);
-    const auto& invoke_ctx = primitive_parameters.CastTo<miopen::fusion::FusionInvokeParams>();
-    const auto& wei_buf =
-        dynamic_cast<miopen::fusion::ConvolutionOpInvokeParam&>(*invoke_ctx.op_args.params[0])
-            .weights;
-    const auto& bias_buf =
-        dynamic_cast<miopen::fusion::BiasOpInvokeParam&>(*invoke_ctx.op_args.params[1]).bdata;
-
-    auto argument_ptr = conv_ck->MakeArgumentPointer(
-        const_cast<void*>( // NOLINT (cppcoreguidelines-pro-type-const-cast)
-            static_cast<const void*>(invoke_ctx.in)),
-        const_cast<void*>( // NOLINT (cppcoreguidelines-pro-type-const-cast)
-            static_cast<const void*>(wei_buf)),
-        invoke_ctx.out,
-        const_cast<void*>( // NOLINT (cppcoreguidelines-pro-type-const-cast)
-            static_cast<const void*>(bias_buf)),
-        args.N,
-        args.K,
-        args.C,
-        args.input,
-        args.filter,
-        args.output,
-        args.strides,
-        args.dilation,
-        args.lPadding,
-        args.rPadding,
-        {},
-        {},
-        {});
-    auto invoker_ptr            = conv_ck->MakeInvokerPointer();
-    const auto enable_profiling = handle.IsProfilingEnabled();
-
-    float elapsed_time =
-        invoker_ptr->Run(argument_ptr.get(), {handle.GetStream(), enable_profiling});
-    if(enable_profiling)
-    {
-        handle.ResetKernelTime();
-        handle.AccumKernelTime(elapsed_time);
-    }
-}
-
-} // namespace
-#endif
-
 void PerformanceConfigConvCKIgemmFwdBiasActivFused::HeuristicInit(
     const FusionDescription& fdesc_problem)
 {
-#if !MIOPEN_BACKEND_HIP || !MIOPEN_USE_COMPOSABLEKERNEL
-    std::ignore = fdesc_problem;
-#else
-    const auto conv_problem = fdesc_problem.GetConvProblem(0, miopen::conv::Direction::Forward);
-    switch(conv_problem.GetInDataType())
-    {
-    case miopenHalf: Init<ck::half_t>(conv_problem); break;
-    case miopenFloat8_fnuz:
-    case miopenBFloat8_fnuz:
-    case miopenInt8:
-    case miopenFloat:
-    case miopenInt32:
-    case miopenInt64:
-    case miopenBFloat16:
-    case miopenDouble:
-    default: MIOPEN_THROW("Unsupported datatype");
-    }
+    const auto& loader = CKGroupedConvLibLoader::Get(GetCurrentDeviceName());
+    if(!loader.IsLoaded())
+        return;
 
-#endif
+    const auto conv_problem = fdesc_problem.GetConvProblem(0, miopen::conv::Direction::Forward);
+    const auto data_type    = conv_problem.GetInDataType();
+
+    valid_kernels = loader.FillValidKernels(
+        CKSolverType::FusedBiasActiv, conv_problem, data_type, false);
+
+    if(!valid_kernels.empty())
+    {
+        index     = 0;
+        kernel_id = valid_kernels[0];
+    }
 }
 
 bool PerformanceConfigConvCKIgemmFwdBiasActivFused::SetNextValue(
     const FusionDescription& fdesc_problem)
 {
-#if !MIOPEN_BACKEND_HIP || !MIOPEN_USE_COMPOSABLEKERNEL
-    std::ignore = fdesc_problem;
-    return false;
-#else
     if(this->valid_kernels.empty())
     {
         this->HeuristicInit(fdesc_problem);
-        assert(!valid_kernels.empty());
+        if(valid_kernels.empty())
+            return false;
         return true;
     }
     if((this->index + 1) < valid_kernels.size())
@@ -328,7 +78,6 @@ bool PerformanceConfigConvCKIgemmFwdBiasActivFused::SetNextValue(
     }
     else
         return false;
-#endif
 }
 
 bool PerformanceConfigConvCKIgemmFwdBiasActivFused::IsValidValue() const
@@ -339,27 +88,14 @@ bool PerformanceConfigConvCKIgemmFwdBiasActivFused::IsValidValue() const
 bool PerformanceConfigConvCKIgemmFwdBiasActivFused::IsValid(
     const FusionContext&, const FusionDescription& fdesc_problem) const
 {
-#if !MIOPEN_BACKEND_HIP || !MIOPEN_USE_COMPOSABLEKERNEL
-    std::ignore = fdesc_problem;
-    return false;
-#else
-    // Extract convolution problem from the fusion context.
+    const auto& loader = CKGroupedConvLibLoader::Get(GetCurrentDeviceName());
+    if(!loader.IsLoaded())
+        return false;
+
     const auto conv_problem = fdesc_problem.GetConvProblem(0, miopen::conv::Direction::Forward);
-    switch(conv_problem.GetInDataType())
-    {
-    case miopenHalf: return CheckIsSupportCKArgs<ck::half_t>(conv_problem);
-    case miopenFloat8_fnuz:
-    case miopenBFloat8_fnuz:
-    case miopenInt8:
-    case miopenFloat:
-    case miopenInt32:
-    case miopenInt64:
-    case miopenBFloat16:
-    case miopenDouble:
-    default: MIOPEN_THROW("Unsupported datatype");
-    }
-    return false;
-#endif
+    const auto data_type    = conv_problem.GetInDataType();
+    return loader.IsArgsSupported(
+        CKSolverType::FusedBiasActiv, conv_problem, kernel_id, data_type, false);
 }
 
 bool PerformanceConfigConvCKIgemmFwdBiasActivFused::operator==(
@@ -397,11 +133,6 @@ ConvCKIgemmFwdBiasActivFused::Search(const FusionContext& ctx,
 bool ConvCKIgemmFwdBiasActivFused::IsApplicable(const FusionContext& ctx,
                                                 const FusionDescription& fdesc_problem) const
 {
-#if !MIOPEN_BACKEND_HIP || !MIOPEN_USE_COMPOSABLEKERNEL
-    std::ignore = ctx;
-    std::ignore = fdesc_problem;
-    return false;
-#else
     const auto& desc = *fdesc_problem.fusion_plan_desc;
     if(desc.op_map.empty())
     {
@@ -445,57 +176,26 @@ bool ConvCKIgemmFwdBiasActivFused::IsApplicable(const FusionContext& ctx,
     if(conv_problem.GetGroupCount() > 1)
         return false;
 
-    switch(conv_problem.GetInDataType())
-    {
-    case miopenHalf: return CheckCKApplicability<ck::half_t>(conv_problem);
-    case miopenFloat8_fnuz:
-    case miopenBFloat8_fnuz:
-    case miopenInt8:
-    case miopenFloat:
-    case miopenInt32:
-    case miopenInt64:
-    case miopenBFloat16:
-    case miopenDouble:
-    default: MIOPEN_THROW("Unsupported datatype");
-    }
-    return false;
-#endif
+    const auto& loader = CKGroupedConvLibLoader::Get(arch);
+    if(!loader.IsLoaded())
+        return false;
+
+    return loader.IsApplicable(
+        CKSolverType::FusedBiasActiv, conv_problem, conv_problem.GetInDataType(), false);
 }
 
 ConvSolution ConvCKIgemmFwdBiasActivFused::GetSolution(
-    const FusionContext&,
+    const FusionContext& ctx,
     const FusionDescription& fdesc_problem,
     const PerformanceConfigConvCKIgemmFwdBiasActivFused& config) const
 {
-#if !MIOPEN_BACKEND_HIP || !MIOPEN_USE_COMPOSABLEKERNEL
-    std::ignore = fdesc_problem;
-    std::ignore = config;
-    return {};
-#else
+    const auto& loader = CKGroupedConvLibLoader::Get(ctx.GetStream().GetDeviceName());
+    if(!loader.IsLoaded())
+        return {};
+
     const auto conv_problem = fdesc_problem.GetConvProblem(0, miopen::conv::Direction::Forward);
-    ConvSolution result;
-    result.invoker_factory = [=](const std::vector<Kernel>& kernels) {
-        std::ignore = kernels;
-        return [=](const Handle& handle, const AnyInvokeParams& primitive_parameters) {
-            switch(conv_problem.GetInDataType())
-            {
-            case miopenHalf:
-                RunCKSolution<ck::half_t>(handle, primitive_parameters, conv_problem, config);
-                break;
-            case miopenFloat8_fnuz:
-            case miopenBFloat8_fnuz:
-            case miopenInt8:
-            case miopenFloat:
-            case miopenInt32:
-            case miopenInt64:
-            case miopenBFloat16:
-            case miopenDouble:
-            default: MIOPEN_THROW("Unsupported datatype");
-            }
-        };
-    };
-    return result;
-#endif
+    return loader.GetSolution(
+        CKSolverType::FusedBiasActiv, ctx, conv_problem, config.kernel_id, false);
 }
 
 } // namespace fusion

--- a/projects/miopen/src/solver/conv_ck_igemm_fwd_bias_activ_fused.cpp
+++ b/projects/miopen/src/solver/conv_ck_igemm_fwd_bias_activ_fused.cpp
@@ -50,8 +50,8 @@ void PerformanceConfigConvCKIgemmFwdBiasActivFused::HeuristicInit(
     const auto conv_problem = fdesc_problem.GetConvProblem(0, miopen::conv::Direction::Forward);
     const auto data_type    = conv_problem.GetInDataType();
 
-    valid_kernels = loader.FillValidKernels(
-        CKSolverType::FusedBiasActiv, conv_problem, data_type, false);
+    valid_kernels =
+        loader.FillValidKernels(CKSolverType::FusedBiasActiv, conv_problem, data_type, false);
 
     if(!valid_kernels.empty())
     {

--- a/projects/miopen/src/solver/conv_ck_igemm_fwd_bias_res_add_activ_fused.cpp
+++ b/projects/miopen/src/solver/conv_ck_igemm_fwd_bias_res_add_activ_fused.cpp
@@ -54,8 +54,8 @@ void PerfConfigConvCKIgemmFwdBiasResAddActivFused::HeuristicInit(
     const auto conv_problem = fdesc_problem.GetConvProblem(0, miopen::conv::Direction::Forward);
     const auto data_type    = conv_problem.GetInDataType();
 
-    valid_kernels = loader.FillValidKernels(
-        CKSolverType::FusedBiasResAddActiv, conv_problem, data_type, false);
+    valid_kernels =
+        loader.FillValidKernels(CKSolverType::FusedBiasResAddActiv, conv_problem, data_type, false);
 
     if(!valid_kernels.empty())
     {

--- a/projects/miopen/src/solver/conv_ck_igemm_fwd_bias_res_add_activ_fused.cpp
+++ b/projects/miopen/src/solver/conv_ck_igemm_fwd_bias_res_add_activ_fused.cpp
@@ -28,241 +28,18 @@
 #include <vector>
 #include <cstdint>
 
-#include <miopen/check_numerics.hpp>
 #include <miopen/env.hpp>
 #include <miopen/fusion/solvers.hpp>
 #include <miopen/generic_search.hpp>
 #include <miopen/conv/data_invoke_params.hpp>
-#include <miopen/solver/problem_description_interpreter.hpp>
-#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
 #include <miopen/solver/ck_utility_common.hpp>
-#include <miopen/solver/implicitgemm_ck_util.hpp>
-#include <ck/tensor_operation/gpu/device/device_conv_fwd_bias_activation.hpp>
-#include <ck/library/tensor_operation_instance/gpu/grouped_convolution_forward_scaleadd_scaleadd_relu.hpp>
-#endif
+#include <miopen/solver/ck_grouped_conv_lib_loader.hpp>
+
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_CONV_CK_IGEMM_FWD_BIAS_RES_ADD_ACTIV)
 
 namespace miopen {
 namespace solver {
 namespace fusion {
-
-#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
-
-using CK_OutLayout = ck::tensor_layout::convolution::NDHWGK;
-
-// DataType also applies to weights
-// AccumDataType also applies to added z & bias tensors
-template <typename DataType, typename AccumDataType = DataType>
-using DeviceOp = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
-    ck::tensor_operation::device::DeviceGroupedConvFwdMultipleABD<
-        3,
-        ck::tensor_layout::convolution::NDHWGC,
-        ck::tensor_layout::convolution::GKZYXC,
-        ck::Tuple<CK_OutLayout, ck::tensor_layout::convolution::G_K>,
-        CK_OutLayout,
-        DataType,                                // in data type
-        DataType,                                // wei data type
-        ck::Tuple<AccumDataType, AccumDataType>, // z & bias tensors data type
-        DataType,                                // out data type
-        ck::tensor_operation::element_wise::PassThrough,
-        ck::tensor_operation::element_wise::PassThrough,
-        ck::tensor_operation::element_wise::
-            ScaleAddScaleAddRelu>>; // end DeviceOperationInstanceFactory
-
-namespace {
-
-struct CKArgs
-{
-    CKArgs(const miopen::conv::ProblemDescription& problem)
-    {
-        G  = ProblemInterpreter::GetGroupCountG(problem);
-        N  = ProblemInterpreter::GetBatchN(problem);
-        K1 = ProblemInterpreter::GetOutputChannelK(problem);
-        C1 = ProblemInterpreter::GetInputChannelC(problem);
-        C  = C1 / G; // Number of input Channel per group
-        K  = K1 / G; // Number of output Channel per group
-        Hi = ProblemInterpreter::GetInputHeightHi(problem);
-        Wi = ProblemInterpreter::GetInputWidthWi(problem);
-        Ho = ProblemInterpreter::GetOutputHeightHo(problem);
-        Wo = ProblemInterpreter::GetOutputWidthWo(problem);
-        Y  = ProblemInterpreter::GetFilterHeightY(problem);
-        X  = ProblemInterpreter::GetFilterWidthX(problem);
-        Di = ProblemInterpreter::GetInputDepthDi(problem);
-        Do = ProblemInterpreter::GetOutputDepthDo(problem);
-        Z  = ProblemInterpreter::GetFilterDepthZ(problem);
-
-        in_lens      = {G, N, C, Di, Hi, Wi};
-        out_lens     = {G, N, K, Do, Ho, Wo};
-        wei_lens     = {G, K, C, Z, Y, X};
-        bias_lens    = {G, 1, K, 1, 1, 1};
-        bias_strides = {K, 0, 1, 0, 0, 0};
-
-        // miopen filter_stride to CK filter_stride
-        auto miopen_in_strides  = problem.GetIn().GetStrides();
-        auto miopen_out_strides = problem.GetOut().GetStrides();
-        auto miopen_wei_strides = problem.GetWeights().GetStrides();
-        miopen_in_strides.insert(miopen_in_strides.begin(), C);
-        miopen_out_strides.insert(miopen_out_strides.begin(), K);
-        miopen_wei_strides.insert(miopen_wei_strides.begin(), K * miopen_wei_strides[0]);
-        std::copy(miopen_in_strides.begin(), miopen_in_strides.end(), in_strides.begin());
-        std::copy(miopen_out_strides.begin(), miopen_out_strides.end(), out_strides.begin());
-        std::copy(miopen_wei_strides.begin(), miopen_wei_strides.end(), wei_strides.begin());
-
-        filter_stride   = {ProblemInterpreter::GetAdjustedConvolutionStrideD(problem),
-                           ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
-                           ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
-        filter_dilation = {ProblemInterpreter::GetAdjustedConvolutionDilationD(problem),
-                           ProblemInterpreter::GetAdjustedConvolutionDilationH(problem),
-                           ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
-        lPadding        = {ProblemInterpreter::GetInputLeftPadD(problem),
-                           ProblemInterpreter::GetInputLeftPadH(problem),
-                           ProblemInterpreter::GetInputLeftPadW(problem)};
-        rPadding        = {ProblemInterpreter::GetAdjustedInputRightPadD(problem),
-                           ProblemInterpreter::GetAdjustedInputRightPadH(problem),
-                           ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
-    }
-
-    CKArgs(const CKArgs&)            = default;
-    CKArgs(CKArgs&&)                 = default;
-    CKArgs& operator=(const CKArgs&) = default;
-
-    template <typename DevOpPtr>
-    auto MakeArgPtr(const DevOpPtr& op_ptr,
-                    ConstData_t in_buf,
-                    ConstData_t wei_buf,
-                    Data_t out_buf,
-                    ConstData_t z_buf,
-                    ConstData_t bias_buf,
-                    float alpha1,
-                    float alpha2) const
-    {
-        using ScaleAddScaleAddRelu = ck::tensor_operation::element_wise::ScaleAddScaleAddRelu;
-        return op_ptr->MakeArgumentPointer(in_buf,
-                                           wei_buf,
-                                           {z_buf, bias_buf},
-                                           out_buf,
-                                           in_lens,
-                                           in_strides,
-                                           wei_lens,
-                                           wei_strides,
-                                           {out_lens, bias_lens},
-                                           {out_strides, bias_strides},
-                                           out_lens,
-                                           out_strides,
-                                           filter_stride,
-                                           filter_dilation,
-                                           lPadding,
-                                           rPadding,
-                                           {}, // PassThrough
-                                           {}, // PassThrough
-                                           ScaleAddScaleAddRelu{alpha1, alpha2});
-    }
-
-    template <typename DevOpPtr>
-    auto MakeArgPtr(const DevOpPtr& op_ptr,
-                    const miopen::fusion::FusionInvokeParams& data_ctx) const
-    {
-        const auto& conv_param =
-            dynamic_cast<miopen::fusion::ConvolutionOpInvokeParam&>(*data_ctx.op_args.params[0]);
-        assert(&conv_param);
-
-        const auto& z_param =
-            dynamic_cast<miopen::fusion::TensorScaleAddOpInvokeParam&>(*data_ctx.op_args.params[1]);
-        assert(&z_param);
-
-        const auto& bias_param =
-            dynamic_cast<miopen::fusion::BiasOpInvokeParam&>(*data_ctx.op_args.params[2]);
-        assert(&bias_param);
-
-        /// \todo: Support general activation functions.
-        /// only relu activation supported and hardcoded for now
-        [[maybe_unused]] const auto& activ_param =
-            dynamic_cast<miopen::fusion::ActivationOpInvokeParam&>(*data_ctx.op_args.params[3]);
-        assert(&activ_param);
-
-        return MakeArgPtr(op_ptr,
-                          data_ctx.in,
-                          conv_param.weights,
-                          data_ctx.out,
-                          z_param.tensor_ptr,
-                          bias_param.bdata,
-                          conv_param.alpha,
-                          z_param.alpha);
-    }
-
-#if 0
-    template <typename OpPtr>
-    auto MakeArgPtr(const OpPtr& op_ptr, const ConvDataTensors& tensors) const
-    {
-        return MakeArgPtr(op_ptr, tensors.in, tensors.w, tensors.out);
-    }
-#endif
-
-    template <typename DevOpPtr>
-    bool IsSupportedBy(const DevOpPtr& op_ptr) const
-    {
-        auto arg_ptr = MakeArgPtr(op_ptr, nullptr, nullptr, nullptr, nullptr, nullptr, 1.0, 1.0);
-        return op_ptr->IsSupportedArgument(arg_ptr.get());
-    }
-
-    int G;
-    int N;
-    int K;
-    int C;
-    int C1;
-    int K1;
-    int Hi;
-    int Wi;
-    int Di;
-    int Ho;
-    int Wo;
-    int Do;
-    int Y;
-    int X;
-    int Z;
-    std::array<ck::index_t, 6> in_lens;
-    std::array<ck::index_t, 6> in_strides;
-    std::array<ck::index_t, 6> out_lens;
-    std::array<ck::index_t, 6> out_strides;
-    std::array<ck::index_t, 6> wei_lens;
-    std::array<ck::index_t, 6> wei_strides;
-    std::array<ck::index_t, 6> bias_lens;
-    std::array<ck::index_t, 6> bias_strides;
-    std::array<ck::index_t, 3> filter_stride;
-    std::array<ck::index_t, 3> filter_dilation;
-    std::array<ck::index_t, 3> lPadding;
-    std::array<ck::index_t, 3> rPadding;
-};
-
-} // namespace
-
-// TODO: deal with separate input/output data types
-template <typename DataType, typename AccumDataType>
-void PerfConfigConvCKIgemmFwdBiasResAddActivFused::Init(
-    const miopen::conv::ProblemDescription& problem)
-{
-
-    valid_kernels = FillValidKernelsIDs<DeviceOp<DataType, AccumDataType>, CKArgs>(problem);
-    index         = 0;
-    assert(!valid_kernels.empty());
-    kernel_id = valid_kernels[0];
-}
-
-template <typename DataType, typename AccumDataType>
-bool PerfConfigConvCKIgemmFwdBiasResAddActivFused::CheckIsSupportCKArgs(
-    const miopen::conv::ProblemDescription& problem) const
-{
-    return IsCKArgsSupported<DeviceOp<DataType, AccumDataType>, CKArgs>(problem, kernel_id);
-}
-
-template <typename DataType, typename AccumDataType>
-bool ConvCKIgemmFwdBiasResAddActivFused::CheckCKApplicability(
-    const miopen::conv::ProblemDescription& problem) const
-{
-    return IsCKApplicable<DeviceOp<DataType, AccumDataType>, CKArgs>(problem);
-}
-
-#endif
 
 void PerfConfigConvCKIgemmFwdBiasResAddActivFused::HeuristicInit(
     const FusionDescription& fdesc_problem)
@@ -270,38 +47,31 @@ void PerfConfigConvCKIgemmFwdBiasResAddActivFused::HeuristicInit(
     index     = 0;
     kernel_id = "";
 
-#if !MIOPEN_BACKEND_HIP || !MIOPEN_USE_COMPOSABLEKERNEL
-    std::ignore = fdesc_problem;
-#else
-    const auto conv_problem = fdesc_problem.GetConvProblem(0, miopen::conv::Direction::Forward);
-    switch(conv_problem.GetInDataType())
-    {
-    case miopenHalf: Init<ck::half_t>(conv_problem); break;
-    case miopenFloat: Init<float>(conv_problem); break;
-    case miopenBFloat16: Init<ck::bhalf_t>(conv_problem); break;
-    case miopenInt8: Init<int8_t, float>(conv_problem); break;
-    case miopenFloat8_fnuz:
-    case miopenBFloat8_fnuz:
-    case miopenInt32:
-    case miopenInt64:
-    case miopenDouble:
-    default: MIOPEN_THROW("Unsupported datatype");
-    }
+    const auto& loader = CKGroupedConvLibLoader::Get(GetCurrentDeviceName());
+    if(!loader.IsLoaded())
+        return;
 
-#endif
+    const auto conv_problem = fdesc_problem.GetConvProblem(0, miopen::conv::Direction::Forward);
+    const auto data_type    = conv_problem.GetInDataType();
+
+    valid_kernels = loader.FillValidKernels(
+        CKSolverType::FusedBiasResAddActiv, conv_problem, data_type, false);
+
+    if(!valid_kernels.empty())
+    {
+        index     = 0;
+        kernel_id = valid_kernels[0];
+    }
 }
 
 bool PerfConfigConvCKIgemmFwdBiasResAddActivFused::SetNextValue(
     const FusionDescription& fdesc_problem)
 {
-#if !MIOPEN_BACKEND_HIP || !MIOPEN_USE_COMPOSABLEKERNEL
-    std::ignore = fdesc_problem;
-    return false;
-#else
     if(this->valid_kernels.empty())
     {
         this->HeuristicInit(fdesc_problem);
-        assert(!valid_kernels.empty());
+        if(valid_kernels.empty())
+            return false;
         return true;
     }
     if((this->index + 1) < valid_kernels.size())
@@ -312,7 +82,6 @@ bool PerfConfigConvCKIgemmFwdBiasResAddActivFused::SetNextValue(
     }
     else
         return false;
-#endif
 }
 
 bool PerfConfigConvCKIgemmFwdBiasResAddActivFused::IsValidValue() const
@@ -323,27 +92,14 @@ bool PerfConfigConvCKIgemmFwdBiasResAddActivFused::IsValidValue() const
 bool PerfConfigConvCKIgemmFwdBiasResAddActivFused::IsValid(
     const FusionContext&, const FusionDescription& fdesc_problem) const
 {
-#if !MIOPEN_BACKEND_HIP || !MIOPEN_USE_COMPOSABLEKERNEL
-    std::ignore = fdesc_problem;
-    return false;
-#else
-    // Extract convolution problem from the fusion context.
+    const auto& loader = CKGroupedConvLibLoader::Get(GetCurrentDeviceName());
+    if(!loader.IsLoaded())
+        return false;
+
     const auto conv_problem = fdesc_problem.GetConvProblem(0, miopen::conv::Direction::Forward);
-    switch(conv_problem.GetInDataType())
-    {
-    case miopenHalf: return CheckIsSupportCKArgs<ck::half_t>(conv_problem);
-    case miopenFloat: return CheckIsSupportCKArgs<float>(conv_problem);
-    case miopenBFloat16: return CheckIsSupportCKArgs<ck::bhalf_t>(conv_problem);
-    case miopenInt8: return CheckIsSupportCKArgs<int8_t, float>(conv_problem);
-    case miopenFloat8_fnuz:
-    case miopenBFloat8_fnuz:
-    case miopenInt32:
-    case miopenInt64:
-    case miopenDouble:
-    default: MIOPEN_THROW("Unsupported datatype");
-    }
-    return false;
-#endif
+    const auto data_type    = conv_problem.GetInDataType();
+    return loader.IsArgsSupported(
+        CKSolverType::FusedBiasResAddActiv, conv_problem, kernel_id, data_type, false);
 }
 
 bool PerfConfigConvCKIgemmFwdBiasResAddActivFused::operator==(
@@ -380,11 +136,6 @@ ConvCKIgemmFwdBiasResAddActivFused::Search(const FusionContext& ctx,
 bool ConvCKIgemmFwdBiasResAddActivFused::IsApplicable(const FusionContext& ctx,
                                                       const FusionDescription& fdesc_problem) const
 {
-#if !MIOPEN_BACKEND_HIP || !MIOPEN_USE_COMPOSABLEKERNEL
-    std::ignore = ctx;
-    std::ignore = fdesc_problem;
-    return false;
-#else
     const auto& desc = *fdesc_problem.fusion_plan_desc;
     if(desc.op_map.empty())
     {
@@ -425,62 +176,26 @@ bool ConvCKIgemmFwdBiasResAddActivFused::IsApplicable(const FusionContext& ctx,
     if(!ck_utility::is_ck_whitelist(ctx.GetStream().GetDeviceName()))
         return false;
 
-    switch(conv_problem.GetInDataType())
-    {
-    case miopenHalf: return CheckCKApplicability<ck::half_t>(conv_problem);
-    case miopenFloat: return CheckCKApplicability<float>(conv_problem);
-    case miopenBFloat16: return CheckCKApplicability<ck::bhalf_t>(conv_problem);
-    case miopenInt8: return CheckCKApplicability<int8_t, float>(conv_problem);
-    case miopenFloat8_fnuz:
-    case miopenBFloat8_fnuz:
-    case miopenInt32:
-    case miopenInt64:
-    case miopenDouble:
-    default: MIOPEN_THROW("Unsupported datatype");
-    }
-    return false;
-#endif
+    const auto& loader = CKGroupedConvLibLoader::Get(ctx.GetStream().GetDeviceName());
+    if(!loader.IsLoaded())
+        return false;
+
+    return loader.IsApplicable(
+        CKSolverType::FusedBiasResAddActiv, conv_problem, conv_problem.GetInDataType(), false);
 }
 
 ConvSolution ConvCKIgemmFwdBiasResAddActivFused::GetSolution(
-    const FusionContext&,
+    const FusionContext& ctx,
     const FusionDescription& fdesc_problem,
     const PerfConfigConvCKIgemmFwdBiasResAddActivFused& config) const
 {
-#if !MIOPEN_BACKEND_HIP || !MIOPEN_USE_COMPOSABLEKERNEL
-    std::ignore = fdesc_problem;
-    std::ignore = config;
-    return {};
-#else
+    const auto& loader = CKGroupedConvLibLoader::Get(ctx.GetStream().GetDeviceName());
+    if(!loader.IsLoaded())
+        return {};
+
     const auto conv_problem = fdesc_problem.GetConvProblem(0, miopen::conv::Direction::Forward);
-
-    using ParamType = miopen::fusion::FusionInvokeParams;
-    switch(conv_problem.GetInDataType())
-    {
-    case miopenInt8:
-        return InitAnyInvokerFactory<DeviceOp<int8_t, float>, CKArgs, ParamType>(conv_problem,
-                                                                                 config.kernel_id);
-    case miopenHalf:
-        return InitAnyInvokerFactory<DeviceOp<ck::half_t, ck::half_t>, CKArgs, ParamType>(
-            conv_problem, config.kernel_id);
-    case miopenFloat:
-        return InitAnyInvokerFactory<DeviceOp<float, float>, CKArgs, ParamType>(conv_problem,
-                                                                                config.kernel_id);
-    case miopenBFloat16:
-        return InitAnyInvokerFactory<DeviceOp<ck::bhalf_t, ck::bhalf_t>, CKArgs, ParamType>(
-            conv_problem, config.kernel_id);
-
-    case miopenInt32:
-    case miopenInt64:
-    case miopenDouble:
-    case miopenFloat8_fnuz:
-    case miopenBFloat8_fnuz:
-    default:
-        MIOPEN_THROW(miopenStatusInternalError,
-                     "ConvHipImplicitGemmBwdXdlops operation not implemented for this data type");
-    }
-
-#endif
+    return loader.GetSolution(
+        CKSolverType::FusedBiasResAddActiv, ctx, conv_problem, config.kernel_id, false);
 }
 
 } // namespace fusion

--- a/projects/miopen/src/solver/conv_ck_igemm_grp_fwd_activ_fused.cpp
+++ b/projects/miopen/src/solver/conv_ck_igemm_grp_fwd_activ_fused.cpp
@@ -31,480 +31,44 @@
 #include <miopen/env.hpp>
 #include <miopen/generic_search.hpp>
 #include <miopen/conv/data_invoke_params.hpp>
-#include <miopen/solver/problem_description_interpreter.hpp>
 #include <miopen/solver/ck_utility_common.hpp>
-#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
 #include <miopen/solver/implicitgemm_ck_util.hpp>
-#include "ck/library/tensor_operation_instance/gpu/grouped_convolution_forward_clamp.hpp"
-#endif
+#include <miopen/solver/ck_grouped_conv_lib_loader.hpp>
+
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_CONV_CK_IGEMM_GRP_FWD_ACTIV)
 
 namespace miopen {
 namespace solver {
 namespace fusion {
 
-using ProblemDescription = miopen::conv::ProblemDescription;
-
-#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
-
-template <ck::index_t NDimSpatial>
-struct LayoutsSelector;
-
-template <>
-struct LayoutsSelector<2>
-{
-    using InLayout  = ck::tensor_layout::convolution::NHWGC;
-    using WeiLayout = ck::tensor_layout::convolution::GKYXC;
-    using OutLayout = ck::tensor_layout::convolution::NHWGK;
-};
-
-template <>
-struct LayoutsSelector<3>
-{
-    using InLayout  = ck::tensor_layout::convolution::NDHWGC;
-    using WeiLayout = ck::tensor_layout::convolution::GKZYXC;
-    using OutLayout = ck::tensor_layout::convolution::NDHWGK;
-};
-
-inline auto Get2DLayouts()
-{
-    struct Layouts
-    {
-        using InLayout  = ck::tensor_layout::convolution::NHWGC;
-        using WeiLayout = ck::tensor_layout::convolution::GKYXC;
-        using OutLayout = ck::tensor_layout::convolution::NHWGK;
-    };
-    return Layouts{};
-}
-
-inline auto Get3DLayouts()
-{
-    struct Layouts
-    {
-        using InLayout  = ck::tensor_layout::convolution::NDHWGC;
-        using WeiLayout = ck::tensor_layout::convolution::GKZYXC;
-        using OutLayout = ck::tensor_layout::convolution::NDHWGK;
-    };
-    return Layouts{};
-}
-
-using InElementOp  = ck::tensor_operation::element_wise::PassThrough;
-using WeiElementOp = ck::tensor_operation::element_wise::PassThrough;
-using OutElementOp = ck::tensor_operation::element_wise::Clamp;
-
-const auto in_element_op  = InElementOp{};
-const auto wei_element_op = WeiElementOp{};
-
-template <ck::index_t NumDimSpatial,
-          typename InDataType,
-          typename WeiDataType,
-          typename OutDataType,
-          typename AComputeType = InDataType,
-          typename BComputeType = AComputeType,
-          typename InLayout     = ck::tensor_layout::convolution::NHWGC,
-          typename WeiLayout    = ck::tensor_layout::convolution::GKYXC,
-          typename OutLayout    = ck::tensor_layout::convolution::NHWGK>
-using DeviceOpGFwdAct =
-    ck::tensor_operation::device::DeviceGroupedConvFwdMultipleABD<NumDimSpatial,
-                                                                  InLayout,
-                                                                  WeiLayout,
-                                                                  ck::Tuple<>, // diff
-                                                                  OutLayout,
-                                                                  InDataType,
-                                                                  WeiDataType,
-                                                                  ck::Tuple<>, // diff
-                                                                  OutDataType,
-                                                                  InElementOp,
-                                                                  WeiElementOp,
-                                                                  OutElementOp,
-                                                                  AComputeType,
-                                                                  BComputeType>;
-
-template <ck::index_t NumDimSpatial,
-          typename DataType,
-          typename InLayout,
-          typename WeiLayout,
-          typename OutLayout>
-using DeviceOpGFwdActPtrs = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
-    DeviceOpGFwdAct<NumDimSpatial,
-                    DataType,
-                    DataType,
-                    DataType,
-                    DataType,
-                    DataType,
-                    InLayout,
-                    WeiLayout,
-                    OutLayout>>;
-
-namespace {
-
-template <int NDimSpatial, typename DataType>
-struct CKArgs
-{
-    using OutputElementOpType = OutElementOp;
-    using OutputDataType      = DataType;
-
-    CKArgs(const ProblemDescription& problem)
-    {
-        G  = ProblemInterpreter::GetGroupCountG(problem);
-        N  = ProblemInterpreter::GetBatchN(problem);
-        K1 = ProblemInterpreter::GetOutputChannelK(problem);
-        C1 = ProblemInterpreter::GetInputChannelC(problem);
-        C  = C1 / G; // Number of input Channel per group
-        K  = K1 / G; // Number of output Channel per group
-
-        if(problem.Is3d())
-        {
-            Di = ProblemInterpreter::GetInputDepthDi(problem);
-            Do = ProblemInterpreter::GetOutputDepthDo(problem);
-            Z  = ProblemInterpreter::GetFilterDepthZ(problem);
-            Hi = ProblemInterpreter::GetInputHeightHi(problem);
-            Wi = ProblemInterpreter::GetInputWidthWi(problem);
-            Ho = ProblemInterpreter::GetOutputHeightHo(problem);
-            Wo = ProblemInterpreter::GetOutputWidthWo(problem);
-            Y  = ProblemInterpreter::GetFilterHeightY(problem);
-            X  = ProblemInterpreter::GetFilterWidthX(problem);
-
-            in_lens  = {G, N, C, Di, Hi, Wi};
-            out_lens = {G, N, K, Do, Ho, Wo};
-            wei_lens = {G, K, C, Z, Y, X};
-
-            in_strides  = {C, Di * Hi * Wi * G * C, 1, Hi * Wi * G * C, Wi * G * C, G * C};
-            out_strides = {K, Do * Ho * Wo * G * K, 1, Ho * Wo * G * K, Wo * G * K, G * K};
-            wei_strides = {K * Z * Y * X * C, Z * Y * X * C, 1, Y * X * C, X * C, C};
-
-            filter_stride   = {ProblemInterpreter::GetAdjustedConvolutionStrideD(problem),
-                               ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
-                               ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
-            filter_dilation = {ProblemInterpreter::GetAdjustedConvolutionDilationD(problem),
-                               ProblemInterpreter::GetAdjustedConvolutionDilationH(problem),
-                               ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
-            lPadding        = {ProblemInterpreter::GetInputLeftPadD(problem),
-                               ProblemInterpreter::GetInputLeftPadH(problem),
-                               ProblemInterpreter::GetInputLeftPadW(problem)};
-            rPadding        = {ProblemInterpreter::GetAdjustedInputRightPadD(problem),
-                               ProblemInterpreter::GetAdjustedInputRightPadH(problem),
-                               ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
-        }
-        else
-        {
-
-            Hi = ProblemInterpreter::GetInputHeightHi(problem);
-            Wi = ProblemInterpreter::GetInputWidthWi(problem);
-            Ho = ProblemInterpreter::GetOutputHeightHo(problem);
-            Wo = ProblemInterpreter::GetOutputWidthWo(problem);
-            Y  = ProblemInterpreter::GetFilterHeightY(problem);
-            X  = ProblemInterpreter::GetFilterWidthX(problem);
-
-            in_lens  = {G, N, C, Hi, Wi};
-            out_lens = {G, N, K, Ho, Wo};
-            wei_lens = {G, K, C, Y, X};
-
-            in_strides  = {C, Hi * Wi * G * C, 1, Wi * G * C, G * C};
-            out_strides = {K, Ho * Wo * G * K, 1, Wo * G * K, G * K};
-            wei_strides = {K * Y * X * C, Y * X * C, 1, X * C, C};
-
-            filter_stride   = {ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
-                               ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
-            filter_dilation = {ProblemInterpreter::GetAdjustedConvolutionDilationH(problem),
-                               ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
-            lPadding        = {ProblemInterpreter::GetInputLeftPadH(problem),
-                               ProblemInterpreter::GetInputLeftPadW(problem)};
-            rPadding        = {ProblemInterpreter::GetAdjustedInputRightPadH(problem),
-                               ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
-        }
-    }
-
-    CKArgs(const CKArgs&)            = default;
-    CKArgs(CKArgs&&)                 = default;
-    CKArgs& operator=(const CKArgs&) = default;
-
-    template <typename ConvPtr>
-    auto MakeArgPtr(const ConvPtr& conv_ptr,
-                    ConstData_t in,
-                    ConstData_t w,
-                    ConstData_t bias,
-                    Data_t out,
-                    float alpha,
-                    float beta,
-                    OutElementOp clampOp) const
-    {
-        (void)alpha;
-        (void)beta;
-        (void)bias;
-        constexpr bool is3DConv = (NDimSpatial == 3);
-
-        if constexpr(is3DConv)
-        {
-            return conv_ptr->MakeArgumentPointer(in,
-                                                 w,
-                                                 {},
-                                                 out,
-                                                 in_lens,
-                                                 in_strides,
-                                                 wei_lens,
-                                                 wei_strides,
-                                                 {},
-                                                 {},
-                                                 out_lens,
-                                                 out_strides,
-                                                 filter_stride,
-                                                 filter_dilation,
-                                                 lPadding,
-                                                 rPadding,
-                                                 in_element_op,
-                                                 wei_element_op,
-                                                 clampOp);
-        }
-        else
-        {
-            std::array<ck::index_t, 5> adjusted_in_lens{};
-            std::array<ck::index_t, 5> adjusted_out_lens{};
-            std::array<ck::index_t, 5> adjusted_wei_lens{};
-
-            std::copy(in_lens.begin(), in_lens.begin() + 5, adjusted_in_lens.begin());
-            std::copy(out_lens.begin(), out_lens.begin() + 5, adjusted_out_lens.begin());
-            std::copy(wei_lens.begin(), wei_lens.begin() + 5, adjusted_wei_lens.begin());
-
-            std::array<ck::index_t, 5> adjusted_in_strides{};
-            std::array<ck::index_t, 5> adjusted_out_strides{};
-            std::array<ck::index_t, 5> adjusted_wei_strides{};
-            std::copy(in_strides.begin(), in_strides.begin() + 5, adjusted_in_strides.begin());
-            std::copy(out_strides.begin(), out_strides.begin() + 5, adjusted_out_strides.begin());
-            std::copy(wei_strides.begin(), wei_strides.begin() + 5, adjusted_wei_strides.begin());
-
-            std::array<ck::index_t, 2> adjusted_filter_stride{};
-            std::array<ck::index_t, 2> adjusted_filter_dilation{};
-            std::array<ck::index_t, 2> adjusted_lPadding{};
-            std::array<ck::index_t, 2> adjusted_rPadding{};
-
-            std::copy(
-                filter_stride.begin(), filter_stride.begin() + 2, adjusted_filter_stride.begin());
-            std::copy(filter_dilation.begin(),
-                      filter_dilation.begin() + 2,
-                      adjusted_filter_dilation.begin());
-            std::copy(lPadding.begin(), lPadding.begin() + 2, adjusted_lPadding.begin());
-            std::copy(rPadding.begin(), rPadding.begin() + 2, adjusted_rPadding.begin());
-
-            return conv_ptr->MakeArgumentPointer(in,
-                                                 w,
-                                                 {},
-                                                 out,
-                                                 adjusted_in_lens,
-                                                 adjusted_in_strides,
-                                                 adjusted_wei_lens,
-                                                 adjusted_wei_strides,
-                                                 {},
-                                                 {},
-                                                 adjusted_out_lens,
-                                                 adjusted_out_strides,
-                                                 adjusted_filter_stride,
-                                                 adjusted_filter_dilation,
-                                                 adjusted_lPadding,
-                                                 adjusted_rPadding,
-                                                 in_element_op,
-                                                 wei_element_op,
-                                                 clampOp);
-        }
-    }
-
-    template <typename DevOpPtr>
-    auto MakeArgPtr(const DevOpPtr& op_ptr,
-                    const miopen::fusion::FusionInvokeParams& data_ctx) const
-    {
-        const auto& conv_param =
-            dynamic_cast<miopen::fusion::ConvolutionOpInvokeParam&>(*data_ctx.op_args.params[0]);
-        assert(&conv_param);
-
-        const auto& activ_param =
-            dynamic_cast<miopen::fusion::ActivationOpInvokeParam&>(*data_ctx.op_args.params[1]);
-
-        return MakeArgPtr(op_ptr,
-                          data_ctx.in,
-                          conv_param.weights,
-                          nullptr,
-                          data_ctx.out,
-                          conv_param.alpha,
-                          conv_param.beta,
-                          GetOutElementOp<DataType, OutElementOp>(activ_param));
-    }
-
-    template <typename ConvPtr>
-    bool IsSupportedBy(const ConvPtr& conv_ptr) const
-    {
-        auto arg_ptr = MakeArgPtr(conv_ptr,
-                                  nullptr,
-                                  nullptr,
-                                  nullptr,
-                                  nullptr,
-                                  1.0f,
-                                  0.0f,
-                                  OutElementOp{0, std::numeric_limits<DataType>::max()});
-        return conv_ptr->IsSupportedArgument(arg_ptr.get());
-    }
-
-    int G;
-    int N;
-    int K1;
-    int C1;
-    int K;
-    int C;
-    int Hi;
-    int Wi;
-    int Ho;
-    int Wo;
-    int Y;
-    int X;
-    int Di = 0; // Depth for 3D
-    int Do = 0; // Depth for 3D
-    int Z  = 0; // Filter depth for 3D
-    std::array<ck::index_t, 6> in_lens;
-    std::array<ck::index_t, 6> in_strides;
-    std::array<ck::index_t, 6> out_lens;
-    std::array<ck::index_t, 6> out_strides;
-    std::array<ck::index_t, 6> wei_lens;
-    std::array<ck::index_t, 6> wei_strides;
-    std::array<ck::index_t, 3> filter_stride;
-    std::array<ck::index_t, 3> filter_dilation;
-    std::array<ck::index_t, 3> lPadding;
-    std::array<ck::index_t, 3> rPadding;
-};
-
-} // namespace
-
-template <typename DataType>
-void PerformanceConfigConvCKIgemmGrpFwdActivFused::Init(
-    const miopen::conv::ProblemDescription& problem)
-{
-    if(valid_kernels.empty())
-    {
-        if(problem.Is3d())
-        {
-            using Layouts = decltype(Get3DLayouts());
-            valid_kernels = FillValidKernelsIDs<DeviceOpGFwdActPtrs<3,
-                                                                    DataType,
-                                                                    Layouts::InLayout,
-                                                                    Layouts::WeiLayout,
-                                                                    Layouts::OutLayout>,
-                                                CKArgs<3, DataType>>(problem);
-        }
-        else
-        {
-            using Layouts = decltype(Get2DLayouts());
-            valid_kernels = FillValidKernelsIDs<DeviceOpGFwdActPtrs<2,
-                                                                    DataType,
-                                                                    Layouts::InLayout,
-                                                                    Layouts::WeiLayout,
-                                                                    Layouts::OutLayout>,
-                                                CKArgs<2, DataType>>(problem);
-        }
-    }
-    index     = 0;
-    kernel_id = valid_kernels[index];
-}
-
-template <typename DataType>
-bool PerformanceConfigConvCKIgemmGrpFwdActivFused::CheckIsSupportCKArgs(
-    const miopen::conv::ProblemDescription& problem) const
-{
-    bool supported = false;
-    if(problem.Is3d())
-    {
-        using Layouts = decltype(Get3DLayouts());
-        supported     = IsCKArgsSupported<DeviceOpGFwdActPtrs<3,
-                                                              DataType,
-                                                              Layouts::InLayout,
-                                                              Layouts::WeiLayout,
-                                                              Layouts::OutLayout>,
-                                          CKArgs<3, DataType>>(problem, kernel_id);
-    }
-    else
-    {
-        using Layouts = decltype(Get2DLayouts());
-        supported     = IsCKArgsSupported<DeviceOpGFwdActPtrs<2,
-                                                              DataType,
-                                                              Layouts::InLayout,
-                                                              Layouts::WeiLayout,
-                                                              Layouts::OutLayout>,
-                                          CKArgs<2, DataType>>(problem, kernel_id);
-    }
-    return supported;
-}
-
-template <typename DataType>
-bool ConvCKIgemmGrpFwdActivFused::CheckCKApplicability(
-    const miopen::conv::ProblemDescription& problem) const
-{
-    bool applicable = false;
-    if(problem.Is3d())
-    {
-        using Layouts = decltype(Get3DLayouts());
-        applicable    = IsCKApplicable<DeviceOpGFwdActPtrs<3,
-                                                           DataType,
-                                                           Layouts::InLayout,
-                                                           Layouts::WeiLayout,
-                                                           Layouts::OutLayout>,
-                                       CKArgs<3, DataType>>(problem);
-    }
-    else
-    {
-        using Layouts = decltype(Get2DLayouts());
-        applicable    = IsCKApplicable<DeviceOpGFwdActPtrs<2,
-                                                           DataType,
-                                                           Layouts::InLayout,
-                                                           Layouts::WeiLayout,
-                                                           Layouts::OutLayout>,
-                                       CKArgs<2, DataType>>(problem);
-    }
-    return applicable;
-}
-
-#endif
-
 void PerformanceConfigConvCKIgemmGrpFwdActivFused::HeuristicInit(
     const FusionDescription& fdesc_problem)
 {
-#if !MIOPEN_BACKEND_HIP || !MIOPEN_USE_COMPOSABLEKERNEL
-    std::ignore = fdesc_problem;
-#else
-    const auto conv_problem = fdesc_problem.GetConvProblem(0, miopen::conv::Direction::Forward);
-    switch(conv_problem.GetInDataType())
-    {
-    case miopenBFloat16: Init<ck::bhalf_t>(conv_problem); break;
-    case miopenHalf: Init<ck::half_t>(conv_problem); break;
-    case miopenFloat: Init<float>(conv_problem); break;
-    case miopenFloat8_fnuz:
-    case miopenBFloat8_fnuz:
-    case miopenInt8:
-    case miopenInt32:
-    case miopenInt64:
-    case miopenDouble:
-    default: MIOPEN_THROW("Unsupported datatype");
-    }
+    const auto& loader = CKGroupedConvLibLoader::Get(GetCurrentDeviceName());
+    if(!loader.IsLoaded())
+        return;
 
-#endif
+    const auto conv_problem = fdesc_problem.GetConvProblem(0, miopen::conv::Direction::Forward);
+    const auto data_type    = conv_problem.GetInDataType();
+
+    valid_kernels = loader.FillValidKernels(
+        CKSolverType::FusedGrpActiv, conv_problem, data_type, false);
+
+    if(!valid_kernels.empty())
+    {
+        index     = 0;
+        kernel_id = valid_kernels[0];
+    }
 }
 
 bool PerformanceConfigConvCKIgemmGrpFwdActivFused::SetNextValue(
     const FusionDescription& fdesc_problem)
 {
-#if MIOPEN_USE_COMPOSABLEKERNEL
     if(valid_kernels.empty())
     {
-        const auto conv_problem = fdesc_problem.GetConvProblem(0, miopen::conv::Direction::Forward);
-        switch(conv_problem.GetInDataType())
-        {
-        case miopenBFloat16: Init<ck::bhalf_t>(conv_problem); break;
-        case miopenHalf: Init<ck::half_t>(conv_problem); break;
-        case miopenFloat: Init<float>(conv_problem); break;
-        case miopenInt8:
-        case miopenInt64:
-        case miopenInt32:
-        case miopenFloat8_fnuz:
-        case miopenBFloat8_fnuz:
-        case miopenDouble: break;
-        }
-        assert(!valid_kernels.empty());
+        this->HeuristicInit(fdesc_problem);
+        if(valid_kernels.empty())
+            return false;
         return true;
     }
     if((index + 1) < valid_kernels.size())
@@ -514,7 +78,6 @@ bool PerformanceConfigConvCKIgemmGrpFwdActivFused::SetNextValue(
         return true;
     }
     else
-#endif
         return false;
 }
 
@@ -526,22 +89,14 @@ bool PerformanceConfigConvCKIgemmGrpFwdActivFused::IsValidValue() const
 bool PerformanceConfigConvCKIgemmGrpFwdActivFused::IsValid(
     const FusionContext&, const FusionDescription& fdesc_problem) const
 {
-#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
+    const auto& loader = CKGroupedConvLibLoader::Get(GetCurrentDeviceName());
+    if(!loader.IsLoaded())
+        return false;
+
     const auto conv_problem = fdesc_problem.GetConvProblem(0, miopen::conv::Direction::Forward);
-    switch(conv_problem.GetInDataType())
-    {
-    case miopenBFloat16: return CheckIsSupportCKArgs<ck::bhalf_t>(conv_problem);
-    case miopenHalf: return CheckIsSupportCKArgs<ck::half_t>(conv_problem);
-    case miopenFloat: return CheckIsSupportCKArgs<float>(conv_problem);
-    case miopenInt8:
-    case miopenInt64:
-    case miopenInt32:
-    case miopenFloat8_fnuz:
-    case miopenBFloat8_fnuz:
-    case miopenDouble: break;
-    }
-#endif
-    return false;
+    const auto data_type    = conv_problem.GetInDataType();
+    return loader.IsArgsSupported(
+        CKSolverType::FusedGrpActiv, conv_problem, kernel_id, data_type, false);
 }
 
 bool PerformanceConfigConvCKIgemmGrpFwdActivFused::operator==(
@@ -571,13 +126,8 @@ bool ConvCKIgemmGrpFwdActivFused::IsValidPerformanceConfig(
 size_t ConvCKIgemmGrpFwdActivFused::GetWorkspaceSize(const FusionContext&,
                                                      const FusionDescription& fdesc_problem) const
 {
-#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
     const auto conv_problem = fdesc_problem.GetConvProblem(0, miopen::conv::Direction::Forward);
     return GetWorkspaceSizeLayoutTransformConv(conv_problem);
-#else
-    std::ignore = fdesc_problem;
-    return 0;
-#endif
 }
 
 PerformanceConfigConvCKIgemmGrpFwdActivFused
@@ -591,11 +141,6 @@ ConvCKIgemmGrpFwdActivFused::Search(const FusionContext& ctx,
 bool ConvCKIgemmGrpFwdActivFused::IsApplicable(const FusionContext& ctx,
                                                const FusionDescription& fdesc_problem) const
 {
-#if !MIOPEN_BACKEND_HIP || !MIOPEN_USE_COMPOSABLEKERNEL
-    std::ignore = ctx;
-    std::ignore = fdesc_problem;
-    return false;
-#else
     const auto& desc = *fdesc_problem.fusion_plan_desc;
     if(desc.op_map.empty())
     {
@@ -634,100 +179,26 @@ bool ConvCKIgemmGrpFwdActivFused::IsApplicable(const FusionContext& ctx,
     if(!conv_problem.IsLayoutNHWC() && !conv_problem.IsLayoutDefault())
         return false;
 
-    switch(conv_problem.GetInDataType())
-    {
-    case miopenBFloat16: return CheckCKApplicability<ck::bhalf_t>(conv_problem);
-    case miopenHalf: return CheckCKApplicability<ck::half_t>(conv_problem);
-    case miopenFloat: return CheckCKApplicability<float>(conv_problem);
-    case miopenFloat8_fnuz:
-    case miopenBFloat8_fnuz:
-    case miopenInt8:
-    case miopenInt32:
-    case miopenInt64:
-    case miopenDouble:
-    default: MIOPEN_THROW("Unsupported datatype");
-    }
-    return false;
-#endif
-}
+    const auto& loader = CKGroupedConvLibLoader::Get(ctx.GetStream().GetDeviceName());
+    if(!loader.IsLoaded())
+        return false;
 
-#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
-template <ck::index_t NDimSpatial, typename DataType>
-ConvSolution
-GetSolutionForDimensionality(const FusionContext& ctx,
-                             const miopen::conv::ProblemDescription& conv_problem,
-                             const PerformanceConfigConvCKIgemmGrpFwdActivFused& config)
-{
-    using Layouts = LayoutsSelector<NDimSpatial>;
-    return MakeSolutionGroupConvImplicitGemmXdlops(
-        conv_problem,
-        [&](auto data_type_val, [[maybe_unused]] auto compute_type_val) {
-            (void)data_type_val;
-            return InitInvokerFactoryFwdNCHW<NDimSpatial,
-                                             false,
-                                             DeviceOpGFwdActPtrs<NDimSpatial,
-                                                                 DataType,
-                                                                 typename Layouts::InLayout,
-                                                                 typename Layouts::WeiLayout,
-                                                                 typename Layouts::OutLayout>,
-                                             CKArgs<NDimSpatial, DataType>,
-                                             miopen::fusion::FusionInvokeParams>(
-                ctx, conv_problem, config.kernel_id);
-        },
-        [&](auto data_type_val, [[maybe_unused]] auto compute_type_val) {
-            (void)data_type_val;
-            return InitInvokerFactoryNHWC<false,
-                                          DeviceOpGFwdActPtrs<NDimSpatial,
-                                                              DataType,
-                                                              typename Layouts::InLayout,
-                                                              typename Layouts::WeiLayout,
-                                                              typename Layouts::OutLayout>,
-                                          CKArgs<NDimSpatial, DataType>,
-                                          miopen::fusion::FusionInvokeParams>(
-                ctx, conv_problem, config.kernel_id);
-        });
+    return loader.IsApplicable(
+        CKSolverType::FusedGrpActiv, conv_problem, conv_problem.GetInDataType(), false);
 }
-
-template <ck::index_t NDim>
-ConvSolution GetSolutionWithDim(const FusionContext& ctx,
-                                const FusionDescription& fdesc_problem,
-                                const PerformanceConfigConvCKIgemmGrpFwdActivFused& config)
-{
-    const auto conv_problem = fdesc_problem.GetConvProblem(0, miopen::conv::Direction::Forward);
-
-    switch(conv_problem.GetInDataType())
-    {
-    case miopenBFloat16:
-        return GetSolutionForDimensionality<NDim, ck::bhalf_t>(ctx, conv_problem, config);
-    case miopenHalf:
-        return GetSolutionForDimensionality<NDim, ck::half_t>(ctx, conv_problem, config);
-    case miopenFloat: return GetSolutionForDimensionality<NDim, float>(ctx, conv_problem, config);
-    case miopenInt8:
-    case miopenInt64:
-    case miopenInt32:
-    case miopenFloat8_fnuz:
-    case miopenBFloat8_fnuz:
-    case miopenDouble:
-    default: MIOPEN_THROW("Unsupported datatype");
-    }
-}
-#endif
 
 ConvSolution ConvCKIgemmGrpFwdActivFused::GetSolution(
     const FusionContext& ctx,
     const FusionDescription& fdesc_problem,
     const PerformanceConfigConvCKIgemmGrpFwdActivFused& config) const
 {
-#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
-    const auto conv_problem = fdesc_problem.GetConvProblem(0, miopen::conv::Direction::Forward);
+    const auto& loader = CKGroupedConvLibLoader::Get(ctx.GetStream().GetDeviceName());
+    if(!loader.IsLoaded())
+        return {};
 
-    if(conv_problem.Is3d())
-        return GetSolutionWithDim<3>(ctx, fdesc_problem, config);
-    else
-        return GetSolutionWithDim<2>(ctx, fdesc_problem, config);
-#else
-    return {};
-#endif
+    const auto conv_problem = fdesc_problem.GetConvProblem(0, miopen::conv::Direction::Forward);
+    return loader.GetSolution(
+        CKSolverType::FusedGrpActiv, ctx, conv_problem, config.kernel_id, false);
 }
 
 } // namespace fusion

--- a/projects/miopen/src/solver/conv_ck_igemm_grp_fwd_activ_fused.cpp
+++ b/projects/miopen/src/solver/conv_ck_igemm_grp_fwd_activ_fused.cpp
@@ -51,8 +51,8 @@ void PerformanceConfigConvCKIgemmGrpFwdActivFused::HeuristicInit(
     const auto conv_problem = fdesc_problem.GetConvProblem(0, miopen::conv::Direction::Forward);
     const auto data_type    = conv_problem.GetInDataType();
 
-    valid_kernels = loader.FillValidKernels(
-        CKSolverType::FusedGrpActiv, conv_problem, data_type, false);
+    valid_kernels =
+        loader.FillValidKernels(CKSolverType::FusedGrpActiv, conv_problem, data_type, false);
 
     if(!valid_kernels.empty())
     {

--- a/projects/miopen/src/solver/conv_ck_igemm_grp_fwd_bias_activ_fused.cpp
+++ b/projects/miopen/src/solver/conv_ck_igemm_grp_fwd_bias_activ_fused.cpp
@@ -28,493 +28,47 @@
 #include <vector>
 #include <cstdint>
 
-#include <miopen/check_numerics.hpp>
 #include <miopen/env.hpp>
 #include <miopen/fusion/solvers.hpp>
 #include <miopen/generic_search.hpp>
 #include <miopen/conv/data_invoke_params.hpp>
-#include <miopen/solver/problem_description_interpreter.hpp>
-
-#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
 #include <miopen/solver/ck_utility_common.hpp>
 #include <miopen/solver/implicitgemm_ck_util.hpp>
-#include "ck/library/tensor_operation_instance/gpu/grouped_convolution_forward_bias_clamp.hpp"
-#endif
+#include <miopen/solver/ck_grouped_conv_lib_loader.hpp>
 
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_CONV_CK_IGEMM_GRP_FWD_BIAS_ACTIV)
 namespace miopen {
 namespace solver {
 namespace fusion {
 
-#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
-
-using InElementOp  = ck::tensor_operation::element_wise::PassThrough;
-using WeiElementOp = ck::tensor_operation::element_wise::PassThrough;
-using OutElementOp = ck::tensor_operation::element_wise::AddClamp;
-
-template <ck::index_t NDimSpatial>
-struct LayoutsSelector;
-
-template <>
-struct LayoutsSelector<2>
-{
-    using InLayout  = ck::tensor_layout::convolution::NHWGC;
-    using WeiLayout = ck::tensor_layout::convolution::GKYXC;
-    using OutLayout = ck::tensor_layout::convolution::NHWGK;
-};
-
-template <>
-struct LayoutsSelector<3>
-{
-    using InLayout  = ck::tensor_layout::convolution::NDHWGC;
-    using WeiLayout = ck::tensor_layout::convolution::GKZYXC;
-    using OutLayout = ck::tensor_layout::convolution::NDHWGK;
-};
-
-const auto in_element_op  = InElementOp{};
-const auto wei_element_op = WeiElementOp{};
-
-inline auto Get2DLayouts()
-{
-    struct Layouts
-    {
-        using InLayout  = ck::tensor_layout::convolution::NHWGC;
-        using WeiLayout = ck::tensor_layout::convolution::GKYXC;
-        using OutLayout = ck::tensor_layout::convolution::NHWGK;
-    };
-    return Layouts{};
-}
-
-inline auto Get3DLayouts()
-{
-    struct Layouts
-    {
-        using InLayout  = ck::tensor_layout::convolution::NDHWGC;
-        using WeiLayout = ck::tensor_layout::convolution::GKZYXC;
-        using OutLayout = ck::tensor_layout::convolution::NDHWGK;
-    };
-    return Layouts{};
-}
-
-template <ck::index_t NumDimSpatial,
-          typename InDataType,
-          typename WeiDataType,
-          typename OutDataType,
-          typename AComputeType = InDataType,
-          typename BComputeType = AComputeType,
-          typename InLayout     = ck::tensor_layout::convolution::NHWGC,
-          typename WeiLayout    = ck::tensor_layout::convolution::GKYXC,
-          typename OutLayout    = ck::tensor_layout::convolution::NHWGK>
-using DeviceOpGFwdBiasActiv =
-    ck::tensor_operation::device::DeviceGroupedConvFwdMultipleABD<NumDimSpatial,
-                                                                  InLayout,
-                                                                  WeiLayout,
-                                                                  ck::Tuple<OutLayout>,
-                                                                  OutLayout,
-                                                                  InDataType,
-                                                                  WeiDataType,
-                                                                  ck::Tuple<OutDataType>,
-                                                                  OutDataType,
-                                                                  InElementOp,
-                                                                  WeiElementOp,
-                                                                  OutElementOp,
-                                                                  AComputeType,
-                                                                  BComputeType>;
-
-template <ck::index_t NumDimSpatial,
-          typename DataType,
-          typename InLayout,
-          typename WeiLayout,
-          typename OutLayout>
-using DeviceOpGFwdBiasActivPtrs =
-    ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
-        DeviceOpGFwdBiasActiv<NumDimSpatial,
-                              DataType,
-                              DataType,
-                              DataType,
-                              DataType,
-                              DataType,
-                              InLayout,
-                              WeiLayout,
-                              OutLayout>>;
-namespace {
-
-template <int NDimSpatial, typename DataType>
-struct CKArgs
-{
-    using OutputElementOpType = OutElementOp;
-    using OutputDataType      = DataType;
-
-    CKArgs(const miopen::conv::ProblemDescription& problem)
-    {
-        G  = ProblemInterpreter::GetGroupCountG(problem);
-        N  = ProblemInterpreter::GetBatchN(problem);
-        K1 = ProblemInterpreter::GetOutputChannelK(problem);
-        C1 = ProblemInterpreter::GetInputChannelC(problem);
-        C  = C1 / G; // Number of input Channel per group
-        K  = K1 / G; // Number of output Channel per group
-
-        if(problem.Is3d())
-        {
-            Di = ProblemInterpreter::GetInputDepthDi(problem);
-            Do = ProblemInterpreter::GetOutputDepthDo(problem);
-            Z  = ProblemInterpreter::GetFilterDepthZ(problem);
-            Hi = ProblemInterpreter::GetInputHeightHi(problem);
-            Wi = ProblemInterpreter::GetInputWidthWi(problem);
-            Ho = ProblemInterpreter::GetOutputHeightHo(problem);
-            Wo = ProblemInterpreter::GetOutputWidthWo(problem);
-            Y  = ProblemInterpreter::GetFilterHeightY(problem);
-            X  = ProblemInterpreter::GetFilterWidthX(problem);
-
-            in_lens  = {G, N, C, Di, Hi, Wi};
-            out_lens = {G, N, K, Do, Ho, Wo};
-            wei_lens = {G, K, C, Z, Y, X};
-
-            in_strides  = {C, Di * Hi * Wi * G * C, 1, Hi * Wi * G * C, Wi * G * C, G * C};
-            out_strides = {K, Do * Ho * Wo * G * K, 1, Ho * Wo * G * K, Wo * G * K, G * K};
-            wei_strides = {K * Z * Y * X * C, Z * Y * X * C, 1, Y * X * C, X * C, C};
-
-            bias_strides = {K, 0, 1, 0, 0, 0};
-
-            filter_stride   = {ProblemInterpreter::GetAdjustedConvolutionStrideD(problem),
-                               ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
-                               ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
-            filter_dilation = {ProblemInterpreter::GetAdjustedConvolutionDilationD(problem),
-                               ProblemInterpreter::GetAdjustedConvolutionDilationH(problem),
-                               ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
-            lPadding        = {ProblemInterpreter::GetInputLeftPadD(problem),
-                               ProblemInterpreter::GetInputLeftPadH(problem),
-                               ProblemInterpreter::GetInputLeftPadW(problem)};
-            rPadding        = {ProblemInterpreter::GetAdjustedInputRightPadD(problem),
-                               ProblemInterpreter::GetAdjustedInputRightPadH(problem),
-                               ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
-        }
-        else
-        {
-            Hi = ProblemInterpreter::GetInputHeightHi(problem);
-            Wi = ProblemInterpreter::GetInputWidthWi(problem);
-            Ho = ProblemInterpreter::GetOutputHeightHo(problem);
-            Wo = ProblemInterpreter::GetOutputWidthWo(problem);
-            Y  = ProblemInterpreter::GetFilterHeightY(problem);
-            X  = ProblemInterpreter::GetFilterWidthX(problem);
-
-            in_lens  = {G, N, C, Hi, Wi};
-            out_lens = {G, N, K, Ho, Wo};
-            wei_lens = {G, K, C, Y, X};
-
-            in_strides  = {C, Hi * Wi * G * C, 1, Wi * G * C, G * C};
-            out_strides = {K, Ho * Wo * G * K, 1, Wo * G * K, G * K};
-            wei_strides = {K * Y * X * C, Y * X * C, 1, X * C, C};
-
-            bias_strides = {K, 0, 1, 0, 0};
-
-            filter_stride   = {ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
-                               ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
-            filter_dilation = {ProblemInterpreter::GetAdjustedConvolutionDilationH(problem),
-                               ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
-            lPadding        = {ProblemInterpreter::GetInputLeftPadH(problem),
-                               ProblemInterpreter::GetInputLeftPadW(problem)};
-            rPadding        = {ProblemInterpreter::GetAdjustedInputRightPadH(problem),
-                               ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
-        }
-    }
-
-    CKArgs(const CKArgs&)            = default;
-    CKArgs(CKArgs&&)                 = default;
-    CKArgs& operator=(const CKArgs&) = default;
-
-    template <typename ConvPtr>
-    auto MakeArgPtr(const ConvPtr& conv_ptr,
-                    ConstData_t in_buf,
-                    ConstData_t w_buf,
-                    ConstData_t bias_buf,
-                    Data_t out_buf,
-                    float alpha,
-                    float beta,
-                    OutElementOp clampOp) const
-    {
-        (void)alpha;
-        (void)beta;
-        constexpr bool is3DConv = (NDimSpatial == 3);
-
-        if constexpr(is3DConv)
-        {
-            return conv_ptr->MakeArgumentPointer(
-                in_buf,
-                w_buf,
-                {bias_buf},
-                out_buf,
-                in_lens,
-                in_strides,
-                wei_lens,
-                wei_strides,
-                {out_lens}, // hack CK's is applicable check. instead of bias_len we use output_len
-                {bias_strides},
-                out_lens,
-                out_strides,
-                filter_stride,
-                filter_dilation,
-                lPadding,
-                rPadding,
-                in_element_op,
-                wei_element_op,
-                clampOp);
-        }
-        else
-        {
-
-            std::array<ck::index_t, 5> adjusted_in_lens{};
-            std::array<ck::index_t, 5> adjusted_out_lens{};
-            std::array<ck::index_t, 5> adjusted_wei_lens{};
-
-            std::copy(in_lens.begin(), in_lens.begin() + 5, adjusted_in_lens.begin());
-            std::copy(out_lens.begin(), out_lens.begin() + 5, adjusted_out_lens.begin());
-            std::copy(wei_lens.begin(), wei_lens.begin() + 5, adjusted_wei_lens.begin());
-
-            std::array<ck::index_t, 5> adjusted_in_strides{};
-            std::array<ck::index_t, 5> adjusted_out_strides{};
-            std::array<ck::index_t, 5> adjusted_wei_strides{};
-            std::array<ck::index_t, 5> adjusted_bias_strides{K, 0, 1, 0, 0};
-            std::copy(in_strides.begin(), in_strides.begin() + 5, adjusted_in_strides.begin());
-            std::copy(out_strides.begin(), out_strides.begin() + 5, adjusted_out_strides.begin());
-            std::copy(wei_strides.begin(), wei_strides.begin() + 5, adjusted_wei_strides.begin());
-
-            std::array<ck::index_t, 2> adjusted_filter_stride{};
-            std::array<ck::index_t, 2> adjusted_filter_dilation{};
-            std::array<ck::index_t, 2> adjusted_lPadding{};
-            std::array<ck::index_t, 2> adjusted_rPadding{};
-
-            std::copy(
-                filter_stride.begin(), filter_stride.begin() + 2, adjusted_filter_stride.begin());
-            std::copy(filter_dilation.begin(),
-                      filter_dilation.begin() + 2,
-                      adjusted_filter_dilation.begin());
-            std::copy(lPadding.begin(), lPadding.begin() + 2, adjusted_lPadding.begin());
-            std::copy(rPadding.begin(), rPadding.begin() + 2, adjusted_rPadding.begin());
-
-            return conv_ptr->MakeArgumentPointer(
-                in_buf,
-                w_buf,
-                {bias_buf},
-                out_buf,
-                adjusted_in_lens,
-                adjusted_in_strides,
-                adjusted_wei_lens,
-                adjusted_wei_strides,
-                {adjusted_out_lens}, // hack CK's is applicable check. instead of bias_len we use
-                                     // output_len
-                {adjusted_bias_strides},
-                adjusted_out_lens,
-                adjusted_out_strides,
-                adjusted_filter_stride,
-                adjusted_filter_dilation,
-                adjusted_lPadding,
-                adjusted_rPadding,
-                in_element_op,
-                wei_element_op,
-                clampOp);
-        }
-    }
-
-    template <typename DevOpPtr>
-    auto MakeArgPtr(const DevOpPtr& op_ptr,
-                    const miopen::fusion::FusionInvokeParams& data_ctx) const
-    {
-        const auto& conv_param =
-            dynamic_cast<miopen::fusion::ConvolutionOpInvokeParam&>(*data_ctx.op_args.params[0]);
-        assert(&conv_param);
-
-        const auto& bias_param =
-            dynamic_cast<miopen::fusion::BiasOpInvokeParam&>(*data_ctx.op_args.params[1]);
-        assert(&bias_param);
-
-        const auto& activ_param =
-            dynamic_cast<miopen::fusion::ActivationOpInvokeParam&>(*data_ctx.op_args.params[2]);
-
-        return MakeArgPtr(op_ptr,
-                          data_ctx.in,
-                          conv_param.weights,
-                          bias_param.bdata,
-                          data_ctx.out,
-                          conv_param.alpha,
-                          conv_param.beta,
-                          GetOutElementOp<DataType, OutElementOp>(activ_param));
-    }
-
-    template <typename ConvPtr>
-    bool IsSupportedBy(const ConvPtr& conv_ptr) const
-    {
-        auto arg_ptr = MakeArgPtr(conv_ptr,
-                                  nullptr,
-                                  nullptr,
-                                  nullptr,
-                                  nullptr,
-                                  1.0f,
-                                  0.0f,
-                                  OutElementOp{0, std::numeric_limits<DataType>::max()});
-        return conv_ptr->IsSupportedArgument(arg_ptr.get());
-    }
-
-    int G;
-    int N;
-    int K1;
-    int C1;
-    int K;
-    int C;
-    int Hi;
-    int Wi;
-    int Ho;
-    int Wo;
-    int Y;
-    int X;
-    int Di = 0; // Depth for 3D
-    int Do = 0; // Depth for 3D
-    int Z  = 0; // Filter depth for 3D
-    std::array<ck::index_t, 6> in_lens;
-    std::array<ck::index_t, 6> in_strides;
-    std::array<ck::index_t, 6> out_lens;
-    std::array<ck::index_t, 6> out_strides;
-    std::array<ck::index_t, 6> wei_lens;
-    std::array<ck::index_t, 6> wei_strides;
-    std::array<ck::index_t, 6> bias_strides;
-    std::array<ck::index_t, 3> filter_stride;
-    std::array<ck::index_t, 3> filter_dilation;
-    std::array<ck::index_t, 3> lPadding;
-    std::array<ck::index_t, 3> rPadding;
-};
-} // namespace
-
-template <typename DataType>
-void PerformanceConfigConvCKIgemmGrpFwdBiasActivFused::Init(
-    const miopen::conv::ProblemDescription& problem)
-{
-    if(valid_kernels.empty())
-    {
-        if(problem.Is3d())
-        {
-            using Layouts = decltype(Get3DLayouts());
-            valid_kernels =
-                FillValidKernelsIDs<DeviceOpGFwdBiasActivPtrs<3,
-                                                              DataType,
-                                                              typename Layouts::InLayout,
-                                                              typename Layouts::WeiLayout,
-                                                              typename Layouts::OutLayout>,
-                                    CKArgs<3, DataType>>(problem);
-        }
-        else
-        {
-            using Layouts = decltype(Get2DLayouts());
-            valid_kernels =
-                FillValidKernelsIDs<DeviceOpGFwdBiasActivPtrs<2,
-                                                              DataType,
-                                                              typename Layouts::InLayout,
-                                                              typename Layouts::WeiLayout,
-                                                              typename Layouts::OutLayout>,
-                                    CKArgs<2, DataType>>(problem);
-        }
-    }
-    index     = 0;
-    kernel_id = valid_kernels[index];
-}
-
-template <typename DataType>
-bool PerformanceConfigConvCKIgemmGrpFwdBiasActivFused::CheckIsSupportCKArgs(
-    const miopen::conv::ProblemDescription& problem) const
-{
-    if(problem.Is3d())
-    {
-        using Layouts = decltype(Get3DLayouts());
-        return IsCKArgsSupported<DeviceOpGFwdBiasActivPtrs<3,
-                                                           DataType,
-                                                           typename Layouts::InLayout,
-                                                           typename Layouts::WeiLayout,
-                                                           typename Layouts::OutLayout>,
-                                 CKArgs<3, DataType>>(problem, kernel_id);
-    }
-    else
-    {
-        using Layouts = decltype(Get2DLayouts());
-        return IsCKArgsSupported<DeviceOpGFwdBiasActivPtrs<2,
-                                                           DataType,
-                                                           typename Layouts::InLayout,
-                                                           typename Layouts::WeiLayout,
-                                                           typename Layouts::OutLayout>,
-                                 CKArgs<2, DataType>>(problem, kernel_id);
-    }
-}
-
-template <typename DataType>
-bool ConvCKIgemmGrpFwdBiasActivFused::CheckCKApplicability(
-    const miopen::conv::ProblemDescription& problem) const
-{
-    if(problem.Is3d())
-    {
-        using Layouts = decltype(Get3DLayouts());
-        return IsCKApplicable<DeviceOpGFwdBiasActivPtrs<3,
-                                                        DataType,
-                                                        typename Layouts::InLayout,
-                                                        typename Layouts::WeiLayout,
-                                                        typename Layouts::OutLayout>,
-                              CKArgs<3, DataType>>(problem);
-    }
-    else
-    {
-        using Layouts = decltype(Get2DLayouts());
-        return IsCKApplicable<DeviceOpGFwdBiasActivPtrs<2,
-                                                        DataType,
-                                                        typename Layouts::InLayout,
-                                                        typename Layouts::WeiLayout,
-                                                        typename Layouts::OutLayout>,
-                              CKArgs<2, DataType>>(problem);
-    }
-}
-
-#endif
-
 void PerformanceConfigConvCKIgemmGrpFwdBiasActivFused::HeuristicInit(
     const FusionDescription& fdesc_problem)
 {
-#if !MIOPEN_BACKEND_HIP || !MIOPEN_USE_COMPOSABLEKERNEL
-    std::ignore = fdesc_problem;
-#else
-    const auto conv_problem = fdesc_problem.GetConvProblem(0, miopen::conv::Direction::Forward);
-    switch(conv_problem.GetInDataType())
-    {
-    case miopenBFloat16: Init<ck::bhalf_t>(conv_problem); break;
-    case miopenHalf: Init<ck::half_t>(conv_problem); break;
-    case miopenFloat: Init<float>(conv_problem); break;
-    case miopenFloat8_fnuz:
-    case miopenBFloat8_fnuz:
-    case miopenInt8:
-    case miopenInt32:
-    case miopenInt64:
-    case miopenDouble:
-    default: MIOPEN_THROW("Unsupported datatype");
-    }
+    const auto& loader = CKGroupedConvLibLoader::Get(GetCurrentDeviceName());
+    if(!loader.IsLoaded())
+        return;
 
-#endif
+    const auto conv_problem = fdesc_problem.GetConvProblem(0, miopen::conv::Direction::Forward);
+    const auto data_type    = conv_problem.GetInDataType();
+
+    valid_kernels = loader.FillValidKernels(
+        CKSolverType::FusedGrpBiasActiv, conv_problem, data_type, false);
+
+    if(!valid_kernels.empty())
+    {
+        index     = 0;
+        kernel_id = valid_kernels[0];
+    }
 }
 
 bool PerformanceConfigConvCKIgemmGrpFwdBiasActivFused::SetNextValue(
     const FusionDescription& fdesc_problem)
 {
-#if MIOPEN_USE_COMPOSABLEKERNEL
     if(valid_kernels.empty())
     {
-        const auto conv_problem = fdesc_problem.GetConvProblem(0, miopen::conv::Direction::Forward);
-        switch(conv_problem.GetInDataType())
-        {
-        case miopenBFloat16: Init<ck::bhalf_t>(conv_problem); break;
-        case miopenHalf: Init<ck::half_t>(conv_problem); break;
-        case miopenFloat: Init<float>(conv_problem); break;
-        case miopenInt8:
-        case miopenInt64:
-        case miopenInt32:
-        case miopenFloat8_fnuz:
-        case miopenBFloat8_fnuz:
-        case miopenDouble: break;
-        }
-        assert(!valid_kernels.empty());
+        this->HeuristicInit(fdesc_problem);
+        if(valid_kernels.empty())
+            return false;
         return true;
     }
     if((index + 1) < valid_kernels.size())
@@ -524,7 +78,6 @@ bool PerformanceConfigConvCKIgemmGrpFwdBiasActivFused::SetNextValue(
         return true;
     }
     else
-#endif
         return false;
 }
 
@@ -536,22 +89,14 @@ bool PerformanceConfigConvCKIgemmGrpFwdBiasActivFused::IsValidValue() const
 bool PerformanceConfigConvCKIgemmGrpFwdBiasActivFused::IsValid(
     const FusionContext&, const FusionDescription& fdesc_problem) const
 {
-#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
+    const auto& loader = CKGroupedConvLibLoader::Get(GetCurrentDeviceName());
+    if(!loader.IsLoaded())
+        return false;
+
     const auto conv_problem = fdesc_problem.GetConvProblem(0, miopen::conv::Direction::Forward);
-    switch(conv_problem.GetInDataType())
-    {
-    case miopenBFloat16: return CheckIsSupportCKArgs<ck::bhalf_t>(conv_problem);
-    case miopenHalf: return CheckIsSupportCKArgs<ck::half_t>(conv_problem);
-    case miopenFloat: return CheckIsSupportCKArgs<float>(conv_problem);
-    case miopenInt8:
-    case miopenInt64:
-    case miopenInt32:
-    case miopenFloat8_fnuz:
-    case miopenBFloat8_fnuz:
-    case miopenDouble: break;
-    }
-#endif
-    return false;
+    const auto data_type    = conv_problem.GetInDataType();
+    return loader.IsArgsSupported(
+        CKSolverType::FusedGrpBiasActiv, conv_problem, kernel_id, data_type, false);
 }
 
 bool PerformanceConfigConvCKIgemmGrpFwdBiasActivFused::operator==(
@@ -582,13 +127,8 @@ size_t
 ConvCKIgemmGrpFwdBiasActivFused::GetWorkspaceSize(const FusionContext&,
                                                   const FusionDescription& fdesc_problem) const
 {
-#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
     const auto conv_problem = fdesc_problem.GetConvProblem(0, miopen::conv::Direction::Forward);
     return GetWorkspaceSizeLayoutTransformConv(conv_problem);
-#else
-    std::ignore = fdesc_problem;
-    return 0;
-#endif
 }
 
 PerformanceConfigConvCKIgemmGrpFwdBiasActivFused
@@ -602,11 +142,6 @@ ConvCKIgemmGrpFwdBiasActivFused::Search(const FusionContext& ctx,
 bool ConvCKIgemmGrpFwdBiasActivFused::IsApplicable(const FusionContext& ctx,
                                                    const FusionDescription& fdesc_problem) const
 {
-#if !MIOPEN_BACKEND_HIP || !MIOPEN_USE_COMPOSABLEKERNEL
-    std::ignore = ctx;
-    std::ignore = fdesc_problem;
-    return false;
-#else
     const auto& desc = *fdesc_problem.fusion_plan_desc;
     if(desc.op_map.empty())
     {
@@ -647,100 +182,26 @@ bool ConvCKIgemmGrpFwdBiasActivFused::IsApplicable(const FusionContext& ctx,
     if(!conv_problem.IsLayoutNHWC() && !conv_problem.IsLayoutDefault())
         return false;
 
-    switch(conv_problem.GetInDataType())
-    {
-    case miopenBFloat16: return CheckCKApplicability<ck::bhalf_t>(conv_problem);
-    case miopenHalf: return CheckCKApplicability<ck::half_t>(conv_problem);
-    case miopenFloat: return CheckCKApplicability<float>(conv_problem);
-    case miopenFloat8_fnuz:
-    case miopenBFloat8_fnuz:
-    case miopenInt8:
-    case miopenInt32:
-    case miopenInt64:
-    case miopenDouble:
-    default: MIOPEN_THROW("Unsupported datatype");
-    }
-    return false;
-#endif
-}
+    const auto& loader = CKGroupedConvLibLoader::Get(ctx.GetStream().GetDeviceName());
+    if(!loader.IsLoaded())
+        return false;
 
-#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
-template <ck::index_t NDimSpatial, typename DataType>
-ConvSolution
-GetSolutionForDimensionality(const FusionContext& ctx,
-                             const miopen::conv::ProblemDescription& conv_problem,
-                             const PerformanceConfigConvCKIgemmGrpFwdBiasActivFused& config)
-{
-    using Layouts = LayoutsSelector<NDimSpatial>;
-    return MakeSolutionGroupConvImplicitGemmXdlops(
-        conv_problem,
-        [&](auto data_type_val, [[maybe_unused]] auto compute_type_val) {
-            (void)data_type_val;
-            return InitInvokerFactoryFwdNCHW<NDimSpatial,
-                                             false,
-                                             DeviceOpGFwdBiasActivPtrs<NDimSpatial,
-                                                                       DataType,
-                                                                       typename Layouts::InLayout,
-                                                                       typename Layouts::WeiLayout,
-                                                                       typename Layouts::OutLayout>,
-                                             CKArgs<NDimSpatial, DataType>,
-                                             miopen::fusion::FusionInvokeParams>(
-                ctx, conv_problem, config.kernel_id);
-        },
-        [&](auto data_type_val, [[maybe_unused]] auto compute_type_val) {
-            (void)data_type_val;
-            return InitInvokerFactoryNHWC<false,
-                                          DeviceOpGFwdBiasActivPtrs<NDimSpatial,
-                                                                    DataType,
-                                                                    typename Layouts::InLayout,
-                                                                    typename Layouts::WeiLayout,
-                                                                    typename Layouts::OutLayout>,
-                                          CKArgs<NDimSpatial, DataType>,
-                                          miopen::fusion::FusionInvokeParams>(
-                ctx, conv_problem, config.kernel_id);
-        });
+    return loader.IsApplicable(
+        CKSolverType::FusedGrpBiasActiv, conv_problem, conv_problem.GetInDataType(), false);
 }
-
-template <ck::index_t NDim>
-ConvSolution GetSolutionWithDim(const FusionContext& ctx,
-                                const FusionDescription& fdesc_problem,
-                                const PerformanceConfigConvCKIgemmGrpFwdBiasActivFused& config)
-{
-    const auto conv_problem = fdesc_problem.GetConvProblem(0, miopen::conv::Direction::Forward);
-
-    switch(conv_problem.GetInDataType())
-    {
-    case miopenBFloat16:
-        return GetSolutionForDimensionality<NDim, ck::bhalf_t>(ctx, conv_problem, config);
-    case miopenHalf:
-        return GetSolutionForDimensionality<NDim, ck::half_t>(ctx, conv_problem, config);
-    case miopenFloat: return GetSolutionForDimensionality<NDim, float>(ctx, conv_problem, config);
-    case miopenInt8:
-    case miopenInt64:
-    case miopenInt32:
-    case miopenFloat8_fnuz:
-    case miopenBFloat8_fnuz:
-    case miopenDouble:
-    default: MIOPEN_THROW("Unsupported datatype");
-    }
-}
-#endif
 
 ConvSolution ConvCKIgemmGrpFwdBiasActivFused::GetSolution(
     const FusionContext& ctx,
     const FusionDescription& fdesc_problem,
     const PerformanceConfigConvCKIgemmGrpFwdBiasActivFused& config) const
 {
-#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
-    const auto conv_problem = fdesc_problem.GetConvProblem(0, miopen::conv::Direction::Forward);
+    const auto& loader = CKGroupedConvLibLoader::Get(ctx.GetStream().GetDeviceName());
+    if(!loader.IsLoaded())
+        return {};
 
-    if(conv_problem.Is3d())
-        return GetSolutionWithDim<3>(ctx, fdesc_problem, config);
-    else
-        return GetSolutionWithDim<2>(ctx, fdesc_problem, config);
-#else
-    return {};
-#endif
+    const auto conv_problem = fdesc_problem.GetConvProblem(0, miopen::conv::Direction::Forward);
+    return loader.GetSolution(
+        CKSolverType::FusedGrpBiasActiv, ctx, conv_problem, config.kernel_id, false);
 }
 
 } // namespace fusion

--- a/projects/miopen/src/solver/conv_ck_igemm_grp_fwd_bias_activ_fused.cpp
+++ b/projects/miopen/src/solver/conv_ck_igemm_grp_fwd_bias_activ_fused.cpp
@@ -51,8 +51,8 @@ void PerformanceConfigConvCKIgemmGrpFwdBiasActivFused::HeuristicInit(
     const auto conv_problem = fdesc_problem.GetConvProblem(0, miopen::conv::Direction::Forward);
     const auto data_type    = conv_problem.GetInDataType();
 
-    valid_kernels = loader.FillValidKernels(
-        CKSolverType::FusedGrpBiasActiv, conv_problem, data_type, false);
+    valid_kernels =
+        loader.FillValidKernels(CKSolverType::FusedGrpBiasActiv, conv_problem, data_type, false);
 
     if(!valid_kernels.empty())
     {

--- a/projects/miopen/test/gtest/unit_ck_grouped_conv_loader.cpp
+++ b/projects/miopen/test/gtest/unit_ck_grouped_conv_loader.cpp
@@ -367,6 +367,56 @@ TEST(CPU_CKGroupedConvLoader_NONE, LoaderReturnsEmptyOnFailure)
     EXPECT_EQ(loader.GetWorkspaceSize(CKSolverType::GrpConv3dWrw, problem, miopenHalf, false), 0u);
     EXPECT_EQ(loader.GetSolution(CKSolverType::GrpConv3dWrw, ctx, problem, "dummy", false).status,
               miopenStatusInternalError);
+
+    EXPECT_TRUE(
+        loader.FillValidKernels(CKSolverType::FusedBiasActiv, problem, miopenHalf, false).empty());
+    EXPECT_FALSE(loader.IsApplicable(CKSolverType::FusedBiasActiv, problem, miopenHalf, false));
+    EXPECT_FALSE(loader.IsArgsSupported(
+        CKSolverType::FusedBiasActiv, problem, "dummy_kernel", miopenHalf, false));
+    EXPECT_EQ(loader.GetWorkspaceSize(CKSolverType::FusedBiasActiv, problem, miopenHalf, false),
+              0u);
+    EXPECT_EQ(
+        loader.GetSolution(CKSolverType::FusedBiasActiv, ctx, problem, "dummy", false).status,
+        miopenStatusInternalError);
+
+    EXPECT_TRUE(
+        loader.FillValidKernels(CKSolverType::FusedBiasResAddActiv, problem, miopenHalf, false)
+            .empty());
+    EXPECT_FALSE(
+        loader.IsApplicable(CKSolverType::FusedBiasResAddActiv, problem, miopenHalf, false));
+    EXPECT_FALSE(loader.IsArgsSupported(
+        CKSolverType::FusedBiasResAddActiv, problem, "dummy_kernel", miopenHalf, false));
+    EXPECT_EQ(
+        loader.GetWorkspaceSize(CKSolverType::FusedBiasResAddActiv, problem, miopenHalf, false),
+        0u);
+    EXPECT_EQ(
+        loader.GetSolution(CKSolverType::FusedBiasResAddActiv, ctx, problem, "dummy", false)
+            .status,
+        miopenStatusInternalError);
+
+    EXPECT_TRUE(
+        loader.FillValidKernels(CKSolverType::FusedGrpActiv, problem, miopenHalf, false).empty());
+    EXPECT_FALSE(loader.IsApplicable(CKSolverType::FusedGrpActiv, problem, miopenHalf, false));
+    EXPECT_FALSE(loader.IsArgsSupported(
+        CKSolverType::FusedGrpActiv, problem, "dummy_kernel", miopenHalf, false));
+    EXPECT_EQ(loader.GetWorkspaceSize(CKSolverType::FusedGrpActiv, problem, miopenHalf, false),
+              0u);
+    EXPECT_EQ(
+        loader.GetSolution(CKSolverType::FusedGrpActiv, ctx, problem, "dummy", false).status,
+        miopenStatusInternalError);
+
+    EXPECT_TRUE(
+        loader.FillValidKernels(CKSolverType::FusedGrpBiasActiv, problem, miopenHalf, false)
+            .empty());
+    EXPECT_FALSE(
+        loader.IsApplicable(CKSolverType::FusedGrpBiasActiv, problem, miopenHalf, false));
+    EXPECT_FALSE(loader.IsArgsSupported(
+        CKSolverType::FusedGrpBiasActiv, problem, "dummy_kernel", miopenHalf, false));
+    EXPECT_EQ(
+        loader.GetWorkspaceSize(CKSolverType::FusedGrpBiasActiv, problem, miopenHalf, false), 0u);
+    EXPECT_EQ(
+        loader.GetSolution(CKSolverType::FusedGrpBiasActiv, ctx, problem, "dummy", false).status,
+        miopenStatusInternalError);
 }
 
 TEST(CPU_CKGroupedConvLoader_NONE, IsDeterministicSplitKValid)

--- a/projects/miopen/test/gtest/unit_ck_grouped_conv_loader.cpp
+++ b/projects/miopen/test/gtest/unit_ck_grouped_conv_loader.cpp
@@ -375,9 +375,8 @@ TEST(CPU_CKGroupedConvLoader_NONE, LoaderReturnsEmptyOnFailure)
         CKSolverType::FusedBiasActiv, problem, "dummy_kernel", miopenHalf, false));
     EXPECT_EQ(loader.GetWorkspaceSize(CKSolverType::FusedBiasActiv, problem, miopenHalf, false),
               0u);
-    EXPECT_EQ(
-        loader.GetSolution(CKSolverType::FusedBiasActiv, ctx, problem, "dummy", false).status,
-        miopenStatusInternalError);
+    EXPECT_EQ(loader.GetSolution(CKSolverType::FusedBiasActiv, ctx, problem, "dummy", false).status,
+              miopenStatusInternalError);
 
     EXPECT_TRUE(
         loader.FillValidKernels(CKSolverType::FusedBiasResAddActiv, problem, miopenHalf, false)
@@ -390,8 +389,7 @@ TEST(CPU_CKGroupedConvLoader_NONE, LoaderReturnsEmptyOnFailure)
         loader.GetWorkspaceSize(CKSolverType::FusedBiasResAddActiv, problem, miopenHalf, false),
         0u);
     EXPECT_EQ(
-        loader.GetSolution(CKSolverType::FusedBiasResAddActiv, ctx, problem, "dummy", false)
-            .status,
+        loader.GetSolution(CKSolverType::FusedBiasResAddActiv, ctx, problem, "dummy", false).status,
         miopenStatusInternalError);
 
     EXPECT_TRUE(
@@ -399,21 +397,17 @@ TEST(CPU_CKGroupedConvLoader_NONE, LoaderReturnsEmptyOnFailure)
     EXPECT_FALSE(loader.IsApplicable(CKSolverType::FusedGrpActiv, problem, miopenHalf, false));
     EXPECT_FALSE(loader.IsArgsSupported(
         CKSolverType::FusedGrpActiv, problem, "dummy_kernel", miopenHalf, false));
-    EXPECT_EQ(loader.GetWorkspaceSize(CKSolverType::FusedGrpActiv, problem, miopenHalf, false),
-              0u);
-    EXPECT_EQ(
-        loader.GetSolution(CKSolverType::FusedGrpActiv, ctx, problem, "dummy", false).status,
-        miopenStatusInternalError);
+    EXPECT_EQ(loader.GetWorkspaceSize(CKSolverType::FusedGrpActiv, problem, miopenHalf, false), 0u);
+    EXPECT_EQ(loader.GetSolution(CKSolverType::FusedGrpActiv, ctx, problem, "dummy", false).status,
+              miopenStatusInternalError);
 
-    EXPECT_TRUE(
-        loader.FillValidKernels(CKSolverType::FusedGrpBiasActiv, problem, miopenHalf, false)
-            .empty());
-    EXPECT_FALSE(
-        loader.IsApplicable(CKSolverType::FusedGrpBiasActiv, problem, miopenHalf, false));
+    EXPECT_TRUE(loader.FillValidKernels(CKSolverType::FusedGrpBiasActiv, problem, miopenHalf, false)
+                    .empty());
+    EXPECT_FALSE(loader.IsApplicable(CKSolverType::FusedGrpBiasActiv, problem, miopenHalf, false));
     EXPECT_FALSE(loader.IsArgsSupported(
         CKSolverType::FusedGrpBiasActiv, problem, "dummy_kernel", miopenHalf, false));
-    EXPECT_EQ(
-        loader.GetWorkspaceSize(CKSolverType::FusedGrpBiasActiv, problem, miopenHalf, false), 0u);
+    EXPECT_EQ(loader.GetWorkspaceSize(CKSolverType::FusedGrpBiasActiv, problem, miopenHalf, false),
+              0u);
     EXPECT_EQ(
         loader.GetSolution(CKSolverType::FusedGrpBiasActiv, ctx, problem, "dummy", false).status,
         miopenStatusInternalError);


### PR DESCRIPTION
## Summary

- Extends the dlopen infrastructure from PR #5720 to cover 4 remaining fused CK solvers: `ConvCKIgemmFwdBiasActivFused`, `ConvCKIgemmFwdBiasResAddActivFused`, `ConvCKIgemmGrpFwdActivFused`, `ConvCKIgemmGrpFwdBiasActivFused`
- Removes direct CK template linking from solver files, replacing with `CKGroupedConvLibLoader` delegation
- Adds 4 new `ck_impl` files implementing extern "C" interfaces for the shared library boundary
- Bumps `CK_GROUPED_CONV_API_VERSION` from 2 to 3
- Net change: +2142/-1803 lines across 13 files

## Changes

| Step | Files | Description |
|------|-------|-------------|
| Enum extension | `ck_grouped_conv_lib_loader.hpp` | Add `FusedBiasActiv`, `FusedBiasResAddActiv`, `FusedGrpActiv`, `FusedGrpBiasActiv` to `CKSolverType` |
| Interface declarations | `ck_grouped_conv_interface.hpp` | 20 new extern "C" function declarations (5 per solver) |
| ck_impl files | `src/ck_impl/ck_fused_*.cpp` (4 new) | Implement extern "C" wrappers around CK template instantiations |
| CMake | `src/ck_impl/CMakeLists.txt` | Add 4 new source files to `CK_IMPL_SOURCES` |
| Loader bindings | `ck_grouped_conv_lib_loader.cpp` | Wire 4 new entries in `solver_bindings[]` |
| Solver refactor | `conv_ck_igemm_*_fused.cpp` (4 files) | Replace CK template code with loader delegation |
| Unit tests | `unit_ck_grouped_conv_loader.cpp` | Add assertions for all 4 new solver types |

## Test plan

- [x] Build: 676/676 targets compiled
- [x] Unit tests: `test_unit_ck_grouped_conv_loader` — 10/10 PASSED
- [x] Integration: `test_cba_infer` (CK filter) — 287 PASSED (Solvers 1 & 4)
- [x] Integration: `test_conv_activ_infer` — 264 PASSED (Solver 3)
- [x] Integration: `test_fused_conv_bias_res_add_activ` — 40 PASSED (Solver 2)
- [x] Integration: `test_fusion_test` — 26 PASSED (workspace validation)
- [x] MIOpenDriver: NHWC — 5 configs verified correct solver selection via logging
- [x] MIOpenDriver: NCHW — 4 configs verified correct solver selection via logging
- [x] Symbol verification: All 20 new extern "C" symbols confirmed in `libMIOpenCKGroupedConv_gfx942.so`

🤖 Generated with [Claude Code](https://claude.com/claude-code)