### PR TITLE
[SDPA][HipDNN] SdpaBwdKernelArgs for 3 backward kernels

### DIFF
--- a/dnn-providers/hip-kernel-provider/src/engines/asm_sdpa_engine/asm/SdpaBwdKernelArgs.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/asm_sdpa_engine/asm/SdpaBwdKernelArgs.hpp
@@ -64,25 +64,25 @@ struct __attribute__((packed)) fmha_bwd_odo_args
     SgprPad2 _p2;
 
     // ---- O/dO tensor strides (in bytes) ------------------------------------
-    unsigned int Hs_odo; // co:Hs_odo  Head stride for O/dO tensors
+    uint32_t Hs_odo; // co:Hs_odo  Head stride for O/dO tensors
     SgprPad3 _p3;
-    unsigned int BAs_odo; // co:BAs_odo  Batch stride for O/dO tensors
+    uint32_t BAs_odo; // co:BAs_odo  Batch stride for O/dO tensors
     SgprPad3 _p4;
-    unsigned int Seqs_odo; // co:Seqs_odo  Sequence stride for O/dO tensors
+    uint32_t Seqs_odo; // co:Seqs_odo  Sequence stride for O/dO tensors
     SgprPad3 _p5;
 
     // ---- D buffer strides (in bytes, FP32) ---------------------------------
-    unsigned int Hs_d; // co:Hs_d  Head stride for D buffer
+    uint32_t Hs_d; // co:Hs_d  Head stride for D buffer
     SgprPad3 _p6;
-    unsigned int BAs_d; // co:BAs_d  Batch stride for D buffer
+    uint32_t BAs_d; // co:BAs_d  Batch stride for D buffer
     SgprPad3 _p7;
-    unsigned int Seqs_d; // co:Seqs_d  Sequence stride for D (always 4 bytes)
+    uint32_t Seqs_d; // co:Seqs_d  Sequence stride for D (always 4 bytes)
     SgprPad3 _p8;
 
     // ---- Dimensions --------------------------------------------------------
-    unsigned int seqlen_q; // co:seqlen_q  Query sequence length
+    uint32_t seqlen_q; // co:seqlen_q  Query sequence length
     SgprPad3 _p9;
-    unsigned int head_dim; // co:head_dim  Head dimension (D_v)
+    uint32_t head_dim; // co:head_dim  Head dimension (D_v)
     SgprPad3 _p10;
 
     // ---- Group mode sequence pointers (nullptr for batch mode) -------------
@@ -141,77 +141,77 @@ struct __attribute__((packed)) fmha_bwd_dqdkdv_args
     SgprPad3 _p10;
 
     // ---- Q dimensions ------------------------------------------------------
-    unsigned int seqlen_q; // co:seqlen_q  Query sequence length
+    uint32_t seqlen_q; // co:seqlen_q  Query sequence length
     SgprPad3 _p11;
-    unsigned int Ts; // co:Ts  Tile size × Seqs_k × 2 (bytes)
+    uint32_t Ts; // co:Ts  Tile size × Seqs_k × 2 (bytes)
     SgprPad3 _p12;
 
     // ---- Q tensor strides (in bytes) ---------------------------------------
-    unsigned int Hs_q; // co:Hs_q  Q head stride
+    uint32_t Hs_q; // co:Hs_q  Q head stride
     SgprPad3 _p13;
-    unsigned int BAs_q; // co:BAs_q  Q batch stride
+    uint32_t BAs_q; // co:BAs_q  Q batch stride
     SgprPad3 _p14;
-    unsigned int Seqs_q; // co:Seqs_q  Q sequence stride
+    uint32_t Seqs_q; // co:Seqs_q  Q sequence stride
     SgprPad3 _p15;
 
     // ---- GQA ratio ---------------------------------------------------------
-    unsigned int ratio; // co:ratio  Grouped-Query Attention ratio (H_q / H_kv)
+    uint32_t ratio; // co:ratio  Grouped-Query Attention ratio (H_q / H_kv)
     SgprPad3 _p16;
 
     // ---- K tensor strides (in bytes) ---------------------------------------
-    unsigned int Hs_k; // co:Hs_k  K head stride
+    uint32_t Hs_k; // co:Hs_k  K head stride
     SgprPad3 _p17;
-    unsigned int BAs_k; // co:BAs_k  K batch stride
+    uint32_t BAs_k; // co:BAs_k  K batch stride
     SgprPad3 _p18;
-    unsigned int Seqs_k; // co:Seqs_k  K sequence stride
+    uint32_t Seqs_k; // co:Seqs_k  K sequence stride
     SgprPad3 _p19;
 
     // ---- dK tensor strides (in bytes) --------------------------------------
-    unsigned int Seqs_dk; // co:Seqs_dk  dK sequence stride
+    uint32_t Seqs_dk; // co:Seqs_dk  dK sequence stride
     SgprPad3 _p20;
 
     // ---- K/V dimensions ----------------------------------------------------
-    unsigned int seqlen_k; // co:seqlen_k  Key/Value sequence length
+    uint32_t seqlen_k; // co:seqlen_k  Key/Value sequence length
     SgprPad3 _p21;
-    unsigned int head_dim_q; // co:head_dim_q  QK head dimension (D_qk)
+    uint32_t head_dim_q; // co:head_dim_q  QK head dimension (D_qk)
     SgprPad3 _p22;
-    unsigned int head_dim_v; // co:head_dim_v  V head dimension (D_v)
+    uint32_t head_dim_v; // co:head_dim_v  V head dimension (D_v)
     SgprPad3 _p23;
-    unsigned int nhead_q; // co:nhead_q  Number of Q heads (H_q)
+    uint32_t nhead_q; // co:nhead_q  Number of Q heads (H_q)
     SgprPad3 _p24;
 
     // ---- V tensor strides (in bytes) ---------------------------------------
-    unsigned int Hs_v; // co:Hs_v  V head stride
+    uint32_t Hs_v; // co:Hs_v  V head stride
     SgprPad3 _p25;
-    unsigned int BAs_v; // co:BAs_v  V batch stride
+    uint32_t BAs_v; // co:BAs_v  V batch stride
     SgprPad3 _p26;
-    unsigned int Seqs_v; // co:Seqs_v  V sequence stride
+    uint32_t Seqs_v; // co:Seqs_v  V sequence stride
     SgprPad3 _p27;
 
     // ---- dO tensor strides (in bytes) --------------------------------------
-    unsigned int Hs_do; // co:Hs_do  dO head stride
+    uint32_t Hs_do; // co:Hs_do  dO head stride
     SgprPad3 _p28;
-    unsigned int BAs_do; // co:BAs_do  dO batch stride
+    uint32_t BAs_do; // co:BAs_do  dO batch stride
     SgprPad3 _p29;
-    unsigned int Seqs_do; // co:Seqs_do  dO sequence stride
+    uint32_t Seqs_do; // co:Seqs_do  dO sequence stride
     SgprPad3 _p30;
 
     // ---- dK tensor strides (in bytes) --------------------------------------
-    unsigned int Hs_dk; // co:Hs_dk  dK head stride
+    uint32_t Hs_dk; // co:Hs_dk  dK head stride
     SgprPad3 _p31;
-    unsigned int BAs_dk; // co:BAs_dk  dK batch stride
+    uint32_t BAs_dk; // co:BAs_dk  dK batch stride
     SgprPad3 _p32;
 
     // ---- dV tensor strides (in bytes) --------------------------------------
-    unsigned int Hs_dv; // co:Hs_dv  dV head stride
+    uint32_t Hs_dv; // co:Hs_dv  dV head stride
     SgprPad3 _p33;
-    unsigned int BAs_dv; // co:BAs_dv  dV batch stride
+    uint32_t BAs_dv; // co:BAs_dv  dV batch stride
     SgprPad3 _p34;
-    unsigned int Seqs_dv; // co:Seqs_dv  dV sequence stride
+    uint32_t Seqs_dv; // co:Seqs_dv  dV sequence stride
     SgprPad3 _p35;
 
     // ---- LSE tensor strides (in bytes) -------------------------------------
-    unsigned int Hs_lsed; // co:Hs_lsed  LSE head stride (group mode)
+    uint32_t Hs_lsed; // co:Hs_lsed  LSE head stride (group mode)
     SgprPad3 _p36;
 
     // ---- Group mode sequence pointers (nullptr for batch mode) -------------
@@ -225,13 +225,13 @@ struct __attribute__((packed)) fmha_bwd_dqdkdv_args
     SgprPad2 _p40;
 
     // ---- dq_acc buffer configuration ---------------------------------------
-    unsigned int max_seqlen_dq; // co:max_seqlen_dq  Max Q seqlen (for a16)
+    uint32_t max_seqlen_dq; // co:max_seqlen_dq  Max Q seqlen (for a16)
     SgprPad3 _p41;
 
     // ---- Window attention mask coordinates ---------------------------------
-    int mask_x; // co:mask_x  Window mask X coordinate (-1 if disabled)
+    int32_t mask_x; // co:mask_x  Window mask X coordinate (-1 if disabled)
     SgprPad3 _p42;
-    int mask_y; // co:mask_y  Window mask Y coordinate (-1 if disabled)
+    int32_t mask_y; // co:mask_y  Window mask Y coordinate (-1 if disabled)
     SgprPad3 _p43;
 };
 
@@ -257,25 +257,25 @@ struct __attribute__((packed)) fmha_bwd_post_kernel_args
     SgprPad2 _p1;
 
     // ---- dq_acc tensor strides (in bytes, FP32) ----------------------------
-    unsigned int Hs_dq_acc; // co:Hs_dq_acc  dq_acc head stride
+    uint32_t Hs_dq_acc; // co:Hs_dq_acc  dq_acc head stride
     SgprPad3 _p2;
-    unsigned int BAs_dq_acc; // co:BAs_dq_acc  dq_acc batch stride
+    uint32_t BAs_dq_acc; // co:BAs_dq_acc  dq_acc batch stride
     SgprPad3 _p3;
-    unsigned int Seqs_dq_acc; // co:Seqs_dq_acc  dq_acc sequence stride
+    uint32_t Seqs_dq_acc; // co:Seqs_dq_acc  dq_acc sequence stride
     SgprPad3 _p4;
 
     // ---- dQ tensor strides (in bytes, BF16) --------------------------------
-    unsigned int Hs_dq; // co:Hs_dq  dQ head stride
+    uint32_t Hs_dq; // co:Hs_dq  dQ head stride
     SgprPad3 _p5;
-    unsigned int BAs_dq; // co:BAs_dq  dQ batch stride
+    uint32_t BAs_dq; // co:BAs_dq  dQ batch stride
     SgprPad3 _p6;
-    unsigned int Seqs_dq; // co:Seqs_dq  dQ sequence stride
+    uint32_t Seqs_dq; // co:Seqs_dq  dQ sequence stride
     SgprPad3 _p7;
 
     // ---- Dimensions --------------------------------------------------------
-    unsigned int seqlen_q; // co:seqlen_q  Query sequence length
+    uint32_t seqlen_q; // co:seqlen_q  Query sequence length
     SgprPad3 _p8;
-    unsigned int head_dim; // co:head_dim  Head dimension (D_qk)
+    uint32_t head_dim; // co:head_dim  Head dimension (D_qk)
     SgprPad3 _p9;
 
     // ---- Group mode sequence pointers (nullptr for batch mode) -------------

--- a/dnn-providers/hip-kernel-provider/src/engines/asm_sdpa_engine/asm/SdpaBwdKernelArgs.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/asm_sdpa_engine/asm/SdpaBwdKernelArgs.hpp
@@ -1,0 +1,301 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+// =============================================================================
+// AITER Provenance
+//
+// Commit:  (TBD - to be filled with actual AITER commit hash)
+// Sources:
+//   - aiter/csrc/include/mha_bwd.h           (lines 149-305: backward kernel args)
+//   - aiter/csrc/include/aiter_hip_common.h  (lines 48-62: p2, p3 padding structs)
+//
+// Adaptations:
+//   - Replaced AITER padding types p2/p3 with SgprPad2/SgprPad3 (see SgprPadding.hpp)
+//   - Removed all AITER #include directives
+//   - Added static_assert on sizeof to catch ABI drift
+//   - Added detailed field documentation for all three backward kernels
+//   - Organized into 3-kernel pipeline: odo → dqdkdv → dq_convert
+// =============================================================================
+
+#pragma once
+
+#include "SgprPadding.hpp"
+
+#include <cstdint>
+
+namespace asm_sdpa_engine
+{
+
+// NOLINTBEGIN(readability-identifier-naming)
+
+// Field naming note:
+// The backward kernel arg structs use the naming convention from AITER's mha_bwd.h
+// (e.g. Hs_q, BAs_q, Seqs_q) which differs from the forward kernel args (e.g.
+// s_Hs, s_Bs, s_Seqs from mha_fwd.h).  This is intentional: each set of field
+// names is kept as close as possible to the corresponding co:<name> AMDHSA
+// metadata tags so that future AITER updates can be reconciled by a direct
+// textual diff.  The forward and backward AITER sources themselves use different
+// naming conventions; we preserve that distinction here.
+
+// =============================================================================
+// Kernel 1: ODO (O ⊙ dO) Pre-Processing Kernel
+// =============================================================================
+// Computes D[b,h,i] = sum_j( O[b,h,i,j] * dO[b,h,i,j] ) reduction along head
+// dimension.  This D buffer is used by the main backward kernel to compute
+// attention gradients.
+//
+// Inputs:  O [B, H_q, S_q, D_v], dO [B, H_q, S_q, D_v]
+// Outputs: D [B, H_q, S_q] (FP32 reduction result)
+//
+// Tensor layout: [Batch, Head, SeqLen, HeadDim]  (BHSD)
+// Stride naming: Hs = head stride, BAs = batch stride, Seqs = sequence stride
+struct __attribute__((packed)) fmha_bwd_odo_args
+{
+    // ---- Input: forward output O -------------------------------------------
+    const void* ptr_o; // co:ptr_o  Output from forward pass [B, H_q, S_q, D_v]
+    SgprPad2 _p0;
+
+    // ---- Input: upstream gradient dO ---------------------------------------
+    const void* ptr_do; // co:ptr_do  Gradient w.r.t. O [B, H_q, S_q, D_v]
+    SgprPad2 _p1;
+
+    // ---- Output: D reduction buffer ----------------------------------------
+    void* ptr_d; // co:ptr_d  Output D buffer [B, H_q, S_q] (FP32)
+    SgprPad2 _p2;
+
+    // ---- O/dO tensor strides (in bytes) ------------------------------------
+    unsigned int Hs_odo; // co:Hs_odo  Head stride for O/dO tensors
+    SgprPad3 _p3;
+    unsigned int BAs_odo; // co:BAs_odo  Batch stride for O/dO tensors
+    SgprPad3 _p4;
+    unsigned int Seqs_odo; // co:Seqs_odo  Sequence stride for O/dO tensors
+    SgprPad3 _p5;
+
+    // ---- D buffer strides (in bytes, FP32) ---------------------------------
+    unsigned int Hs_d; // co:Hs_d  Head stride for D buffer
+    SgprPad3 _p6;
+    unsigned int BAs_d; // co:BAs_d  Batch stride for D buffer
+    SgprPad3 _p7;
+    unsigned int Seqs_d; // co:Seqs_d  Sequence stride for D (always 4 bytes)
+    SgprPad3 _p8;
+
+    // ---- Dimensions --------------------------------------------------------
+    unsigned int seqlen_q; // co:seqlen_q  Query sequence length
+    SgprPad3 _p9;
+    unsigned int head_dim; // co:head_dim  Head dimension (D_v)
+    SgprPad3 _p10;
+
+    // ---- Group mode sequence pointers (nullptr for batch mode) -------------
+    const void* ptr_qseq; // co:ptr_qseq  Cumulative Q sequence starts
+    SgprPad2 _p11;
+    const void* ptr_qseq_padded; // co:ptr_qseq_padded  Q padded seq starts
+    SgprPad2 _p12;
+};
+
+// =============================================================================
+// Kernel 2: DQDKDV Main Backward Kernel
+// =============================================================================
+// Computes gradients dQ, dK, dV from inputs Q, K, V, dO, LSE, D.
+//
+// Inputs:  Q, K, V, dO, LSE [B,H,S] (FP32), D [B,H,S] (FP32 from odo kernel)
+// Outputs: dQ (FP32 if a32, else BF16), dK [B,H_kv,S_k,D], dV [B,H_kv,S_k,D_v]
+//
+// For a32 accumulator variant: dQ output is in FP32 and written to dq_acc
+// workspace buffer. A subsequent dq_convert kernel converts it to BF16.
+//
+// Tensor layout: [Batch, Head, SeqLen, HeadDim]  (BHSD)
+struct __attribute__((packed)) fmha_bwd_dqdkdv_args
+{
+    // ---- Outputs -----------------------------------------------------------
+    void* ptr_dq; // co:ptr_dq  Gradient w.r.t. Q (dq_acc if a32, else dQ)
+    SgprPad2 _p0;
+    void* ptr_dk; // co:ptr_dk  Gradient w.r.t. K [B, H_kv, S_k, D_qk]
+    SgprPad2 _p1;
+    void* ptr_dv; // co:ptr_dv  Gradient w.r.t. V [B, H_kv, S_k, D_v]
+    SgprPad2 _p2;
+
+    // ---- Inputs: forward pass tensors --------------------------------------
+    const void* ptr_q; // co:ptr_q  Query [B, H_q, S_q, D_qk]
+    SgprPad2 _p3;
+    const void* ptr_k; // co:ptr_k  Key [B, H_kv, S_k, D_qk]
+    SgprPad2 _p4;
+    const void* ptr_v; // co:ptr_v  Value [B, H_kv, S_k, D_v]
+    SgprPad2 _p5;
+
+    // ---- Input: upstream gradient ------------------------------------------
+    const void* ptr_do; // co:ptr_do  Gradient w.r.t. O [B, H_q, S_q, D_v]
+    SgprPad2 _p6;
+
+    // ---- Input: forward pass LSE stats -------------------------------------
+    const void* ptr_lse; // co:ptr_lse  LogSumExp from forward [B, H_q, S_q]
+    SgprPad2 _p7;
+
+    // ---- Input: D buffer from odo kernel -----------------------------------
+    const void* ptr_d; // co:ptr_d  D reduction buffer [B, H_q, S_q] (FP32)
+    SgprPad2 _p8;
+
+    // ---- Attention scale ---------------------------------------------------
+    float scalar; // co:scalar  Attention scale (1 / sqrt(D_qk))
+    SgprPad3 _p9;
+    float log2e; // co:log2e  Constant: log2(e) ≈ 1.44269504
+    SgprPad3 _p10;
+
+    // ---- Q dimensions ------------------------------------------------------
+    unsigned int seqlen_q; // co:seqlen_q  Query sequence length
+    SgprPad3 _p11;
+    unsigned int Ts; // co:Ts  Tile size × Seqs_k × 2 (bytes)
+    SgprPad3 _p12;
+
+    // ---- Q tensor strides (in bytes) ---------------------------------------
+    unsigned int Hs_q; // co:Hs_q  Q head stride
+    SgprPad3 _p13;
+    unsigned int BAs_q; // co:BAs_q  Q batch stride
+    SgprPad3 _p14;
+    unsigned int Seqs_q; // co:Seqs_q  Q sequence stride
+    SgprPad3 _p15;
+
+    // ---- GQA ratio ---------------------------------------------------------
+    unsigned int ratio; // co:ratio  Grouped-Query Attention ratio (H_q / H_kv)
+    SgprPad3 _p16;
+
+    // ---- K tensor strides (in bytes) ---------------------------------------
+    unsigned int Hs_k; // co:Hs_k  K head stride
+    SgprPad3 _p17;
+    unsigned int BAs_k; // co:BAs_k  K batch stride
+    SgprPad3 _p18;
+    unsigned int Seqs_k; // co:Seqs_k  K sequence stride
+    SgprPad3 _p19;
+
+    // ---- dK tensor strides (in bytes) --------------------------------------
+    unsigned int Seqs_dk; // co:Seqs_dk  dK sequence stride
+    SgprPad3 _p20;
+
+    // ---- K/V dimensions ----------------------------------------------------
+    unsigned int seqlen_k; // co:seqlen_k  Key/Value sequence length
+    SgprPad3 _p21;
+    unsigned int head_dim_q; // co:head_dim_q  QK head dimension (D_qk)
+    SgprPad3 _p22;
+    unsigned int head_dim_v; // co:head_dim_v  V head dimension (D_v)
+    SgprPad3 _p23;
+    unsigned int nhead_q; // co:nhead_q  Number of Q heads (H_q)
+    SgprPad3 _p24;
+
+    // ---- V tensor strides (in bytes) ---------------------------------------
+    unsigned int Hs_v; // co:Hs_v  V head stride
+    SgprPad3 _p25;
+    unsigned int BAs_v; // co:BAs_v  V batch stride
+    SgprPad3 _p26;
+    unsigned int Seqs_v; // co:Seqs_v  V sequence stride
+    SgprPad3 _p27;
+
+    // ---- dO tensor strides (in bytes) --------------------------------------
+    unsigned int Hs_do; // co:Hs_do  dO head stride
+    SgprPad3 _p28;
+    unsigned int BAs_do; // co:BAs_do  dO batch stride
+    SgprPad3 _p29;
+    unsigned int Seqs_do; // co:Seqs_do  dO sequence stride
+    SgprPad3 _p30;
+
+    // ---- dK tensor strides (in bytes) --------------------------------------
+    unsigned int Hs_dk; // co:Hs_dk  dK head stride
+    SgprPad3 _p31;
+    unsigned int BAs_dk; // co:BAs_dk  dK batch stride
+    SgprPad3 _p32;
+
+    // ---- dV tensor strides (in bytes) --------------------------------------
+    unsigned int Hs_dv; // co:Hs_dv  dV head stride
+    SgprPad3 _p33;
+    unsigned int BAs_dv; // co:BAs_dv  dV batch stride
+    SgprPad3 _p34;
+    unsigned int Seqs_dv; // co:Seqs_dv  dV sequence stride
+    SgprPad3 _p35;
+
+    // ---- LSE tensor strides (in bytes) -------------------------------------
+    unsigned int Hs_lsed; // co:Hs_lsed  LSE head stride (group mode)
+    SgprPad3 _p36;
+
+    // ---- Group mode sequence pointers (nullptr for batch mode) -------------
+    const void* ptr_qseq; // co:ptr_qseq  Q cumulative seq starts
+    SgprPad2 _p37;
+    const void* ptr_kseq; // co:ptr_kseq  K cumulative seq starts
+    SgprPad2 _p38;
+    const void* ptr_qseq_padded; // co:ptr_qseq_padded  Q padded seq starts
+    SgprPad2 _p39;
+    const void* ptr_kseq_padded; // co:ptr_kseq_padded  K padded seq starts
+    SgprPad2 _p40;
+
+    // ---- dq_acc buffer configuration ---------------------------------------
+    unsigned int max_seqlen_dq; // co:max_seqlen_dq  Max Q seqlen (for a16)
+    SgprPad3 _p41;
+
+    // ---- Window attention mask coordinates ---------------------------------
+    int mask_x; // co:mask_x  Window mask X coordinate (-1 if disabled)
+    SgprPad3 _p42;
+    int mask_y; // co:mask_y  Window mask Y coordinate (-1 if disabled)
+    SgprPad3 _p43;
+};
+
+// =============================================================================
+// Kernel 3: DQ_CONVERT Post-Processing Kernel
+// =============================================================================
+// Converts dQ from FP32 accumulator (dq_acc) to BF16 output format.
+// Only used with a32 accumulator kernels.  The a16 accumulator kernels write
+// dQ directly in BF16 and skip this step.
+//
+// Inputs:  dq_acc [B, H_q, S_q, D_qk] (FP32 from dqdkdv kernel)
+// Outputs: dQ [B, H_q, S_q, D_qk] (BF16)
+//
+// Tensor layout: [Batch, Head, SeqLen, HeadDim]  (BHSD)
+struct __attribute__((packed)) fmha_bwd_post_kernel_args
+{
+    // ---- Input: FP32 dq accumulator buffer ---------------------------------
+    void* ptr_dq_acc; // co:ptr_dq_acc  dQ in FP32 [B, H_q, S_q, D_qk]
+    SgprPad2 _p0;
+
+    // ---- Output: BF16 dQ ---------------------------------------------------
+    void* ptr_dq; // co:ptr_dq  dQ in BF16 [B, H_q, S_q, D_qk]
+    SgprPad2 _p1;
+
+    // ---- dq_acc tensor strides (in bytes, FP32) ----------------------------
+    unsigned int Hs_dq_acc; // co:Hs_dq_acc  dq_acc head stride
+    SgprPad3 _p2;
+    unsigned int BAs_dq_acc; // co:BAs_dq_acc  dq_acc batch stride
+    SgprPad3 _p3;
+    unsigned int Seqs_dq_acc; // co:Seqs_dq_acc  dq_acc sequence stride
+    SgprPad3 _p4;
+
+    // ---- dQ tensor strides (in bytes, BF16) --------------------------------
+    unsigned int Hs_dq; // co:Hs_dq  dQ head stride
+    SgprPad3 _p5;
+    unsigned int BAs_dq; // co:BAs_dq  dQ batch stride
+    SgprPad3 _p6;
+    unsigned int Seqs_dq; // co:Seqs_dq  dQ sequence stride
+    SgprPad3 _p7;
+
+    // ---- Dimensions --------------------------------------------------------
+    unsigned int seqlen_q; // co:seqlen_q  Query sequence length
+    SgprPad3 _p8;
+    unsigned int head_dim; // co:head_dim  Head dimension (D_qk)
+    SgprPad3 _p9;
+
+    // ---- Group mode sequence pointers (nullptr for batch mode) -------------
+    const void* ptr_qseq; // co:ptr_qseq  Q cumulative seq starts
+    SgprPad2 _p10;
+    const void* ptr_qseq_padded; // co:ptr_qseq_padded  Q padded seq starts
+    SgprPad2 _p11;
+};
+
+// Compile-time ABI verification: the struct sizes must match AITER's
+// definitions exactly.  Any mismatch indicates the kernel ABI has changed and
+// the structs must be updated.
+static_assert(sizeof(fmha_bwd_dqdkdv_args) == 704,
+              "fmha_bwd_dqdkdv_args size mismatch with AITER ABI");
+
+static_assert(sizeof(fmha_bwd_odo_args) == 208, "fmha_bwd_odo_args size mismatch with AITER ABI");
+
+static_assert(sizeof(fmha_bwd_post_kernel_args) == 192,
+              "fmha_bwd_post_kernel_args size mismatch with AITER ABI");
+
+// NOLINTEND(readability-identifier-naming)
+
+} // namespace asm_sdpa_engine

--- a/dnn-providers/hip-kernel-provider/src/engines/asm_sdpa_engine/asm/SdpaFwdKernelArgs.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/asm_sdpa_engine/asm/SdpaFwdKernelArgs.hpp
@@ -10,7 +10,7 @@
 //   - aiter/csrc/include/aiter_hip_common.h (lines 44-54: p2, p3 padding structs)
 //
 // Adaptations:
-//   - Replaced AITER padding types p2/p3 with self-contained SgprPad2/SgprPad3
+//   - Replaced AITER padding types p2/p3 with SgprPad2/SgprPad3 (see SgprPadding.hpp)
 //   - Removed all AITER #include directives
 //   - Added static_assert on sizeof to catch ABI drift
 //   - Added field documentation from cross-reference with CK fmha_fwd_args
@@ -19,30 +19,14 @@
 
 #pragma once
 
+#include "SgprPadding.hpp"
+
 #include <cstdint>
 
 namespace asm_sdpa_engine
 {
 
 // NOLINTBEGIN(readability-identifier-naming)
-
-// SGPR-aligned padding inserted between kernel arguments to satisfy the AMD GPU
-// SGPR allocation ABI.  Each SGPR is 32 bits; pointers occupy 2 SGPRs (64 bits)
-// and scalars occupy 1 SGPR.  The padding structs ensure every field lands on
-// the correct SGPR boundary expected by the pre-compiled ASM kernel.
-
-struct SgprPad2
-{
-    unsigned int _p0;
-    unsigned int _p1;
-};
-
-struct SgprPad3
-{
-    unsigned int _p0;
-    unsigned int _p1;
-    unsigned int _p2;
-};
 
 // Packed kernel argument struct for the AITER Flash Attention v3 forward kernel.
 // This struct is passed directly to the GPU via HIP_LAUNCH_PARAM_BUFFER_POINTER

--- a/dnn-providers/hip-kernel-provider/src/engines/asm_sdpa_engine/asm/SdpaFwdKernelArgs.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/asm_sdpa_engine/asm/SdpaFwdKernelArgs.hpp
@@ -62,59 +62,59 @@ struct __attribute__((packed)) fmha_fwd_v3_args
     SgprPad3 _p5;
 
     // ---- Q tensor dimensions and strides -----------------------------------
-    unsigned int s_seq_len; // co:seq_len  Query sequence length  (S_q)
+    uint32_t s_seq_len; // co:seq_len  Query sequence length  (S_q)
     SgprPad3 _p6;
-    unsigned int s_Seqs; // co:Seqs  Q stride: sequence dim
+    uint32_t s_Seqs; // co:Seqs  Q stride: sequence dim
     SgprPad3 _p7;
-    unsigned int s_Ts; // co:Ts  Q stride: row
+    uint32_t s_Ts; // co:Ts  Q stride: row
     SgprPad3 _p8;
-    unsigned int s_Hs; // co:Hs  Q stride: head dim
+    uint32_t s_Hs; // co:Hs  Q stride: head dim
     SgprPad3 _p9;
-    unsigned int s_Bs; // co:Bs  Q stride: batch dim
+    uint32_t s_Bs; // co:Bs  Q stride: batch dim
     SgprPad3 _p10;
 
     // ---- GQA ratio ---------------------------------------------------------
-    unsigned int s_gqa; // co:gqa  Grouped-Query Attention ratio (H_q / H_kv)
+    uint32_t s_gqa; // co:gqa  Grouped-Query Attention ratio (H_q / H_kv)
     SgprPad3 _p11;
 
     // ---- K tensor strides --------------------------------------------------
-    unsigned int s_k_Seqs; // co:k_Seqs  K stride: sequence dim
+    uint32_t s_k_Seqs; // co:k_Seqs  K stride: sequence dim
     SgprPad3 _p12;
-    unsigned int s_k_Hs; // co:k_Hs  K stride: head dim
+    uint32_t s_k_Hs; // co:k_Hs  K stride: head dim
     SgprPad3 _p13;
-    unsigned int s_k_Bs; // co:k_Bs  K stride: batch dim
+    uint32_t s_k_Bs; // co:k_Bs  K stride: batch dim
     SgprPad3 _p14;
 
     // ---- Options and flags -------------------------------------------------
-    unsigned int s_opt; // co:msk_opt  Options bitmask (e.g., rounding mode)
+    uint32_t s_opt; // co:msk_opt  Options bitmask (e.g., rounding mode)
     SgprPad3 _p15;
-    unsigned int s_lse; // co:lse  Whether to compute LSE output (0 or 1)
+    uint32_t s_lse; // co:lse  Whether to compute LSE output (0 or 1)
     SgprPad3 _p16;
 
     // ---- KV sequence and head dimensions -----------------------------------
-    unsigned int s_kv_seq_len; // co:kv_seq_len  KV sequence length (S_kv)
+    uint32_t s_kv_seq_len; // co:kv_seq_len  KV sequence length (S_kv)
     SgprPad3 _p17;
-    unsigned int s_qk_head_dim; // co:qk_head_dim  QK head dimension  (D_qk)
+    uint32_t s_qk_head_dim; // co:qk_head_dim  QK head dimension  (D_qk)
     SgprPad3 _p18;
-    unsigned int s_v_head_dim; // co:v_head_dim  V head dimension   (D_v)
+    uint32_t s_v_head_dim; // co:v_head_dim  V head dimension   (D_v)
     SgprPad3 _p19;
-    unsigned int s_q_head_num; // co:q_head_num  Number of Q heads  (H_q)
+    uint32_t s_q_head_num; // co:q_head_num  Number of Q heads  (H_q)
     SgprPad3 _p20;
 
     // ---- V tensor strides --------------------------------------------------
-    unsigned int s_v_Seqs; // co:v_Seqs  V stride: sequence dim
+    uint32_t s_v_Seqs; // co:v_Seqs  V stride: sequence dim
     SgprPad3 _p21;
-    unsigned int s_v_Hs; // co:v_Hs  V stride: head dim
+    uint32_t s_v_Hs; // co:v_Hs  V stride: head dim
     SgprPad3 _p22;
-    unsigned int s_v_Bs; // co:v_Bs  V stride: batch dim
+    uint32_t s_v_Bs; // co:v_Bs  V stride: batch dim
     SgprPad3 _p23;
 
     // ---- O tensor strides --------------------------------------------------
-    unsigned int s_o_Seqs; // co:r_Seqs  O stride: sequence dim
+    uint32_t s_o_Seqs; // co:r_Seqs  O stride: sequence dim
     SgprPad3 _p24;
-    unsigned int s_o_Hs; // co:r_Hs  O stride: head dim
+    uint32_t s_o_Hs; // co:r_Hs  O stride: head dim
     SgprPad3 _p25;
-    unsigned int s_o_Bs; // co:r_Bs  O stride: batch dim
+    uint32_t s_o_Bs; // co:r_Bs  O stride: batch dim
     SgprPad3 _p26;
 
     // ---- Variable-length sequence pointers (nullptr for batch mode) --------
@@ -124,7 +124,7 @@ struct __attribute__((packed)) fmha_fwd_v3_args
     SgprPad2 _p28;
 
     // ---- LSE stride --------------------------------------------------------
-    unsigned int s_lse_Hs; // co:lse_Hs  LSE stride: head dim
+    uint32_t s_lse_Hs; // co:lse_Hs  LSE stride: head dim
     SgprPad3 _p29;
 
     // ---- Padding sequence pointers (nullptr for batch mode) ----------------
@@ -142,17 +142,17 @@ struct __attribute__((packed)) fmha_fwd_v3_args
     SgprPad2 _p34;
 
     // ---- FP8 descale strides -----------------------------------------------
-    unsigned int s_descale_q_Bs; // co:descale_q_Bs  Q descale batch stride
+    uint32_t s_descale_q_Bs; // co:descale_q_Bs  Q descale batch stride
     SgprPad3 _p35;
-    unsigned int s_descale_q_Hs; // co:descale_q_Hs  Q descale head stride
+    uint32_t s_descale_q_Hs; // co:descale_q_Hs  Q descale head stride
     SgprPad3 _p36;
-    unsigned int s_descale_k_Bs; // co:descale_k_Bs  K descale batch stride
+    uint32_t s_descale_k_Bs; // co:descale_k_Bs  K descale batch stride
     SgprPad3 _p37;
-    unsigned int s_descale_k_Hs; // co:descale_k_Hs  K descale head stride
+    uint32_t s_descale_k_Hs; // co:descale_k_Hs  K descale head stride
     SgprPad3 _p38;
-    unsigned int s_descale_v_Bs; // co:descale_v_Bs  V descale batch stride
+    uint32_t s_descale_v_Bs; // co:descale_v_Bs  V descale batch stride
     SgprPad3 _p39;
-    unsigned int s_descale_v_Hs; // co:descale_v_Hs  V descale head stride
+    uint32_t s_descale_v_Hs; // co:descale_v_Hs  V descale head stride
     SgprPad3 _p40;
 };
 

--- a/dnn-providers/hip-kernel-provider/src/engines/asm_sdpa_engine/asm/SgprPadding.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/asm_sdpa_engine/asm/SgprPadding.hpp
@@ -14,10 +14,10 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace asm_sdpa_engine
 {
-
-// NOLINTBEGIN(readability-identifier-naming)
 
 // SGPR-aligned padding inserted between kernel arguments to satisfy the AMD GPU
 // SGPR allocation ABI.  Each SGPR is 32 bits; pointers occupy 2 SGPRs (64 bits)
@@ -29,17 +29,12 @@ namespace asm_sdpa_engine
 
 struct SgprPad2
 {
-    unsigned int _p0;
-    unsigned int _p1;
+    uint32_t pad[2]; // NOLINT(readability-identifier-naming)
 };
 
 struct SgprPad3
 {
-    unsigned int _p0;
-    unsigned int _p1;
-    unsigned int _p2;
+    uint32_t pad[3]; // NOLINT(readability-identifier-naming)
 };
-
-// NOLINTEND(readability-identifier-naming)
 
 } // namespace asm_sdpa_engine

--- a/dnn-providers/hip-kernel-provider/src/engines/asm_sdpa_engine/asm/SgprPadding.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/asm_sdpa_engine/asm/SgprPadding.hpp
@@ -1,0 +1,45 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+// =============================================================================
+// AITER Provenance
+//
+// Source: aiter/csrc/include/aiter_hip_common.h  (lines 44-54: p2, p3 padding)
+// Commit: 9522048dc10de20ba9dcda1c0a3f640867e7a586
+//
+// Adaptations:
+//   - Renamed AITER types p2/p3 → SgprPad2/SgprPad3 for clarity
+//   - Extracted into a shared header (included by both fwd and bwd kernel args)
+// =============================================================================
+
+#pragma once
+
+namespace asm_sdpa_engine
+{
+
+// NOLINTBEGIN(readability-identifier-naming)
+
+// SGPR-aligned padding inserted between kernel arguments to satisfy the AMD GPU
+// SGPR allocation ABI.  Each SGPR is 32 bits; pointers occupy 2 SGPRs (64 bits)
+// and scalars occupy 1 SGPR.  The padding structs ensure every field lands on
+// the correct SGPR boundary expected by the pre-compiled ASM kernel.
+//
+// These types are shared by both the forward (SdpaFwdKernelArgs.hpp) and
+// backward (SdpaBwdKernelArgs.hpp) kernel arg structs.
+
+struct SgprPad2
+{
+    unsigned int _p0;
+    unsigned int _p1;
+};
+
+struct SgprPad3
+{
+    unsigned int _p0;
+    unsigned int _p1;
+    unsigned int _p2;
+};
+
+// NOLINTEND(readability-identifier-naming)
+
+} // namespace asm_sdpa_engine

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/asm_sdpa_engine/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/asm_sdpa_engine/CMakeLists.txt
@@ -5,6 +5,7 @@ target_sources(hip_kernel_provider_tests PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/TestAsmSdpaEngine.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/TestSdpaFwdPlanBuilder.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/TestSdpaFwdKernelArgs.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/TestSdpaBwdKernelArgs.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/TestAsmKernelPath.cpp
 )
 

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/asm_sdpa_engine/TestSdpaBwdKernelArgs.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/asm_sdpa_engine/TestSdpaBwdKernelArgs.cpp
@@ -1,0 +1,192 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <cstddef>
+
+#include <gtest/gtest.h>
+
+#include "engines/asm_sdpa_engine/asm/SdpaBwdKernelArgs.hpp"
+
+using asm_sdpa_engine::fmha_bwd_dqdkdv_args;
+using asm_sdpa_engine::fmha_bwd_odo_args;
+using asm_sdpa_engine::fmha_bwd_post_kernel_args;
+
+// =============================================================================
+// Tests for fmha_bwd_odo_args (Kernel 1: O ⊙ dO pre-processing)
+// =============================================================================
+
+TEST(TestSdpaBwdOdoKernelArgs, TotalSizeMatches)
+{
+    EXPECT_EQ(sizeof(fmha_bwd_odo_args), 208u);
+}
+
+TEST(TestSdpaBwdOdoKernelArgs, PointerFieldOffsets)
+{
+    EXPECT_EQ(offsetof(fmha_bwd_odo_args, ptr_o), 0u);
+    EXPECT_EQ(offsetof(fmha_bwd_odo_args, ptr_do), 16u);
+    EXPECT_EQ(offsetof(fmha_bwd_odo_args, ptr_d), 32u);
+}
+
+TEST(TestSdpaBwdOdoKernelArgs, StrideFieldOffsets)
+{
+    EXPECT_EQ(offsetof(fmha_bwd_odo_args, Hs_odo), 48u);
+    EXPECT_EQ(offsetof(fmha_bwd_odo_args, BAs_odo), 64u);
+    EXPECT_EQ(offsetof(fmha_bwd_odo_args, Seqs_odo), 80u);
+    EXPECT_EQ(offsetof(fmha_bwd_odo_args, Hs_d), 96u);
+    EXPECT_EQ(offsetof(fmha_bwd_odo_args, BAs_d), 112u);
+    EXPECT_EQ(offsetof(fmha_bwd_odo_args, Seqs_d), 128u);
+}
+
+TEST(TestSdpaBwdOdoKernelArgs, DimensionFieldOffsets)
+{
+    EXPECT_EQ(offsetof(fmha_bwd_odo_args, seqlen_q), 144u);
+    EXPECT_EQ(offsetof(fmha_bwd_odo_args, head_dim), 160u);
+}
+
+TEST(TestSdpaBwdOdoKernelArgs, SequencePointerFieldOffsets)
+{
+    EXPECT_EQ(offsetof(fmha_bwd_odo_args, ptr_qseq), 176u);
+    EXPECT_EQ(offsetof(fmha_bwd_odo_args, ptr_qseq_padded), 192u);
+}
+
+// =============================================================================
+// Tests for fmha_bwd_dqdkdv_args (Kernel 2: Main backward computation)
+// =============================================================================
+
+TEST(TestSdpaBwdDqdkdvKernelArgs, TotalSizeMatches)
+{
+    EXPECT_EQ(sizeof(fmha_bwd_dqdkdv_args), 704u);
+}
+
+TEST(TestSdpaBwdDqdkdvKernelArgs, OutputPointerFieldOffsets)
+{
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, ptr_dq), 0u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, ptr_dk), 16u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, ptr_dv), 32u);
+}
+
+TEST(TestSdpaBwdDqdkdvKernelArgs, InputPointerFieldOffsets)
+{
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, ptr_q), 48u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, ptr_k), 64u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, ptr_v), 80u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, ptr_do), 96u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, ptr_lse), 112u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, ptr_d), 128u);
+}
+
+TEST(TestSdpaBwdDqdkdvKernelArgs, ScalarFieldOffsets)
+{
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, scalar), 144u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, log2e), 160u);
+}
+
+TEST(TestSdpaBwdDqdkdvKernelArgs, QDimensionsAndStrideOffsets)
+{
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, seqlen_q), 176u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, Ts), 192u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, Hs_q), 208u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, BAs_q), 224u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, Seqs_q), 240u);
+}
+
+TEST(TestSdpaBwdDqdkdvKernelArgs, GqaAndKStrideOffsets)
+{
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, ratio), 256u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, Hs_k), 272u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, BAs_k), 288u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, Seqs_k), 304u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, Seqs_dk), 320u);
+}
+
+TEST(TestSdpaBwdDqdkdvKernelArgs, KVDimensionOffsets)
+{
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, seqlen_k), 336u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, head_dim_q), 352u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, head_dim_v), 368u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, nhead_q), 384u);
+}
+
+TEST(TestSdpaBwdDqdkdvKernelArgs, VStrideOffsets)
+{
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, Hs_v), 400u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, BAs_v), 416u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, Seqs_v), 432u);
+}
+
+TEST(TestSdpaBwdDqdkdvKernelArgs, DOStrideOffsets)
+{
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, Hs_do), 448u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, BAs_do), 464u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, Seqs_do), 480u);
+}
+
+TEST(TestSdpaBwdDqdkdvKernelArgs, DKDVStrideOffsets)
+{
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, Hs_dk), 496u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, BAs_dk), 512u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, Hs_dv), 528u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, BAs_dv), 544u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, Seqs_dv), 560u);
+}
+
+TEST(TestSdpaBwdDqdkdvKernelArgs, LseStrideOffset)
+{
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, Hs_lsed), 576u);
+}
+
+TEST(TestSdpaBwdDqdkdvKernelArgs, SequencePointerOffsets)
+{
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, ptr_qseq), 592u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, ptr_kseq), 608u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, ptr_qseq_padded), 624u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, ptr_kseq_padded), 640u);
+}
+
+TEST(TestSdpaBwdDqdkdvKernelArgs, MaxSeqlenAndMaskOffsets)
+{
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, max_seqlen_dq), 656u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, mask_x), 672u);
+    EXPECT_EQ(offsetof(fmha_bwd_dqdkdv_args, mask_y), 688u);
+}
+
+// =============================================================================
+// Tests for fmha_bwd_post_kernel_args (Kernel 3: dQ convert FP32→BF16)
+// =============================================================================
+
+TEST(TestSdpaBwdPostKernelArgs, TotalSizeMatches)
+{
+    EXPECT_EQ(sizeof(fmha_bwd_post_kernel_args), 192u);
+}
+
+TEST(TestSdpaBwdPostKernelArgs, PointerFieldOffsets)
+{
+    EXPECT_EQ(offsetof(fmha_bwd_post_kernel_args, ptr_dq_acc), 0u);
+    EXPECT_EQ(offsetof(fmha_bwd_post_kernel_args, ptr_dq), 16u);
+}
+
+TEST(TestSdpaBwdPostKernelArgs, DqAccStrideOffsets)
+{
+    EXPECT_EQ(offsetof(fmha_bwd_post_kernel_args, Hs_dq_acc), 32u);
+    EXPECT_EQ(offsetof(fmha_bwd_post_kernel_args, BAs_dq_acc), 48u);
+    EXPECT_EQ(offsetof(fmha_bwd_post_kernel_args, Seqs_dq_acc), 64u);
+}
+
+TEST(TestSdpaBwdPostKernelArgs, DqStrideOffsets)
+{
+    EXPECT_EQ(offsetof(fmha_bwd_post_kernel_args, Hs_dq), 80u);
+    EXPECT_EQ(offsetof(fmha_bwd_post_kernel_args, BAs_dq), 96u);
+    EXPECT_EQ(offsetof(fmha_bwd_post_kernel_args, Seqs_dq), 112u);
+}
+
+TEST(TestSdpaBwdPostKernelArgs, DimensionFieldOffsets)
+{
+    EXPECT_EQ(offsetof(fmha_bwd_post_kernel_args, seqlen_q), 128u);
+    EXPECT_EQ(offsetof(fmha_bwd_post_kernel_args, head_dim), 144u);
+}
+
+TEST(TestSdpaBwdPostKernelArgs, SequencePointerFieldOffsets)
+{
+    EXPECT_EQ(offsetof(fmha_bwd_post_kernel_args, ptr_qseq), 160u);
+    EXPECT_EQ(offsetof(fmha_bwd_post_kernel_args, ptr_qseq_padded), 176u);
+}


### PR DESCRIPTION
 ## Motivation

Add backward-kernel argument packing support for the ASM SDPA path in `hip-kernel-provider`.

This PR introduces `SdpaBwdKernelArgs` for the supported backward kernels and factors out shared SGPR padding utilities so the backward argument layout is explicit, testable, and easier to extend.

  ## Technical Details

  - Add `SdpaBwdKernelArgs.hpp` with argument layouts for 3 SDPA backward kernels.
  - Add `SgprPadding.hpp` to centralize SGPR padding helpers used by the kernel arg structs.
  - Update `SdpaFwdKernelArgs.hpp` to share the common padding/alignment approach.
  - Add `TestSdpaBwdKernelArgs.cpp` and register it in the ASM SDPA test CMakeLists.

  ## Test Plan

  - Add unit tests covering `SdpaBwdKernelArgs` layout/packing behavior for the supported backward kernels.

  ## Test Result

  - Added new unit coverage in `TestSdpaBwdKernelArgs.cpp`.
```
  ./bin/hip_kernel_provider_tests --gtest_filter='TestSdpaBwd*.*'
  [  PASSED  ] 24 tests.
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
