### PR TITLE
[rocsparse] Fix spsm_csr stress test skipped on MI350P in CPX mode

### DIFF
--- a/projects/rocsparse/clients/tests/test_spsm_csr.yaml
+++ b/projects/rocsparse/clients/tests/test_spsm_csr.yaml
@@ -1,4 +1,4 @@
-# ########################################################################
+.# ########################################################################
 # Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -455,7 +455,7 @@ Tests:
              shipsec1,
              bmwcra_1]
   host_memory_gb: 64
-  device_memory_gb: 32
+  device_memory_gb: 47
 
 - name: spsm_csr_file
   category: stress

--- a/projects/rocsparse/clients/tests/test_spsm_csr.yaml
+++ b/projects/rocsparse/clients/tests/test_spsm_csr.yaml
@@ -1,4 +1,4 @@
-.# ########################################################################
+# ########################################################################
 # Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
## Motivation

Increase device_memory_gb threshold from 32 to 47 for the spsm_csr stress tests (scircuit, sme3Dc, shipsec1, bmwcra_1). In CPX mode, MI350P reports ~35 GB free via hipMemGetInfo but the test requires more device storage, causing an allocation failure at runtime. The higher threshold ensures the test is correctly skipped on hardware with insufficient device memory.