### PR TITLE
[MIOpen] Fixed GPU segmentation fault for test_find_2_conv preallocate=1 cases

### DIFF
--- a/projects/miopen/test/gtest/find_2_conv.cpp
+++ b/projects/miopen/test/gtest/find_2_conv.cpp
@@ -99,6 +99,7 @@ void RunFind2ConvTest(const Find2ConvTestCase& test_case)
         EXPECT_EQ(miopenSetFindOptionAttachBinaries(options, test_case.attach_binaries),
                   miopenStatusSuccess);
 
+        Workspace wspace{}; // This GPU buffer may be used by miopenFindSolutions
         if(test_case.preallocate)
         {
             std::size_t workspace_max = 0;
@@ -123,7 +124,7 @@ void RunFind2ConvTest(const Find2ConvTestCase& test_case)
             }
 
             const auto workspace_size = std::min(test_case.workspace_limit, workspace_max);
-            Workspace wspace{workspace_size};
+            wspace.resize(workspace_size);
 
             EXPECT_EQ(
                 miopenSetFindOptionPreallocatedWorkspace(options, wspace.ptr(), wspace.size()),
@@ -276,17 +277,6 @@ TEST_P(GPU_Find2Conv_FP32, Find2ConvTest)
                          std::get<2>(param),
                          std::get<3>(param),
                          std::get<4>(param)};
-
-    // Temporarily disable 6 test cases.
-    // When the entire test suite is executed, all test cases pass.
-    // However, running any of these test cases in isolation results in a failure.
-    // This issue is also reproducible with the original ctest when executing tests individually.
-    if((tc.tune == 1) && (tc.preallocate == 1) &&
-       (tc.workspace_limit == std::numeric_limits<std::size_t>::max()))
-    {
-        GTEST_SKIP();
-    }
-
     RunFind2ConvTest(tc);
 }
 


### PR DESCRIPTION
## Motivation

There was a GPU segfault in `test_find_2_conv` with `preallocate=1`. The PR aims to fix this bug and re-enable those disabled tests.

## Technical Details

For `preallocate=1` test cases the test uses RAII-style GPU buffer which gets destroyed before use. This PR moves it in the correct visibility space in order to exist when GPU kernel actually uses it.

## Test Plan

Running unit tests locally, using CI to verify.

## Test Result

We should not observe GPU segfaults anymore

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
