### PR TITLE
Add conversion for MX types for Origami

### DIFF
--- a/projects/hipblaslt/tensilelite/include/Tensile/UtilsOrigami.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/UtilsOrigami.hpp
@@ -83,7 +83,7 @@ namespace TensileLite
             return origami::data_type_t::Float4;
 
         default:
-      throw std::runtime_error("Unsupported data type: " + std::to_string(static_cast<int>(type)));
+            throw std::runtime_error("Unsupported data type: " + std::to_string(static_cast<int>(type)));
         }
     }
 } // namespace TensileLite

--- a/projects/hipblaslt/tensilelite/include/Tensile/UtilsOrigami.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/UtilsOrigami.hpp
@@ -25,7 +25,7 @@
  *******************************************************************************/
 
 #pragma once
-
+#include <stdexcept>
 #include <origami/origami.hpp>
 #include <rocisa/include/enum.hpp>
 #include <origami/simulator/tensilelite/formocast_simulator.hpp>
@@ -75,9 +75,15 @@ namespace TensileLite
             return origami::data_type_t::Float8BFloat8;
         case rocisa::DataType::BFloat8Float8:
             return origami::data_type_t::BFloat8Float8;
+        case rocisa::DataType::Float6:
+            return origami::data_type_t::Float6;
+        case rocisa::DataType::BFloat6:
+            return origami::data_type_t::BFloat6;   
+        case rocisa::DataType::Float4:
+            return origami::data_type_t::Float4;
 
         default:
-            return origami::data_type_t::None;
+      throw std::runtime_error("Unsupported data type: " + std::to_string(static_cast<int>(type)));
         }
     }
 } // namespace TensileLite


### PR DESCRIPTION
## Motivation

Datatype conversion from tensilelite MX datatypes (F6, B6, F4) were needed for Origami to find correct MI latencies.

## Technical Details

Added F6, B6 and F4 conversions to Origami datatypes.
Changed default conversion to throw runtime error such that missing datatype conversions do not silently fail.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
