### PR TITLE
CK: Refactor 144 contraction instance files with shared CK_CONTRACTION_INSTANCE macro

### DIFF
--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction/CMakeLists.txt
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
+
+# This directory contains only shared header files (contraction_instance_common.hpp).
+# There are no source files to compile here — the header is included by the
+# contraction_bilinear/ and contraction_scale/ instance directories.

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction/contraction_instance_common.hpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction/contraction_instance_common.hpp
@@ -1,0 +1,77 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
+// setting Don't use this hack unless absolutely necessary!
+// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
+#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+
+#include <cstdlib>
+
+#include "ck/ck.hpp"
+#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
+#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
+#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
+#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
+
+// Macro to generate a contraction device operation instance definition and its
+// registration function. Each invocation produces one using-alias and one
+// add_device_* function inside ck::tensor_operation::device::instance.
+//
+// Parameters:
+//   INST_TPL     — instance template (e.g. device_contraction_kk_instance,
+//                  device_contraction_f64_kk_instance)
+//   OP_NAME      — lowercase operation name for identifier construction
+//                  (bilinear or scale)
+//   CDE_OP       — C++ element-wise operation type for template argument
+//                  (Bilinear or Scale)
+//   NDIM_VAL     — number of dimensions (2 or 6)
+//   NAME_SUFFIX  — data-type and layout suffix for the generated names
+//                  (e.g. f32_f32_f32_f32_kknn, bf16_bf16_bf16_bf16_compute_f32_knnn)
+//   ADATA        — ADataType
+//   BDATA        — BDataType
+//   ACC          — AccDataType
+//   CSHUFFLE     — CShuffleDataType
+//   DS_TUPLE     — DsDataType (e.g. F32_Tuple, Empty_Tuple)
+//   EDATA        — EDataType
+//   COMPUTE      — ComputeDataType
+//
+// Example — bilinear, F32, kk layout, 2D:
+//
+//   CK_CONTRACTION_INSTANCE(device_contraction_kk_instance,
+//       bilinear, Bilinear, 2, f32_f32_f32_f32_kknn,
+//       F32, F32, F32, F32, F32_Tuple, F32, F32)
+//
+// Expands to:
+//   using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_kknn_instance = ...;
+//   void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_kknn_instance(...)
+//   { ... }
+//
+// clang-format off
+#define CK_CONTRACTION_INSTANCE(INST_TPL, OP_NAME, CDE_OP, NDIM_VAL,                             \
+    NAME_SUFFIX, ADATA, BDATA, ACC, CSHUFFLE, DS_TUPLE, EDATA, COMPUTE)                           \
+                                                                                                   \
+namespace ck {                                                                                     \
+namespace tensor_operation {                                                                       \
+namespace device {                                                                                 \
+namespace instance {                                                                               \
+                                                                                                   \
+using device_contraction_##OP_NAME##_m##NDIM_VAL##_n##NDIM_VAL##_k##NDIM_VAL##_xdl_c_shuffle_##NAME_SUFFIX##_instance = \
+    INST_TPL<ADATA, BDATA, ACC, CSHUFFLE, DS_TUPLE, EDATA, COMPUTE,                               \
+             PassThrough, PassThrough, CDE_OP, NDIM_VAL>;                                         \
+                                                                                                   \
+void add_device_contraction_##OP_NAME##_m##NDIM_VAL##_n##NDIM_VAL##_k##NDIM_VAL##_xdl_c_shuffle_##NAME_SUFFIX##_instance( \
+    std::vector<std::unique_ptr<DeviceContractionMultipleD<NDIM_VAL, NDIM_VAL, NDIM_VAL,          \
+        ADATA, BDATA, DS_TUPLE, EDATA, PassThrough, PassThrough, CDE_OP, COMPUTE>>>& instances)   \
+{                                                                                                  \
+    add_device_operation_instances(instances,                                                       \
+        device_contraction_##OP_NAME##_m##NDIM_VAL##_n##NDIM_VAL##_k##NDIM_VAL##_xdl_c_shuffle_##NAME_SUFFIX##_instance{}); \
+}                                                                                                  \
+                                                                                                   \
+} /* namespace instance */                                                                         \
+} /* namespace device */                                                                           \
+} /* namespace tensor_operation */                                                                 \
+} /* namespace ck */
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_kknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_kknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_kknn_instance =
-    device_contraction_kk_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   BF16_Tuple,
-                                   BF16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_kknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           BF16,
-                                                           BF16,
-                                                           BF16_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_kknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kk_instance,
+    bilinear, Bilinear, 2, bf16_bf16_bf16_bf16_compute_f32_kknn,
+    BF16, BF16, F32, BF16, BF16_Tuple, BF16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_knnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_knnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_knnn_instance =
-    device_contraction_kn_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   BF16_Tuple,
-                                   BF16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_knnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           BF16,
-                                                           BF16,
-                                                           BF16_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_knnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kn_instance,
+    bilinear, Bilinear, 2, bf16_bf16_bf16_bf16_compute_f32_knnn,
+    BF16, BF16, F32, BF16, BF16_Tuple, BF16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_mknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_mknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_mknn_instance =
-    device_contraction_mk_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   BF16_Tuple,
-                                   BF16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_mknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           BF16,
-                                                           BF16,
-                                                           BF16_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_mknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mk_instance,
+    bilinear, Bilinear, 2, bf16_bf16_bf16_bf16_compute_f32_mknn,
+    BF16, BF16, F32, BF16, BF16_Tuple, BF16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_mnnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_mnnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_mnnn_instance =
-    device_contraction_mn_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   BF16_Tuple,
-                                   BF16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_mnnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           BF16,
-                                                           BF16,
-                                                           BF16_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_mnnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mn_instance,
+    bilinear, Bilinear, 2, bf16_bf16_bf16_bf16_compute_f32_mnnn,
+    BF16, BF16, F32, BF16, BF16_Tuple, BF16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_kknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_kknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_kknn_instance =
-    device_contraction_kk_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   BF16_Tuple,
-                                   BF16,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_kknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           BF16,
-                                                           BF16,
-                                                           BF16_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_kknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kk_instance,
+    bilinear, Bilinear, 2, bf16_bf16_bf16_bf16_kknn,
+    BF16, BF16, F32, BF16, BF16_Tuple, BF16, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_knnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_knnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_knnn_instance =
-    device_contraction_kn_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   BF16_Tuple,
-                                   BF16,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_knnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           BF16,
-                                                           BF16,
-                                                           BF16_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_knnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kn_instance,
+    bilinear, Bilinear, 2, bf16_bf16_bf16_bf16_knnn,
+    BF16, BF16, F32, BF16, BF16_Tuple, BF16, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_mknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_mknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_mknn_instance =
-    device_contraction_mk_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   BF16_Tuple,
-                                   BF16,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_mknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           BF16,
-                                                           BF16,
-                                                           BF16_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_mknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mk_instance,
+    bilinear, Bilinear, 2, bf16_bf16_bf16_bf16_mknn,
+    BF16, BF16, F32, BF16, BF16_Tuple, BF16, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_mnnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_mnnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_mnnn_instance =
-    device_contraction_mn_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   BF16_Tuple,
-                                   BF16,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_mnnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           BF16,
-                                                           BF16,
-                                                           BF16_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_bf16_mnnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mn_instance,
+    bilinear, Bilinear, 2, bf16_bf16_bf16_bf16_mnnn,
+    BF16, BF16, F32, BF16, BF16_Tuple, BF16, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_kknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_kknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_kknn_instance =
-    device_contraction_kk_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   F16_Tuple,
-                                   F16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_kknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F16,
-                                                           F16,
-                                                           F16_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_kknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kk_instance,
+    bilinear, Bilinear, 2, f16_f16_f16_f16_compute_f32_kknn,
+    F16, F16, F32, F16, F16_Tuple, F16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_knnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_knnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_knnn_instance =
-    device_contraction_kn_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   F16_Tuple,
-                                   F16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_knnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F16,
-                                                           F16,
-                                                           F16_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_knnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kn_instance,
+    bilinear, Bilinear, 2, f16_f16_f16_f16_compute_f32_knnn,
+    F16, F16, F32, F16, F16_Tuple, F16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_mknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_mknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_mknn_instance =
-    device_contraction_mk_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   F16_Tuple,
-                                   F16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_mknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F16,
-                                                           F16,
-                                                           F16_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_mknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mk_instance,
+    bilinear, Bilinear, 2, f16_f16_f16_f16_compute_f32_mknn,
+    F16, F16, F32, F16, F16_Tuple, F16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_mnnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_mnnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_mnnn_instance =
-    device_contraction_mn_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   F16_Tuple,
-                                   F16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_mnnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F16,
-                                                           F16,
-                                                           F16_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_mnnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mn_instance,
+    bilinear, Bilinear, 2, f16_f16_f16_f16_compute_f32_mnnn,
+    F16, F16, F32, F16, F16_Tuple, F16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_kknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_kknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_kknn_instance =
-    device_contraction_kk_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   F16_Tuple,
-                                   F16,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_kknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F16,
-                                                           F16,
-                                                           F16_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_kknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kk_instance,
+    bilinear, Bilinear, 2, f16_f16_f16_f16_kknn,
+    F16, F16, F32, F16, F16_Tuple, F16, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_knnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_knnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_knnn_instance =
-    device_contraction_kn_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   F16_Tuple,
-                                   F16,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_knnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F16,
-                                                           F16,
-                                                           F16_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_knnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kn_instance,
+    bilinear, Bilinear, 2, f16_f16_f16_f16_knnn,
+    F16, F16, F32, F16, F16_Tuple, F16, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_mknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_mknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_mknn_instance =
-    device_contraction_mk_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   F16_Tuple,
-                                   F16,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_mknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F16,
-                                                           F16,
-                                                           F16_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_mknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mk_instance,
+    bilinear, Bilinear, 2, f16_f16_f16_f16_mknn,
+    F16, F16, F32, F16, F16_Tuple, F16, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_mnnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_mnnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_mnnn_instance =
-    device_contraction_mn_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   F16_Tuple,
-                                   F16,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_mnnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F16,
-                                                           F16,
-                                                           F16_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_f16_mnnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mn_instance,
+    bilinear, Bilinear, 2, f16_f16_f16_f16_mnnn,
+    F16, F16, F32, F16, F16_Tuple, F16, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_kknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_kknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_kknn_instance =
-    device_contraction_kk_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   F32_Tuple,
-                                   F32,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_kknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F32,
-                                                           F32,
-                                                           F32_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_kknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kk_instance,
+    bilinear, Bilinear, 2, f32_f32_f32_f32_compute_bf16_kknn,
+    F32, F32, F32, F32, F32_Tuple, F32, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_knnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_knnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_knnn_instance =
-    device_contraction_kn_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   F32_Tuple,
-                                   F32,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_knnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F32,
-                                                           F32,
-                                                           F32_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_knnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kn_instance,
+    bilinear, Bilinear, 2, f32_f32_f32_f32_compute_bf16_knnn,
+    F32, F32, F32, F32, F32_Tuple, F32, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_mknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_mknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_mknn_instance =
-    device_contraction_mk_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   F32_Tuple,
-                                   F32,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_mknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F32,
-                                                           F32,
-                                                           F32_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_mknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mk_instance,
+    bilinear, Bilinear, 2, f32_f32_f32_f32_compute_bf16_mknn,
+    F32, F32, F32, F32, F32_Tuple, F32, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_mnnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_mnnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_mnnn_instance =
-    device_contraction_mn_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   F32_Tuple,
-                                   F32,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_mnnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F32,
-                                                           F32,
-                                                           F32_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_mnnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mn_instance,
+    bilinear, Bilinear, 2, f32_f32_f32_f32_compute_bf16_mnnn,
+    F32, F32, F32, F32, F32_Tuple, F32, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_kknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_kknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_kknn_instance =
-    device_contraction_kk_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   F32_Tuple,
-                                   F32,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_kknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F32,
-                                                           F32,
-                                                           F32_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_kknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kk_instance,
+    bilinear, Bilinear, 2, f32_f32_f32_f32_compute_f16_kknn,
+    F32, F32, F32, F32, F32_Tuple, F32, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_knnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_knnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_knnn_instance =
-    device_contraction_kn_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   F32_Tuple,
-                                   F32,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_knnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F32,
-                                                           F32,
-                                                           F32_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_knnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kn_instance,
+    bilinear, Bilinear, 2, f32_f32_f32_f32_compute_f16_knnn,
+    F32, F32, F32, F32, F32_Tuple, F32, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_mknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_mknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_mknn_instance =
-    device_contraction_mk_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   F32_Tuple,
-                                   F32,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_mknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F32,
-                                                           F32,
-                                                           F32_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_mknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mk_instance,
+    bilinear, Bilinear, 2, f32_f32_f32_f32_compute_f16_mknn,
+    F32, F32, F32, F32, F32_Tuple, F32, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_mnnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_mnnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_mnnn_instance =
-    device_contraction_mn_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   F32_Tuple,
-                                   F32,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_mnnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F32,
-                                                           F32,
-                                                           F32_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_mnnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mn_instance,
+    bilinear, Bilinear, 2, f32_f32_f32_f32_compute_f16_mnnn,
+    F32, F32, F32, F32, F32_Tuple, F32, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_kknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_kknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_kknn_instance =
-    device_contraction_kk_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   F32_Tuple,
-                                   F32,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_kknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F32,
-                                                           F32,
-                                                           F32_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_kknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kk_instance,
+    bilinear, Bilinear, 2, f32_f32_f32_f32_kknn,
+    F32, F32, F32, F32, F32_Tuple, F32, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_knnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_knnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_knnn_instance =
-    device_contraction_kn_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   F32_Tuple,
-                                   F32,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_knnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F32,
-                                                           F32,
-                                                           F32_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_knnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kn_instance,
+    bilinear, Bilinear, 2, f32_f32_f32_f32_knnn,
+    F32, F32, F32, F32, F32_Tuple, F32, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_mknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_mknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_mknn_instance =
-    device_contraction_mk_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   F32_Tuple,
-                                   F32,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_mknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F32,
-                                                           F32,
-                                                           F32_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_mknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mk_instance,
+    bilinear, Bilinear, 2, f32_f32_f32_f32_mknn,
+    F32, F32, F32, F32, F32_Tuple, F32, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_mnnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_mnnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_mnnn_instance =
-    device_contraction_mn_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   F32_Tuple,
-                                   F32,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_mnnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F32,
-                                                           F32,
-                                                           F32_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_f32_mnnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mn_instance,
+    bilinear, Bilinear, 2, f32_f32_f32_f32_mnnn,
+    F32, F32, F32, F32, F32_Tuple, F32, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_kknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_kknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_kknn_instance =
-    device_contraction_f64_kk_instance<F64,
-                                       F64,
-                                       F32,
-                                       F64,
-                                       F64_Tuple,
-                                       F64,
-                                       F32,
-                                       PassThrough,
-                                       PassThrough,
-                                       Bilinear,
-                                       2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_kknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F64,
-                                                           F64,
-                                                           F64_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_kknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_kk_instance,
+    bilinear, Bilinear, 2, f64_f64_f64_f64_compute_f32_kknn,
+    F64, F64, F32, F64, F64_Tuple, F64, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_knnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_knnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_knnn_instance =
-    device_contraction_f64_kn_instance<F64,
-                                       F64,
-                                       F32,
-                                       F64,
-                                       F64_Tuple,
-                                       F64,
-                                       F32,
-                                       PassThrough,
-                                       PassThrough,
-                                       Bilinear,
-                                       2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_knnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F64,
-                                                           F64,
-                                                           F64_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_knnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_kn_instance,
+    bilinear, Bilinear, 2, f64_f64_f64_f64_compute_f32_knnn,
+    F64, F64, F32, F64, F64_Tuple, F64, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_mknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_mknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_mknn_instance =
-    device_contraction_f64_mk_instance<F64,
-                                       F64,
-                                       F32,
-                                       F64,
-                                       F64_Tuple,
-                                       F64,
-                                       F32,
-                                       PassThrough,
-                                       PassThrough,
-                                       Bilinear,
-                                       2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_mknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F64,
-                                                           F64,
-                                                           F64_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_mknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_mk_instance,
+    bilinear, Bilinear, 2, f64_f64_f64_f64_compute_f32_mknn,
+    F64, F64, F32, F64, F64_Tuple, F64, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_mnnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_mnnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_mnnn_instance =
-    device_contraction_f64_mn_instance<F64,
-                                       F64,
-                                       F32,
-                                       F64,
-                                       F64_Tuple,
-                                       F64,
-                                       F32,
-                                       PassThrough,
-                                       PassThrough,
-                                       Bilinear,
-                                       2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_mnnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F64,
-                                                           F64,
-                                                           F64_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_mnnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_mn_instance,
+    bilinear, Bilinear, 2, f64_f64_f64_f64_compute_f32_mnnn,
+    F64, F64, F32, F64, F64_Tuple, F64, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_kknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_kknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_kknn_instance =
-    device_contraction_f64_kk_instance<F64,
-                                       F64,
-                                       F64,
-                                       F64,
-                                       F64_Tuple,
-                                       F64,
-                                       F64,
-                                       PassThrough,
-                                       PassThrough,
-                                       Bilinear,
-                                       2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_kknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F64,
-                                                           F64,
-                                                           F64_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F64>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_kknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_kk_instance,
+    bilinear, Bilinear, 2, f64_f64_f64_f64_kknn,
+    F64, F64, F64, F64, F64_Tuple, F64, F64)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_knnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_knnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_knnn_instance =
-    device_contraction_f64_kn_instance<F64,
-                                       F64,
-                                       F64,
-                                       F64,
-                                       F64_Tuple,
-                                       F64,
-                                       F64,
-                                       PassThrough,
-                                       PassThrough,
-                                       Bilinear,
-                                       2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_knnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F64,
-                                                           F64,
-                                                           F64_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F64>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_knnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_kn_instance,
+    bilinear, Bilinear, 2, f64_f64_f64_f64_knnn,
+    F64, F64, F64, F64, F64_Tuple, F64, F64)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_mknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_mknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_mknn_instance =
-    device_contraction_f64_mk_instance<F64,
-                                       F64,
-                                       F64,
-                                       F64,
-                                       F64_Tuple,
-                                       F64,
-                                       F64,
-                                       PassThrough,
-                                       PassThrough,
-                                       Bilinear,
-                                       2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_mknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F64,
-                                                           F64,
-                                                           F64_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F64>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_mknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_mk_instance,
+    bilinear, Bilinear, 2, f64_f64_f64_f64_mknn,
+    F64, F64, F64, F64, F64_Tuple, F64, F64)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_mnnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/2D/device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_mnnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_mnnn_instance =
-    device_contraction_f64_mn_instance<F64,
-                                       F64,
-                                       F64,
-                                       F64,
-                                       F64_Tuple,
-                                       F64,
-                                       F64,
-                                       PassThrough,
-                                       PassThrough,
-                                       Bilinear,
-                                       2>;
-
-void add_device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_mnnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F64,
-                                                           F64,
-                                                           F64_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F64>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_f64_mnnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_mn_instance,
+    bilinear, Bilinear, 2, f64_f64_f64_f64_mnnn,
+    F64, F64, F64, F64, F64_Tuple, F64, F64)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_kknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_kknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_kknn_instance =
-    device_contraction_kk_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   BF16_Tuple,
-                                   BF16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_kknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           BF16,
-                                                           BF16,
-                                                           BF16_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_kknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kk_instance,
+    bilinear, Bilinear, 6, bf16_bf16_bf16_bf16_compute_f32_kknn,
+    BF16, BF16, F32, BF16, BF16_Tuple, BF16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_knnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_knnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_knnn_instance =
-    device_contraction_kn_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   BF16_Tuple,
-                                   BF16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_knnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           BF16,
-                                                           BF16,
-                                                           BF16_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_knnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kn_instance,
+    bilinear, Bilinear, 6, bf16_bf16_bf16_bf16_compute_f32_knnn,
+    BF16, BF16, F32, BF16, BF16_Tuple, BF16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_mknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_mknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_mknn_instance =
-    device_contraction_mk_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   BF16_Tuple,
-                                   BF16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_mknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           BF16,
-                                                           BF16,
-                                                           BF16_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_mknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mk_instance,
+    bilinear, Bilinear, 6, bf16_bf16_bf16_bf16_compute_f32_mknn,
+    BF16, BF16, F32, BF16, BF16_Tuple, BF16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_mnnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_mnnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_mnnn_instance =
-    device_contraction_mn_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   BF16_Tuple,
-                                   BF16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_mnnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           BF16,
-                                                           BF16,
-                                                           BF16_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_mnnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mn_instance,
+    bilinear, Bilinear, 6, bf16_bf16_bf16_bf16_compute_f32_mnnn,
+    BF16, BF16, F32, BF16, BF16_Tuple, BF16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_kknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_kknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_kknn_instance =
-    device_contraction_kk_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   BF16_Tuple,
-                                   BF16,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_kknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           BF16,
-                                                           BF16,
-                                                           BF16_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_kknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kk_instance,
+    bilinear, Bilinear, 6, bf16_bf16_bf16_bf16_kknn,
+    BF16, BF16, F32, BF16, BF16_Tuple, BF16, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_knnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_knnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_knnn_instance =
-    device_contraction_kn_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   BF16_Tuple,
-                                   BF16,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_knnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           BF16,
-                                                           BF16,
-                                                           BF16_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_knnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kn_instance,
+    bilinear, Bilinear, 6, bf16_bf16_bf16_bf16_knnn,
+    BF16, BF16, F32, BF16, BF16_Tuple, BF16, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_mknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_mknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_mknn_instance =
-    device_contraction_mk_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   BF16_Tuple,
-                                   BF16,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_mknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           BF16,
-                                                           BF16,
-                                                           BF16_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_mknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mk_instance,
+    bilinear, Bilinear, 6, bf16_bf16_bf16_bf16_mknn,
+    BF16, BF16, F32, BF16, BF16_Tuple, BF16, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_mnnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_mnnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_mnnn_instance =
-    device_contraction_mn_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   BF16_Tuple,
-                                   BF16,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_mnnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           BF16,
-                                                           BF16,
-                                                           BF16_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_mnnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mn_instance,
+    bilinear, Bilinear, 6, bf16_bf16_bf16_bf16_mnnn,
+    BF16, BF16, F32, BF16, BF16_Tuple, BF16, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_kknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_kknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_kknn_instance =
-    device_contraction_kk_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   F16_Tuple,
-                                   F16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_kknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F16,
-                                                           F16,
-                                                           F16_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_kknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kk_instance,
+    bilinear, Bilinear, 6, f16_f16_f16_f16_compute_f32_kknn,
+    F16, F16, F32, F16, F16_Tuple, F16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_knnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_knnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_knnn_instance =
-    device_contraction_kn_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   F16_Tuple,
-                                   F16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_knnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F16,
-                                                           F16,
-                                                           F16_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_knnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kn_instance,
+    bilinear, Bilinear, 6, f16_f16_f16_f16_compute_f32_knnn,
+    F16, F16, F32, F16, F16_Tuple, F16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_mknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_mknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_mknn_instance =
-    device_contraction_mk_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   F16_Tuple,
-                                   F16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_mknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F16,
-                                                           F16,
-                                                           F16_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_mknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mk_instance,
+    bilinear, Bilinear, 6, f16_f16_f16_f16_compute_f32_mknn,
+    F16, F16, F32, F16, F16_Tuple, F16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_mnnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_mnnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_mnnn_instance =
-    device_contraction_mn_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   F16_Tuple,
-                                   F16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_mnnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F16,
-                                                           F16,
-                                                           F16_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_mnnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mn_instance,
+    bilinear, Bilinear, 6, f16_f16_f16_f16_compute_f32_mnnn,
+    F16, F16, F32, F16, F16_Tuple, F16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_kknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_kknn_instance.cpp
@@ -1,60 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_kknn_instance =
-    device_contraction_kk_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   F16_Tuple,
-                                   F16,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_kknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F16,
-                                                           F16,
-                                                           F16_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F16>>>& instances)
-{
-    printf("[CK_DEBUG] f16+f16+f16+f16_kknn_instance: before add, size=%zu\n", instances.size());
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_kknn_instance{});
-    printf("[CK_DEBUG] f16+f16+f16+f16_kknn_instance: after add, size=%zu\n", instances.size());
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kk_instance,
+    bilinear, Bilinear, 6, f16_f16_f16_f16_kknn,
+    F16, F16, F32, F16, F16_Tuple, F16, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_knnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_knnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_knnn_instance =
-    device_contraction_kn_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   F16_Tuple,
-                                   F16,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_knnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F16,
-                                                           F16,
-                                                           F16_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_knnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kn_instance,
+    bilinear, Bilinear, 6, f16_f16_f16_f16_knnn,
+    F16, F16, F32, F16, F16_Tuple, F16, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_mknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_mknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_mknn_instance =
-    device_contraction_mk_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   F16_Tuple,
-                                   F16,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_mknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F16,
-                                                           F16,
-                                                           F16_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_mknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mk_instance,
+    bilinear, Bilinear, 6, f16_f16_f16_f16_mknn,
+    F16, F16, F32, F16, F16_Tuple, F16, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_mnnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_mnnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_mnnn_instance =
-    device_contraction_mn_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   F16_Tuple,
-                                   F16,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_mnnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F16,
-                                                           F16,
-                                                           F16_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_mnnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mn_instance,
+    bilinear, Bilinear, 6, f16_f16_f16_f16_mnnn,
+    F16, F16, F32, F16, F16_Tuple, F16, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_kknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_kknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_kknn_instance =
-    device_contraction_kk_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   F32_Tuple,
-                                   F32,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_kknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           F32_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_kknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kk_instance,
+    bilinear, Bilinear, 6, f32_f32_f32_f32_compute_bf16_kknn,
+    F32, F32, F32, F32, F32_Tuple, F32, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_knnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_knnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_knnn_instance =
-    device_contraction_kn_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   F32_Tuple,
-                                   F32,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_knnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           F32_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_knnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kn_instance,
+    bilinear, Bilinear, 6, f32_f32_f32_f32_compute_bf16_knnn,
+    F32, F32, F32, F32, F32_Tuple, F32, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_mknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_mknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_mknn_instance =
-    device_contraction_mk_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   F32_Tuple,
-                                   F32,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_mknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           F32_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_mknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mk_instance,
+    bilinear, Bilinear, 6, f32_f32_f32_f32_compute_bf16_mknn,
+    F32, F32, F32, F32, F32_Tuple, F32, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_mnnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_mnnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_mnnn_instance =
-    device_contraction_mn_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   F32_Tuple,
-                                   F32,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_mnnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           F32_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_bf16_mnnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mn_instance,
+    bilinear, Bilinear, 6, f32_f32_f32_f32_compute_bf16_mnnn,
+    F32, F32, F32, F32, F32_Tuple, F32, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_kknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_kknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_kknn_instance =
-    device_contraction_kk_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   F32_Tuple,
-                                   F32,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_kknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           F32_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_kknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kk_instance,
+    bilinear, Bilinear, 6, f32_f32_f32_f32_compute_f16_kknn,
+    F32, F32, F32, F32, F32_Tuple, F32, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_knnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_knnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_knnn_instance =
-    device_contraction_kn_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   F32_Tuple,
-                                   F32,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_knnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           F32_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_knnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kn_instance,
+    bilinear, Bilinear, 6, f32_f32_f32_f32_compute_f16_knnn,
+    F32, F32, F32, F32, F32_Tuple, F32, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_mknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_mknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_mknn_instance =
-    device_contraction_mk_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   F32_Tuple,
-                                   F32,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_mknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           F32_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_mknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mk_instance,
+    bilinear, Bilinear, 6, f32_f32_f32_f32_compute_f16_mknn,
+    F32, F32, F32, F32, F32_Tuple, F32, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_mnnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_mnnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_mnnn_instance =
-    device_contraction_mn_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   F32_Tuple,
-                                   F32,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_mnnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           F32_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_compute_f16_mnnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mn_instance,
+    bilinear, Bilinear, 6, f32_f32_f32_f32_compute_f16_mnnn,
+    F32, F32, F32, F32, F32_Tuple, F32, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_kknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_kknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_kknn_instance =
-    device_contraction_kk_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   F32_Tuple,
-                                   F32,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_kknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           F32_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_kknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kk_instance,
+    bilinear, Bilinear, 6, f32_f32_f32_f32_kknn,
+    F32, F32, F32, F32, F32_Tuple, F32, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_knnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_knnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_knnn_instance =
-    device_contraction_kn_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   F32_Tuple,
-                                   F32,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_knnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           F32_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_knnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kn_instance,
+    bilinear, Bilinear, 6, f32_f32_f32_f32_knnn,
+    F32, F32, F32, F32, F32_Tuple, F32, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_mknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_mknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_mknn_instance =
-    device_contraction_mk_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   F32_Tuple,
-                                   F32,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_mknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           F32_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_mknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mk_instance,
+    bilinear, Bilinear, 6, f32_f32_f32_f32_mknn,
+    F32, F32, F32, F32, F32_Tuple, F32, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_mnnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_mnnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_mnnn_instance =
-    device_contraction_mn_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   F32_Tuple,
-                                   F32,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Bilinear,
-                                   6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_mnnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           F32_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_f32_mnnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mn_instance,
+    bilinear, Bilinear, 6, f32_f32_f32_f32_mnnn,
+    F32, F32, F32, F32, F32_Tuple, F32, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_kknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_kknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_kknn_instance =
-    device_contraction_f64_kk_instance<F64,
-                                       F64,
-                                       F32,
-                                       F64,
-                                       F64_Tuple,
-                                       F64,
-                                       F32,
-                                       PassThrough,
-                                       PassThrough,
-                                       Bilinear,
-                                       6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_kknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F64,
-                                                           F64,
-                                                           F64_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_kknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_kk_instance,
+    bilinear, Bilinear, 6, f64_f64_f64_f64_compute_f32_kknn,
+    F64, F64, F32, F64, F64_Tuple, F64, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_knnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_knnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_knnn_instance =
-    device_contraction_f64_kn_instance<F64,
-                                       F64,
-                                       F32,
-                                       F64,
-                                       F64_Tuple,
-                                       F64,
-                                       F32,
-                                       PassThrough,
-                                       PassThrough,
-                                       Bilinear,
-                                       6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_knnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F64,
-                                                           F64,
-                                                           F64_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_knnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_kn_instance,
+    bilinear, Bilinear, 6, f64_f64_f64_f64_compute_f32_knnn,
+    F64, F64, F32, F64, F64_Tuple, F64, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_mknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_mknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_mknn_instance =
-    device_contraction_f64_mk_instance<F64,
-                                       F64,
-                                       F32,
-                                       F64,
-                                       F64_Tuple,
-                                       F64,
-                                       F32,
-                                       PassThrough,
-                                       PassThrough,
-                                       Bilinear,
-                                       6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_mknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F64,
-                                                           F64,
-                                                           F64_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_mknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_mk_instance,
+    bilinear, Bilinear, 6, f64_f64_f64_f64_compute_f32_mknn,
+    F64, F64, F32, F64, F64_Tuple, F64, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_mnnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_mnnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_mnnn_instance =
-    device_contraction_f64_mn_instance<F64,
-                                       F64,
-                                       F32,
-                                       F64,
-                                       F64_Tuple,
-                                       F64,
-                                       F32,
-                                       PassThrough,
-                                       PassThrough,
-                                       Bilinear,
-                                       6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_mnnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F64,
-                                                           F64,
-                                                           F64_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_compute_f32_mnnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_mn_instance,
+    bilinear, Bilinear, 6, f64_f64_f64_f64_compute_f32_mnnn,
+    F64, F64, F32, F64, F64_Tuple, F64, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_kknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_kknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_kknn_instance =
-    device_contraction_f64_kk_instance<F64,
-                                       F64,
-                                       F64,
-                                       F64,
-                                       F64_Tuple,
-                                       F64,
-                                       F64,
-                                       PassThrough,
-                                       PassThrough,
-                                       Bilinear,
-                                       6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_kknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F64,
-                                                           F64,
-                                                           F64_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F64>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_kknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_kk_instance,
+    bilinear, Bilinear, 6, f64_f64_f64_f64_kknn,
+    F64, F64, F64, F64, F64_Tuple, F64, F64)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_knnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_knnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_knnn_instance =
-    device_contraction_f64_kn_instance<F64,
-                                       F64,
-                                       F64,
-                                       F64,
-                                       F64_Tuple,
-                                       F64,
-                                       F64,
-                                       PassThrough,
-                                       PassThrough,
-                                       Bilinear,
-                                       6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_knnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F64,
-                                                           F64,
-                                                           F64_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F64>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_knnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_kn_instance,
+    bilinear, Bilinear, 6, f64_f64_f64_f64_knnn,
+    F64, F64, F64, F64, F64_Tuple, F64, F64)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_mknn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_mknn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_mknn_instance =
-    device_contraction_f64_mk_instance<F64,
-                                       F64,
-                                       F64,
-                                       F64,
-                                       F64_Tuple,
-                                       F64,
-                                       F64,
-                                       PassThrough,
-                                       PassThrough,
-                                       Bilinear,
-                                       6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_mknn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F64,
-                                                           F64,
-                                                           F64_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F64>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_mknn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_mk_instance,
+    bilinear, Bilinear, 6, f64_f64_f64_f64_mknn,
+    F64, F64, F64, F64, F64_Tuple, F64, F64)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_mnnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_bilinear/6D/device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_mnnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_mnnn_instance =
-    device_contraction_f64_mn_instance<F64,
-                                       F64,
-                                       F64,
-                                       F64,
-                                       F64_Tuple,
-                                       F64,
-                                       F64,
-                                       PassThrough,
-                                       PassThrough,
-                                       Bilinear,
-                                       6>;
-
-void add_device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_mnnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F64,
-                                                           F64,
-                                                           F64_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Bilinear,
-                                                           F64>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_bilinear_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_f64_mnnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_mn_instance,
+    bilinear, Bilinear, 6, f64_f64_f64_f64_mnnn,
+    F64, F64, F64, F64, F64_Tuple, F64, F64)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_kkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_kkn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_kkn_instance =
-    device_contraction_kk_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   Empty_Tuple,
-                                   BF16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_kkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           BF16,
-                                                           BF16,
-                                                           Empty_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_kkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kk_instance,
+    scale, Scale, 2, bf16_bf16_bf16_compute_f32_kkn,
+    BF16, BF16, F32, BF16, Empty_Tuple, BF16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_knn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_knn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_knn_instance =
-    device_contraction_kn_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   Empty_Tuple,
-                                   BF16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_knn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           BF16,
-                                                           BF16,
-                                                           Empty_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_knn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kn_instance,
+    scale, Scale, 2, bf16_bf16_bf16_compute_f32_knn,
+    BF16, BF16, F32, BF16, Empty_Tuple, BF16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_mkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_mkn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_mkn_instance =
-    device_contraction_mk_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   Empty_Tuple,
-                                   BF16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_mkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           BF16,
-                                                           BF16,
-                                                           Empty_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_mkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mk_instance,
+    scale, Scale, 2, bf16_bf16_bf16_compute_f32_mkn,
+    BF16, BF16, F32, BF16, Empty_Tuple, BF16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_mnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_mnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_mnn_instance =
-    device_contraction_mn_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   Empty_Tuple,
-                                   BF16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_mnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           BF16,
-                                                           BF16,
-                                                           Empty_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_mnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mn_instance,
+    scale, Scale, 2, bf16_bf16_bf16_compute_f32_mnn,
+    BF16, BF16, F32, BF16, Empty_Tuple, BF16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_kkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_kkn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_kkn_instance =
-    device_contraction_kk_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   Empty_Tuple,
-                                   BF16,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_kkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           BF16,
-                                                           BF16,
-                                                           Empty_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_kkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kk_instance,
+    scale, Scale, 2, bf16_bf16_bf16_kkn,
+    BF16, BF16, F32, BF16, Empty_Tuple, BF16, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_knn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_knn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_knn_instance =
-    device_contraction_kn_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   Empty_Tuple,
-                                   BF16,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_knn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           BF16,
-                                                           BF16,
-                                                           Empty_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_knn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kn_instance,
+    scale, Scale, 2, bf16_bf16_bf16_knn,
+    BF16, BF16, F32, BF16, Empty_Tuple, BF16, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_mkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_mkn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_mkn_instance =
-    device_contraction_mk_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   Empty_Tuple,
-                                   BF16,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_mkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           BF16,
-                                                           BF16,
-                                                           Empty_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_mkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mk_instance,
+    scale, Scale, 2, bf16_bf16_bf16_mkn,
+    BF16, BF16, F32, BF16, Empty_Tuple, BF16, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_mnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_mnn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_mnn_instance =
-    device_contraction_mn_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   Empty_Tuple,
-                                   BF16,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_mnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           BF16,
-                                                           BF16,
-                                                           Empty_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m2_n2_k2_xdl_c_shuffle_bf16_bf16_bf16_mnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mn_instance,
+    scale, Scale, 2, bf16_bf16_bf16_mnn,
+    BF16, BF16, F32, BF16, Empty_Tuple, BF16, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_compute_f32_kkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_compute_f32_kkn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_compute_f32_kkn_instance =
-    device_contraction_kk_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   Empty_Tuple,
-                                   F16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_compute_f32_kkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F16,
-                                                           F16,
-                                                           Empty_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_compute_f32_kkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kk_instance,
+    scale, Scale, 2, f16_f16_f16_compute_f32_kkn,
+    F16, F16, F32, F16, Empty_Tuple, F16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_compute_f32_knn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_compute_f32_knn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_compute_f32_knn_instance =
-    device_contraction_kn_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   Empty_Tuple,
-                                   F16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_compute_f32_knn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F16,
-                                                           F16,
-                                                           Empty_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_compute_f32_knn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kn_instance,
+    scale, Scale, 2, f16_f16_f16_compute_f32_knn,
+    F16, F16, F32, F16, Empty_Tuple, F16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_compute_f32_mkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_compute_f32_mkn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_compute_f32_mkn_instance =
-    device_contraction_mk_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   Empty_Tuple,
-                                   F16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_compute_f32_mkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F16,
-                                                           F16,
-                                                           Empty_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_compute_f32_mkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mk_instance,
+    scale, Scale, 2, f16_f16_f16_compute_f32_mkn,
+    F16, F16, F32, F16, Empty_Tuple, F16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_compute_f32_mnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_compute_f32_mnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_compute_f32_mnn_instance =
-    device_contraction_mn_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   Empty_Tuple,
-                                   F16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_compute_f32_mnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F16,
-                                                           F16,
-                                                           Empty_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_compute_f32_mnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mn_instance,
+    scale, Scale, 2, f16_f16_f16_compute_f32_mnn,
+    F16, F16, F32, F16, Empty_Tuple, F16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_kkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_kkn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_kkn_instance =
-    device_contraction_kk_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   Empty_Tuple,
-                                   F16,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_kkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F16,
-                                                           F16,
-                                                           Empty_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_kkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kk_instance,
+    scale, Scale, 2, f16_f16_f16_kkn,
+    F16, F16, F32, F16, Empty_Tuple, F16, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_knn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_knn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_knn_instance =
-    device_contraction_kn_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   Empty_Tuple,
-                                   F16,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_knn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F16,
-                                                           F16,
-                                                           Empty_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_knn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kn_instance,
+    scale, Scale, 2, f16_f16_f16_knn,
+    F16, F16, F32, F16, Empty_Tuple, F16, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_mkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_mkn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_mkn_instance =
-    device_contraction_mk_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   Empty_Tuple,
-                                   F16,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_mkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F16,
-                                                           F16,
-                                                           Empty_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_mkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mk_instance,
+    scale, Scale, 2, f16_f16_f16_mkn,
+    F16, F16, F32, F16, Empty_Tuple, F16, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_mnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_mnn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_mnn_instance =
-    device_contraction_mn_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   Empty_Tuple,
-                                   F16,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_mnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F16,
-                                                           F16,
-                                                           Empty_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f16_f16_f16_mnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mn_instance,
+    scale, Scale, 2, f16_f16_f16_mnn,
+    F16, F16, F32, F16, Empty_Tuple, F16, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_bf16_kkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_bf16_kkn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_bf16_kkn_instance =
-    device_contraction_kk_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   Empty_Tuple,
-                                   F32,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_bf16_kkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_bf16_kkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kk_instance,
+    scale, Scale, 2, f32_f32_f32_compute_bf16_kkn,
+    F32, F32, F32, F32, Empty_Tuple, F32, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_bf16_knn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_bf16_knn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_bf16_knn_instance =
-    device_contraction_kn_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   Empty_Tuple,
-                                   F32,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_bf16_knn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_bf16_knn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kn_instance,
+    scale, Scale, 2, f32_f32_f32_compute_bf16_knn,
+    F32, F32, F32, F32, Empty_Tuple, F32, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_bf16_mkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_bf16_mkn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_bf16_mkn_instance =
-    device_contraction_mk_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   Empty_Tuple,
-                                   F32,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_bf16_mkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_bf16_mkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mk_instance,
+    scale, Scale, 2, f32_f32_f32_compute_bf16_mkn,
+    F32, F32, F32, F32, Empty_Tuple, F32, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_bf16_mnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_bf16_mnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_bf16_mnn_instance =
-    device_contraction_mn_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   Empty_Tuple,
-                                   F32,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_bf16_mnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_bf16_mnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mn_instance,
+    scale, Scale, 2, f32_f32_f32_compute_bf16_mnn,
+    F32, F32, F32, F32, Empty_Tuple, F32, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_f16_kkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_f16_kkn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_f16_kkn_instance =
-    device_contraction_kk_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   Empty_Tuple,
-                                   F32,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_f16_kkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_f16_kkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kk_instance,
+    scale, Scale, 2, f32_f32_f32_compute_f16_kkn,
+    F32, F32, F32, F32, Empty_Tuple, F32, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_f16_knn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_f16_knn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_f16_knn_instance =
-    device_contraction_kn_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   Empty_Tuple,
-                                   F32,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_f16_knn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_f16_knn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kn_instance,
+    scale, Scale, 2, f32_f32_f32_compute_f16_knn,
+    F32, F32, F32, F32, Empty_Tuple, F32, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_f16_mkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_f16_mkn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_f16_mkn_instance =
-    device_contraction_mk_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   Empty_Tuple,
-                                   F32,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_f16_mkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_f16_mkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mk_instance,
+    scale, Scale, 2, f32_f32_f32_compute_f16_mkn,
+    F32, F32, F32, F32, Empty_Tuple, F32, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_f16_mnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_f16_mnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_f16_mnn_instance =
-    device_contraction_mn_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   Empty_Tuple,
-                                   F32,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_f16_mnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_compute_f16_mnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mn_instance,
+    scale, Scale, 2, f32_f32_f32_compute_f16_mnn,
+    F32, F32, F32, F32, Empty_Tuple, F32, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_kkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_kkn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_kkn_instance =
-    device_contraction_kk_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   Empty_Tuple,
-                                   F32,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_kkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_kkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kk_instance,
+    scale, Scale, 2, f32_f32_f32_kkn,
+    F32, F32, F32, F32, Empty_Tuple, F32, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_knn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_knn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_knn_instance =
-    device_contraction_kn_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   Empty_Tuple,
-                                   F32,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_knn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_knn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kn_instance,
+    scale, Scale, 2, f32_f32_f32_knn,
+    F32, F32, F32, F32, Empty_Tuple, F32, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_mkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_mkn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_mkn_instance =
-    device_contraction_mk_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   Empty_Tuple,
-                                   F32,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_mkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_mkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mk_instance,
+    scale, Scale, 2, f32_f32_f32_mkn,
+    F32, F32, F32, F32, Empty_Tuple, F32, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_mnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_mnn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_mnn_instance =
-    device_contraction_mn_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   Empty_Tuple,
-                                   F32,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_mnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f32_f32_f32_mnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mn_instance,
+    scale, Scale, 2, f32_f32_f32_mnn,
+    F32, F32, F32, F32, Empty_Tuple, F32, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_compute_f32_kkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_compute_f32_kkn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_compute_f32_kkn_instance =
-    device_contraction_f64_kk_instance<F64,
-                                       F64,
-                                       F32,
-                                       F64,
-                                       Empty_Tuple,
-                                       F64,
-                                       F32,
-                                       PassThrough,
-                                       PassThrough,
-                                       Scale,
-                                       2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_compute_f32_kkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F64,
-                                                           F64,
-                                                           Empty_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_compute_f32_kkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_kk_instance,
+    scale, Scale, 2, f64_f64_f64_compute_f32_kkn,
+    F64, F64, F32, F64, Empty_Tuple, F64, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_compute_f32_knn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_compute_f32_knn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_compute_f32_knn_instance =
-    device_contraction_f64_kn_instance<F64,
-                                       F64,
-                                       F32,
-                                       F64,
-                                       Empty_Tuple,
-                                       F64,
-                                       F32,
-                                       PassThrough,
-                                       PassThrough,
-                                       Scale,
-                                       2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_compute_f32_knn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F64,
-                                                           F64,
-                                                           Empty_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_compute_f32_knn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_kn_instance,
+    scale, Scale, 2, f64_f64_f64_compute_f32_knn,
+    F64, F64, F32, F64, Empty_Tuple, F64, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_compute_f32_mkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_compute_f32_mkn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_compute_f32_mkn_instance =
-    device_contraction_f64_mk_instance<F64,
-                                       F64,
-                                       F32,
-                                       F64,
-                                       Empty_Tuple,
-                                       F64,
-                                       F32,
-                                       PassThrough,
-                                       PassThrough,
-                                       Scale,
-                                       2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_compute_f32_mkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F64,
-                                                           F64,
-                                                           Empty_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_compute_f32_mkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_mk_instance,
+    scale, Scale, 2, f64_f64_f64_compute_f32_mkn,
+    F64, F64, F32, F64, Empty_Tuple, F64, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_compute_f32_mnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_compute_f32_mnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_compute_f32_mnn_instance =
-    device_contraction_f64_mn_instance<F64,
-                                       F64,
-                                       F32,
-                                       F64,
-                                       Empty_Tuple,
-                                       F64,
-                                       F32,
-                                       PassThrough,
-                                       PassThrough,
-                                       Scale,
-                                       2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_compute_f32_mnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F64,
-                                                           F64,
-                                                           Empty_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_compute_f32_mnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_mn_instance,
+    scale, Scale, 2, f64_f64_f64_compute_f32_mnn,
+    F64, F64, F32, F64, Empty_Tuple, F64, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_kkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_kkn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_kkn_instance =
-    device_contraction_f64_kk_instance<F64,
-                                       F64,
-                                       F64,
-                                       F64,
-                                       Empty_Tuple,
-                                       F64,
-                                       F64,
-                                       PassThrough,
-                                       PassThrough,
-                                       Scale,
-                                       2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_kkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F64,
-                                                           F64,
-                                                           Empty_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F64>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_kkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_kk_instance,
+    scale, Scale, 2, f64_f64_f64_kkn,
+    F64, F64, F64, F64, Empty_Tuple, F64, F64)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_knn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_knn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_knn_instance =
-    device_contraction_f64_kn_instance<F64,
-                                       F64,
-                                       F64,
-                                       F64,
-                                       Empty_Tuple,
-                                       F64,
-                                       F64,
-                                       PassThrough,
-                                       PassThrough,
-                                       Scale,
-                                       2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_knn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F64,
-                                                           F64,
-                                                           Empty_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F64>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_knn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_kn_instance,
+    scale, Scale, 2, f64_f64_f64_knn,
+    F64, F64, F64, F64, Empty_Tuple, F64, F64)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_mkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_mkn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_mkn_instance =
-    device_contraction_f64_mk_instance<F64,
-                                       F64,
-                                       F64,
-                                       F64,
-                                       Empty_Tuple,
-                                       F64,
-                                       F64,
-                                       PassThrough,
-                                       PassThrough,
-                                       Scale,
-                                       2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_mkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F64,
-                                                           F64,
-                                                           Empty_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F64>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_mkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_mk_instance,
+    scale, Scale, 2, f64_f64_f64_mkn,
+    F64, F64, F64, F64, Empty_Tuple, F64, F64)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_mnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/2D/device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_mnn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_mnn_instance =
-    device_contraction_f64_mn_instance<F64,
-                                       F64,
-                                       F64,
-                                       F64,
-                                       Empty_Tuple,
-                                       F64,
-                                       F64,
-                                       PassThrough,
-                                       PassThrough,
-                                       Scale,
-                                       2>;
-
-void add_device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_mnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<2,
-                                                           2,
-                                                           2,
-                                                           F64,
-                                                           F64,
-                                                           Empty_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F64>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m2_n2_k2_xdl_c_shuffle_f64_f64_f64_mnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_mn_instance,
+    scale, Scale, 2, f64_f64_f64_mnn,
+    F64, F64, F64, F64, Empty_Tuple, F64, F64)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_kkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_kkn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_kkn_instance =
-    device_contraction_kk_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   Empty_Tuple,
-                                   BF16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_kkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           BF16,
-                                                           BF16,
-                                                           Empty_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_kkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kk_instance,
+    scale, Scale, 6, bf16_bf16_bf16_compute_f32_kkn,
+    BF16, BF16, F32, BF16, Empty_Tuple, BF16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_knn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_knn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_knn_instance =
-    device_contraction_kn_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   Empty_Tuple,
-                                   BF16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_knn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           BF16,
-                                                           BF16,
-                                                           Empty_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_knn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kn_instance,
+    scale, Scale, 6, bf16_bf16_bf16_compute_f32_knn,
+    BF16, BF16, F32, BF16, Empty_Tuple, BF16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_mkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_mkn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_mkn_instance =
-    device_contraction_mk_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   Empty_Tuple,
-                                   BF16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_mkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           BF16,
-                                                           BF16,
-                                                           Empty_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_mkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mk_instance,
+    scale, Scale, 6, bf16_bf16_bf16_compute_f32_mkn,
+    BF16, BF16, F32, BF16, Empty_Tuple, BF16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_mnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_mnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_mnn_instance =
-    device_contraction_mn_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   Empty_Tuple,
-                                   BF16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_mnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           BF16,
-                                                           BF16,
-                                                           Empty_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_mnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mn_instance,
+    scale, Scale, 6, bf16_bf16_bf16_compute_f32_mnn,
+    BF16, BF16, F32, BF16, Empty_Tuple, BF16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_kkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_kkn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_kkn_instance =
-    device_contraction_kk_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   Empty_Tuple,
-                                   BF16,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_kkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           BF16,
-                                                           BF16,
-                                                           Empty_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_kkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kk_instance,
+    scale, Scale, 6, bf16_bf16_bf16_kkn,
+    BF16, BF16, F32, BF16, Empty_Tuple, BF16, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_knn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_knn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_knn_instance =
-    device_contraction_kn_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   Empty_Tuple,
-                                   BF16,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_knn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           BF16,
-                                                           BF16,
-                                                           Empty_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_knn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kn_instance,
+    scale, Scale, 6, bf16_bf16_bf16_knn,
+    BF16, BF16, F32, BF16, Empty_Tuple, BF16, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_mkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_mkn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_mkn_instance =
-    device_contraction_mk_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   Empty_Tuple,
-                                   BF16,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_mkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           BF16,
-                                                           BF16,
-                                                           Empty_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_mkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mk_instance,
+    scale, Scale, 6, bf16_bf16_bf16_mkn,
+    BF16, BF16, F32, BF16, Empty_Tuple, BF16, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_mnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_mnn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_mnn_instance =
-    device_contraction_mn_instance<BF16,
-                                   BF16,
-                                   F32,
-                                   BF16,
-                                   Empty_Tuple,
-                                   BF16,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_mnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           BF16,
-                                                           BF16,
-                                                           Empty_Tuple,
-                                                           BF16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_mnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mn_instance,
+    scale, Scale, 6, bf16_bf16_bf16_mnn,
+    BF16, BF16, F32, BF16, Empty_Tuple, BF16, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_kkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_kkn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_kkn_instance =
-    device_contraction_kk_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   Empty_Tuple,
-                                   F16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_kkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F16,
-                                                           F16,
-                                                           Empty_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_kkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kk_instance,
+    scale, Scale, 6, f16_f16_f16_compute_f32_kkn,
+    F16, F16, F32, F16, Empty_Tuple, F16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_knn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_knn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_knn_instance =
-    device_contraction_kn_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   Empty_Tuple,
-                                   F16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_knn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F16,
-                                                           F16,
-                                                           Empty_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_knn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kn_instance,
+    scale, Scale, 6, f16_f16_f16_compute_f32_knn,
+    F16, F16, F32, F16, Empty_Tuple, F16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_mkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_mkn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_mkn_instance =
-    device_contraction_mk_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   Empty_Tuple,
-                                   F16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_mkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F16,
-                                                           F16,
-                                                           Empty_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_mkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mk_instance,
+    scale, Scale, 6, f16_f16_f16_compute_f32_mkn,
+    F16, F16, F32, F16, Empty_Tuple, F16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_mnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_mnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_mnn_instance =
-    device_contraction_mn_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   Empty_Tuple,
-                                   F16,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_mnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F16,
-                                                           F16,
-                                                           Empty_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_mnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mn_instance,
+    scale, Scale, 6, f16_f16_f16_compute_f32_mnn,
+    F16, F16, F32, F16, Empty_Tuple, F16, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_kkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_kkn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_kkn_instance =
-    device_contraction_kk_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   Empty_Tuple,
-                                   F16,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_kkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F16,
-                                                           F16,
-                                                           Empty_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_kkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kk_instance,
+    scale, Scale, 6, f16_f16_f16_kkn,
+    F16, F16, F32, F16, Empty_Tuple, F16, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_knn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_knn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_knn_instance =
-    device_contraction_kn_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   Empty_Tuple,
-                                   F16,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_knn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F16,
-                                                           F16,
-                                                           Empty_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_knn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kn_instance,
+    scale, Scale, 6, f16_f16_f16_knn,
+    F16, F16, F32, F16, Empty_Tuple, F16, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_mkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_mkn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_mkn_instance =
-    device_contraction_mk_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   Empty_Tuple,
-                                   F16,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_mkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F16,
-                                                           F16,
-                                                           Empty_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_mkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mk_instance,
+    scale, Scale, 6, f16_f16_f16_mkn,
+    F16, F16, F32, F16, Empty_Tuple, F16, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_mnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_mnn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_mnn_instance =
-    device_contraction_mn_instance<F16,
-                                   F16,
-                                   F32,
-                                   F16,
-                                   Empty_Tuple,
-                                   F16,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_mnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F16,
-                                                           F16,
-                                                           Empty_Tuple,
-                                                           F16,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_mnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mn_instance,
+    scale, Scale, 6, f16_f16_f16_mnn,
+    F16, F16, F32, F16, Empty_Tuple, F16, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_kkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_kkn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_kkn_instance =
-    device_contraction_kk_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   Empty_Tuple,
-                                   F32,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_kkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_kkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kk_instance,
+    scale, Scale, 6, f32_f32_f32_compute_bf16_kkn,
+    F32, F32, F32, F32, Empty_Tuple, F32, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_knn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_knn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_knn_instance =
-    device_contraction_kn_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   Empty_Tuple,
-                                   F32,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_knn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_knn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kn_instance,
+    scale, Scale, 6, f32_f32_f32_compute_bf16_knn,
+    F32, F32, F32, F32, Empty_Tuple, F32, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_mkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_mkn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_mkn_instance =
-    device_contraction_mk_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   Empty_Tuple,
-                                   F32,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_mkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_mkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mk_instance,
+    scale, Scale, 6, f32_f32_f32_compute_bf16_mkn,
+    F32, F32, F32, F32, Empty_Tuple, F32, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_mnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_mnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_mnn_instance =
-    device_contraction_mn_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   Empty_Tuple,
-                                   F32,
-                                   BF16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_mnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           BF16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_mnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mn_instance,
+    scale, Scale, 6, f32_f32_f32_compute_bf16_mnn,
+    F32, F32, F32, F32, Empty_Tuple, F32, BF16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_kkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_kkn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_kkn_instance =
-    device_contraction_kk_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   Empty_Tuple,
-                                   F32,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_kkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_kkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kk_instance,
+    scale, Scale, 6, f32_f32_f32_compute_f16_kkn,
+    F32, F32, F32, F32, Empty_Tuple, F32, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_knn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_knn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_knn_instance =
-    device_contraction_kn_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   Empty_Tuple,
-                                   F32,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_knn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_knn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kn_instance,
+    scale, Scale, 6, f32_f32_f32_compute_f16_knn,
+    F32, F32, F32, F32, Empty_Tuple, F32, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_mkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_mkn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_mkn_instance =
-    device_contraction_mk_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   Empty_Tuple,
-                                   F32,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_mkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_mkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mk_instance,
+    scale, Scale, 6, f32_f32_f32_compute_f16_mkn,
+    F32, F32, F32, F32, Empty_Tuple, F32, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_mnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_mnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_mnn_instance =
-    device_contraction_mn_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   Empty_Tuple,
-                                   F32,
-                                   F16,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_mnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F16>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_mnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mn_instance,
+    scale, Scale, 6, f32_f32_f32_compute_f16_mnn,
+    F32, F32, F32, F32, Empty_Tuple, F32, F16)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_kkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_kkn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_kkn_instance =
-    device_contraction_kk_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   Empty_Tuple,
-                                   F32,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_kkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_kkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kk_instance,
+    scale, Scale, 6, f32_f32_f32_kkn,
+    F32, F32, F32, F32, Empty_Tuple, F32, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_knn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_knn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_knn_instance =
-    device_contraction_kn_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   Empty_Tuple,
-                                   F32,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_knn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_knn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_kn_instance,
+    scale, Scale, 6, f32_f32_f32_knn,
+    F32, F32, F32, F32, Empty_Tuple, F32, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_mkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_mkn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_mkn_instance =
-    device_contraction_mk_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   Empty_Tuple,
-                                   F32,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_mkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_mkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mk_instance,
+    scale, Scale, 6, f32_f32_f32_mkn,
+    F32, F32, F32, F32, Empty_Tuple, F32, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_mnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_mnn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_mnn_instance =
-    device_contraction_mn_instance<F32,
-                                   F32,
-                                   F32,
-                                   F32,
-                                   Empty_Tuple,
-                                   F32,
-                                   F32,
-                                   PassThrough,
-                                   PassThrough,
-                                   Scale,
-                                   6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_mnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_mnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_mn_instance,
+    scale, Scale, 6, f32_f32_f32_mnn,
+    F32, F32, F32, F32, Empty_Tuple, F32, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_kkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_kkn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_kkn_instance =
-    device_contraction_f64_kk_instance<F64,
-                                       F64,
-                                       F32,
-                                       F64,
-                                       Empty_Tuple,
-                                       F64,
-                                       F32,
-                                       PassThrough,
-                                       PassThrough,
-                                       Scale,
-                                       6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_kkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F64,
-                                                           F64,
-                                                           Empty_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_kkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_kk_instance,
+    scale, Scale, 6, f64_f64_f64_compute_f32_kkn,
+    F64, F64, F32, F64, Empty_Tuple, F64, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_knn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_knn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_knn_instance =
-    device_contraction_f64_kn_instance<F64,
-                                       F64,
-                                       F32,
-                                       F64,
-                                       Empty_Tuple,
-                                       F64,
-                                       F32,
-                                       PassThrough,
-                                       PassThrough,
-                                       Scale,
-                                       6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_knn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F64,
-                                                           F64,
-                                                           Empty_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_knn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_kn_instance,
+    scale, Scale, 6, f64_f64_f64_compute_f32_knn,
+    F64, F64, F32, F64, Empty_Tuple, F64, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_mkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_mkn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_mkn_instance =
-    device_contraction_f64_mk_instance<F64,
-                                       F64,
-                                       F32,
-                                       F64,
-                                       Empty_Tuple,
-                                       F64,
-                                       F32,
-                                       PassThrough,
-                                       PassThrough,
-                                       Scale,
-                                       6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_mkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F64,
-                                                           F64,
-                                                           Empty_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_mkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_mk_instance,
+    scale, Scale, 6, f64_f64_f64_compute_f32_mkn,
+    F64, F64, F32, F64, Empty_Tuple, F64, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_mnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_mnn_instance.cpp
@@ -1,58 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_mnn_instance =
-    device_contraction_f64_mn_instance<F64,
-                                       F64,
-                                       F32,
-                                       F64,
-                                       Empty_Tuple,
-                                       F64,
-                                       F32,
-                                       PassThrough,
-                                       PassThrough,
-                                       Scale,
-                                       6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_mnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F64,
-                                                           F64,
-                                                           Empty_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F32>>>& instances)
-{
-    add_device_operation_instances(
-        instances,
-        device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_mnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_mn_instance,
+    scale, Scale, 6, f64_f64_f64_compute_f32_mnn,
+    F64, F64, F32, F64, Empty_Tuple, F64, F32)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_kkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_kkn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_kkn_instance =
-    device_contraction_f64_kk_instance<F64,
-                                       F64,
-                                       F64,
-                                       F64,
-                                       Empty_Tuple,
-                                       F64,
-                                       F64,
-                                       PassThrough,
-                                       PassThrough,
-                                       Scale,
-                                       6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_kkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F64,
-                                                           F64,
-                                                           Empty_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F64>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_kkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_kk_instance,
+    scale, Scale, 6, f64_f64_f64_kkn,
+    F64, F64, F64, F64, Empty_Tuple, F64, F64)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_knn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_knn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// k/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_knn_instance =
-    device_contraction_f64_kn_instance<F64,
-                                       F64,
-                                       F64,
-                                       F64,
-                                       Empty_Tuple,
-                                       F64,
-                                       F64,
-                                       PassThrough,
-                                       PassThrough,
-                                       Scale,
-                                       6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_knn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F64,
-                                                           F64,
-                                                           Empty_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F64>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_knn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_kn_instance,
+    scale, Scale, 6, f64_f64_f64_knn,
+    F64, F64, F64, F64, Empty_Tuple, F64, F64)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_mkn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_mkn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/k/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_mkn_instance =
-    device_contraction_f64_mk_instance<F64,
-                                       F64,
-                                       F64,
-                                       F64,
-                                       Empty_Tuple,
-                                       F64,
-                                       F64,
-                                       PassThrough,
-                                       PassThrough,
-                                       Scale,
-                                       6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_mkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F64,
-                                                           F64,
-                                                           Empty_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F64>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_mkn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_mk_instance,
+    scale, Scale, 6, f64_f64_f64_mkn,
+    F64, F64, F64, F64, Empty_Tuple, F64, F64)
+// clang-format on

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_mnn_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/contraction_scale/6D/device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_mnn_instance.cpp
@@ -1,57 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-// This (ifndef) is a hack to use customized behavior for buffer load rather than using default
-// setting Don't use this hack unless absolutely necessary!
-// FIXME: make the behavior of buffer load a configurable (template) parameter of each device op
-#define CK_EXPERIMENTAL_USE_BUFFER_LOAD_OOB_CHECK_OFFSET_TRICK 1
+#include "../../contraction/contraction_instance_common.hpp"
 
-#include <cstdlib>
-
-#include "ck/ck.hpp"
-#include "ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp"
-#include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
-#include "ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp"
-#include "ck/library/tensor_operation_instance/add_device_operation_instance.hpp"
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
-// m/n/n/n are the fast changing dimension for A/B/D/E
-using device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_mnn_instance =
-    device_contraction_f64_mn_instance<F64,
-                                       F64,
-                                       F64,
-                                       F64,
-                                       Empty_Tuple,
-                                       F64,
-                                       F64,
-                                       PassThrough,
-                                       PassThrough,
-                                       Scale,
-                                       6>;
-
-void add_device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_mnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F64,
-                                                           F64,
-                                                           Empty_Tuple,
-                                                           F64,
-                                                           PassThrough,
-                                                           PassThrough,
-                                                           Scale,
-                                                           F64>>>& instances)
-{
-    add_device_operation_instances(
-        instances, device_contraction_scale_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_mnn_instance{});
-}
-
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+// Instantiate contraction device operation and register via add_device_* function.
+// See contraction_instance_common.hpp for macro definition and parameter documentation.
+// clang-format off
+CK_CONTRACTION_INSTANCE(device_contraction_f64_mn_instance,
+    scale, Scale, 6, f64_f64_f64_mnn,
+    F64, F64, F64, F64, Empty_Tuple, F64, F64)
+// clang-format on


### PR DESCRIPTION
Depends on #6324

## Summary

Refactor all 144 contraction library instance `.cpp` files (bilinear + scale, 2D/6D, f32/f64/bf16/cf32/cf64) to use a shared `CK_CONTRACTION_INSTANCE` macro defined in `contraction_instance_common.hpp`. Each 58-line file is reduced to 12 lines — zero unique logic, pure parameterization.

| Metric | Value |
|--------|-------|
| Files changed | 145 (144 instances + 1 new shared header) |
| Insertions | +1,373 |
| Deletions | −7,890 |
| **Net lines removed** | **−6,517** |

### What changed

| Before | After |
|--------|-------|
| 144 instance files, each ~58 lines of identical boilerplate (includes, namespace, type alias, registration function) differing only in 12 template parameters | 1 shared macro header + 144 files at ~12 lines each (copyright + include + macro invocation) |

### Macro parameters (12)

```
CK_CONTRACTION_INSTANCE(INST_TPL, OP_NAME, CDE_OP, NDIM_VAL, NAME_SUFFIX,
    ADATA, BDATA, ACC, CSHUFFLE, DS_TUPLE, EDATA, COMPUTE)
```

| Parameter | Example | Purpose |
|-----------|---------|---------|
| `INST_TPL` | `device_contraction_kk_instance` | Device template to instantiate |
| `OP_NAME` | `bilinear` | Lowercase, used in `##` token pasting for function/type names |
| `CDE_OP` | `Bilinear` | C++ type name (capitalized) for template args |
| `NDIM_VAL` | `2` or `6` | Number of dimensions |
| `NAME_SUFFIX` | `f32_f32_f32_f32_kknn` | Data type + layout suffix |
| `ADATA..COMPUTE` | `F32, F32, ...` | Template type arguments |

### Readability assessment

A code realist review confirmed this change **improves readability**: the original 58-line files contained zero unique logic — just mechanical boilerplate wrappers that varied only in 12 template parameters. After the macro, each file's intent is immediately clear from a single macro call, and the 12 parameters serve as a concise specification of what the instance does (data types, layout, operation). Adding a new contraction instance requires writing 1 line instead of copying and modifying 58 lines. The realist also noted that the area has very low activity (1 functional commit in 18 months), so merge conflict risk is negligible.

### Cumulative cleanup series stats

| PR | Description | Net lines |
|----|-------------|-----------|
| #6300 | Remove 61 dead `#if 0` blocks | −2,648 |
| #6302 | Remove 41 commented-out dead code blocks | −2,861 |
| #6303 | Remove 4 orphaned files | −3,886 |
| #6323 | Extract gemm_quant test boilerplate | −693 |
| #6324 | Extract contraction example boilerplate | −1,016 |
| This PR | Refactor 144 contraction instance files | −6,517 |
| **Total** | | **−17,621** |