### PR TITLE
[hipCUB] Fix ASAN build: Suppress ROCMChecks warning and set regex backend for Google Benchmark

### DIFF
--- a/projects/hipcub/cmake/Dependencies.cmake
+++ b/projects/hipcub/cmake/Dependencies.cmake
@@ -45,6 +45,13 @@ endif()
 set(USER_ROCM_WARN_TOOLCHAIN_VAR ${ROCM_WARN_TOOLCHAIN_VAR})
 
 set(ROCM_WARN_TOOLCHAIN_VAR OFF CACHE BOOL "")
+# Suppress ROCMChecks WARNING on third-party dependencies
+set(_HIPCUB_DISABLE_ROCM_CHECKS FALSE)
+macro(rocm_check_toolchain_var var access value list_file)
+  if(NOT _HIPCUB_DISABLE_ROCM_CHECKS)
+    _rocm_check_toolchain_var("${var}" "${access}" "${value}" "${list_file}")
+  endif()
+endmacro()
 # Turn off warnings and errors for all warnings in dependencies
 separate_arguments(CXX_FLAGS_LIST NATIVE_COMMAND ${CMAKE_CXX_FLAGS})
 list(REMOVE_ITEM CXX_FLAGS_LIST /WX -Werror -Werror=pendantic -pedantic-errors)
@@ -323,7 +330,9 @@ if(USER_BUILD_TEST)
         GIT_TAG        release-1.11.0
       )
     endif()
+    set(_HIPCUB_DISABLE_ROCM_CHECKS TRUE)
     FetchContent_MakeAvailable(googletest)
+    set(_HIPCUB_DISABLE_ROCM_CHECKS FALSE)
     add_library(GTest::GTest ALIAS gtest)
     add_library(GTest::Main  ALIAS gtest_main)
   else()
@@ -349,7 +358,9 @@ if(USER_BUILD_BENCHMARK)
       GIT_REPOSITORY https://github.com/google/benchmark.git
       GIT_TAG        v${BENCHMARK_VERSION}
     )
+    set(_HIPCUB_DISABLE_ROCM_CHECKS TRUE)
     FetchContent_MakeAvailable(googlebench)
+    set(_HIPCUB_DISABLE_ROCM_CHECKS FALSE)
     if(NOT TARGET benchmark::benchmark)
       add_library(benchmark::benchmark ALIAS benchmark)
     endif()

--- a/projects/hipcub/cmake/Dependencies.cmake
+++ b/projects/hipcub/cmake/Dependencies.cmake
@@ -358,6 +358,8 @@ if(USER_BUILD_BENCHMARK)
       GIT_REPOSITORY https://github.com/google/benchmark.git
       GIT_TAG        v${BENCHMARK_VERSION}
     )
+    set(HAVE_STD_REGEX ON)
+    set(RUN_HAVE_STD_REGEX 1)
     set(_HIPCUB_DISABLE_ROCM_CHECKS TRUE)
     FetchContent_MakeAvailable(googlebench)
     set(_HIPCUB_DISABLE_ROCM_CHECKS FALSE)


### PR DESCRIPTION
## Motivation

hipCUB ASAN build fail in TheRock CI during configure when `BUILD_BENCHMARK=ON`.
https://github.com/ROCm/TheRock/issues/4455

## Technical Details

Two issues when fetching Google Benchmark under ASAN:
1. **ROCMChecks warning**: `add_cxx_compiler_flag()` modifies `CMAKE_CXX_FLAGS`, triggering a `variable_watch()` callback. The existing `set(ROCM_WARN_TOOLCHAIN_VAR OFF CACHE BOOL "")` is a no-op because ROCMChecks is loaded earlier in `CMakeLists.txt` and the cache value is already ON. Fixed by overriding `rocm_check_toolchain_var` with a flag-gated no-op macro (same pattern as rocwmma and composablekernel).
2. **Regex detection failure**: Google Benchmark's `try_run` tests compile but can't execute under ASAN (sanitizer runtime not preloaded during configure). Fixed by pre-setting `HAVE_STD_REGEX` and `RUN_HAVE_STD_REGEX` before
   `FetchContent_MakeAvailable` (same as rocRAND).

## Test Plan

- hipCUB configures and builds with ASAN + `BUILD_BENCHMARK=ON`
- hipCUB benchmarks build without ASAN (no regression)