### PR TITLE
Fix memory leaks in rocRAND and hipRAND

### DIFF
--- a/projects/hiprand/test/test_hiprand_kernel.cpp
+++ b/projects/hiprand/test/test_hiprand_kernel.cpp
@@ -728,10 +728,8 @@ void hiprand_kernel_h_hiprand_sobol_init_test()
     const unsigned int dimensions = 8;
 
     DirectionVectors_t<int_type>* d_vector;
-    int_type*                     d_constants;
 
 	load_sobol_vectors_to_gpu<state_type, int_type>(dimensions, &d_vector);
-	d_constants = NULL;
 
     unsigned long long offset = 4;
 
@@ -746,7 +744,6 @@ void hiprand_kernel_h_hiprand_sobol_init_test()
     HIP_CHECK(hipDeviceSynchronize());
     HIP_CHECK(hipFree(states));
     HIP_CHECK(hipFree(d_vector));
-    HIP_CHECK(hipFree(d_constants));
 }
 
 template<class state_type>
@@ -1429,19 +1426,8 @@ void hiprand_kernel_h_hiprand_log_normal_sobol_test()
     const unsigned int dimensions = 8;
 
     DirectionVectors_t<int_type>* d_vector;
-    int_type*                     d_constants;
 
-    if(is_sobol_scrambled<state_type>::value)
-    {
-        load_scrambled_sobol_constants_and_vectors_to_gpu<state_type, int_type>(dimensions,
-                                                                                &d_vector,
-                                                                                &d_constants);
-    }
-    else
-    {
-        load_sobol_vectors_to_gpu<state_type, int_type>(dimensions, &d_vector);
-        d_constants = NULL;
-    }
+    load_sobol_vectors_to_gpu<state_type, int_type>(dimensions, &d_vector);
 
     const size_t output_size = 8192;
     float*       output;
@@ -1458,10 +1444,7 @@ void hiprand_kernel_h_hiprand_log_normal_sobol_test()
     HIP_CHECK(hipDeviceSynchronize());
     HIP_CHECK(hipFree(output));
     HIP_CHECK(hipFree(d_vector));
-    if(is_sobol_scrambled<state_type>::value)
-    {
-        HIP_CHECK(hipFree(d_constants));
-    }
+
     double mean = 0;
     for(auto v : output_host)
     {
@@ -1617,7 +1600,7 @@ void hiprand_kernel_h_sobol()
     const size_t       output_size         = dimensions * items_per_dimension;
 
     DirectionVectors_t<T>* d_vector;
-    T*                     d_constants;
+    T*                     d_constants = nullptr;
     T*                     d_output;
 
     HIP_CHECK(hipMallocHelper(reinterpret_cast<void**>(&d_output), output_size * sizeof(T)));
@@ -1632,7 +1615,6 @@ void hiprand_kernel_h_sobol()
     else
     {
         load_sobol_vectors_to_gpu<S, T>(dimensions, &d_vector);
-        d_constants = NULL;
     }
     HIP_CHECK(hipDeviceSynchronize());
 
@@ -1645,11 +1627,7 @@ void hiprand_kernel_h_sobol()
 
     HIP_CHECK(hipFree(d_output));
     HIP_CHECK(hipFree(d_vector));
-
-    if(is_sobol_scrambled<S>::value)
-    {
-        HIP_CHECK(hipFree(d_constants));
-    }
+    HIP_CHECK(hipFree(d_constants));
 
     const double int_type_max = (double)std::numeric_limits<T>::max();
 

--- a/projects/hiprand/test/test_hiprand_kernel.cpp
+++ b/projects/hiprand/test/test_hiprand_kernel.cpp
@@ -754,6 +754,11 @@ void hiprand_kernel_h_hiprand_sobol_init_test()
     HIP_CHECK(hipGetLastError());
     HIP_CHECK(hipDeviceSynchronize());
     HIP_CHECK(hipFree(states));
+    HIP_CHECK(hipFree(d_vector));
+    if(is_sobol_scrambled<state_type>::value)
+    {
+        HIP_CHECK(hipFree(d_constants));
+    }
 }
 
 template<class state_type>
@@ -772,6 +777,7 @@ void hiprand_kernel_h_hiprand_mtgp_init_test()
         hiprandMakeMTGP32KernelState(states, mtgp32dc_params_fast_11213, k, states_size, seed));
 
     HIP_CHECK(hipFree(states));
+    HIP_CHECK(hipFree(k));
 }
 
 TEST(hiprand_kernel_h_philox4x32_10, hiprand_init)
@@ -977,7 +983,12 @@ void hiprand_kernel_h_hiprand_sobol_test()
                         hipMemcpyDeviceToHost));
     HIP_CHECK(hipDeviceSynchronize());
     HIP_CHECK(hipFree(output));
-
+    HIP_CHECK(hipFree(d_vector));
+    if(is_sobol_scrambled<state_type>::value)
+    {
+        HIP_CHECK(hipFree(d_constants));
+    }
+    
     double mean = 0;
     for(auto v : output_host)
     {
@@ -1019,6 +1030,7 @@ void hiprand_kernel_h_hiprand_mtgp_test()
     HIP_CHECK(hipDeviceSynchronize());
     HIP_CHECK(hipFree(output));
     HIP_CHECK(hipFree(states));
+    HIP_CHECK(hipFree(k));
 
     double mean = 0;
     for(auto v : output_host)
@@ -1136,6 +1148,11 @@ void hiprand_kernel_h_hiprand_uniform_sobol_test()
         hipMemcpy(output_host.data(), output, output_size * sizeof(float), hipMemcpyDeviceToHost));
     HIP_CHECK(hipDeviceSynchronize());
     HIP_CHECK(hipFree(output));
+    HIP_CHECK(hipFree(d_vector));
+    if(is_sobol_scrambled<state_type>::value)
+    {
+        HIP_CHECK(hipFree(d_constants));
+    }
 
     double mean = 0;
     for(auto v : output_host)
@@ -1176,6 +1193,7 @@ void hiprand_kernel_h_hiprand_uniform_mtgp_test()
     HIP_CHECK(hipDeviceSynchronize());
     HIP_CHECK(hipFree(output));
     HIP_CHECK(hipFree(states));
+    HIP_CHECK(hipFree(k));
 
     double mean = 0;
     for(auto v : output_host)
@@ -1301,6 +1319,11 @@ void hiprand_kernel_h_hiprand_normal_sobol_test()
         hipMemcpy(output_host.data(), output, output_size * sizeof(float), hipMemcpyDeviceToHost));
     HIP_CHECK(hipDeviceSynchronize());
     HIP_CHECK(hipFree(output));
+    HIP_CHECK(hipFree(d_vector));
+    if(is_sobol_scrambled<state_type>::value)
+    {
+        HIP_CHECK(hipFree(d_constants));
+    }
 
     double mean = 0;
     for(auto v : output_host)
@@ -1354,6 +1377,7 @@ void hiprand_kernel_h_hiprand_normal_mtgp_test()
     HIP_CHECK(hipDeviceSynchronize());
     HIP_CHECK(hipFree(output));
     HIP_CHECK(hipFree(states));
+    HIP_CHECK(hipFree(k));
 
     double mean = 0;
     for(auto v : output_host)
@@ -1491,7 +1515,11 @@ void hiprand_kernel_h_hiprand_log_normal_sobol_test()
         hipMemcpy(output_host.data(), output, output_size * sizeof(float), hipMemcpyDeviceToHost));
     HIP_CHECK(hipDeviceSynchronize());
     HIP_CHECK(hipFree(output));
-
+    HIP_CHECK(hipFree(d_vector));
+    if(is_sobol_scrambled<state_type>::value)
+    {
+        HIP_CHECK(hipFree(d_constants));
+    }
     double mean = 0;
     for(auto v : output_host)
     {
@@ -1548,6 +1576,7 @@ void hiprand_kernel_h_hiprand_log_normal_mtgp_test()
     HIP_CHECK(hipDeviceSynchronize());
     HIP_CHECK(hipFree(output));
     HIP_CHECK(hipFree(states));
+    HIP_CHECK(hipFree(k));
 
     double mean = 0;
     for(auto v : output_host)
@@ -1801,7 +1830,11 @@ void hiprand_kernel_h_hiprand_poisson_sobol_test(double lambda)
                         hipMemcpyDeviceToHost));
     HIP_CHECK(hipDeviceSynchronize());
     HIP_CHECK(hipFree(output));
-
+    HIP_CHECK(hipFree(d_vector));
+    if(is_sobol_scrambled<state_type>::value)
+    {
+        HIP_CHECK(hipFree(d_constants));
+    }
     double mean = 0;
     for(auto v : output_host)
     {
@@ -1852,7 +1885,7 @@ void hiprand_kernel_h_hiprand_poisson_mtgp_test(double lambda)
     HIP_CHECK(hipDeviceSynchronize());
     HIP_CHECK(hipFree(output));
     HIP_CHECK(hipFree(states));
-
+    HIP_CHECK(hipFree(k));
     double mean = 0;
     for(auto v : output_host)
     {
@@ -1961,6 +1994,11 @@ void hiprand_kernel_h_hiprand_discrete_sobol_test(double lambda)
                         hipMemcpyDeviceToHost));
     HIP_CHECK(hipDeviceSynchronize());
     HIP_CHECK(hipFree(output));
+    HIP_CHECK(hipFree(d_vector));
+    if(is_sobol_scrambled<state_type>::value)
+    {
+        HIP_CHECK(hipFree(d_constants));
+    }
     ASSERT_EQ(hiprandDestroyDistribution(discrete_distribution), HIPRAND_STATUS_SUCCESS);
 
     double mean = 0;
@@ -2017,6 +2055,7 @@ void hiprand_kernel_h_hiprand_discrete_mtgp_test(double lambda)
     HIP_CHECK(hipDeviceSynchronize());
     HIP_CHECK(hipFree(output));
     HIP_CHECK(hipFree(states));
+    HIP_CHECK(hipFree(k));
     ASSERT_EQ(hiprandDestroyDistribution(discrete_distribution), HIPRAND_STATUS_SUCCESS);
 
     double mean = 0;

--- a/projects/hiprand/test/test_hiprand_kernel.cpp
+++ b/projects/hiprand/test/test_hiprand_kernel.cpp
@@ -730,17 +730,8 @@ void hiprand_kernel_h_hiprand_sobol_init_test()
     DirectionVectors_t<int_type>* d_vector;
     int_type*                     d_constants;
 
-    if(is_sobol_scrambled<state_type>::value)
-    {
-        load_scrambled_sobol_constants_and_vectors_to_gpu<state_type, int_type>(dimensions,
-                                                                                &d_vector,
-                                                                                &d_constants);
-    }
-    else
-    {
-        load_sobol_vectors_to_gpu<state_type, int_type>(dimensions, &d_vector);
-        d_constants = NULL;
-    }
+	load_sobol_vectors_to_gpu<state_type, int_type>(dimensions, &d_vector);
+	d_constants = NULL;
 
     unsigned long long offset = 4;
 
@@ -755,10 +746,7 @@ void hiprand_kernel_h_hiprand_sobol_init_test()
     HIP_CHECK(hipDeviceSynchronize());
     HIP_CHECK(hipFree(states));
     HIP_CHECK(hipFree(d_vector));
-    if(is_sobol_scrambled<state_type>::value)
-    {
-        HIP_CHECK(hipFree(d_constants));
-    }
+    HIP_CHECK(hipFree(d_constants));
 }
 
 template<class state_type>
@@ -954,19 +942,8 @@ void hiprand_kernel_h_hiprand_sobol_test()
     const unsigned int dimensions = 8;
 
     DirectionVectors_t<int_type>* d_vector;
-    int_type*                     d_constants;
 
-    if(is_sobol_scrambled<state_type>::value)
-    {
-        load_scrambled_sobol_constants_and_vectors_to_gpu<state_type, int_type>(dimensions,
-                                                                                &d_vector,
-                                                                                &d_constants);
-    }
-    else
-    {
-        load_sobol_vectors_to_gpu<state_type, int_type>(dimensions, &d_vector);
-        d_constants = NULL;
-    }
+	load_sobol_vectors_to_gpu<state_type, int_type>(dimensions, &d_vector);
 
     const size_t output_size = 8192;
     int_type*    output;
@@ -984,10 +961,6 @@ void hiprand_kernel_h_hiprand_sobol_test()
     HIP_CHECK(hipDeviceSynchronize());
     HIP_CHECK(hipFree(output));
     HIP_CHECK(hipFree(d_vector));
-    if(is_sobol_scrambled<state_type>::value)
-    {
-        HIP_CHECK(hipFree(d_constants));
-    }
     
     double mean = 0;
     for(auto v : output_host)
@@ -1120,19 +1093,7 @@ void hiprand_kernel_h_hiprand_uniform_sobol_test()
     const unsigned int dimensions = 8;
 
     DirectionVectors_t<int_type>* d_vector;
-    int_type*                     d_constants;
-
-    if(is_sobol_scrambled<state_type>::value)
-    {
-        load_scrambled_sobol_constants_and_vectors_to_gpu<state_type, int_type>(dimensions,
-                                                                                &d_vector,
-                                                                                &d_constants);
-    }
-    else
-    {
-        load_sobol_vectors_to_gpu<state_type, int_type>(dimensions, &d_vector);
-        d_constants = NULL;
-    }
+    load_sobol_vectors_to_gpu<state_type, int_type>(dimensions, &d_vector);
 
     const size_t output_size = 8192;
     float*       output;
@@ -1149,10 +1110,6 @@ void hiprand_kernel_h_hiprand_uniform_sobol_test()
     HIP_CHECK(hipDeviceSynchronize());
     HIP_CHECK(hipFree(output));
     HIP_CHECK(hipFree(d_vector));
-    if(is_sobol_scrambled<state_type>::value)
-    {
-        HIP_CHECK(hipFree(d_constants));
-    }
 
     double mean = 0;
     for(auto v : output_host)
@@ -1291,19 +1248,8 @@ void hiprand_kernel_h_hiprand_normal_sobol_test()
     const unsigned int dimensions = 8;
 
     DirectionVectors_t<int_type>* d_vector;
-    int_type*                     d_constants;
-
-    if(is_sobol_scrambled<state_type>::value)
-    {
-        load_scrambled_sobol_constants_and_vectors_to_gpu<state_type, int_type>(dimensions,
-                                                                                &d_vector,
-                                                                                &d_constants);
-    }
-    else
-    {
-        load_sobol_vectors_to_gpu<state_type, int_type>(dimensions, &d_vector);
-        d_constants = NULL;
-    }
+	
+    load_sobol_vectors_to_gpu<state_type, int_type>(dimensions, &d_vector);
 
     const size_t output_size = 8192;
     float*       output;
@@ -1320,10 +1266,6 @@ void hiprand_kernel_h_hiprand_normal_sobol_test()
     HIP_CHECK(hipDeviceSynchronize());
     HIP_CHECK(hipFree(output));
     HIP_CHECK(hipFree(d_vector));
-    if(is_sobol_scrambled<state_type>::value)
-    {
-        HIP_CHECK(hipFree(d_constants));
-    }
 
     double mean = 0;
     for(auto v : output_host)
@@ -1800,19 +1742,7 @@ void hiprand_kernel_h_hiprand_poisson_sobol_test(double lambda)
     const unsigned int dimensions = 8;
 
     DirectionVectors_t<int_type>* d_vector;
-    int_type*                     d_constants;
-
-    if(is_sobol_scrambled<state_type>::value)
-    {
-        load_scrambled_sobol_constants_and_vectors_to_gpu<state_type, int_type>(dimensions,
-                                                                                &d_vector,
-                                                                                &d_constants);
-    }
-    else
-    {
-        load_sobol_vectors_to_gpu<state_type, int_type>(dimensions, &d_vector);
-        d_constants = NULL;
-    }
+    load_sobol_vectors_to_gpu<state_type, int_type>(dimensions, &d_vector);
 
     const size_t  output_size = 8192;
     unsigned int* output;
@@ -1831,10 +1761,7 @@ void hiprand_kernel_h_hiprand_poisson_sobol_test(double lambda)
     HIP_CHECK(hipDeviceSynchronize());
     HIP_CHECK(hipFree(output));
     HIP_CHECK(hipFree(d_vector));
-    if(is_sobol_scrambled<state_type>::value)
-    {
-        HIP_CHECK(hipFree(d_constants));
-    }
+
     double mean = 0;
     for(auto v : output_host)
     {
@@ -1960,19 +1887,7 @@ void hiprand_kernel_h_hiprand_discrete_sobol_test(double lambda)
     const unsigned int dimensions = 8;
 
     DirectionVectors_t<int_type>* d_vector;
-    int_type*                     d_constants;
-
-    if(is_sobol_scrambled<state_type>::value)
-    {
-        load_scrambled_sobol_constants_and_vectors_to_gpu<state_type, int_type>(dimensions,
-                                                                                &d_vector,
-                                                                                &d_constants);
-    }
-    else
-    {
-        load_sobol_vectors_to_gpu<state_type, int_type>(dimensions, &d_vector);
-        d_constants = NULL;
-    }
+    load_sobol_vectors_to_gpu<state_type, int_type>(dimensions, &d_vector);
 
     const size_t  output_size = 8192;
     unsigned int* output;
@@ -1995,10 +1910,7 @@ void hiprand_kernel_h_hiprand_discrete_sobol_test(double lambda)
     HIP_CHECK(hipDeviceSynchronize());
     HIP_CHECK(hipFree(output));
     HIP_CHECK(hipFree(d_vector));
-    if(is_sobol_scrambled<state_type>::value)
-    {
-        HIP_CHECK(hipFree(d_constants));
-    }
+
     ASSERT_EQ(hiprandDestroyDistribution(discrete_distribution), HIPRAND_STATUS_SUCCESS);
 
     double mean = 0;

--- a/projects/rocrand/library/src/rng/mtgp32.hpp
+++ b/projects/rocrand/library/src/rng/mtgp32.hpp
@@ -80,7 +80,8 @@ namespace rocrand_impl::host
 struct mtgp32_device_engine : ::rocrand_device::mtgp32_engine
 {
     // suppress warning about no initialization for __shared__ variables
-    __host__ __device__ mtgp32_device_engine(){};
+    __host__ __device__
+    mtgp32_device_engine() {};
 
     __forceinline__ __host__ __device__
     unsigned int next()
@@ -366,14 +367,14 @@ public:
         return *this;
     }
 
-	void free_engines()
-	{
+    void free_engines()
+    {
         if(m_engines != nullptr)
         {
             system_type::free(m_engines);
             m_engines = nullptr;
         }
-	}
+    }
 
     ~mtgp32_generator_template()
     {

--- a/projects/rocrand/library/src/rng/mtgp32.hpp
+++ b/projects/rocrand/library/src/rng/mtgp32.hpp
@@ -366,13 +366,18 @@ public:
         return *this;
     }
 
-    ~mtgp32_generator_template()
-    {
+	void free_engines()
+	{
         if(m_engines != nullptr)
         {
             system_type::free(m_engines);
             m_engines = nullptr;
         }
+	}
+
+    ~mtgp32_generator_template()
+    {
+        free_engines();
     }
 
     static constexpr rocrand_rng_type type()
@@ -382,6 +387,7 @@ public:
 
     void reset() override final
     {
+        free_engines();
         m_engines_initialized = false;
     }
 

--- a/projects/rocrand/test/internal/test_rocrand_discrete.cpp
+++ b/projects/rocrand/test/internal/test_rocrand_discrete.cpp
@@ -650,6 +650,7 @@ TEST(ExternalDiscreteDistributionTests, Philox4x32_10WithUIN4OutputTest)
 
     delete [] host_output;
     HIP_CHECK(hipFree(device_output));
+    HIP_CHECK(hipFree(device_states));
 }
 
 /* #################################################
@@ -730,6 +731,10 @@ void run_internal_host_test(const DiscreteFunc& df)
             actual_prob[i] = histogram[i] / static_cast<double>(test_size);
 
         ASSERT_TRUE(ks_test_2(expected_prob, actual_prob));
+
+        rocrand_err = discrete_distribution_factory<discrete_method::DISCRETE_METHOD_UNIVERSAL,
+												true>::deallocate(discrete_dis);
+        ROCRAND_CHECK(rocrand_err);
     }
 }
 
@@ -873,6 +878,9 @@ void run_host_test(const DiscreteFunc& df)
 
         ASSERT_TRUE(ks_test_2(expected_prob, actual_prob));
 
+        rocrand_err = discrete_distribution_factory<discrete_method::DISCRETE_METHOD_UNIVERSAL,
+                                            true>::deallocate(discrete_dis);
+        ROCRAND_CHECK(rocrand_err);
     }
 }
 

--- a/projects/rocrand/test/internal/test_rocrand_discrete.cpp
+++ b/projects/rocrand/test/internal/test_rocrand_discrete.cpp
@@ -43,12 +43,14 @@ struct GlobalSizes
     static constexpr size_t size             = grid_size * items_per_block;
 };
 
-using DiscreteDataType = ::testing::Types<double, unsigned int, unsigned long, unsigned long long int>;
+using DiscreteDataType
+    = ::testing::Types<double, unsigned int, unsigned long, unsigned long long int>;
 
-template <typename DT>
-class InternalDiscreteDistributionTests : public ::testing::Test{
-    public:
-        using T = DT;
+template<typename DT>
+class InternalDiscreteDistributionTests : public ::testing::Test
+{
+public:
+    using T = DT;
 };
 
 TYPED_TEST_SUITE(InternalDiscreteDistributionTests, DiscreteDataType);
@@ -60,9 +62,11 @@ void internal_discrete_kernel(T*                                device_input,
                               rocrand_discrete_distribution_st& dis)
 {
     const size_t items_per_block = GlobalSizes::items_per_thread * GlobalSizes::block_size;
-    const size_t offset = (items_per_block * blockIdx.x) + (GlobalSizes::items_per_thread * threadIdx.x);
+    const size_t offset
+        = (items_per_block * blockIdx.x) + (GlobalSizes::items_per_thread * threadIdx.x);
 
-    for(size_t i = 0; i < GlobalSizes::items_per_thread; i++){
+    for(size_t i = 0; i < GlobalSizes::items_per_thread; i++)
+    {
         device_output[offset + i] = DiscreteWrapper{}(device_input[offset + i], dis);
     }
 }
@@ -78,44 +82,55 @@ void run_internal_discrete_tests()
     };
 
     std::random_device rd;
-    std::mt19937 gen(rd());
+    std::mt19937       gen(rd());
 
-    T * host_input = new T[GlobalSizes::size];
-    unsigned int * host_output = new unsigned int[GlobalSizes::size];
+    T*            host_input  = new T[GlobalSizes::size];
+    unsigned int* host_output = new unsigned int[GlobalSizes::size];
 
     // Check for different types of data input and generate the input data
-    if constexpr (std::is_same_v<T, double>){
+    if constexpr(std::is_same_v<T, double>)
+    {
         std::uniform_real_distribution<double> dis(0, 1);
-        for(size_t i = 0; i < GlobalSizes::size; i++) host_input[i] = dis(gen);
+        for(size_t i = 0; i < GlobalSizes::size; i++)
+            host_input[i] = dis(gen);
     }
-    else if constexpr(std::is_same_v<T, unsigned long> || std::is_same_v<T, unsigned int>){
+    else if constexpr(std::is_same_v<T, unsigned long> || std::is_same_v<T, unsigned int>)
+    {
         std::uniform_int_distribution<T> dis(0, std::numeric_limits<unsigned int>::max());
-        for(size_t i = 0; i < GlobalSizes::size; i++) host_input[i] = dis(gen);
+        for(size_t i = 0; i < GlobalSizes::size; i++)
+            host_input[i] = dis(gen);
     }
-    else{
+    else
+    {
         std::uniform_int_distribution<T> dis(0, std::numeric_limits<T>::max());
-        for(size_t i = 0; i < GlobalSizes::size; i++) host_input[i] = dis(gen);
+        for(size_t i = 0; i < GlobalSizes::size; i++)
+            host_input[i] = dis(gen);
     }
 
-    T * device_input;
-    unsigned int * device_output;
+    T*            device_input;
+    unsigned int* device_output;
 
     HIP_CHECK(hipMalloc(&device_input, sizeof(T) * GlobalSizes::size));
     HIP_CHECK(hipMalloc(&device_output, sizeof(unsigned int) * GlobalSizes::size));
 
-    HIP_CHECK(hipMemcpy(device_input, host_input, sizeof(T) * GlobalSizes::size, hipMemcpyHostToDevice));
+    HIP_CHECK(
+        hipMemcpy(device_input, host_input, sizeof(T) * GlobalSizes::size, hipMemcpyHostToDevice));
 
     // Generate different discrete distributions and check them against expected
-    for(std::vector<double> distribution : all_distributions){
+    for(std::vector<double> distribution : all_distributions)
+    {
         // Getting expected Results
-        double sum = std::accumulate(distribution.begin(), distribution.end(), 0);
+        double              sum = std::accumulate(distribution.begin(), distribution.end(), 0);
         std::vector<double> expected_prob(distribution.size());
         for(size_t i = 0; i < distribution.size(); i++)
             expected_prob[i] = distribution[i] / sum;
 
         // Creating the discrete distribution
         rocrand_discrete_distribution discrete_distribution;
-        ROCRAND_CHECK(rocrand_create_discrete_distribution(expected_prob.data(), expected_prob.size(), 0, &discrete_distribution));
+        ROCRAND_CHECK(rocrand_create_discrete_distribution(expected_prob.data(),
+                                                           expected_prob.size(),
+                                                           0,
+                                                           &discrete_distribution));
 
         internal_discrete_kernel<T, DiscreteWrapper>
             <<<dim3(GlobalSizes::grid_size), dim3(GlobalSizes::block_size), 0, 0>>>(
@@ -123,7 +138,10 @@ void run_internal_discrete_tests()
                 device_output,
                 *discrete_distribution);
 
-        HIP_CHECK(hipMemcpy(host_output, device_output, sizeof(unsigned int) * GlobalSizes::size, hipMemcpyDeviceToHost));
+        HIP_CHECK(hipMemcpy(host_output,
+                            device_output,
+                            sizeof(unsigned int) * GlobalSizes::size,
+                            hipMemcpyDeviceToHost));
 
         std::vector<double> histogram(distribution.size());
 
@@ -140,8 +158,8 @@ void run_internal_discrete_tests()
         ROCRAND_CHECK(rocrand_destroy_discrete_distribution(discrete_distribution));
     }
 
-    delete [] host_input;
-    delete [] host_output;
+    delete[] host_input;
+    delete[] host_output;
 
     HIP_CHECK(hipFree(device_input));
     HIP_CHECK(hipFree(device_output));
@@ -167,31 +185,35 @@ struct internal_discrete_cdf
     }
 };
 
-TYPED_TEST(InternalDiscreteDistributionTests, InternalDiscreteAliasTest){
+TYPED_TEST(InternalDiscreteDistributionTests, InternalDiscreteAliasTest)
+{
     using T = typename TestFixture::T;
 
     run_internal_discrete_tests<T, internal_discrete_alias<T>>();
 }
 
-TYPED_TEST(InternalDiscreteDistributionTests, InternalDiscreteCDFTest){
+TYPED_TEST(InternalDiscreteDistributionTests, InternalDiscreteCDFTest)
+{
     using T = typename TestFixture::T;
 
     run_internal_discrete_tests<T, internal_discrete_cdf<T>>();
 }
 
 template<class RocRandPrngType>
-__global__ void block_wide_external_discrete_kernel(
-    RocRandPrngType * states,
-    unsigned int * device_output,
-    rocrand_discrete_distribution_st & dis,
-    size_t items_per_thread,
-    size_t block_size
-){
+__global__
+void block_wide_external_discrete_kernel(RocRandPrngType*                  states,
+                                         unsigned int*                     device_output,
+                                         rocrand_discrete_distribution_st& dis,
+                                         size_t                            items_per_thread,
+                                         size_t                            block_size)
+{
     const size_t items_per_block = items_per_thread * block_size;
     const size_t offset = (items_per_block * blockIdx.x) + (items_per_thread * threadIdx.x);
 
-    for(size_t i = 0; i < items_per_thread; i++){
-        __shared__ RocRandPrngType state;
+    for(size_t i = 0; i < items_per_thread; i++)
+    {
+        __shared__
+        RocRandPrngType state;
         if(threadIdx.x == 0)
             state = states[blockIdx.x];
         __syncthreads();
@@ -205,31 +227,31 @@ __global__ void block_wide_external_discrete_kernel(
 }
 
 template<class RocRandPrngType>
-__global__ void external_discrete_kernel(
-    RocRandPrngType * states,
-    unsigned int * device_output,
-    rocrand_discrete_distribution_st & dis,
-    size_t items_per_thread,
-    size_t block_size
-){
+__global__
+void external_discrete_kernel(RocRandPrngType*                  states,
+                              unsigned int*                     device_output,
+                              rocrand_discrete_distribution_st& dis,
+                              size_t                            items_per_thread,
+                              size_t                            block_size)
+{
     const size_t items_per_block = items_per_thread * block_size;
     const size_t offset = (items_per_block * blockIdx.x) + (items_per_thread * threadIdx.x);
 
-    for(size_t i = 0; i < items_per_thread; i++){
-        auto local_state = states[offset + i];
+    for(size_t i = 0; i < items_per_thread; i++)
+    {
+        auto local_state          = states[offset + i];
         device_output[offset + i] = rocrand_discrete(&local_state, &dis);
-        states[offset + i] = local_state;
+        states[offset + i]        = local_state;
     }
 }
 
 template<bool block_wide, class PrngState>
-void run_external_discrete_tests(
-    PrngState & device_states,
-    size_t items_per_thread = GlobalSizes::items_per_thread,
-    size_t block_size = GlobalSizes::block_size,
-    size_t grid_size = GlobalSizes::grid_size,
-    size_t size = GlobalSizes::size
-){
+void run_external_discrete_tests(PrngState& device_states,
+                                 size_t     items_per_thread = GlobalSizes::items_per_thread,
+                                 size_t     block_size       = GlobalSizes::block_size,
+                                 size_t     grid_size        = GlobalSizes::grid_size,
+                                 size_t     size             = GlobalSizes::size)
+{
 
     std::vector<std::vector<double>> all_distributions = {
         {10, 10, 10, 10},
@@ -238,38 +260,57 @@ void run_external_discrete_tests(
         {1, 2, 8, 4, 3, 2, 1}
     };
 
-    unsigned int * host_output = new unsigned int[size];
-    unsigned int * device_output;
+    unsigned int* host_output = new unsigned int[size];
+    unsigned int* device_output;
     HIP_CHECK(hipMalloc(&device_output, sizeof(unsigned int) * size));
 
-    for(std::vector<double> distribution : all_distributions){
+    for(std::vector<double> distribution : all_distributions)
+    {
 
         // Getting expected Results
-        double sum = std::accumulate(distribution.begin(), distribution.end(), 0);
+        double              sum = std::accumulate(distribution.begin(), distribution.end(), 0);
         std::vector<double> expected_prob(distribution.size());
         for(size_t i = 0; i < distribution.size(); i++)
             expected_prob[i] = distribution[i] / sum;
 
         // Creating the discrete distribution
         rocrand_discrete_distribution discrete_distribution;
-        ROCRAND_CHECK(rocrand_create_discrete_distribution(expected_prob.data(), expected_prob.size(), 0, &discrete_distribution));
+        ROCRAND_CHECK(rocrand_create_discrete_distribution(expected_prob.data(),
+                                                           expected_prob.size(),
+                                                           0,
+                                                           &discrete_distribution));
 
-        if constexpr(block_wide){
-            hipLaunchKernelGGL(
-                HIP_KERNEL_NAME(block_wide_external_discrete_kernel),
-                dim3(grid_size), dim3(block_size), 0, 0,
-                device_states, device_output, *discrete_distribution, items_per_thread, block_size
-            );
+        if constexpr(block_wide)
+        {
+            hipLaunchKernelGGL(HIP_KERNEL_NAME(block_wide_external_discrete_kernel),
+                               dim3(grid_size),
+                               dim3(block_size),
+                               0,
+                               0,
+                               device_states,
+                               device_output,
+                               *discrete_distribution,
+                               items_per_thread,
+                               block_size);
         }
-        else{
-            hipLaunchKernelGGL(
-                HIP_KERNEL_NAME(external_discrete_kernel),
-                dim3(grid_size), dim3(block_size), 0, 0,
-                device_states, device_output, *discrete_distribution, items_per_thread, block_size
-            );
+        else
+        {
+            hipLaunchKernelGGL(HIP_KERNEL_NAME(external_discrete_kernel),
+                               dim3(grid_size),
+                               dim3(block_size),
+                               0,
+                               0,
+                               device_states,
+                               device_output,
+                               *discrete_distribution,
+                               items_per_thread,
+                               block_size);
         }
 
-        HIP_CHECK(hipMemcpy(host_output, device_output, sizeof(unsigned int) * size, hipMemcpyDeviceToHost));
+        HIP_CHECK(hipMemcpy(host_output,
+                            device_output,
+                            sizeof(unsigned int) * size,
+                            hipMemcpyDeviceToHost));
         std::vector<double> histogram(distribution.size());
 
         // Calculating the actual results
@@ -284,7 +325,7 @@ void run_external_discrete_tests(
         ROCRAND_CHECK(rocrand_destroy_discrete_distribution(discrete_distribution));
     }
 
-    delete [] host_output;
+    delete[] host_output;
     HIP_CHECK(hipFree(device_output));
 }
 
@@ -293,7 +334,8 @@ __global__
 void init_rocrand_states_kernel(RocRandPrngType* states)
 {
     constexpr size_t items_per_block = GlobalSizes::items_per_thread * GlobalSizes::block_size;
-    const size_t offset = (items_per_block * blockIdx.x) + (GlobalSizes::items_per_thread * threadIdx.x);
+    const size_t     offset
+        = (items_per_block * blockIdx.x) + (GlobalSizes::items_per_thread * threadIdx.x);
 
     for(size_t i = 0; i < GlobalSizes::items_per_thread; i++)
     {
@@ -321,9 +363,10 @@ void init_rocrand_states_kernel4(RocRandPrngType* states)
     }
 }
 
-TEST(ExternalDiscreteDistributionTests, Philox4x32_10Test){
+TEST(ExternalDiscreteDistributionTests, Philox4x32_10Test)
+{
     // Initialize the prng state
-    rocrand_state_philox4x32_10 * device_states;
+    rocrand_state_philox4x32_10* device_states;
     HIP_CHECK(hipMalloc(&device_states, sizeof(rocrand_state_philox4x32_10) * GlobalSizes::size));
 
     struct f
@@ -345,9 +388,10 @@ TEST(ExternalDiscreteDistributionTests, Philox4x32_10Test){
     HIP_CHECK(hipFree(device_states));
 }
 
-TEST(ExternalDiscreteDistributionTests, Mrg31k3pTest){
+TEST(ExternalDiscreteDistributionTests, Mrg31k3pTest)
+{
     // Initialize the prng state
-    rocrand_state_mrg31k3p * device_states;
+    rocrand_state_mrg31k3p* device_states;
     HIP_CHECK(hipMalloc(&device_states, sizeof(rocrand_state_mrg31k3p) * GlobalSizes::size));
 
     struct f
@@ -369,9 +413,10 @@ TEST(ExternalDiscreteDistributionTests, Mrg31k3pTest){
     HIP_CHECK(hipFree(device_states));
 }
 
-TEST(ExternalDiscreteDistributionTests, Mrg32k3aTest){
+TEST(ExternalDiscreteDistributionTests, Mrg32k3aTest)
+{
     // Initialize the prng state
-    rocrand_state_mrg32k3a * device_states;
+    rocrand_state_mrg32k3a* device_states;
     HIP_CHECK(hipMalloc(&device_states, sizeof(rocrand_state_mrg32k3a) * GlobalSizes::size));
 
     init_rocrand_states_kernel<<<dim3(GlobalSizes::grid_size),
@@ -384,9 +429,10 @@ TEST(ExternalDiscreteDistributionTests, Mrg32k3aTest){
     HIP_CHECK(hipFree(device_states));
 }
 
-TEST(ExternalDiscreteDistributionTests, XorwowTest){
+TEST(ExternalDiscreteDistributionTests, XorwowTest)
+{
     // Initialize the prng state
-    rocrand_state_xorwow * device_states;
+    rocrand_state_xorwow* device_states;
     HIP_CHECK(hipMalloc(&device_states, sizeof(rocrand_state_xorwow) * GlobalSizes::size));
 
     init_rocrand_states_kernel<<<dim3(GlobalSizes::grid_size),
@@ -399,32 +445,28 @@ TEST(ExternalDiscreteDistributionTests, XorwowTest){
     HIP_CHECK(hipFree(device_states));
 }
 
-TEST(ExternalDiscreteDistributionTests, Mtgp32Test){
+TEST(ExternalDiscreteDistributionTests, Mtgp32Test)
+{
     constexpr size_t items_per_thread = 1024;
-    constexpr size_t block_size = 256;
-    constexpr size_t grid_size = 12;
-    constexpr size_t items_per_block = block_size * items_per_thread;
+    constexpr size_t block_size       = 256;
+    constexpr size_t grid_size        = 12;
+    constexpr size_t items_per_block  = block_size * items_per_thread;
 
-    constexpr size_t test_size = items_per_block * grid_size;
-    rocrand_state_mtgp32 * states;
+    constexpr size_t      test_size = items_per_block * grid_size;
+    rocrand_state_mtgp32* states;
 
     HIP_CHECK(hipMalloc(&states, sizeof(rocrand_state_mtgp32) * grid_size));
-    rocrand_make_state_mtgp32(states,  mtgp32dc_params_fast_11213, grid_size, 123456);
+    rocrand_make_state_mtgp32(states, mtgp32dc_params_fast_11213, grid_size, 123456);
     HIP_CHECK(hipDeviceSynchronize());
 
-    run_external_discrete_tests<true>(
-        states,
-        items_per_thread,
-        block_size,
-        grid_size,
-        test_size
-    );
+    run_external_discrete_tests<true>(states, items_per_thread, block_size, grid_size, test_size);
     HIP_CHECK(hipFree(states));
 }
 
-TEST(ExternalDiscreteDistributionTests, Lfsr113Test){
+TEST(ExternalDiscreteDistributionTests, Lfsr113Test)
+{
     // Initialize the prng state
-    rocrand_state_lfsr113 * device_states;
+    rocrand_state_lfsr113* device_states;
     HIP_CHECK(hipMalloc(&device_states, sizeof(rocrand_state_lfsr113) * GlobalSizes::size));
 
     init_rocrand_states_kernel4<<<dim3(GlobalSizes::grid_size),
@@ -437,89 +479,114 @@ TEST(ExternalDiscreteDistributionTests, Lfsr113Test){
     HIP_CHECK(hipFree(device_states));
 }
 
-TEST(ExternalDiscreteDistributionTests, Sobol32Test){
+TEST(ExternalDiscreteDistributionTests, Sobol32Test)
+{
     // Initialize the prng state
-    rocrand_state_sobol32 * host_states = new rocrand_state_sobol32[GlobalSizes::size];
-    const unsigned int* directions;
-    ROCRAND_CHECK(rocrand_get_direction_vectors32(&directions, ROCRAND_DIRECTION_VECTORS_32_JOEKUO6));
+    rocrand_state_sobol32* host_states = new rocrand_state_sobol32[GlobalSizes::size];
+    const unsigned int*    directions;
+    ROCRAND_CHECK(
+        rocrand_get_direction_vectors32(&directions, ROCRAND_DIRECTION_VECTORS_32_JOEKUO6));
 
     // 640000 is the size of directions. This is to prevent overflow stuff
     for(size_t i = 0; i < GlobalSizes::size; i++)
         rocrand_init(directions, i % 640000, host_states + i);
 
-    rocrand_state_sobol32 * device_states;
+    rocrand_state_sobol32* device_states;
     HIP_CHECK(hipMalloc(&device_states, sizeof(rocrand_state_sobol32) * GlobalSizes::size));
-    HIP_CHECK(hipMemcpy(device_states, host_states, sizeof(rocrand_state_sobol32) * GlobalSizes::size, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(device_states,
+                        host_states,
+                        sizeof(rocrand_state_sobol32) * GlobalSizes::size,
+                        hipMemcpyHostToDevice));
 
     run_external_discrete_tests<false>(device_states);
 
-    delete [] host_states;
+    delete[] host_states;
     HIP_CHECK(hipFree(device_states));
 }
 
-TEST(ExternalDiscreteDistributionTests, ScrambledSobol32Test){
+TEST(ExternalDiscreteDistributionTests, ScrambledSobol32Test)
+{
     // Initialize the prng state
-    rocrand_state_scrambled_sobol32 * host_states = new rocrand_state_scrambled_sobol32[GlobalSizes::size];
+    rocrand_state_scrambled_sobol32* host_states
+        = new rocrand_state_scrambled_sobol32[GlobalSizes::size];
     const unsigned int* directions;
-    ROCRAND_CHECK(rocrand_get_direction_vectors32(&directions, ROCRAND_DIRECTION_VECTORS_32_JOEKUO6));
+    ROCRAND_CHECK(
+        rocrand_get_direction_vectors32(&directions, ROCRAND_DIRECTION_VECTORS_32_JOEKUO6));
 
     // 640000 is the size of directions. This is to prevent overflow stuff
     for(size_t i = 0; i < GlobalSizes::size; i++)
         rocrand_init(directions, 123456 ^ i, i % 640000, host_states + i);
 
-    rocrand_state_scrambled_sobol32 * device_states;
-    HIP_CHECK(hipMalloc(&device_states, sizeof(rocrand_state_scrambled_sobol32) * GlobalSizes::size));
-    HIP_CHECK(hipMemcpy(device_states, host_states, sizeof(rocrand_state_scrambled_sobol32) * GlobalSizes::size, hipMemcpyHostToDevice));
+    rocrand_state_scrambled_sobol32* device_states;
+    HIP_CHECK(
+        hipMalloc(&device_states, sizeof(rocrand_state_scrambled_sobol32) * GlobalSizes::size));
+    HIP_CHECK(hipMemcpy(device_states,
+                        host_states,
+                        sizeof(rocrand_state_scrambled_sobol32) * GlobalSizes::size,
+                        hipMemcpyHostToDevice));
 
     run_external_discrete_tests<false>(device_states);
 
-    delete [] host_states;
+    delete[] host_states;
     HIP_CHECK(hipFree(device_states));
 }
 
-TEST(ExternalDiscreteDistributionTests, Sobol64Test){
+TEST(ExternalDiscreteDistributionTests, Sobol64Test)
+{
     // Initialize the prng state
-    rocrand_state_sobol64 * host_states = new rocrand_state_sobol64[GlobalSizes::size];
+    rocrand_state_sobol64*    host_states = new rocrand_state_sobol64[GlobalSizes::size];
     const unsigned long long* directions;
-    ROCRAND_CHECK(rocrand_get_direction_vectors64(&directions, ROCRAND_DIRECTION_VECTORS_64_JOEKUO6));
+    ROCRAND_CHECK(
+        rocrand_get_direction_vectors64(&directions, ROCRAND_DIRECTION_VECTORS_64_JOEKUO6));
 
     // 1280000 is the size of directions. This is to prevent overflow stuff
     for(size_t i = 0; i < GlobalSizes::size; i++)
         rocrand_init(directions, i % 1280000, host_states + i);
 
-    rocrand_state_sobol64 * device_states;
+    rocrand_state_sobol64* device_states;
     HIP_CHECK(hipMalloc(&device_states, sizeof(rocrand_state_sobol64) * GlobalSizes::size));
-    HIP_CHECK(hipMemcpy(device_states, host_states, sizeof(rocrand_state_sobol64) * GlobalSizes::size, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(device_states,
+                        host_states,
+                        sizeof(rocrand_state_sobol64) * GlobalSizes::size,
+                        hipMemcpyHostToDevice));
 
     run_external_discrete_tests<false>(device_states);
 
-    delete [] host_states;
+    delete[] host_states;
     HIP_CHECK(hipFree(device_states));
 }
 
-TEST(ExternalDiscreteDistributionTests, ScrambledSobol64Test){
+TEST(ExternalDiscreteDistributionTests, ScrambledSobol64Test)
+{
     // Initialize the prng state
-    rocrand_state_scrambled_sobol64 * host_states = new rocrand_state_scrambled_sobol64[GlobalSizes::size];
+    rocrand_state_scrambled_sobol64* host_states
+        = new rocrand_state_scrambled_sobol64[GlobalSizes::size];
     const unsigned long long* directions;
-    ROCRAND_CHECK(rocrand_get_direction_vectors64(&directions, ROCRAND_DIRECTION_VECTORS_64_JOEKUO6));
+    ROCRAND_CHECK(
+        rocrand_get_direction_vectors64(&directions, ROCRAND_DIRECTION_VECTORS_64_JOEKUO6));
 
     // 1280000 is the size of directions. This is to prevent overflow stuff
     for(size_t i = 0; i < GlobalSizes::size; i++)
         rocrand_init(directions, 123456 ^ i, i % 1280000, host_states + i);
 
-    rocrand_state_scrambled_sobol64 * device_states;
-    HIP_CHECK(hipMalloc(&device_states, sizeof(rocrand_state_scrambled_sobol64) * GlobalSizes::size));
-    HIP_CHECK(hipMemcpy(device_states, host_states, sizeof(rocrand_state_scrambled_sobol64) * GlobalSizes::size, hipMemcpyHostToDevice));
+    rocrand_state_scrambled_sobol64* device_states;
+    HIP_CHECK(
+        hipMalloc(&device_states, sizeof(rocrand_state_scrambled_sobol64) * GlobalSizes::size));
+    HIP_CHECK(hipMemcpy(device_states,
+                        host_states,
+                        sizeof(rocrand_state_scrambled_sobol64) * GlobalSizes::size,
+                        hipMemcpyHostToDevice));
 
     run_external_discrete_tests<false>(device_states);
 
-    delete [] host_states;
+    delete[] host_states;
     HIP_CHECK(hipFree(device_states));
 }
 
-TEST(ExternalDiscreteDistributionTests, Threefry2x32_20Test){
+TEST(ExternalDiscreteDistributionTests, Threefry2x32_20Test)
+{
     // Initialize the prng state
-    rocrand_state_threefry2x32_20 * device_states;
+    rocrand_state_threefry2x32_20* device_states;
     HIP_CHECK(hipMalloc(&device_states, sizeof(rocrand_state_threefry2x32_20) * GlobalSizes::size));
 
     init_rocrand_states_kernel<<<dim3(GlobalSizes::grid_size),
@@ -532,9 +599,10 @@ TEST(ExternalDiscreteDistributionTests, Threefry2x32_20Test){
     HIP_CHECK(hipFree(device_states));
 }
 
-TEST(ExternalDiscreteDistributionTests, Threefry2x64_20Test){
+TEST(ExternalDiscreteDistributionTests, Threefry2x64_20Test)
+{
     // Initialize the prng state
-    rocrand_state_threefry2x64_20 * device_states;
+    rocrand_state_threefry2x64_20* device_states;
     HIP_CHECK(hipMalloc(&device_states, sizeof(rocrand_state_threefry2x64_20) * GlobalSizes::size));
 
     init_rocrand_states_kernel<<<dim3(GlobalSizes::grid_size),
@@ -547,9 +615,10 @@ TEST(ExternalDiscreteDistributionTests, Threefry2x64_20Test){
     HIP_CHECK(hipFree(device_states));
 }
 
-TEST(ExternalDiscreteDistributionTests, Threefry4x32_20Test){
+TEST(ExternalDiscreteDistributionTests, Threefry4x32_20Test)
+{
     // Initialize the prng state
-    rocrand_state_threefry4x32_20 * device_states;
+    rocrand_state_threefry4x32_20* device_states;
     HIP_CHECK(hipMalloc(&device_states, sizeof(rocrand_state_threefry4x32_20) * GlobalSizes::size));
 
     init_rocrand_states_kernel<<<dim3(GlobalSizes::grid_size),
@@ -562,9 +631,10 @@ TEST(ExternalDiscreteDistributionTests, Threefry4x32_20Test){
     HIP_CHECK(hipFree(device_states));
 }
 
-TEST(ExternalDiscreteDistributionTests, Threefry4x64_20Test){
+TEST(ExternalDiscreteDistributionTests, Threefry4x64_20Test)
+{
     // Initialize the prng state
-    rocrand_state_threefry4x64_20 * device_states;
+    rocrand_state_threefry4x64_20* device_states;
     HIP_CHECK(hipMalloc(&device_states, sizeof(rocrand_state_threefry4x64_20) * GlobalSizes::size));
 
     init_rocrand_states_kernel<<<dim3(GlobalSizes::grid_size),
@@ -578,21 +648,26 @@ TEST(ExternalDiscreteDistributionTests, Threefry4x64_20Test){
 }
 
 template<size_t items_per_thread, size_t block_size>
-__global__ void uint4_kernel(rocrand_state_philox4x32_10 * states, uint4 * device_output, rocrand_discrete_distribution_st & dis){
+__global__
+void uint4_kernel(rocrand_state_philox4x32_10*      states,
+                  uint4*                            device_output,
+                  rocrand_discrete_distribution_st& dis)
+{
     const size_t items_per_block = items_per_thread * block_size;
     const size_t offset = (items_per_block * blockIdx.x) + (items_per_thread * threadIdx.x);
 
-    for(size_t i = 0; i < items_per_thread; i++){
-        auto local_state = states[offset + i];
+    for(size_t i = 0; i < items_per_thread; i++)
+    {
+        auto local_state          = states[offset + i];
         device_output[offset + i] = rocrand_discrete4(&local_state, &dis);
-        states[offset + i] = local_state;
+        states[offset + i]        = local_state;
     }
 }
 
 TEST(ExternalDiscreteDistributionTests, Philox4x32_10WithUIN4OutputTest)
 {
     // Initialize the prng state
-    rocrand_state_philox4x32_10 * device_states;
+    rocrand_state_philox4x32_10* device_states;
     HIP_CHECK(hipMalloc(&device_states, sizeof(rocrand_state_philox4x32_10) * GlobalSizes::size));
 
     init_rocrand_states_kernel<<<dim3(GlobalSizes::grid_size),
@@ -607,33 +682,45 @@ TEST(ExternalDiscreteDistributionTests, Philox4x32_10WithUIN4OutputTest)
         {1, 2, 8, 4, 3, 2, 1}
     };
 
-    uint4 * host_output = new uint4[GlobalSizes::size];
-    uint4 * device_output;
+    uint4* host_output = new uint4[GlobalSizes::size];
+    uint4* device_output;
     HIP_CHECK(hipMalloc(&device_output, sizeof(uint4) * GlobalSizes::size));
 
-    for(std::vector<double> distribution : all_distributions){
+    for(std::vector<double> distribution : all_distributions)
+    {
 
         // Getting expected Results
-        double sum = std::accumulate(distribution.begin(), distribution.end(), 0);
+        double              sum = std::accumulate(distribution.begin(), distribution.end(), 0);
         std::vector<double> expected_prob(distribution.size());
         for(size_t i = 0; i < distribution.size(); i++)
             expected_prob[i] = distribution[i] / sum;
 
         // Creating the discrete distribution
         rocrand_discrete_distribution discrete_distribution;
-        ROCRAND_CHECK(rocrand_create_discrete_distribution(expected_prob.data(), expected_prob.size(), 0, &discrete_distribution));
+        ROCRAND_CHECK(rocrand_create_discrete_distribution(expected_prob.data(),
+                                                           expected_prob.size(),
+                                                           0,
+                                                           &discrete_distribution));
 
         hipLaunchKernelGGL(
             HIP_KERNEL_NAME(uint4_kernel<GlobalSizes::items_per_thread, GlobalSizes::block_size>),
-            dim3(GlobalSizes::grid_size), dim3(GlobalSizes::block_size), 0, 0,
-            device_states, device_output, * discrete_distribution
-        );
+            dim3(GlobalSizes::grid_size),
+            dim3(GlobalSizes::block_size),
+            0,
+            0,
+            device_states,
+            device_output,
+            *discrete_distribution);
 
-        HIP_CHECK(hipMemcpy(host_output, device_output, sizeof(uint4) * GlobalSizes::size, hipMemcpyDeviceToHost));
+        HIP_CHECK(hipMemcpy(host_output,
+                            device_output,
+                            sizeof(uint4) * GlobalSizes::size,
+                            hipMemcpyDeviceToHost));
         std::vector<double> histogram(distribution.size());
 
         // Calculating the actual results
-        for(size_t i = 0; i < GlobalSizes::size; i++){
+        for(size_t i = 0; i < GlobalSizes::size; i++)
+        {
             histogram[host_output[i].w]++;
             histogram[host_output[i].x]++;
             histogram[host_output[i].y]++;
@@ -648,7 +735,7 @@ TEST(ExternalDiscreteDistributionTests, Philox4x32_10WithUIN4OutputTest)
         ROCRAND_CHECK(rocrand_destroy_discrete_distribution(discrete_distribution));
     }
 
-    delete [] host_output;
+    delete[] host_output;
     HIP_CHECK(hipFree(device_output));
     HIP_CHECK(hipFree(device_states));
 }
@@ -733,7 +820,7 @@ void run_internal_host_test(const DiscreteFunc& df)
         ASSERT_TRUE(ks_test_2(expected_prob, actual_prob));
 
         rocrand_err = discrete_distribution_factory<discrete_method::DISCRETE_METHOD_UNIVERSAL,
-												true>::deallocate(discrete_dis);
+                                                    true>::deallocate(discrete_dis);
         ROCRAND_CHECK(rocrand_err);
     }
 }
@@ -879,7 +966,7 @@ void run_host_test(const DiscreteFunc& df)
         ASSERT_TRUE(ks_test_2(expected_prob, actual_prob));
 
         rocrand_err = discrete_distribution_factory<discrete_method::DISCRETE_METHOD_UNIVERSAL,
-                                            true>::deallocate(discrete_dis);
+                                                    true>::deallocate(discrete_dis);
         ROCRAND_CHECK(rocrand_err);
     }
 }


### PR DESCRIPTION
## Motivation

Fixing memory leaks is good.

## Technical Details

Fixed assorted memory leaks in the rocRAND/hipRAND unit tests, and one memory leak in mtgp32.hpp - the test code showed a pattern which could cause rocRAND's mtgp32_generator_template to not free m_engines.

## Test Plan

Run unit tests to verify nothing is broken and leaks are gone.

## Test Result

Memory leaks no longer reported by ASAN.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
