### PR TITLE
[rocThrust] Fix memory leak in binary search test

### DIFF
--- a/projects/rocthrust/test/test_binary_search.cpp
+++ b/projects/rocthrust/test/test_binary_search.cpp
@@ -123,6 +123,7 @@ void RunSingleValueTest(const ExpectedFunction& ef, const ThrustDeviceFunction& 
   }
 
   delete[] host_search;
+  delete[] host_input;
   delete[] host_expected;
   delete[] host_thrust_output;
   delete[] device_thrust_output;


### PR DESCRIPTION
## Motivation

This commit fixes a memory leak in binary_search.hip.

## Technical Details

The test was was missing a delete[] for a host-side allocation.

## Test Plan

Build binary_search.hip with ASAN enabled. Run the test and verify that no leaks are reported.

## Test Result

No leaks are reported with the fix in my local testing.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
