### PR TITLE
[rocsparse] Fix csr2gebsr hangs when using rocsparse_int==int64_t

### DIFF
--- a/projects/rocsparse/library/src/conversion/csr2gebsr_device.h
+++ b/projects/rocsparse/library/src/conversion/csr2gebsr_device.h
@@ -1,6 +1,6 @@
 /*! \file */
 /* ************************************************************************
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/projects/rocsparse/library/src/conversion/csr2gebsr_device.h
+++ b/projects/rocsparse/library/src/conversion/csr2gebsr_device.h
@@ -471,6 +471,10 @@ namespace rocsparse
                                                   rocsparse_int* __restrict__ bsr_row_ptr,
                                                   rocsparse_int* __restrict__ bsr_col_ind)
     {
+        constexpr uint32_t REQUIRED_SHARED_MEMORY
+            = std::max(ROW_BLOCKDIM * COL_BLOCKDIM,
+                       BLOCKSIZE * static_cast<uint32_t>(sizeof(rocsparse_int) / sizeof(T)));
+
         int bid = hipBlockIdx_x;
         int tid = hipThreadIdx_x;
 
@@ -483,7 +487,7 @@ namespace rocsparse
         rocsparse_int row       = row_block_dim * bid + wid;
 
         __shared__ bool table;
-        __shared__ T    data[ROW_BLOCKDIM * COL_BLOCKDIM];
+        __shared__ T    data[REQUIRED_SHARED_MEMORY];
 
         rocsparse_int row_begin
             = (row < m && wid < row_block_dim) ? csr_row_ptr[row] - csr_base : 0;


### PR DESCRIPTION
## Motivation

Fix csr2gebsr hangs when using `rocsparse_int==int64_t`

## Technical Details

Fixes csr2gebsr hangs resulting from reading/writing past the end of the allocated amount shared memory in the kernel `csr2gebsr_block_per_row_multipass_kernel`