### PR TITLE
[tensilelite] Fix timing instrumentation in Reference.cpp and analyze_timing.py

### DIFF
--- a/projects/hipblaslt/tensilelite/client/src/Reference.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/Reference.cpp
@@ -28,6 +28,7 @@
 #include "DataInitialization.hpp"
 #include "Tensile/TensorDescriptor_fwd.hpp"
 #include "Tensile/Utils.hpp"
+#include "TimingInstrumentation.hpp"
 #include "TypedId.hpp"
 
 #include <cstddef>
@@ -2592,12 +2593,16 @@ namespace TensileLite
 
             if(tryFastPath && isDenseEnoughForFastPath && isFastPathEligible(problem))
             {
+                ScopedTimer timer("solve_cpu_fast");
                 solveCPUFastInF32(problem, inputs);
                 return;
             }
 
-            auto contractionInputsTypeId = getInputContractionInputsTypeId(problem);
-            SolveCPUTemplates(contractionInputsTypeId, problem, inputs, elementsToValidate);
+            {
+                ScopedTimer timer("solve_cpu_slow");
+                auto contractionInputsTypeId = getInputContractionInputsTypeId(problem);
+                SolveCPUTemplates(contractionInputsTypeId, problem, inputs, elementsToValidate);
+            }
         }
 
         void SolveCPU(ContractionProblem const* problem,

--- a/projects/hipblaslt/tensilelite/scripts/analyze_timing.py
+++ b/projects/hipblaslt/tensilelite/scripts/analyze_timing.py
@@ -81,9 +81,13 @@ TIMING_HIERARCHY = {
             "solution_iterator_setup": {},
             "listener_setup": {},
             "reporter_setup": {},
-            "pre_problem": {},
-            "cpu_data_init": {},
-            "cpu_reference_gemm": {},
+            "pre_problem": {
+                "cpu_data_init": {},
+                "cpu_reference_gemm": {
+                    "solve_cpu_fast": {},
+                    "solve_cpu_slow": {},
+                },
+            },
             "validate_warmups": {
                 "validate_gpu_sync": {},
                 "validate_gpu_readback": {},
@@ -136,13 +140,11 @@ CPP_PHASE_GROUPS = {
     ],
     "Data Preparation": [
         "pre_problem",
-        "cpu_data_init",
         "gpu_input_preparation",
         "gpu_input_reset",
         "rotating_buffer_preparation",
     ],
     "Reference Computation": [
-        "cpu_reference_gemm",
         "validate_warmups",
     ],
     "Kernel Execution": [


### PR DESCRIPTION
Add TimingInstrumentation include and ScopedTimer blocks around solveCPUFastInF32 and SolveCPUTemplates calls. Fix timing hierarchy in analyze_timing.py (cpu_reference_gemm is a child of pre_problem).

## Motivation

1. Current timing instrumentation only shows total time spent on the reference cpu gemm, it does not break it down by fast vs slow implementation making it harder to know if the slow path is being taken, and how big of a deal that is.
2. analyze_timing script had the cpu reference gemm in the wrong place in the hierarchy, double counting its contribution to total runtime.

## Technical Details

Depends on #6269.

1. Use scoped timer for both the fast and slow reference gemm.

## Test Plan

Manually test.

## Test Result

Produces expected timing results.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
