### PR TITLE
[tensilelite] Add logging for why the fast gemm implementation was rejected

### DIFF
--- a/projects/hipblaslt/tensilelite/client/src/Reference.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/Reference.cpp
@@ -31,6 +31,7 @@
 #include "TypedId.hpp"
 
 #include <cstddef>
+#include <iostream>
 #include <omp.h>
 
 #define MAX_OMP_THREADS 64
@@ -828,9 +829,14 @@ namespace TensileLite
             // If we knew at this point that the data was initialized as whole number floats,
             // we could continue down this fast path, because there would be no rounding
             // errors incurred by f32 accumulation. But we do not.
+            auto rejectFast = [](const char* reason) {
+                std::clog << "FAST_PATH_REJECT: " << reason << std::endl;
+                return false;
+            };
+
             if(problem.f32XdlMathOp() == rocisa::DataType::XFloat32)
             {
-                return false;
+                return rejectFast("XFloat32");
             }
 
             // Guard rails to check that the fast path is appropriate to use.
@@ -844,48 +850,53 @@ namespace TensileLite
                || !isSupportedType(problem.c().dataType())
                || !isSupportedType(problem.d().dataType()))
             {
-                return false;
+                std::string detail = "unsupported_type"
+                    " A=" + TensileLite::ToString(problem.a().dataType())
+                    + " B=" + TensileLite::ToString(problem.b().dataType())
+                    + " C=" + TensileLite::ToString(problem.c().dataType())
+                    + " D=" + TensileLite::ToString(problem.d().dataType());
+                return rejectFast(detail.c_str());
             }
 
             if(problem.batchIndices().empty())
             {
-                return false;
+                return rejectFast("no_batch_indices");
             }
 
             if(problem.useGradient())
             {
-                return false;
+                return rejectFast("gradient");
             }
 
             if(problem.outputAmaxD())
             {
-                return false;
+                return rejectFast("amaxD");
             }
 
             if(problem.useE())
             {
-                return false;
+                return rejectFast("useE");
             }
 
             if(problem.useScaleCD())
             {
-                return false;
+                return rejectFast("scaleCD");
             }
 
             if(problem.useScaleAB() == "Scalar")
             {
-                return false;
+                return rejectFast("scaleAB_scalar");
             }
 
             if(problem.useScaleAB() == "Vector")
             {
-                return false;
+                return rejectFast("scaleAB_vector");
             }
 
             if(problem.boundIndices().size() != 1 || problem.freeIndicesA().size() != 1
                || problem.freeIndicesB().size() != 1)
             {
-                return false;
+                return rejectFast("multi_index");
             }
 
             bool               doActivation = false;
@@ -916,7 +927,7 @@ namespace TensileLite
             bool isPackedD = (problem.d().strides()[indexMD] == 1);
             if(!isPackedA || !isPackedB || !isPackedD)
             {
-                return false;
+                return rejectFast("layout");
             }
 
             size_t indexND  = problem.freeIndices()[1].d;

--- a/projects/hipblaslt/tensilelite/client/src/Reference.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/Reference.cpp
@@ -830,7 +830,9 @@ namespace TensileLite
             // we could continue down this fast path, because there would be no rounding
             // errors incurred by f32 accumulation. But we do not.
             auto rejectFast = [](const char* reason) {
-                std::clog << "FAST_PATH_REJECT: " << reason << std::endl;
+                if (false) {  // Re-enable when testing to find reason.
+                    std::clog << "FAST_PATH_REJECT: " << reason << std::endl;
+                }
                 return false;
             };
 


### PR DESCRIPTION
## Motivation

Current implementation does not specify why the fast reference gemm implementation was not used, making it hard to identify what extension to the fast implementation would produce a speedup for a given slow test.

## Technical Details

Replace bare return-false statements with descriptive rejection reasons for easier debugging.

## Test Plan

Run current tests, no changes expected since this is not a functional change.

## Test Result

Pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
