### PR TITLE
[hip-kernel-provider] Fix hip-kernel-provider tests: rename createValidSdpaFpropGraph to createValidSdpaFwdGraph

### DIFF
--- a/dnn-providers/hip-kernel-provider/src/tests/engines/asm_sdpa_engine/TestAsmSdpaEngine.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/asm_sdpa_engine/TestAsmSdpaEngine.cpp
@@ -41,7 +41,7 @@ TEST_F(TestAsmSdpaEngine, IsApplicableReturnsFalseForNonSdpaGraph)
 TEST_F(TestAsmSdpaEngine, IsApplicableReturnsTrueForSdpaGraph)
 {
     // Create a SDPA forward inference graph
-    auto builder = hipdnn_test_sdk::utilities::createValidSdpaFpropGraph();
+    auto builder = hipdnn_test_sdk::utilities::createValidSdpaFwdGraph();
 
     hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graphWrapper(builder.GetBufferPointer(),
                                                                      builder.GetSize());

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/asm_sdpa_engine/TestSdpaFwdPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/asm_sdpa_engine/TestSdpaFwdPlanBuilder.cpp
@@ -35,7 +35,7 @@ TEST_F(TestSdpaFwdPlanBuilder, IsApplicableReturnsFalseForNonSdpaGraph)
 
 TEST_F(TestSdpaFwdPlanBuilder, IsApplicableReturnsTrueForSdpaGraph)
 {
-    auto builder = hipdnn_test_sdk::utilities::createValidSdpaFpropGraph();
+    auto builder = hipdnn_test_sdk::utilities::createValidSdpaFwdGraph();
 
     hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graphWrapper(builder.GetBufferPointer(),
                                                                      builder.GetSize());
@@ -46,7 +46,7 @@ TEST_F(TestSdpaFwdPlanBuilder, IsApplicableReturnsTrueForSdpaGraph)
 TEST_F(TestSdpaFwdPlanBuilder, GetMaxWorkspaceSizeCalculatesCorrectly)
 {
     // Create an SDPA graph with known dimensions (withStats = false by default)
-    auto builder = hipdnn_test_sdk::utilities::createValidSdpaFpropGraph();
+    auto builder = hipdnn_test_sdk::utilities::createValidSdpaFwdGraph();
 
     hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graphWrapper(builder.GetBufferPointer(),
                                                                      builder.GetSize());


### PR DESCRIPTION
## Summary

- Renames 3 call sites of `createValidSdpaFpropGraph` → `createValidSdpaFwdGraph` in hip-kernel-provider unit tests
- These were missed when the SDPA FPROP/BPROP → FWD/BWD rename landed in commit 613c35c0f2
- Affected files: `TestSdpaFwdPlanBuilder.cpp`, `TestAsmSdpaEngine.cpp`

## Test plan

- [x] hip-kernel-provider builds cleanly against develop SDK
- [x] `hip_kernel_provider_tests` unit tests pass (1/1, 0.43s)
- [ ]  Integration tests (fails, but seems pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)