### PR TITLE
Add f4 to conversion utility

### DIFF
--- a/projects/hipblaslt/tensilelite/include/Tensile/UtilsOrigami.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/UtilsOrigami.hpp
@@ -75,6 +75,8 @@ namespace TensileLite
             return origami::data_type_t::Float8BFloat8;
         case rocisa::DataType::BFloat8Float8:
             return origami::data_type_t::BFloat8Float8;
+        case rocisa::DataType::Float4:
+            return origami::data_type_t::Float4;
 
         default:
             return origami::data_type_t::None;


### PR DESCRIPTION
## Motivation

Add Float4 to conversion utility for Origami.

## Technical Details

Correct datatype conversion from rocisa to Origami for Float4.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
