### PR TITLE
[rocprim] updated links to examples

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/block/block_load.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/block/block_load.hpp
@@ -111,7 +111,7 @@ enum class block_load_method
 /// In the examples load operation is performed on block of 128 threads, using type
 /// \p int and 8 items per thread.
 ///
-/// The full example is [on GitHub](https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocprim/example/rocprim/block/block_load.cpp).
+/// The full example is [on GitHub](https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocprim/example/rocprim/block/example_block_load.cpp).
 ///
 /// \code{.cpp}
 /// __global__ void example_kernel(int * input, ...)

--- a/projects/rocprim/rocprim/include/rocprim/block/block_shuffle.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/block/block_shuffle.hpp
@@ -69,7 +69,7 @@ BEGIN_ROCPRIM_NAMESPACE
 /// In the examples shuffle operation is performed on block of 192 threads, each provides
 /// one \p int value, result is returned using the same variable as for input.
 ///
-/// The full example is [on GitHub](https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocprim/example/rocprim/block/block_shuffle.cpp).
+/// The full example is [on GitHub](https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocprim/example/rocprim/block/example_block_shuffle.cpp).
 ///
 /// \code{.cpp}
 /// __global__ void example_kernel(...)

--- a/projects/rocprim/rocprim/include/rocprim/block/block_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/block/block_sort.hpp
@@ -147,7 +147,7 @@ struct select_block_sort_impl<block_sort_algorithm::stable_merge_sort>
 /// In the examples sort is performed on a block of 256 threads, each thread provides
 /// 8 \p int values, results are returned using the same variable as for input.
 ///
-/// The full example is [on GitHub](https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocprim/example/rocprim/block/block_sort.cpp).
+/// The full example is [on GitHub](https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocprim/example/rocprim/block/example_block_sort.cpp).
 ///
 /// \code{.cpp}
 /// __global__ void example_kernel(...)

--- a/projects/rocprim/rocprim/include/rocprim/device/device_segmented_reduce.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_segmented_reduce.hpp
@@ -164,7 +164,7 @@ inline hipError_t segmented_reduce_impl(void*          temporary_storage,
 /// In this example a device-level segmented min-reduction operation is performed on an array of
 /// integer values (<tt>short</tt>s are reduced into <tt>int</tt>s) using custom operator.
 ///
-/// The full example is [on GitHub](https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocprim/example/rocprim/device/example_device_segemented_reduce.cpp).
+/// The full example is [on GitHub](https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocprim/example/rocprim/device/example_device_segmented_reduce.cpp).
 ///
 /// \code{.cpp}
 /// #include <rocprim/rocprim.hpp>


### PR DESCRIPTION
## Motivation

The in-code documentation pointed to some examples that had been renamed, causing broken links in the doc.  

I went in and fixed that.