### PR TITLE
[hipTensor][Docs] Update regex pattern to match modified CMakeLists.txt

### DIFF
--- a/projects/hiptensor/docs/conf.py
+++ b/projects/hiptensor/docs/conf.py
@@ -34,7 +34,7 @@ import re
 from rocm_docs import ROCmDocs
 
 with open('../CMakeLists.txt', encoding='utf-8') as f:
-    match = re.search(r'.*\bset \( VERSION_STRING\s+\"?([0-9.]+)[^0-9.]+', f.read())
+    match = re.search(r'.*\bset\s*\(\s*VERSION_STRING\s+\"?([0-9.]+)[^0-9.]+', f.read())
     if not match:
         raise ValueError("VERSION not found!")
     version_number = match[1]


### PR DESCRIPTION
## Motivation

Original regex pattern no longer extracts project version, causing docs build failure.

## Technical Details

CMakeLists.txt updated by https://github.com/ROCm/rocm-libraries/commit/533c946d34f55e250b2d635b2604bc605839a363 removed spaces from the version string. New pattern makes trailing space optional.

## Test Plan

Build the docs locally.

## Test Result

Docs built successfully.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
