### PR TITLE
Fix example_splitK_gemm_xdl_lds_direct_load_fp16 failing on gfx908

### DIFF
--- a/projects/composablekernel/example/35_splitK_gemm/splitK_gemm_xdl_lds_direct_load_fp16.cpp
+++ b/projects/composablekernel/example/35_splitK_gemm/splitK_gemm_xdl_lds_direct_load_fp16.cpp
@@ -85,7 +85,7 @@ using DeviceGemmInstance          = ck::tensor_operation::device::DeviceGemmXdlS
 
 int main(int argc, char* argv[])
 {
-    if(ck::is_gfx11_supported() || ck::is_gfx12_supported())
+    if(ck::is_gfx11_supported() || ck::is_gfx12_supported() || !ck::is_lds_direct_load_supported())
     {
         return 0;
     }


### PR DESCRIPTION
## Summary

- `example_splitK_gemm_xdl_lds_direct_load_fp16` was failing on gfx908 in CI with exit code 1
- Root cause: `IsSupportedArgument()` calls `ck::is_lds_direct_load_supported()`, which returns false on gfx908 (only supported on gfx90a, gfx942, gfx950), causing the example to print "does not support this problem" and return 0; `main()` then inverts this via `!` to exit code 1
- Fix: add `!ck::is_lds_direct_load_supported()` to the early-return guard in `main()`, consistent with the existing gfx11/gfx12 skip pattern
- Since CK does not often check CI on gfx908, this was not noticed for a while.