### PR TITLE
[hipBLAS] Tear down HIP context before CRT/static destructors

### DIFF
--- a/projects/hipblas/clients/gtest/hipblas_gtest_main.cpp
+++ b/projects/hipblas/clients/gtest/hipblas_gtest_main.cpp
@@ -344,5 +344,11 @@ int main(int argc, char** argv)
 
     hipblas_print_args(args);
 
+    // Tear down HIP context before CRT/static destructors (matches
+    // hipsparse_gtest_main.cpp). Avoids intermittent Windows post-main failures
+    // where dependent DLLs (e.g. amd_comgr) fault during process exit.
+    (void)hipDeviceSynchronize();
+    (void)hipDeviceReset();
+
     return status;
 }


### PR DESCRIPTION
## Motivation

To fix https://github.com/ROCm/rocm-libraries/issues/6372
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

TEST MANUALLY on CS-UCICD-DT123  by download the artifact and run the following commands:

## Test Result
```
PS C:\Users\defaultuser\TheRock> .venv\Scripts\Activate.bat
PS C:\Users\defaultuser\TheRock> python build_tools/install_rocm_from_artifacts.py --run-id 24329484987 --amdgpu-family gfx110X-all --blas --tests --output-dir build
### Installing TheRock using artifacts ###
Creating output directory 'C:\Users\defaultuser\TheRock\build'
Created output directory 'C:\Users\defaultuser\TheRock\build'
Retrieving artifacts for run ID 24329484987

Calling fetch_artifacts_main with args:
  --run-id 24329484987 --artifact-group gfx110X-all --output-dir build --flatten core-hipinfo_run core-runtime_run core-runtime_lib sysdeps_lib base_run base_lib amd-llvm_run amd-llvm_lib core-amdsmi_run core-amdsmi_lib core-hip_lib core-hip_dev core-kpack_lib core-ocl_lib core-ocl_dev rocprofiler-sdk_lib host-suite-sparse_lib blas_lib blas_test

Retrieving bucket info...
  (implicit) github_repository: ROCm/TheRock
  workflow_run_id             : 24329484987
  head_github_repository      : ROCm/TheRock
  is_pr_from_fork             : False
Retrieved bucket info:
  external_repo:
  bucket       : therock-ci-artifacts
Retrieving artifacts from 's3://therock-ci-artifacts/24329484987-windows'
Matching artifact target families: ['generic', 'gfx110X-all']

Retrieved artifacts for run ID 24329484987
PS C:\Users\defaultuser\TheRock> ./build/bin/hipinfo.exe

--------------------------------------------------------------------------------
device#                           0
Name:                             AMD Radeon RX 7600 XT
...
gcnArchName:                      gfx1102
maxAvailableVgprsPerThread:       256 DWORDs
peers:
non-peers:                        device#0

memInfo.total:                    15.98 GB
memInfo.free:                     15.84 GB (99%)

PS C:\Users\defaultuser\TheRock> ./build/bin/hipblas-test --yaml ./build/bin/hipblas_smoke.yaml '--gtest_filter=-*known_bug*:_/getrs*:_/getri_batched.solver*:_/gels_batched.solver*'
hipBLAS version 3.4.0.e3e588ef
Query device success: there are 1 devices
Device ID 0 : AMD Radeon RX 7600 XT ------------------------------------------------------
with 17.2 GB memory, clock rate 2539MHz @ computing capability 11.0
maxGridDimX 2147483647, sharedMemPerBlock 65.5 KB, maxThreadsPerBlock 1024, warpSize 32
-------------------------------------------------------------------------
info: parsing of test data may take a couple minutes before any test output appears...

python C:\Users\defaultuser\TheRock\build\bin\/hipblas_gentest.py --template C:\Users\defaultuser\TheRock\build\bin\/hipblas_template.yaml -o C:\Users\DEFAUL~3\AppData\Local\Temp\hipblas-fu7qHn ./build/bin/hipblas_smoke.yaml
Note: Google Test filter = -*known_bug*:_/getrs*:_/getri_batched.solver*:_/gels_batched.solver*
[==========] Running 1676 tests from 162 test suites.
[----------] Global test environment set-up.
[----------] 1 test from hipblas_auxiliary
[----------] 1 test from hipblas_auxiliary (0 ms total)

.......
[----------] 8 tests from _/herk_ex
[----------] 8 tests from _/herk_ex (38 ms total)

[----------] Global test environment tear-down
[==========] 1676 tests from 162 test suites ran. (4616 ms total)
[  PASSED  ] 1676 tests.
hipBLAS version 3.4.0.e3e588ef
command line: C:\Users\defaultuser\TheRock\build\bin\hipblas-test.exe --yaml ./build/bin/hipblas_smoke.yaml --gtest_filter=-*known_bug*:_/getrs*:_/getri_batched.solver*:_/gels_batched.solver*
```
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

ROCM-21618
