### PR TITLE
[fusilli-provider] Add int4 datatype support

### DIFF
--- a/dnn-providers/fusilli-provider/include/graph_import.h
+++ b/dnn-providers/fusilli-provider/include/graph_import.h
@@ -52,6 +52,8 @@ inline fusilli::ErrorOr<fusilli::DataType> hipDnnDataTypeToFusilliDataType(
     return ok(fusilli::DataType::Uint8);
   case hipdnn_data_sdk::data_objects::DataType::INT32:
     return ok(fusilli::DataType::Int32);
+  case hipdnn_data_sdk::data_objects::DataType::INT4:
+    return ok(fusilli::DataType::Int4);
   case hipdnn_data_sdk::data_objects::DataType::UNSET:
     return ok(fusilli::DataType::NotSet);
   default:

--- a/dnn-providers/fusilli-provider/include/utils.h
+++ b/dnn-providers/fusilli-provider/include/utils.h
@@ -165,6 +165,8 @@ fusilliDataTypeToIreeHalDataType(fusilli::DataType fusilliDataType) {
     return fusilli::ok(IREE_HAL_ELEMENT_TYPE_INT_16);
   case fusilli::DataType::Int32:
     return fusilli::ok(IREE_HAL_ELEMENT_TYPE_INT_32);
+  case fusilli::DataType::Int4:
+    return fusilli::ok(IREE_HAL_ELEMENT_TYPE_SINT_4);
   case fusilli::DataType::Int64:
     return fusilli::ok(IREE_HAL_ELEMENT_TYPE_INT_64);
   case fusilli::DataType::Boolean:

--- a/dnn-providers/fusilli-provider/src/fusilli_plugin.cpp
+++ b/dnn-providers/fusilli-provider/src/fusilli_plugin.cpp
@@ -512,8 +512,8 @@ hipdnnPluginStatus_t hipdnnEnginePluginExecuteOpGraph(
     FUSILLI_PLUGIN_ASSIGN_OR_RETURN(
         auto elementType,
         fusilliDataTypeToIreeHalDataType(tensorAttr->getDataType()));
-    size_t sizeBytes = iree_hal_element_dense_byte_count(elementType) *
-                       static_cast<size_t>(tensorAttr->getVolume());
+    size_t sizeBytes = iree_hal_element_packed_byte_count(
+        elementType, static_cast<size_t>(tensorAttr->getVolume()));
     std::vector<int64_t> dims = tensorAttr->getPhysicalDim();
     std::vector<iree_hal_dim_t> shape(dims.begin(), dims.end());
     FUSILLI_PLUGIN_ASSIGN_OR_RETURN(

--- a/dnn-providers/fusilli-provider/test/integration/CMakeLists.txt
+++ b/dnn-providers/fusilli-provider/test/integration/CMakeLists.txt
@@ -111,8 +111,8 @@ add_fusilli_plugin_test(
 )
 
 add_fusilli_plugin_test(
-  NAME fusilli_plugin_simple_matmul_int4_fp16_test
-  SRCS matmul/simple_matmul_int4_fp16.cpp
+  NAME fusilli_plugin_simple_batched_matmul_int4_fp16_test
+  SRCS matmul/simple_batched_matmul_int4_fp16.cpp
   DEPS
     GTest::gtest_main
     hip::host

--- a/dnn-providers/fusilli-provider/test/integration/CMakeLists.txt
+++ b/dnn-providers/fusilli-provider/test/integration/CMakeLists.txt
@@ -111,6 +111,21 @@ add_fusilli_plugin_test(
 )
 
 add_fusilli_plugin_test(
+  NAME fusilli_plugin_simple_matmul_int4_fp16_test
+  SRCS matmul/simple_matmul_int4_fp16.cpp
+  DEPS
+    GTest::gtest_main
+    hip::host
+    hipdnn_frontend
+    hipdnn_plugin_sdk
+    hipdnn_data_sdk
+    hipdnn_test_sdk
+    Threads::Threads
+  COMPILE_DEFS
+    FUSILLI_PLUGIN_PATH="../${FUSILLI_PLUGIN_RELATIVE_PATH}"
+)
+
+add_fusilli_plugin_test(
   NAME fusilli_plugin_simple_scaled_matmul_accumulate_test
   SRCS matmul/simple_scaled_matmul_accumulate.cpp
   DEPS

--- a/dnn-providers/fusilli-provider/test/integration/matmul/simple_batched_matmul_int4_fp16.cpp
+++ b/dnn-providers/fusilli-provider/test/integration/matmul/simple_batched_matmul_int4_fp16.cpp
@@ -102,20 +102,8 @@ TEST(MatmulIntegrationTest, Int4xFp16Matmul) {
       .set_data_type(DataType_t::HALF)
       .set_output(true);
 
-  // Build + validate + build plans for graph.
-  auto result = graph->validate();
-  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
-
-  result = graph->build_operation_graph(handle);
-  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
-
-  result = graph->create_execution_plans();
-  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
-
-  result = graph->check_support();
-  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
-
-  result = graph->build_plans();
+  // Build graph.
+  auto result = graph->build(handle);
   ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
 
   // Create variant pack.

--- a/dnn-providers/fusilli-provider/test/integration/matmul/simple_matmul_int4_fp16.cpp
+++ b/dnn-providers/fusilli-provider/test/integration/matmul/simple_matmul_int4_fp16.cpp
@@ -1,0 +1,146 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <gtest/gtest.h>
+#include <hip/hip_runtime.h>
+#include <hipdnn_backend.h>
+#include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_frontend/Graph.hpp>
+#include <hipdnn_frontend/attributes/MatmulAttributes.hpp>
+#include <hipdnn_frontend/attributes/TensorAttributes.hpp>
+#include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
+#include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+using namespace hipdnn_frontend;
+using namespace hipdnn_data_sdk::utilities;
+using namespace hipdnn_test_sdk::utilities;
+
+// Test: Int4 x fp16 matmul with non-uniform nibble values.
+// A[1,M,K] (int4, packed) x B[1,K,N] (fp16) = C[1,M,N] (fp16)
+TEST(MatmulIntegrationTest, Int4xFp16Matmul) {
+  // Initialize HIP.
+  ASSERT_EQ(hipInit(0), hipSuccess);
+  ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+  hipStream_t stream = nullptr;
+  ASSERT_EQ(hipStreamCreate(&stream), hipSuccess);
+
+  // Set plugin paths.
+  auto pluginPath = std::filesystem::canonical(getCurrentExecutableDirectory() /
+                                               FUSILLI_PLUGIN_PATH);
+  const std::array<const char *, 1> paths = {pluginPath.c_str()};
+  ASSERT_EQ(hipdnnSetEnginePluginPaths_ext(paths.size(), paths.data(),
+                                           HIPDNN_PLUGIN_LOADING_ABSOLUTE),
+            HIPDNN_STATUS_SUCCESS);
+
+  // Create handle.
+  hipdnnHandle_t handle;
+  ASSERT_EQ(hipdnnCreate(&handle), HIPDNN_STATUS_SUCCESS);
+  ASSERT_EQ(hipdnnSetStream(handle, stream), HIPDNN_STATUS_SUCCESS);
+
+  // Dimensions: A[1,4,8] x B[1,8,4] = C[1,4,4]
+  // Rank-3 required for mixed-precision matmul (torch.bmm).
+  const int64_t batch = 1;
+  const int64_t M = 4;
+  const int64_t K = 8;
+  const int64_t N = 4;
+
+  // UIDs.
+  const int64_t aUID = 0;
+  const int64_t bUID = 1;
+  const int64_t cUID = 2;
+
+  // Initialize tensor A (int4, packed 2 elements per byte, LSB-first nibble).
+  // Byte 0x72: low nibble = 2, high nibble = 7.
+  // Each row of K=8: [2, 7, 2, 7, 2, 7, 2, 7].
+  const size_t aNumElements = static_cast<size_t>(batch * M * K);
+  const size_t aPackedBytes = (aNumElements + 1) / 2;
+  std::vector<uint8_t> aHostPacked(aPackedBytes, 0x72);
+
+  void *aDevicePtr = nullptr;
+  ASSERT_EQ(hipMalloc(&aDevicePtr, aPackedBytes), hipSuccess);
+  ASSERT_EQ(hipMemcpyHtoD(aDevicePtr, aHostPacked.data(), aPackedBytes),
+            hipSuccess);
+
+  // Initialize tensors B and C.
+  PinnedTensor<half> bTensor({batch, K, N});
+  bTensor.fillWithValue(static_cast<half>(1.0f));
+  PinnedTensor<half> cTensor({batch, M, N});
+  cTensor.fillWithValue(static_cast<half>(0.0f));
+
+  // Create graph.
+  auto graph = std::make_shared<graph::Graph>();
+  graph->set_name("matmul_int4_fp16_test");
+  graph->set_io_data_type(DataType_t::HALF)
+      .set_intermediate_data_type(DataType_t::HALF)
+      .set_compute_data_type(DataType_t::FLOAT);
+
+  // Create tensor attributes.
+  auto aAttr =
+      std::make_shared<graph::TensorAttributes>(graph::makeTensorAttributes(
+          "A", DataType_t::INT4, {batch, M, K}, {M * K, K, 1}));
+  aAttr->set_uid(aUID);
+  auto bAttr = std::make_shared<graph::TensorAttributes>(
+      graph::makeTensorAttributes("B", DataType_t::HALF, bTensor));
+  bAttr->set_uid(bUID);
+
+  // Create matmul node.
+  graph::MatmulAttributes matmulAttr;
+  matmulAttr.set_name("matmul");
+
+  auto cAttr = graph->matmul(aAttr, bAttr, matmulAttr);
+  cAttr->set_uid(cUID);
+  cAttr->set_dim(cTensor.dims())
+      .set_stride(cTensor.strides())
+      .set_data_type(DataType_t::HALF)
+      .set_output(true);
+
+  // Build + validate + build plans for graph.
+  auto result = graph->validate();
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+
+  result = graph->build_operation_graph(handle);
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+
+  result = graph->create_execution_plans();
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+
+  result = graph->check_support();
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+
+  result = graph->build_plans();
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+
+  // Create variant pack.
+  std::unordered_map<int64_t, void *> variantPack;
+  variantPack[aUID] = aDevicePtr;
+  variantPack[bUID] = bTensor.memory().deviceData();
+  variantPack[cUID] = cTensor.memory().deviceData();
+
+  // Execute graph.
+  result = graph->execute(handle, variantPack, nullptr);
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+  cTensor.memory().markDeviceModified();
+
+  // Check results: dot(row, ones) = (K/2)*2 + (K/2)*7 = 8 + 28 = 36.
+  const int64_t halfK = K / 2;
+  const auto expected = static_cast<half>(static_cast<float>(halfK) * 2.0f +
+                                          static_cast<float>(halfK) * 7.0f);
+  PinnedTensor<half> expectedOutput({batch, M, N});
+  expectedOutput.fillWithValue(expected);
+
+  CpuFpReferenceValidation<half> validator(1e-3f, 1e-3f);
+  EXPECT_TRUE(validator.allClose(expectedOutput, cTensor));
+
+  // Clean up.
+  ASSERT_EQ(hipFree(aDevicePtr), hipSuccess);
+  ASSERT_EQ(hipStreamDestroy(stream), HIPDNN_STATUS_SUCCESS);
+  ASSERT_EQ(hipdnnDestroy(handle), HIPDNN_STATUS_SUCCESS);
+}

--- a/dnn-providers/fusilli-provider/test/test_fusilli_plugin_api.cpp
+++ b/dnn-providers/fusilli-provider/test/test_fusilli_plugin_api.cpp
@@ -452,6 +452,55 @@ TEST(TestFusilliPluginApi, GetApplicableEngineIdsMatmulPointwise) {
   EXPECT_EQ(hipdnnEnginePluginDestroy(handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
 }
 
+TEST(TestFusilliPluginApi, GetApplicableEngineIdsInt4NonBatchedMatmul) {
+  hipdnnEnginePluginHandle_t handle = nullptr;
+  ASSERT_EQ(hipdnnEnginePluginCreate(&handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+
+  // Non-batched (2D) mixed-precision int4 x fp16 matmul is not supported —
+  // mixed element types require rank-3 tensors (torch.bmm). The plugin should
+  // report 0 engines.
+  using DT = hipdnn_data_sdk::data_objects::DataType;
+  flatbuffers::FlatBufferBuilder builder;
+  std::vector<int64_t> aDims = {4, 8}, aStrides = {8, 1};
+  std::vector<int64_t> bDims = {8, 4}, bStrides = {4, 1};
+  std::vector<int64_t> cDims = {4, 4}, cStrides = {4, 1};
+
+  std::vector<
+      ::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+      tensors;
+  tensors.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+      builder, 1, "A", DT::INT4, &aStrides, &aDims));
+  tensors.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+      builder, 2, "B", DT::HALF, &bStrides, &bDims));
+  tensors.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+      builder, 3, "C", DT::HALF, &cStrides, &cDims));
+
+  auto matmulAttr =
+      hipdnn_data_sdk::data_objects::CreateMatmulAttributes(builder, 1, 2, 3);
+  std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+  nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+      builder, "matmul", DT::FLOAT,
+      hipdnn_data_sdk::data_objects::NodeAttributes::MatmulAttributes,
+      matmulAttr.Union()));
+
+  auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+      builder, "test", DT::HALF, DT::HALF, DT::FLOAT, &tensors, &nodes);
+  builder.Finish(graphOffset);
+
+  hipdnnPluginConstData_t opGraph;
+  opGraph.ptr = builder.GetBufferPointer();
+  opGraph.size = builder.GetSize();
+
+  std::array<int64_t, 5> engineIDs;
+  uint32_t numEngines = 10;
+  ASSERT_EQ(hipdnnEnginePluginGetApplicableEngineIds(
+                handle, &opGraph, engineIDs.data(), 5, &numEngines),
+            HIPDNN_PLUGIN_STATUS_SUCCESS);
+  ASSERT_EQ(numEngines, 0);
+
+  EXPECT_EQ(hipdnnEnginePluginDestroy(handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+}
+
 TEST(TestFusilliPluginApi, CreateExecutionContext) {
   // Create plugin handle.
   hipdnnEnginePluginHandle_t handle = nullptr;

--- a/dnn-providers/fusilli-provider/test/test_graph_import.cpp
+++ b/dnn-providers/fusilli-provider/test/test_graph_import.cpp
@@ -41,6 +41,10 @@ TEST(TestGraphImport, ConvertHipDnnToFusilli) {
                         hipdnn_data_sdk::data_objects::DataType::INT32));
   EXPECT_EQ(int32Dt, fusilli::DataType::Int32);
   FUSILLI_PLUGIN_EXPECT_OR_ASSIGN(
+      auto int4Dt, hipDnnDataTypeToFusilliDataType(
+                       hipdnn_data_sdk::data_objects::DataType::INT4));
+  EXPECT_EQ(int4Dt, fusilli::DataType::Int4);
+  FUSILLI_PLUGIN_EXPECT_OR_ASSIGN(
       auto unsetDt, hipDnnDataTypeToFusilliDataType(
                         hipdnn_data_sdk::data_objects::DataType::UNSET));
   EXPECT_EQ(unsetDt, fusilli::DataType::NotSet);


### PR DESCRIPTION
## Motivation

Connect hipdnn DataType::INT4 to Fusilli's int4.

## Technical Details

- hipDnnDataTypeToFusilliDataType: INT4 -> fusilli::DataType::Int4
- fusilliDataTypeToIreeHalDataType: Int4 -> IREE_HAL_ELEMENT_TYPE_SINT_4
- Fix buffer size computation.

## Test Plan

Add end-to-end integration test for int4 x fp16 matmul.

## Test Result

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
