### PR TITLE
build(rocprim): use mold if available

### DIFF
--- a/projects/rocprim/CHANGELOG.md
+++ b/projects/rocprim/CHANGELOG.md
@@ -34,6 +34,7 @@ Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projec
 * Benchmarking now requires [AMD SMI](https://rocm.docs.amd.com/projects/amdsmi/en/latest/) to be installed.
   * rocPRIM now uses the new single-header library 'primbench' for benchmarks, rather than Google Benchmark. primbench requires AMD SMI.
   * See `shared/primbench/README.md` for primbench its documentation.
+* Uses mold linker for compilation if availible.
 
 ### Removed
 

--- a/projects/rocprim/CMakeLists.txt
+++ b/projects/rocprim/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2017-2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -133,6 +133,15 @@ if(ROCPRIM_ENABLE_ASSERTS)
       string(REGEX REPLACE "-DNDEBUG( |$)" "" ${BUILD_TYPE_CXX_FLAGS} "${${BUILD_TYPE_CXX_FLAGS}}")
       string(REGEX REPLACE "-DNDEBUG( |$)" "" ${BUILD_TYPE_C_FLAGS} "${${BUILD_TYPE_C_FLAGS}}")
   endif()
+endif()
+
+# Check if mold linker is available and use it if so
+find_program(MOLD_LINKER mold)
+if(MOLD_LINKER)
+    message(STATUS "Using mold linker")
+    add_link_options(-fuse-ld=mold)
+else()
+    message(STATUS "mold not found, using default linker")
 endif()
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE CACHE BOOL "Add paths to linker search and installed rpath")

--- a/projects/rocprim/README.md
+++ b/projects/rocprim/README.md
@@ -26,6 +26,8 @@ Optional:
   * This is automatically downloaded and built by the CMake script.
 * [AMD SMI](https://github.com/ROCm/amdsmi)
   * Required only for benchmarks. Building benchmarks is off by default.
+* [Mold](https://github.com/rui314/mold)
+  * Optional for building. Used if installed to speed up building.
 
 ## Build and install
 


### PR DESCRIPTION
## Motivation

The linking step uses a significant amount of time during compilation. This can be sped up with mold.

## Technical Details

[Mold](https://github.com/rui314/mold) functions as a drop-in replacement to the default linker. Offering better parallelization and performance.
This change checks if mold is installed. If yes, it is used during the linking step. If not, the default linker is used as a fallback.

## Test Plan

1. build binary
2. check what linker is used: strings binary | grep -i "mold|linker"
3. install mold
4. verify that mold was used: strings binary | grep -i "mold|linker"

## Test Result

Mold is used when installed.
Build times are improved:
<img width="1400" height="17680" alt="image" src="https://github.com/user-attachments/assets/cfee6b87-caaa-40e8-8bc0-c8080b8f3f98" />
Switching to mold decreased the compile time by up to 58% on some of the tests. Though the largest (relative) speedup was measured on the (already) fastest builds, the slower builds also gained up to 20% build time improvements.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
