### PR TITLE
Fix broken image link in CPU Graph Executor RFC

### DIFF
--- a/projects/hipdnn/docs/rfcs/0001_CpuGraphExecutorDesign.md
+++ b/projects/hipdnn/docs/rfcs/0001_CpuGraphExecutorDesign.md
@@ -28,7 +28,7 @@ The CPU Graph Executor is a reference implementation system designed to execute 
 
 The CPU Graph Executor follows a modular architecture pattern with clear separation of concerns:
 
-![CPU Graph Executor Architecture](./images/CPU_reference_graph_executor_high_level_arch.png)
+![CPU Graph Executor Architecture](../images/CPU_reference_graph_executor_high_level_arch.png)
 
 ## Architecture Components
 


### PR DESCRIPTION
## Motivation

 The architecture diagram image in the CPU Graph Executor RFC was broken due to an incorrect relative path (`./images/` instead of `../images/`)
