### PR TITLE
Baseline: CTEST_PARALLEL_LEVEL=1 for sequential test comparison

### DIFF
--- a/projects/composablekernel/script/dependency-parser/smart_build_and_test.sh
+++ b/projects/composablekernel/script/dependency-parser/smart_build_and_test.sh
@@ -65,8 +65,8 @@ export PARALLEL
 if ! bash "${SCRIPT_DIR}/smart_build_ci.sh"; then
     # Full build required (exit code 1 from smart_build_ci.sh)
     echo "⚠ Full build mode - building and testing everything"
-    # Baseline: run ck_tile gemm + reduce tests sequentially (parallel=1)
-    CTEST_PARALLEL_LEVEL=1 ninja -j${NINJA_JOBS} ck_tile_gemm_tests ck_tile_reduce_tests
+    # Baseline: run all tests sequentially (parallel=1)
+    CTEST_PARALLEL_LEVEL=1 ninja -j${NINJA_JOBS} check
 
     # Process ninja build trace if requested
     if [ "$PROCESS_NINJA_TRACE" = "true" ]; then

--- a/projects/composablekernel/script/dependency-parser/smart_build_and_test.sh
+++ b/projects/composablekernel/script/dependency-parser/smart_build_and_test.sh
@@ -65,7 +65,8 @@ export PARALLEL
 if ! bash "${SCRIPT_DIR}/smart_build_ci.sh"; then
     # Full build required (exit code 1 from smart_build_ci.sh)
     echo "⚠ Full build mode - building and testing everything"
-    ninja -j${NINJA_JOBS} check
+    # Baseline: run ck_tile gemm + reduce tests sequentially (parallel=1)
+    CTEST_PARALLEL_LEVEL=1 ninja -j${NINJA_JOBS} ck_tile_gemm_tests ck_tile_reduce_tests
 
     # Process ninja build trace if requested
     if [ "$PROCESS_NINJA_TRACE" = "true" ]; then

--- a/projects/composablekernel/test/ck_tile/CMakeLists.txt
+++ b/projects/composablekernel/test/ck_tile/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 # SPDX-License-Identifier: MIT
 
+# TODO: remove this comment after CI parallel test experiment (baseline)
 ################################################################################
 # CK Tile Test Organization
 ################################################################################


### PR DESCRIPTION
Same test scope (ck_tile gemm + reduce) but with parallel=1 to establish baseline sequential timing for comparison against the parallel-ctest-experiment branch (parallel=16).

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
