### PR TITLE
Correct .readthedocs.yml file path

### DIFF
--- a/projects/composablekernel/.readthedocs.yaml
+++ b/projects/composablekernel/.readthedocs.yaml
@@ -4,13 +4,13 @@
 version: 2
 
 sphinx:
-   configuration: docs/conf.py
+   configuration: projects/composablekernel/docs/conf.py
 
 formats: [htmlzip, pdf, epub]
 
 python:
    install:
-   - requirements: docs/sphinx/requirements.txt
+   - requirements: projects/composablekernel/docs/sphinx/requirements.txt
 
 build:
    os: ubuntu-22.04

--- a/projects/hipblas/.readthedocs.yaml
+++ b/projects/hipblas/.readthedocs.yaml
@@ -4,13 +4,13 @@
 version: 2
 
 sphinx:
-   configuration: docs/conf.py
+   configuration: projects/hipblas/docs/conf.py
 
 formats: [htmlzip, pdf, epub]
 
 python:
    install:
-   - requirements: docs/sphinx/requirements.txt
+   - requirements: projects/hipblas/docs/sphinx/requirements.txt
 
 build:
    os: ubuntu-22.04

--- a/projects/hipblaslt/.readthedocs.yaml
+++ b/projects/hipblaslt/.readthedocs.yaml
@@ -4,13 +4,13 @@
 version: 2
 
 sphinx:
-   configuration: docs/conf.py
+   configuration: projects/hipblaslt/docs/conf.py
 
 formats: [htmlzip, pdf, epub]
 
 python:
    install:
-   - requirements: docs/sphinx/requirements.txt
+   - requirements: projects/hipblaslt/docs/sphinx/requirements.txt
 
 build:
    os: ubuntu-22.04

--- a/projects/hipcub/.readthedocs.yaml
+++ b/projects/hipcub/.readthedocs.yaml
@@ -4,13 +4,13 @@
 version: 2
 
 sphinx:
-   configuration: docs/conf.py
+   configuration: projects/hipcub/docs/conf.py
 
 formats: [htmlzip, pdf, epub]
 
 python:
    install:
-   - requirements: docs/sphinx/requirements.txt
+   - requirements: projects/hipcub/docs/sphinx/requirements.txt
 
 build:
    os: ubuntu-22.04

--- a/projects/hipfft/.readthedocs.yaml
+++ b/projects/hipfft/.readthedocs.yaml
@@ -4,13 +4,13 @@
 version: 2
 
 sphinx:
-   configuration: docs/conf.py
+   configuration: projects/hipfft/docs/conf.py
 
 formats: [htmlzip, pdf, epub]
 
 python:
    install:
-   - requirements: docs/sphinx/requirements.txt
+   - requirements: projects/hipfft/docs/sphinx/requirements.txt
 
 build:
    os: ubuntu-22.04

--- a/projects/hiprand/.readthedocs.yaml
+++ b/projects/hiprand/.readthedocs.yaml
@@ -4,13 +4,13 @@
 version: 2
 
 sphinx:
-   configuration: docs/conf.py
+   configuration: projects/hiprand/docs/conf.py
 
 formats: [htmlzip, pdf, epub]
 
 python:
    install:
-   - requirements: docs/sphinx/requirements.txt
+   - requirements: projects/hiprand/docs/sphinx/requirements.txt
 
 build:
    os: ubuntu-22.04

--- a/projects/hipsolver/.readthedocs.yaml
+++ b/projects/hipsolver/.readthedocs.yaml
@@ -4,13 +4,13 @@
 version: 2
 
 sphinx:
-   configuration: docs/conf.py
+   configuration: projects/hipsolver/docs/conf.py
 
 formats: [htmlzip, pdf, epub]
 
 python:
    install:
-   - requirements: docs/sphinx/requirements.txt
+   - requirements: projects/hipsolver/docs/sphinx/requirements.txt
 
 build:
    os: ubuntu-22.04

--- a/projects/hipsparse/.readthedocs.yaml
+++ b/projects/hipsparse/.readthedocs.yaml
@@ -4,13 +4,13 @@
 version: 2
 
 sphinx:
-   configuration: docs/conf.py
+   configuration: projects/hipsparse/docs/conf.py
 
 formats: [htmlzip]
 
 python:
    install:
-   - requirements: docs/sphinx/requirements.txt
+   - requirements: projects/hipsparse/docs/sphinx/requirements.txt
 
 build:
    os: ubuntu-22.04

--- a/projects/hipsparselt/.readthedocs.yaml
+++ b/projects/hipsparselt/.readthedocs.yaml
@@ -4,13 +4,13 @@
 version: 2
 
 sphinx:
-   configuration: docs/conf.py
+   configuration: projects/hipsparselt/docs/conf.py
 
 formats: [htmlzip, pdf, epub]
 
 python:
    install:
-   - requirements: docs/sphinx/requirements.txt
+   - requirements: projects/hipsparselt/docs/sphinx/requirements.txt
 
 build:
    os: ubuntu-22.04

--- a/projects/hiptensor/.readthedocs.yaml
+++ b/projects/hiptensor/.readthedocs.yaml
@@ -4,13 +4,13 @@
 version: 2
 
 sphinx:
-   configuration: docs/conf.py
+   configuration: projects/hiptensor/docs/conf.py
 
 formats: [htmlzip, pdf, epub]
 
 python:
    install:
-   - requirements: docs/sphinx/requirements.txt
+   - requirements: projects/hiptensor/docs/sphinx/requirements.txt
 
 build:
    os: ubuntu-22.04

--- a/projects/miopen/.readthedocs.yaml
+++ b/projects/miopen/.readthedocs.yaml
@@ -4,13 +4,13 @@
 version: 2
 
 sphinx:
-   configuration: docs/conf.py
+   configuration: projects/miopen/docs/conf.py
 
 formats: [htmlzip, pdf, epub]
 
 python:
    install:
-   - requirements: docs/sphinx/requirements.txt
+   - requirements: projects/miopen/docs/sphinx/requirements.txt
 
 build:
    os: ubuntu-22.04

--- a/projects/rocblas/.readthedocs.yaml
+++ b/projects/rocblas/.readthedocs.yaml
@@ -4,13 +4,13 @@
 version: 2
 
 sphinx:
-   configuration: docs/conf.py
+   configuration: projects/rocblas/docs/conf.py
 
 formats: [htmlzip, pdf, epub]
 
 python:
    install:
-   - requirements: docs/sphinx/requirements.txt
+   - requirements: projects/rocblas/docs/sphinx/requirements.txt
 
 build:
    os: ubuntu-22.04

--- a/projects/rocfft/.readthedocs.yaml
+++ b/projects/rocfft/.readthedocs.yaml
@@ -4,13 +4,13 @@
 version: 2
 
 sphinx:
-   configuration: docs/conf.py
+   configuration: projects/rocfft/docs/conf.py
 
 formats: [htmlzip, pdf, epub]
 
 python:
    install:
-   - requirements: docs/sphinx/requirements.txt
+   - requirements: projects/rocfft/docs/sphinx/requirements.txt
 
 build:
    os: ubuntu-22.04

--- a/projects/rocprim/.readthedocs.yaml
+++ b/projects/rocprim/.readthedocs.yaml
@@ -4,13 +4,13 @@
 version: 2
 
 sphinx:
-   configuration: docs/conf.py
+   configuration: projects/rocprim/docs/conf.py
 
 formats: [htmlzip, pdf, epub]
 
 python:
    install:
-   - requirements: docs/sphinx/requirements.txt
+   - requirements: projects/rocprim/docs/sphinx/requirements.txt
 
 build:
    os: ubuntu-22.04

--- a/projects/rocrand/.readthedocs.yaml
+++ b/projects/rocrand/.readthedocs.yaml
@@ -4,13 +4,13 @@
 version: 2
 
 sphinx:
-   configuration: docs/conf.py
+   configuration: projects/rocrand/docs/conf.py
 
 formats: [htmlzip, pdf, epub]
 
 python:
    install:
-   - requirements: docs/sphinx/requirements.txt
+   - requirements: projects/rocrand/docs/sphinx/requirements.txt
 
 build:
    os: ubuntu-22.04

--- a/projects/rocsolver/.readthedocs.yaml
+++ b/projects/rocsolver/.readthedocs.yaml
@@ -4,13 +4,13 @@
 version: 2
 
 sphinx:
-   configuration: docs/conf.py
+   configuration: projects/rocsolver/docs/conf.py
 
 formats: [htmlzip, pdf, epub]
 
 python:
    install:
-   - requirements: docs/sphinx/requirements.txt
+   - requirements: projects/rocsolver/docs/sphinx/requirements.txt
 
 build:
    os: ubuntu-22.04

--- a/projects/rocsparse/.readthedocs.yaml
+++ b/projects/rocsparse/.readthedocs.yaml
@@ -4,13 +4,13 @@
 version: 2
 
 sphinx:
-   configuration: docs/conf.py
+   configuration: projects/rocsparse/docs/conf.py
 
 formats: [htmlzip, epub]
 
 python:
    install:
-   - requirements: docs/sphinx/requirements.txt
+   - requirements: projects/rocsparse/docs/sphinx/requirements.txt
 
 build:
    os: ubuntu-22.04

--- a/projects/rocthrust/.readthedocs.yaml
+++ b/projects/rocthrust/.readthedocs.yaml
@@ -4,13 +4,13 @@
 version: 2
 
 sphinx:
-   configuration: docs/conf.py
+   configuration: projects/rocthrust/docs/conf.py
 
 formats: [htmlzip, pdf, epub]
 
 python:
    install:
-   - requirements: docs/sphinx/requirements.txt
+   - requirements: projects/rocthrust/docs/sphinx/requirements.txt
 
 build:
    os: ubuntu-22.04

--- a/projects/rocwmma/.readthedocs.yaml
+++ b/projects/rocwmma/.readthedocs.yaml
@@ -4,13 +4,13 @@
 version: 2
 
 sphinx:
-   configuration: docs/conf.py
+   configuration: projects/rocwmma/docs/conf.py
 
 formats: [htmlzip, pdf, epub]
 
 python:
    install:
-   - requirements: docs/sphinx/requirements.txt
+   - requirements: projects/rocwmma/docs/sphinx/requirements.txt
 
 build:
    os: ubuntu-22.04

--- a/shared/tensile/.readthedocs.yaml
+++ b/shared/tensile/.readthedocs.yaml
@@ -4,13 +4,13 @@
 version: 2
 
 sphinx:
-   configuration: docs/conf.py
+   configuration: shared/tensile/docs/conf.py
 
 formats: [htmlzip, pdf, epub]
 
 python:
    install:
-   - requirements: docs/sphinx/requirements.txt
+   - requirements: shared/tensile/docs/sphinx/requirements.txt
 
 build:
    os: ubuntu-22.04


### PR DESCRIPTION
## Motivation

Read the Docs config files contains outdated file path from their legacy repos. Update and correct all paths.

## Technical Details


## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
