### PR TITLE
[hipDNN]  Move kernel source embedding from configure time to build time

### DIFF
--- a/dnn-providers/integration-tests/gpu_ref/CMakeLists.txt
+++ b/dnn-providers/integration-tests/gpu_ref/CMakeLists.txt
@@ -1,11 +1,32 @@
-# Copyright © Advanced Micro Devices, Inc., or its affiliates.
-# SPDX-License-Identifier:  MIT
+# Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
 
 add_compile_definitions(__HIP_PLATFORM_AMD__)
 find_package(hiprtc REQUIRED)
 find_package(hip REQUIRED)
 
 add_subdirectory(kernels)
+
+# Join with pipe separator so VERBATIM can pass the value through the shell
+# without semicolons being misinterpreted.
+list(JOIN GPU_REF_KERNEL_FILES "|" GPU_REF_KERNEL_FILES_PIPE)
+
+# Generate embedded kernel sources at build time
+add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/kernels/GpuRefKernelSources.cpp
+           ${CMAKE_CURRENT_BINARY_DIR}/kernels/GpuRefKernelSources.hpp
+    COMMAND ${CMAKE_COMMAND}
+        "-DKERNEL_FILES=${GPU_REF_KERNEL_FILES_PIPE}"
+        "-DTEMPLATE_DIR=${GPU_REF_KERNEL_TEMPLATE_DIR}"
+        "-DOUTPUT_DIR=${CMAKE_CURRENT_BINARY_DIR}/kernels"
+        -P "${GPU_REF_KERNEL_EMBED_SCRIPT}"
+    DEPENDS ${GPU_REF_KERNEL_FILES}
+            ${GPU_REF_KERNEL_TEMPLATE_DIR}/GpuRefKernelSources.hpp.in
+            ${GPU_REF_KERNEL_TEMPLATE_DIR}/GpuRefKernelSources.cpp.in
+            ${GPU_REF_KERNEL_EMBED_SCRIPT}
+    COMMENT "Embedding GPU reference kernel sources"
+    VERBATIM
+)
 
 add_library(
     hipdnn_gpu_ref STATIC
@@ -15,7 +36,7 @@ add_library(
     src/GpuReferenceValidationFactory.cpp
     src/GpuRefKernelCompiler.cpp
     src/GpuRefValidatorHelpers.cpp
-    ${GPU_REF_KERNEL_GENERATED_SOURCES}
+    ${CMAKE_CURRENT_BINARY_DIR}/kernels/GpuRefKernelSources.cpp
 )
 
 target_include_directories(

--- a/dnn-providers/integration-tests/gpu_ref/kernels/CMakeLists.txt
+++ b/dnn-providers/integration-tests/gpu_ref/kernels/CMakeLists.txt
@@ -1,76 +1,15 @@
-# Copyright © Advanced Micro Devices, Inc., or its affiliates.
-# SPDX-License-Identifier:  MIT
+# Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
 
-# Function to embed GPU reference kernel sources as C++ strings at configure time
-function(embed_gpu_ref_kernel_sources OUTPUT_CPP OUTPUT_HPP KERNEL_FILES)
-    set(KERNEL_DECLARATIONS "")
-    set(KERNEL_DEFINITIONS "")
-    set(KERNEL_MAP_ENTRIES "")
-    set(HEADER_DECLARATIONS "")
-    set(HEADER_DEFINITIONS "")
-    set(HEADER_MAP_ENTRIES "")
-    set(HEADER_FILENAMES "")
-
-    foreach(KERNEL_FILE ${KERNEL_FILES})
-        file(READ ${KERNEL_FILE} KERNEL_CONTENT)
-        get_filename_component(KERNEL_NAME ${KERNEL_FILE} NAME_WE)
-        get_filename_component(KERNEL_FILENAME ${KERNEL_FILE} NAME)
-        get_filename_component(KERNEL_EXT ${KERNEL_FILE} EXT)
-        string(TOUPPER ${KERNEL_NAME} KERNEL_VAR_NAME)
-
-        if(KERNEL_EXT STREQUAL ".h" OR KERNEL_EXT STREQUAL ".hpp")
-            string(APPEND HEADER_DECLARATIONS
-                   "extern const char* const GPU_REF_${KERNEL_VAR_NAME}_SOURCE;\n")
-
-            string(APPEND HEADER_DEFINITIONS
-                   "const char* const GPU_REF_${KERNEL_VAR_NAME}_SOURCE = R\"KERNEL_SOURCE(\n")
-            string(APPEND HEADER_DEFINITIONS "${KERNEL_CONTENT}")
-            string(APPEND HEADER_DEFINITIONS "\n)KERNEL_SOURCE\";\n\n")
-
-            string(APPEND HEADER_MAP_ENTRIES
-                   "        {\"${KERNEL_FILENAME}\", GPU_REF_${KERNEL_VAR_NAME}_SOURCE},\n")
-
-            string(APPEND HEADER_FILENAMES "        \"${KERNEL_FILENAME}\",\n")
-        else()
-            string(APPEND KERNEL_DECLARATIONS
-                   "extern const char* const GPU_REF_${KERNEL_VAR_NAME}_SOURCE;\n")
-
-            string(APPEND KERNEL_DEFINITIONS
-                   "const char* const GPU_REF_${KERNEL_VAR_NAME}_SOURCE = R\"KERNEL_SOURCE(\n")
-            string(APPEND KERNEL_DEFINITIONS "${KERNEL_CONTENT}")
-            string(APPEND KERNEL_DEFINITIONS "\n)KERNEL_SOURCE\";\n\n")
-
-            string(APPEND KERNEL_MAP_ENTRIES
-                   "        {\"${KERNEL_FILENAME}\", GPU_REF_${KERNEL_VAR_NAME}_SOURCE},\n")
-        endif()
-    endforeach()
-
-    configure_file(
-        ${CMAKE_CURRENT_SOURCE_DIR}/templates/GpuRefKernelSources.hpp.in ${OUTPUT_HPP} @ONLY
-    )
-    configure_file(
-        ${CMAKE_CURRENT_SOURCE_DIR}/templates/GpuRefKernelSources.cpp.in ${OUTPUT_CPP} @ONLY
-    )
-endfunction()
-
-# List kernel files to embed
+# Kernel files to embed as C++ string literals at build time.
 set(GPU_REF_KERNEL_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/convolution/GpuRefConvFwd.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/validator/GpuRefValidator.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/types/GpuRefConvArgs.h
     ${CMAKE_CURRENT_SOURCE_DIR}/types/GpuRefValidatorArgs.h
     ${CMAKE_CURRENT_SOURCE_DIR}/types/GpuRefTypes.h
+    PARENT_SCOPE
 )
 
-# Force CMake reconfigure when kernel files change
-set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${GPU_REF_KERNEL_FILES})
-
-# Generate embedded kernel sources at configure time
-embed_gpu_ref_kernel_sources(
-    ${CMAKE_CURRENT_BINARY_DIR}/GpuRefKernelSources.cpp
-    ${CMAKE_CURRENT_BINARY_DIR}/GpuRefKernelSources.hpp
-    "${GPU_REF_KERNEL_FILES}"
-)
-
-# Export generated source files to parent scope
-set(GPU_REF_KERNEL_GENERATED_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/GpuRefKernelSources.cpp PARENT_SCOPE)
+set(GPU_REF_KERNEL_TEMPLATE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/templates PARENT_SCOPE)
+set(GPU_REF_KERNEL_EMBED_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/cmake/EmbedKernelSources.cmake PARENT_SCOPE)

--- a/dnn-providers/integration-tests/gpu_ref/kernels/cmake/EmbedKernelSources.cmake
+++ b/dnn-providers/integration-tests/gpu_ref/kernels/cmake/EmbedKernelSources.cmake
@@ -1,0 +1,54 @@
+# Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
+
+# Standalone CMake script that embeds kernel source files as C++ string literals.
+#
+# Invoked at build time via:
+#   cmake -DKERNEL_FILES="file1.cpp|file2.cpp"
+#         -DTEMPLATE_DIR=/path/to/templates
+#         -DOUTPUT_DIR=/path/to/output
+#         -P EmbedKernelSources.cmake
+#
+# KERNEL_FILES uses pipe (|) as the separator instead of semicolons to avoid
+# escaping issues when VERBATIM passes the argument through the shell.
+#
+# Reads each file in KERNEL_FILES, classifies it as a kernel source (.cpp) or
+# a kernel header (.h/.hpp), and populates template variables used by
+# configure_file() to generate GpuRefKernelSources.hpp / GpuRefKernelSources.cpp.
+
+# Convert pipe-separated list back to CMake list (semicolons)
+string(REPLACE "|" ";" KERNEL_FILES "${KERNEL_FILES}")
+
+set(KERNEL_DECLARATIONS "")
+set(KERNEL_DEFINITIONS "")
+set(KERNEL_MAP_ENTRIES "")
+set(HEADER_DECLARATIONS "")
+set(HEADER_DEFINITIONS "")
+set(HEADER_MAP_ENTRIES "")
+set(HEADER_FILENAMES "")
+
+foreach(KERNEL_FILE ${KERNEL_FILES})
+    file(READ ${KERNEL_FILE} KERNEL_CONTENT)
+    get_filename_component(KERNEL_NAME ${KERNEL_FILE} NAME_WE)
+    get_filename_component(KERNEL_FILENAME ${KERNEL_FILE} NAME)
+    get_filename_component(KERNEL_EXT ${KERNEL_FILE} EXT)
+    string(TOUPPER ${KERNEL_NAME} KERNEL_VAR_NAME)
+
+    if(KERNEL_EXT STREQUAL ".h" OR KERNEL_EXT STREQUAL ".hpp")
+        string(APPEND HEADER_DECLARATIONS "extern const char* const ${KERNEL_VAR_NAME}_SOURCE;\n")
+        string(APPEND HEADER_DEFINITIONS "const char* const ${KERNEL_VAR_NAME}_SOURCE = R\"KERNEL_SOURCE(\n")
+        string(APPEND HEADER_DEFINITIONS "${KERNEL_CONTENT}")
+        string(APPEND HEADER_DEFINITIONS "\n)KERNEL_SOURCE\";\n\n")
+        string(APPEND HEADER_MAP_ENTRIES "        {\"${KERNEL_FILENAME}\", ${KERNEL_VAR_NAME}_SOURCE},\n")
+        string(APPEND HEADER_FILENAMES "        \"${KERNEL_FILENAME}\",\n")
+    else()
+        string(APPEND KERNEL_DECLARATIONS "extern const char* const ${KERNEL_VAR_NAME}_SOURCE;\n")
+        string(APPEND KERNEL_DEFINITIONS "const char* const ${KERNEL_VAR_NAME}_SOURCE = R\"KERNEL_SOURCE(\n")
+        string(APPEND KERNEL_DEFINITIONS "${KERNEL_CONTENT}")
+        string(APPEND KERNEL_DEFINITIONS "\n)KERNEL_SOURCE\";\n\n")
+        string(APPEND KERNEL_MAP_ENTRIES "        {\"${KERNEL_FILENAME}\", ${KERNEL_VAR_NAME}_SOURCE},\n")
+    endif()
+endforeach()
+
+configure_file(${TEMPLATE_DIR}/GpuRefKernelSources.hpp.in ${OUTPUT_DIR}/GpuRefKernelSources.hpp @ONLY)
+configure_file(${TEMPLATE_DIR}/GpuRefKernelSources.cpp.in ${OUTPUT_DIR}/GpuRefKernelSources.cpp @ONLY)


### PR DESCRIPTION
# Motivation
The configure-time approach (`file(READ)` + `configure_file()` + `CMAKE_CONFIGURE_DEPENDS`) forces a full `CMake` reconfigure whenever a kernel file changes. Reconfiguring re-evaluates the entire build system, dependency resolution, compiler checks, find_package calls, just to re-embed a string. `add_custom_command` scopes the rebuild to only the embedding step and its downstream dependents.
