### PR TITLE
[rocBLAS] Use precheckin gtest patterns for comprehensive/full categories

### DIFF
--- a/projects/rocblas/clients/gtest/test_categories.yaml
+++ b/projects/rocblas/clients/gtest/test_categories.yaml
@@ -27,7 +27,8 @@ test_categories:
   comprehensive:
     description: "Extended - same as Jenkins extended/nightly (timeout: 8 hours)"
     test_patterns:
-      - "*nightly*"
+      - "*quick*"
+      - "*pre_checkin*"
     exclude:
       - "*known_bug*"
     labels:
@@ -38,8 +39,8 @@ test_categories:
   full:
     description: "Stress / weekly - same as Jenkins weekly (stress + HMM)"
     test_patterns:
-      - "*stress*"
-      - "*HMM*"
+      - "*quick*"
+      - "*pre_checkin*"
     exclude:
       - "*known_bug*"
     labels:


### PR DESCRIPTION
## Motivation

The rocBLAS nightly, extended, and full client test selections depend on ILP64 OpenBLAS support for LAPACK and reference checks. That support on TheRock is incomplete at the moment; a later change will restore the broader coverage once the stack is ready.

## What changed

- `comprehensive` and `full` entries in `projects/rocblas/clients/gtest/test_categories.yaml` now use the same test pattern set as the standard precheckin category (`*quick*` and `*pre_checkin*`), instead of additional nightly/stress filters that fail or time out under the current environment.

## Tracking

ROCM-21549

Made with [Cursor](https://cursor.com)