### PR TITLE
[Fusilli] Race condition on commits caused a test failure

### DIFF
--- a/dnn-providers/fusilli-provider/test/test_graph_import.cpp
+++ b/dnn-providers/fusilli-provider/test/test_graph_import.cpp
@@ -59,7 +59,7 @@ TEST(TestGraphImport, ConvertHipDnnToFusilli) {
 
 // Build a hipDNN frontend custom op graph and serialize to flatbuffer.
 // The customOpId parameter controls the custom_op_id field.
-static flatbuffers::DetachedBuffer
+static std::vector<uint8_t>
 buildCustomOpGraph(const std::string &customOpId = "fusilli.my_add") {
   using namespace hipdnn_frontend;
 
@@ -119,7 +119,12 @@ buildCustomOpGraph(const std::string &customOpId = "fusilli.my_add") {
                              result.get_message());
   }
 
-  return graph.buildFlatbufferOperationGraph();
+  auto [serializedGraph, serErr] = graph.to_binary();
+  if (serErr.is_bad()) {
+    throw std::runtime_error("Graph serialization failed: " +
+                             serErr.get_message());
+  }
+  return serializedGraph;
 }
 
 TEST(TestGraphImport, ImportCustomOpGraph) {


### PR DESCRIPTION
Some of the serialization code for fusilli plugin failed to be updated on a separate commit. Updated for correctness.

## Motivation

Minor bug fix from commit race condition

## Technical Details

Migrated fusilli test to the new seriazation API

## Test Plan

Test is updated and passing.

## Test Result

Tests are now passing

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
