### PR TITLE
fix(rocprim): fix out-of-bounds access on shared memory in block run length decode

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/block/block_run_length_decode.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/block/block_run_length_decode.hpp
@@ -342,7 +342,8 @@ public:
 #pragma unroll
         for(DecodedOffsetT i = 0; i < DECODED_ITEMS_PER_THREAD; ++i, ++thread_decoded_offset)
         {
-            // If we are in a new run...
+            // Check if we are in a new run. Short-circuit the check on 'i==0', since 'current_run_end'
+            // is uninitialized.
             if(i == 0 || thread_decoded_offset == current_run_end)
             {
                 // The value of the new run

--- a/projects/rocprim/rocprim/include/rocprim/block/block_run_length_decode.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/block/block_run_length_decode.hpp
@@ -334,7 +334,8 @@ public:
               - static_cast<RunOffsetT>(1U);
 
         // Set the current_run_end to thread_decoded_offset to trigger new run branch in the first iteration
-        DecodedOffsetT current_run_begin, current_run_end = thread_decoded_offset;
+        DecodedOffsetT current_run_begin;
+        DecodedOffsetT current_run_end;
 
         ItemT val{};
 
@@ -342,14 +343,24 @@ public:
         for(DecodedOffsetT i = 0; i < DECODED_ITEMS_PER_THREAD; ++i, ++thread_decoded_offset)
         {
             // If we are in a new run...
-            if(thread_decoded_offset == current_run_end)
+            if(i == 0 || thread_decoded_offset == current_run_end)
             {
                 // The value of the new run
                 val = temp_storage.runs.run_values[current_run];
 
                 // The run bounds
                 current_run_begin = temp_storage.runs.run_offsets[current_run];
-                current_run_end   = temp_storage.runs.run_offsets[++current_run];
+                // Move the cursor to the next run if it exists.
+
+                // Otherwise just use the begin offset if we are the last run of the thread. On the next
+                // iteration, thread_decoded_offset will be moved away from the begin offset and we will
+                // emit infinite elements until the call-site detects we are outside the decoded values
+                // per thread.
+                if(current_run + 1 < BLOCK_RUNS)
+                {
+                    current_run++;
+                }
+                current_run_end   = temp_storage.runs.run_offsets[current_run];
             }
 
             // Decode the current run by storing the run's value

--- a/projects/rocprim/rocprim/include/rocprim/block/block_run_length_decode.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/block/block_run_length_decode.hpp
@@ -360,7 +360,7 @@ public:
                 {
                     current_run++;
                 }
-                current_run_end   = temp_storage.runs.run_offsets[current_run];
+                current_run_end = temp_storage.runs.run_offsets[current_run];
             }
 
             // Decode the current run by storing the run's value


### PR DESCRIPTION
## Motivation

Block length decode tests fails under ASAN. This change set fixes an out-of-bounds LDS access in block run length decode.

## Technical Details

We introduce a guard before incrementing the run identifier in our decode loop. Previously this would still be fine since in both debug and release mode, the accessed memory would return an invalid run identifier which does not collide with the run identifier bounds. However, this is still (technically) UB.

## Test Plan

Compile and run with ASAN.

## Test Result

Works on my machine.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
