### PR TITLE
[rocBLAS] hipblaslt on windows is supported

### DIFF
--- a/projects/rocblas/docs/conceptual/rocblas-design-notes.rst
+++ b/projects/rocblas/docs/conceptual/rocblas-design-notes.rst
@@ -40,7 +40,7 @@ The environment variables ``ROCBLAS_USE_HIPBLASLT`` and ``ROCBLAS_USE_HIPBLASLT_
 
 .. note::
 
-   The hipBLASLt backend for rocBLAS is currently not supported on Windows builds or static builds,
+   The hipBLASLt backend for rocBLAS is currently not supported on static builds,
    and is not included if building without Tensile.
 
 rocBLAS API and legacy BLAS functions


### PR DESCRIPTION
This pull request updates the documentation to clarify the limitations of the hipBLASLt backend support in rocBLAS. The main change is to the note about platform and build support.

Documentation update:

* Updated the note in `rocblas-design-notes.rst` to specify that the hipBLASLt backend for rocBLAS is only not supported on static builds, removing the mention of Windows builds.