### PR TITLE
Update Origami problem with scale block size

### DIFF
--- a/projects/hipblaslt/tensilelite/include/Tensile/PredictionLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/PredictionLibrary.hpp
@@ -177,8 +177,8 @@ namespace TensileLite
                 .c_dtype     = datatypeToAnalyticalDatatype(problem.c().dataType()),
                 .d_dtype     = datatypeToAnalyticalDatatype(problem.d().dataType()),
                 .mi_dtype    = miDataType,
-                .a_mx_block_size = 0, // MX Data types come from rocroller
-                .b_mx_block_size = 0, // MX Data types come from rocroller
+                .a_mx_block_size = problem.mxBlockA(), // MXA scale size
+                .b_mx_block_size = problem.mxBlockB(), // MXB scale size
             };
 
             auto prediction_result = origami::rank_configs(

--- a/shared/origami/src/origami/gemm.cpp
+++ b/shared/origami/src/origami/gemm.cpp
@@ -983,6 +983,10 @@ double compute_total_latency(const problem_t& problem,
     OLOG_DEBUG("MatrixInstruction: " << int(MI_M) << "x" << int(MI_N) << "x" << int(MI_K));
     OLOG_DEBUG("Element size A (bits): " << int(a_bits));
     OLOG_DEBUG("Element size B (bits): " << int(b_bits));
+    OLOG_DEBUG("cache_hints_a: " << int(config.cache_hints_a));
+    OLOG_DEBUG("cache_hints_b: " << int(config.cache_hints_b));
+    OLOG_DEBUG("problem mxa_block_size: " << int(problem.a_mx_block_size));
+    OLOG_DEBUG("problem mxb_block_size: " << int(problem.b_mx_block_size));
   }
   // 1-1) To compute the latency, use default WGM. And WGM can't be greater than one
   int defaultWGM =


### PR DESCRIPTION
## Motivation

Update problem parameter in PredictionLibrary for MX datatypes.

## Technical Details

Origami can now account for scale block size in memory latency modeling.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
