### PR TITLE
Review fixes for CK dlopen conversion (#6170)

### DIFF
--- a/projects/miopen/cmake/unbundle_archive.cmake
+++ b/projects/miopen/cmake/unbundle_archive.cmake
@@ -152,7 +152,6 @@ foreach(obj IN LISTS obj_files)
             "  exit code: ${unbundle_result}\n"
             "  stderr: ${unbundle_error}\n"
             "  stdout: ${unbundle_output}")
-        continue()
     endif()
 
     # Re-bundle with only host + target arch, compressed
@@ -174,7 +173,6 @@ foreach(obj IN LISTS obj_files)
             "  exit code: ${rebundle_result}\n"
             "  stderr: ${rebundle_error}\n"
             "  stdout: ${rebundle_output}")
-        continue()
     endif()
 
     # Replace the .hip_fatbin section with the single-arch fatbin.

--- a/projects/miopen/src/CMakeLists.txt
+++ b/projects/miopen/src/CMakeLists.txt
@@ -906,30 +906,10 @@ target_include_directories(MIOpen PUBLIC
 )
 
 if(MIOPEN_USE_COMPOSABLEKERNEL)
-    if(MIOPEN_BUILD_CK )
-        # the aliased target doesnt exist when we build CK inline as part of MIOPEN.  The aliased target only is not
-        # global when you build it so we dont have access to it.
-        set(MIOPEN_CK_LINK_FLAGS device_conv_operations hip::host)
-
-        # The include directories also dont propagate correctly when using the non aliased targets.
-        # Manually including them fixes this problem for inline builds.
-        target_include_directories(MIOpen SYSTEM PRIVATE
-            ${MIOPEN_CK_INCLUDE_DIR}
-            ${MIOPEN_CK_BUILD_INCLUDE_DIR}
-            ${MIOPEN_CK_LIBRARY_INCLUDE_DIR})
-    else()
-        # Use the aliased targets when we pull CK from /opt/rocm or other place on disc.
-        set(MIOPEN_CK_LINK_FLAGS composable_kernel::device_conv_operations hip::host)
-        
+    if(MIOPEN_BUILD_CK)
         if(MIOPEN_CK_BUILDER_EXPERIMENTAL)
             add_definitions(-DCK_EXPERIMENTAL_BUILDER)
         endif()
-    endif()
-    if(GPU_TARGETS MATCHES "gfx942" OR GPU_TARGETS MATCHES "gfx950")
-        target_compile_definitions(MIOpen PRIVATE CK_ENABLE_TF32)
-    endif()
-    if(GPU_TARGETS MATCHES "gfx950")
-        target_compile_definitions(MIOpen PRIVATE CK_USE_GFX95)
     endif()
 
     # Build per-GPU-target CK grouped conv shared libraries
@@ -956,7 +936,7 @@ endif()
 target_include_directories(MIOpen SYSTEM PUBLIC $<BUILD_INTERFACE:${HALF_INCLUDE_DIR}>)
 # Workaround : change in rocm-cmake was causing linking error so had to add ${CMAKE_DL_LIBS}
 #               We can remove ${CMAKE_DL_LIBS} once root cause is identified.
-target_link_libraries(MIOpen PRIVATE ${CMAKE_DL_LIBS} Threads::Threads BZip2::BZip2 ${MIOPEN_CK_LINK_FLAGS})
+target_link_libraries(MIOpen PRIVATE ${CMAKE_DL_LIBS} Threads::Threads BZip2::BZip2)
 miopen_generate_export_header(MIOpen)
 
 if(WIN32)

--- a/projects/miopen/src/ck_impl/CMakeLists.txt
+++ b/projects/miopen/src/ck_impl/CMakeLists.txt
@@ -63,6 +63,15 @@ foreach(gpu_target IN LISTS GPU_TARGETS)
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}"
     )
 
+    set_target_properties(${lib_name} PROPERTIES
+        SOVERSION ${MIOpen_SOVERSION}
+        CXX_VISIBILITY_PRESET hidden
+        VISIBILITY_INLINES_HIDDEN 1
+    )
+    if(NOT WIN32 AND NOT APPLE)
+        target_link_libraries(${lib_name} PRIVATE "-Wl,--exclude-libs,ALL")
+    endif()
+
     # Full target string needed for correct device codegen
     target_compile_options(${lib_name} PRIVATE
         --offload-arch=${gpu_target}
@@ -113,8 +122,8 @@ foreach(gpu_target IN LISTS GPU_TARGETS)
 
     # Install alongside MIOpen
     install(TARGETS ${lib_name}
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT ck_plugins
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT ck_plugins
     )
 endforeach()
 

--- a/projects/miopen/src/include/miopen/solver/ck_impl_lib_loader.hpp
+++ b/projects/miopen/src/include/miopen/solver/ck_impl_lib_loader.hpp
@@ -125,7 +125,7 @@ private:
     void BindRequiredCommonSymbols(std::vector<std::string>& missing);
     void
     BindSolverSymbols(CKSolverType solver, const char* prefix, std::vector<std::string>& missing);
-    void BindOptionalKernelTypeSymbols(std::vector<std::string>& missing);
+    void BindOptionalKernelTypeSymbols();
     static constexpr int ToSolverIndex(CKSolverType solver) { return static_cast<int>(solver); }
 
     // Singleton cache
@@ -204,25 +204,6 @@ private:
     ConvSolution
     ExtractSolution(ck_impl_status_t status, ConvSolution* ptr, const char* operation) const;
 };
-
-#if MIOPEN_ENABLE_AI_KERNEL_TUNING
-/// Tokenize a CK kernel name string by extracting the template parameters
-/// between '<' and '>', splitting on commas, and stripping whitespace.
-inline std::vector<std::string> GetKernelAsTokens(const std::string& kernel)
-{
-    std::vector<std::string> tokens;
-    std::string token;
-    std::istringstream tokenStream(
-        kernel.substr(kernel.find('<') + 1, kernel.find('>') - kernel.find('<') - 1));
-    while(std::getline(tokenStream, token, ','))
-    {
-        token.erase(remove_if(token.begin(), token.end(), isspace),
-                    token.end()); // strip whitespace
-        tokens.push_back(token);
-    }
-    return tokens;
-}
-#endif // MIOPEN_ENABLE_AI_KERNEL_TUNING
 
 /// Check whether a kernel_id with embedded split_k is valid for deterministic
 /// execution.  Returns false (invalid) if deterministic is requested and

--- a/projects/miopen/src/solver/ck_impl_lib_loader.cpp
+++ b/projects/miopen/src/solver/ck_impl_lib_loader.cpp
@@ -320,21 +320,21 @@ void CkImplLibLoader::BindSolverSymbols(CKSolverType solver,
     bind_symbol(fns.get_solution, (sym + "get_solution").c_str());
 }
 
-void CkImplLibLoader::BindOptionalKernelTypeSymbols(std::vector<std::string>& missing)
+void CkImplLibLoader::BindOptionalKernelTypeSymbols()
 {
-    auto bind_symbol = [this, &missing](auto& member, const char* symbol_name) {
+    auto bind_optional = [this](auto& member, const char* symbol_name) {
         using FnPtr = std::remove_reference_t<decltype(member)>;
         member      = reinterpret_cast<FnPtr>(ResolveRawSymbol(symbol_name));
         if(member == nullptr)
-            missing.emplace_back(symbol_name);
+            MIOPEN_LOG_I2("Optional CK symbol not found: " << symbol_name);
     };
 
-    bind_symbol(solver_fns_[ToSolverIndex(CKSolverType::GrpConv3dFwd)].get_all_kernel_types,
-                "ck_impl_3d_fwd_get_all_kernel_type_strings");
-    bind_symbol(solver_fns_[ToSolverIndex(CKSolverType::GrpConv3dBwd)].get_all_kernel_types,
-                "ck_impl_3d_bwd_get_all_kernel_type_strings");
-    bind_symbol(solver_fns_[ToSolverIndex(CKSolverType::GrpConv3dWrw)].get_all_kernel_types,
-                "ck_impl_3d_wrw_get_all_kernel_type_strings");
+    bind_optional(solver_fns_[ToSolverIndex(CKSolverType::GrpConv3dFwd)].get_all_kernel_types,
+                  "ck_impl_3d_fwd_get_all_kernel_type_strings");
+    bind_optional(solver_fns_[ToSolverIndex(CKSolverType::GrpConv3dBwd)].get_all_kernel_types,
+                  "ck_impl_3d_bwd_get_all_kernel_type_strings");
+    bind_optional(solver_fns_[ToSolverIndex(CKSolverType::GrpConv3dWrw)].get_all_kernel_types,
+                  "ck_impl_3d_wrw_get_all_kernel_type_strings");
 }
 
 bool CkImplLibLoader::LoadSymbols()
@@ -366,7 +366,7 @@ bool CkImplLibLoader::LoadSymbols()
     for(const auto& binding : solver_bindings)
         BindSolverSymbols(binding.solver, binding.prefix, missing);
 
-    BindOptionalKernelTypeSymbols(missing);
+    BindOptionalKernelTypeSymbols();
 
     if(missing.empty())
         return true;

--- a/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_xdlops.cpp
+++ b/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_xdlops.cpp
@@ -39,12 +39,10 @@ MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_CK_DEFAULT_KERNELS)
 #include <miopen/conv/wrw_invoke_params.hpp>
 #include <miopen/solver/problem_description_interpreter.hpp>
 #include <miopen/solver/ck_impl_lib_loader.hpp>
-#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
 #if MIOPEN_ENABLE_AI_KERNEL_TUNING
 #include <miopen/conv/heuristics/ai_heuristics.hpp>
 #include <miopen/conv/heuristics/ai_candidate_selection.hpp>
 #include <miopen/conv/heuristics/ai_conv_3d_kernel_tuning_utils.hpp>
-#endif
 #endif
 #include <miopen/solver/implicitgemm_ck_util_common.hpp>
 #include <miopen/solver/implicitgemm_util.hpp>
@@ -54,8 +52,6 @@ namespace solver {
 namespace conv {
 
 using ProblemDescription = miopen::conv::ProblemDescription;
-
-#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
 
 namespace {
 
@@ -90,7 +86,6 @@ void PerformanceConfigHipImplicitGemm3DGroupWrwXdlops::InitValidKernels(
         kernel_id = valid_kernels[index] + "+" + std::to_string(split_k);
     }
 }
-#endif
 
 // clang-format off
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, cert-err58-cpp)
@@ -174,14 +169,12 @@ void PerformanceConfigHipImplicitGemm3DGroupWrwXdlops::DefaultKernelFromList(
 }
 
 void PerformanceConfigHipImplicitGemm3DGroupWrwXdlops::HeuristicInit(
-    [[maybe_unused]] const miopen::ExecutionContext& ctx,
-    const ::miopen::conv::ProblemDescription& problem)
+    const miopen::ExecutionContext& ctx, const ::miopen::conv::ProblemDescription& problem)
 {
     index     = 0;
     kernel_id = "None";
     split_k   = 1;
 
-#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
     const bool is_deterministic = problem.GetConv().attribute.deterministic;
 
 #if MIOPEN_ENABLE_AI_KERNEL_TUNING
@@ -309,13 +302,11 @@ void PerformanceConfigHipImplicitGemm3DGroupWrwXdlops::HeuristicInit(
 
     // Invariant: split_k must always be 1 in deterministic mode
     assert(!is_deterministic || split_k == 1);
-#endif
 }
 
 bool PerformanceConfigHipImplicitGemm3DGroupWrwXdlops::SetNextValue(
     const ::miopen::conv::ProblemDescription& problem)
 {
-#if MIOPEN_USE_COMPOSABLEKERNEL
     if(valid_kernels.empty())
     {
         InitValidKernels(problem);
@@ -358,7 +349,6 @@ bool PerformanceConfigHipImplicitGemm3DGroupWrwXdlops::SetNextValue(
         // All split_k and index values were iterated
         return false;
     } while(false);
-#endif
     return true;
 }
 
@@ -368,9 +358,8 @@ bool PerformanceConfigHipImplicitGemm3DGroupWrwXdlops::IsValidValue() const
 }
 
 bool PerformanceConfigHipImplicitGemm3DGroupWrwXdlops::IsValid(
-    [[maybe_unused]] const ::miopen::conv::ProblemDescription& problem) const
+    const ::miopen::conv::ProblemDescription& problem) const
 {
-#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
     if(!IsDeterministicSplitKValid(kernel_id, problem.GetConv().attribute.deterministic))
         return false;
 
@@ -405,9 +394,6 @@ bool PerformanceConfigHipImplicitGemm3DGroupWrwXdlops::IsValid(
             CKSolverType::GrpConv3dWrw, problem, kernel_id, miopenBFloat16, false);
     default: return false;
     }
-#else
-    return false;
-#endif
 }
 
 bool PerformanceConfigHipImplicitGemm3DGroupWrwXdlops::operator==(
@@ -436,7 +422,6 @@ bool ConvHipImplicitGemm3DGroupWrwXdlops::IsValidPerformanceConfig(
 size_t ConvHipImplicitGemm3DGroupWrwXdlops::GetCKMaxWorkspaceSize(
     const ::miopen::conv::ProblemDescription& problem) const
 {
-#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
     const auto& loader = CkImplLibLoader::Get(GetCurrentDeviceName());
     if(!loader.IsLoaded())
         return 0;
@@ -448,10 +433,6 @@ size_t ConvHipImplicitGemm3DGroupWrwXdlops::GetCKMaxWorkspaceSize(
         ws = std::max(
             ws, loader.GetWorkspaceSize(CKSolverType::GrpConv3dWrw, problem, data_type, true));
     return ws;
-#else
-    (void)problem;
-    return 0;
-#endif
 }
 
 size_t ConvHipImplicitGemm3DGroupWrwXdlops::GetWorkspaceSize(
@@ -470,10 +451,8 @@ ConvHipImplicitGemm3DGroupWrwXdlops::Search(const ExecutionContext& ctx,
 }
 
 bool ConvHipImplicitGemm3DGroupWrwXdlops::IsApplicable(
-    [[maybe_unused]] const ExecutionContext& ctx,
-    [[maybe_unused]] const ::miopen::conv::ProblemDescription& problem) const
+    const ExecutionContext& ctx, const ::miopen::conv::ProblemDescription& problem) const
 {
-#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
     if(env::disabled(MIOPEN_DEBUG_3D_CONV_IMPLICIT_GEMM_HIP_WRW_XDLOPS))
         return false;
     if(!problem.AllTensorsDimsFitIntoInt())
@@ -500,38 +479,20 @@ bool ConvHipImplicitGemm3DGroupWrwXdlops::IsApplicable(
         return true;
 
     return loader.IsApplicable(CKSolverType::GrpConv3dWrw, problem, data_type, false);
-#else
-    (void)ctx;
-    (void)problem;
-    return false;
-#endif
 }
 
 ConvSolution ConvHipImplicitGemm3DGroupWrwXdlops::GetSolution(
-    [[maybe_unused]] const ExecutionContext& ctx,
-    [[maybe_unused]] const ::miopen::conv::ProblemDescription& problem,
-    [[maybe_unused]] const PerformanceConfigHipImplicitGemm3DGroupWrwXdlops& config) const
+    const ExecutionContext& ctx,
+    const ::miopen::conv::ProblemDescription& problem,
+    const PerformanceConfigHipImplicitGemm3DGroupWrwXdlops& config) const
 {
-#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
     const auto& loader = CkImplLibLoader::Get(ctx.GetStream().GetDeviceName());
     if(!loader.IsLoaded())
         return ConvSolution{miopenStatusInternalError};
 
     return loader.GetSolution(
         CKSolverType::GrpConv3dWrw, ctx, problem, config.kernel_id, config.UseTF32());
-
-#else
-    return {};
-#endif
 }
-
-#if !(MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL)
-void miopen::solver::conv::PerformanceConfigHipImplicitGemm3DGroupWrwXdlops::InitValidKernels(
-    const ::miopen::conv::ProblemDescription&)
-{
-    // No-op stub for non-CK builds
-}
-#endif
 
 } // namespace conv
 } // namespace solver

--- a/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_grouped_bwd_xdlops.cpp
+++ b/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_grouped_bwd_xdlops.cpp
@@ -34,6 +34,7 @@
 #include <miopen/solver/problem_description_interpreter.hpp>
 #if MIOPEN_ENABLE_AI_KERNEL_TUNING
 #include <miopen/conv/heuristics/ai_heuristics.hpp>
+#include <miopen/conv/heuristics/ai_conv_3d_kernel_tuning_utils.hpp>
 #endif
 #include <miopen/solver/implicitgemm_ck_util_common.hpp>
 #include <miopen/solver/implicitgemm_util.hpp>

--- a/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_grouped_fwd_xdlops.cpp
+++ b/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_grouped_fwd_xdlops.cpp
@@ -33,6 +33,7 @@
 #include <miopen/conv/data_invoke_params.hpp>
 #if MIOPEN_ENABLE_AI_KERNEL_TUNING
 #include <miopen/conv/heuristics/ai_heuristics.hpp>
+#include <miopen/conv/heuristics/ai_conv_3d_kernel_tuning_utils.hpp>
 #endif
 #include <miopen/solver/implicitgemm_ck_util_common.hpp>
 #include <miopen/solver/ck_impl_lib_loader.hpp>

--- a/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
+++ b/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
@@ -35,6 +35,7 @@
 #include <miopen/solver/ck_impl_lib_loader.hpp>
 #if MIOPEN_ENABLE_AI_KERNEL_TUNING
 #include <miopen/conv/heuristics/ai_heuristics.hpp>
+#include <miopen/conv/heuristics/ai_conv_3d_kernel_tuning_utils.hpp>
 #endif
 #include <miopen/solver/implicitgemm_ck_util_common.hpp>
 #include <miopen/solver/implicitgemm_util.hpp>


### PR DESCRIPTION
## Summary

Review fixes for the CK dlopen conversion PR #6170, addressing 6 issues found during a comprehensive code review.

- **Remove CK link from MIOpen**: Drop `MIOPEN_CK_LINK_FLAGS`, CK include directories, and `CK_ENABLE_TF32`/`CK_USE_GFX95` compile definitions from the MIOpen target. CK code now lives exclusively in plugin `.so` files.
- **Plugin shared library hardening**: Add `SOVERSION`, hidden symbol visibility (`CXX_VISIBILITY_PRESET`, `--exclude-libs,ALL`), and install `COMPONENT ck_plugins` to CK plugin targets.
- **Complete 3D WRW solver conversion**: Remove 9 leftover `#if MIOPEN_USE_COMPOSABLEKERNEL` guards from `conv_hip_implicit_gemm_3d_grouped_wrw_xdlops.cpp` to match the fully-converted Fwd/Bwd pattern.
- **Fix buggy `GetKernelAsTokens`**: Remove the inline version in `ck_impl_lib_loader.hpp` (uses `find('>')` which breaks on nested templates like `DeviceGroupedConvBwdWeight_Explicit_Xdl<DeviceBatchedGemmXdlUniversal<...>>`) and route callers to the correct exported version with bracket-depth counting.
- **Make optional symbols actually optional**: `BindOptionalKernelTypeSymbols` was adding missing symbols to the `missing` vector, causing `LoadSymbols()` to fail and disable the entire loader. These symbols are only used in tests and already have null-check fallbacks.
- **Remove dead code**: Two unreachable `continue()` statements after `message(FATAL_ERROR)` in `unbundle_archive.cmake`.

## Test plan

- [x] Full clean build (gfx942) — 0 errors
- [x] Binary verification: `libMIOpen.so` = 557MB with 0 CK symbols (vs 867MB on develop)
- [x] Plugin SOVERSION working: `libMIOpenCKGroupedConv_gfx942.so` → `libMIOpenCKGroupedConv_gfx942.so.1.0`
- [x] All 9 CK-related test suites pass (37 passed, 786 skipped for non-gfx942)
- [x] clang-format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)