### PR TITLE
[tensilelite] Add rejection function for CPU reference GEMM

### DIFF
--- a/projects/hipblaslt/tensilelite/client/cpu_gemm_driver.cpp
+++ b/projects/hipblaslt/tensilelite/client/cpu_gemm_driver.cpp
@@ -303,6 +303,13 @@ int runGemm(size_t         m,
 
     auto start = std::chrono::high_resolution_clock::now();
 
+    if(tryFastPath && !TensileLite::Client::isFastPathEligible(contraction))
+    {
+        throw std::runtime_error(
+            "--tryFastPath was requested but the problem is not eligible "
+            "for the fast CPU GEMM path.");
+    }
+
     // Execute the 'device under test'.
     // passing -1 for elementsToValidate ensures that the 'fast path' which we
     // currently want to test is maybe taken.

--- a/projects/hipblaslt/tensilelite/client/include/Reference.hpp
+++ b/projects/hipblaslt/tensilelite/client/include/Reference.hpp
@@ -183,5 +183,10 @@ namespace TensileLite
                           size_t                        elementsToValidate,
                           bool                          tryFastPath = true);
 
+        // Check whether a given contraction problem is eligible for the fast CPU GEMM path.
+        // This inspects problem geometry, data types, and feature flags but does not
+        // look at runtime input buffers.
+        bool isFastPathEligible(ContractionProblemGemm const& problem);
+
     } // namespace Client
 } // namespace TensileLite

--- a/projects/hipblaslt/tensilelite/client/src/Reference.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/Reference.cpp
@@ -818,11 +818,7 @@ namespace TensileLite
             throw std::runtime_error("Unsupported input type.");
         }
 
-        // Solve combinations of f16, bf16, f32 gemm problems using efficient CPU code.
-        // This versions only solves for a subset of geometries. The set of geometries
-        // supported should be extended as new bottlenecks in validation are discovered.
-        bool solveCPUFastInF32(ContractionProblemGemm const& problem,
-                               ContractionInputs const&      inputs)
+        bool isFastPathEligible(ContractionProblemGemm const& problem)
         {
 
             // For more precise numerical correctness with XFloat32, skip this fast path.
@@ -841,8 +837,6 @@ namespace TensileLite
                 return rejectFast("XFloat32");
             }
 
-            // Guard rails to check that the fast path is appropriate to use.
-            // Some of these can be relaxed  as support on this path is generalized.
             auto isSupportedType = [](rocisa::DataType t) {
                 return t == rocisa::DataType::Float || t == rocisa::DataType::Half
                        || t == rocisa::DataType::BFloat16;
@@ -901,6 +895,43 @@ namespace TensileLite
                 return rejectFast("multi_index");
             }
 
+            // Layout validation — index accesses are safe because the
+            // index-structure check above verified exactly 1 element in each.
+            size_t indexMA = problem.freeIndicesA()[0].i;
+            size_t indexKA = problem.boundIndices()[0].a;
+            size_t indexNB = problem.freeIndicesB()[0].i;
+            size_t indexKB = problem.boundIndices()[0].b;
+            size_t indexMD = problem.freeIndices()[0].d;
+
+            size_t strideMA = problem.a().strides()[indexMA];
+            size_t strideKA = problem.a().strides()[indexKA];
+            size_t strideNB = problem.b().strides()[indexNB];
+            size_t strideKB = problem.b().strides()[indexKB];
+
+            bool isPackedA = (strideMA == 1 || strideKA == 1);
+            bool isPackedB = (strideNB == 1 || strideKB == 1);
+            bool isPackedD = (problem.d().strides()[indexMD] == 1);
+            if(!isPackedA || !isPackedB || !isPackedD)
+            {
+                return rejectFast("layout");
+            }
+
+            return true;
+        }
+
+        // Solve combinations of f16, bf16, f32 gemm problems using efficient CPU code.
+        // This function assumes the problem is eligible for the fast path — callers
+        // must check isFastPathEligible() first.
+        void solveCPUFastInF32(ContractionProblemGemm const& problem,
+                               ContractionInputs const&      inputs)
+        {
+            if(!isFastPathEligible(problem))
+            {
+                throw std::runtime_error(
+                    "solveCPUFastInF32 called on an ineligible problem. "
+                    "Callers must check isFastPathEligible() first.");
+            }
+
             bool               doActivation = false;
             std::vector<float> actArgs;
             if(problem.activationType() != ActivationType::None)
@@ -922,15 +953,6 @@ namespace TensileLite
             size_t strideKA = problem.a().strides()[indexKA];
             size_t strideNB = problem.b().strides()[indexNB];
             size_t strideKB = problem.b().strides()[indexKB];
-
-            // Layout validation
-            bool isPackedA = (strideMA == 1 || strideKA == 1);
-            bool isPackedB = (strideNB == 1 || strideKB == 1);
-            bool isPackedD = (problem.d().strides()[indexMD] == 1);
-            if(!isPackedA || !isPackedB || !isPackedD)
-            {
-                return rejectFast("layout");
-            }
 
             size_t indexND  = problem.freeIndices()[1].d;
             size_t strideND = problem.d().strides()[indexND];
@@ -1197,7 +1219,6 @@ namespace TensileLite
                     inputs.d, shadowD, problem.d().totalAllocatedElements());
             }
 
-            return true;
         }
 
         template <typename Accumulator,
@@ -2569,8 +2590,9 @@ namespace TensileLite
                 isDenseEnoughForFastPath = false;
             }
 
-            if(tryFastPath && isDenseEnoughForFastPath && solveCPUFastInF32(problem, inputs))
+            if(tryFastPath && isDenseEnoughForFastPath && isFastPathEligible(problem))
             {
+                solveCPUFastInF32(problem, inputs);
                 return;
             }
 


### PR DESCRIPTION
## Motivation

Currently the `SolveGemmCPU` function will opaquely fall back to using the slower reference GEMM. There is no clean way of knowing if the fast or slow path were taken (one could parse cout, but that's not a good solution).

One place this becomes an issue is for writing tests that target the `SolveGemmCPU` function, it isn't clear if it took the fast path or not, which is a big problem if trying to test the fast path through this function.

## Technical Details

Depends on #6256.

1. More the checks on whether the fast path can be taken into a helper method.
2. Call helper method from `SolveGemmCPU` to know if the fast path can be run.
3. Defensively call the helper method from inside `solveCPUFastInF32` and error out if it returns false (someone called this function with incorrect args).
4. Call the function from `cpu_gemmdriver.cpp` and error out if its false and the fast path was supposed to be used.

## Test Plan

Run existing tests.

## Test Result

Pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
