### PR TITLE
Remove unneeded hipGraphCreate

### DIFF
--- a/projects/rocrand/test/hipgraphs_doc_sample.hpp
+++ b/projects/rocrand/test/hipgraphs_doc_sample.hpp
@@ -28,7 +28,6 @@ HIP_CHECK(hipMalloc(&data_0, sizeof(*data_0) * size));
 HIP_CHECK(hipMalloc(&data_1, sizeof(*data_1) * size));
 
 hipGraph_t graph;
-HIP_CHECK(hipGraphCreate(&graph, 0));
 
 hipStream_t stream;
 HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));


### PR DESCRIPTION
## Motivation

Remove a memory leak from the hipgraph sample code.

## Technical Details

The hipGraph example has an extra hipGraphCreate().  It is not needed when using the API hipStreamEndCapture() which creates another graph.  Basically the first graph ceated is overwritten by this new graph and that memory is leaked, which is reported by LeakSanitizer.

## Test Plan

Reran test for correctness and to check if the memory leak is gone.

## Test Result

All is good.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
