### PR TITLE
[origami] Query XCD Count at Runtime

### DIFF
--- a/shared/origami/include/origami/hardware.hpp
+++ b/shared/origami/include/origami/hardware.hpp
@@ -580,9 +580,11 @@ class hardware_t {
   /**
    * @brief Get the default (hardcoded) XCD count for a known architecture.
    *
-   * Only covers architectures with established default XCD counts. Throws
-   * for architectures not in the table — use get_hardware_for_device() to
-   * query at runtime for new/unlisted architectures.
+   * Legacy fallback table for architectures that predate the runtime XCC
+   * query (hipDeviceAttributeNumberOfXccs, HIP 7.0+). Do NOT add new
+   * architectures here — new hardware should rely solely on the runtime
+   * query via get_hardware_for_device(). Throws for architectures not in
+   * the table.
    *
    * @param arch Architecture enum value
    * @return Number of XCDs for the architecture

--- a/shared/origami/include/origami/hardware.hpp
+++ b/shared/origami/include/origami/hardware.hpp
@@ -104,7 +104,6 @@ class hardware_t {
    *
    */
   struct architecture_constants {
-    size_t num_xcds;  ///< Number of XCDs (XCD = XGMI Complex Die)
     double mem1_perf_ratio;
     double mem2_perf_ratio;
     double mem3_perf_ratio;
@@ -113,15 +112,13 @@ class hardware_t {
         mem_bw_per_wg_coefficients;  ///< Memory bandwidth coefficients per workgroup
     double mem_clock_ratio;          ///< Memory clock ratio relative to compute clock
 
-    constexpr architecture_constants(size_t num_xcds,
-                                     double mem1_perf_ratio,
+    constexpr architecture_constants(double mem1_perf_ratio,
                                      double mem2_perf_ratio,
                                      double mem3_perf_ratio,
                                      size_t parallel_mi_cu,
                                      std::tuple<double, double, double> mem_bw_per_wg_coefficients,
                                      double mem_clock_ratio)  // Obtained through microbenchmarking
-        : num_xcds(num_xcds)
-        , mem1_perf_ratio(mem1_perf_ratio)
+        : mem1_perf_ratio(mem1_perf_ratio)
         , mem2_perf_ratio(mem2_perf_ratio)
         , mem3_perf_ratio(mem3_perf_ratio)
         , parallel_mi_cu(parallel_mi_cu)
@@ -148,35 +145,33 @@ class hardware_t {
   static constexpr architecture_constants get_arch_constants(architecture_t arch) {
     switch (arch) {
       case architecture_t::gfx90a:
-        return {1, 5.5, 1.21875121875121875122 * 1.2, 1.2, 4, std::make_tuple(0, 0.03, 0), 1.5};
+        return {5.5, 1.21875121875121875122 * 1.2, 1.2, 4, std::make_tuple(0, 0.03, 0), 1.5};
       case architecture_t::gfx942:
-        return {8, 17, 1.21875121875121875122 * 6, 4, 4, std::make_tuple(0, 0.015, 0), 1.5};
+        return {17, 1.21875121875121875122 * 6, 4, 4, std::make_tuple(0, 0.015, 0), 1.5};
       case architecture_t::gfx950:
-        // return {8, 17, 1.21875121875121875122 * 7, 6, 4, std::make_tuple(0, 0.008, 0), 1.5};
-        return {8,
-                17,
+        return {17,
                 1.21875121875121875122 * 7,
                 6,
                 4,
                 std::make_tuple(-0.000013, 0.007070, 0.027355),
                 1.5};
       case architecture_t::gfx1201:
-        return {1, 5.74, 1.21875121875121875122 * 2.41, 0.464, 2, std::make_tuple(0, 0.17, 0), 1.5};
+        return {5.74, 1.21875121875121875122 * 2.41, 0.464, 2, std::make_tuple(0, 0.17, 0), 1.5};
       case architecture_t::gfx1100:
-        return {1, 7.12, 1.21875121875121875122 * 3.48, 0.732, 2, std::make_tuple(0, 0.11, 0), 1.5};
+        return {7.12, 1.21875121875121875122 * 3.48, 0.732, 2, std::make_tuple(0, 0.11, 0), 1.5};
       case architecture_t::gfx1150:
         // AMD Strix Point iGPU
-        return {1, 1.497, NO_MALL_AVAILABLE, 0.077, 16, std::make_tuple(0, 0.18, 0), 1.5};
+        return {1.497, NO_MALL_AVAILABLE, 0.077, 16, std::make_tuple(0, 0.18, 0), 1.5};
       case architecture_t::gfx1151:
         // AMD Strix Halo iGPU
-        return {1, 2.47, 1.21875121875121875122 * 0.93, 0.215, 2, std::make_tuple(0, 0.22, 0), 1.5};
+        return {2.47, 1.21875121875121875122 * 0.93, 0.215, 2, std::make_tuple(0, 0.22, 0), 1.5};
       case architecture_t::gfx1152:
         // AMD Radeon 840M iGPU
-        return {1, 0.849, NO_MALL_AVAILABLE, 0.096, 4, std::make_tuple(0, 0.13, 0), 1.5};
+        return {0.849, NO_MALL_AVAILABLE, 0.096, 4, std::make_tuple(0, 0.13, 0), 1.5};
       case architecture_t::gfx1153:
         // AMD Radeon 820M iGPU
-        return {1, 0.240, NO_MALL_AVAILABLE, 0.066, 2, std::make_tuple(0, 0.19, 0), 1.5};
-      default: return {0, 0, 0, 0, 0, std::make_tuple(0, 0, 0), 0};
+        return {0.240, NO_MALL_AVAILABLE, 0.066, 2, std::make_tuple(0, 0.19, 0), 1.5};
+      default: return {0, 0, 0, 0, std::make_tuple(0, 0, 0), 0};
     }
   }
 
@@ -507,6 +502,8 @@ class hardware_t {
    * @param N_CU Number of compute units
    * @param lds_capacity LDS capacity in bytes
    * @param constants Architecture-specific constants
+   * @param num_xcds Number of XCDs — provided separately from constants so that
+   *                 it can come from a runtime query or a known-architecture table
    * @param L2_capacity L2 cache capacity in bytes
    * @param compute_clock_ghz Compute clock frequency in GHz
    * @param memory_clock_ghz Memory clock frequency in GHz
@@ -515,6 +512,7 @@ class hardware_t {
              size_t N_CU,
              size_t lds_capacity,
              const architecture_constants& constants,
+             size_t num_xcds,
              size_t L2_capacity,
              double compute_clock_ghz,
              double memory_clock_ghz);
@@ -539,11 +537,14 @@ class hardware_t {
   /**
    * @brief Create hardware_t instance from HIP device properties.
    *
-   *
    * @param properties HIP device properties structure
+   * @param num_xcds_override If non-zero, use this XCD count instead of
+   *                          the hardcoded default. Passed by
+   *                          get_hardware_for_device() after a runtime query.
    * @return hardware_t Configured hardware instance
    */
-  static hardware_t get_hardware_for_properties(hipDeviceProp_t properties);
+  static hardware_t get_hardware_for_properties(hipDeviceProp_t properties,
+                                                size_t num_xcds_override = 0);
 
   /**
    * @brief Create hardware_t instance for a specific HIP device.
@@ -575,6 +576,19 @@ class hardware_t {
                                           size_t lds_capacity,
                                           size_t L2_capacity,
                                           int compute_clock_khz);
+
+  /**
+   * @brief Get the default (hardcoded) XCD count for a known architecture.
+   *
+   * Only covers architectures with established default XCD counts. Throws
+   * for architectures not in the table — use get_hardware_for_device() to
+   * query at runtime for new/unlisted architectures.
+   *
+   * @param arch Architecture enum value
+   * @return Number of XCDs for the architecture
+   * @throws std::runtime_error if the architecture has no hardcoded default
+   */
+  static size_t get_default_num_xcds(architecture_t arch);
 
   /**
    * @brief Check if the hardware described by properties is supported.

--- a/shared/origami/src/origami/hardware.cpp
+++ b/shared/origami/src/origami/hardware.cpp
@@ -141,6 +141,7 @@ bool hardware_t::is_hardware_supported(hipDeviceProp_t properties) {
 }
 
 size_t hardware_t::get_default_num_xcds(architecture_t arch) {
+  // Do NOT add new architectures here — see declaration in hardware.hpp.
   switch (arch) {
     case architecture_t::gfx90a:  return 1;
     case architecture_t::gfx942:  return 8;

--- a/shared/origami/src/origami/hardware.cpp
+++ b/shared/origami/src/origami/hardware.cpp
@@ -39,6 +39,7 @@ hardware_t::hardware_t(architecture_t arch,
                        size_t N_CU,
                        size_t lds_capacity,
                        const architecture_constants& constants,
+                       size_t num_xcds,
                        size_t L2_capacity,
                        double compute_clock_ghz,
                        double memory_clock_ghz)
@@ -46,7 +47,7 @@ hardware_t::hardware_t(architecture_t arch,
           arch,
           N_CU,
           lds_capacity,
-          constants.num_xcds,
+          num_xcds,
           1e9 * constants.mem1_perf_ratio / (compute_clock_ghz * 1e6),
           1e9 * constants.mem2_perf_ratio / (memory_clock_ghz * 1e6 * constants.mem_clock_ratio),
           1e9 * constants.mem3_perf_ratio / (memory_clock_ghz * 1e6),
@@ -72,7 +73,8 @@ hardware_t::hardware_t(const hardware_t& other)
     , mem_bw_per_wg_coefficients(other.mem_bw_per_wg_coefficients)
     , NUM_XCD(other.NUM_XCD) {}
 
-hardware_t hardware_t::get_hardware_for_properties(hipDeviceProp_t properties) {
+hardware_t hardware_t::get_hardware_for_properties(hipDeviceProp_t properties,
+                                                   size_t num_xcds_override) {
   auto arch_name = get_before_first_colon(properties.gcnArchName);
   auto arch_enum = arch_name_to_enum(arch_name);
   if (arch_enum == architecture_t::Count) {
@@ -80,11 +82,15 @@ hardware_t hardware_t::get_hardware_for_properties(hipDeviceProp_t properties) {
         std::string("Attempting to retrieve hardware constants for unsupported architecture: ") +
         std::string(arch_name));
   }
-  auto constants = get_arch_constants(arch_enum);
+  auto constants  = get_arch_constants(arch_enum);
+  auto num_xcds   = (num_xcds_override > 0)
+                      ? num_xcds_override
+                      : get_default_num_xcds(arch_enum);
   return hardware_t(arch_enum,
                     properties.multiProcessorCount,
                     properties.sharedMemPerBlock,
                     constants,
+                    num_xcds,
                     properties.l2CacheSize,
                     properties.clockRate / 1.e6,
                     properties.memoryClockRate / 1.e6);
@@ -94,7 +100,17 @@ hardware_t hardware_t::get_hardware_for_device(int deviceId) {
   hipDeviceProp_t prop;
   hipError_t e = hipGetDeviceProperties(&prop, deviceId);
   if (e) { throw std::runtime_error(hipGetErrorString(e)); }
-  return get_hardware_for_properties(prop);
+
+  size_t num_xcds = 0;
+#if HIP_VERSION_MAJOR >= 7
+  int queried_xccs = 0;
+  if (hipDeviceGetAttribute(&queried_xccs, hipDeviceAttributeNumberOfXccs, deviceId) == hipSuccess
+      && queried_xccs > 0) {
+    num_xcds = static_cast<size_t>(queried_xccs);
+  }
+#endif
+
+  return get_hardware_for_properties(prop, num_xcds);
 }
 
 hardware_t hardware_t::get_hardware_for_arch(architecture_t arch,
@@ -112,6 +128,7 @@ hardware_t hardware_t::get_hardware_for_arch(architecture_t arch,
                     N_CU,
                     lds_capacity,
                     constants,
+                    get_default_num_xcds(arch),
                     L2_capacity,
                     compute_clock_khz / 1.e6,
                     compute_clock_khz / 1.e6 / constants.mem_clock_ratio);
@@ -121,6 +138,25 @@ bool hardware_t::is_hardware_supported(hipDeviceProp_t properties) {
   auto arch_name = get_before_first_colon(properties.gcnArchName);
   auto arch_enum = arch_name_to_enum(arch_name);
   return arch_enum != architecture_t::Count;
+}
+
+size_t hardware_t::get_default_num_xcds(architecture_t arch) {
+  switch (arch) {
+    case architecture_t::gfx90a:  return 1;
+    case architecture_t::gfx942:  return 8;
+    case architecture_t::gfx950:  return 8;
+    case architecture_t::gfx1201: return 1;
+    case architecture_t::gfx1100: return 1;
+    case architecture_t::gfx1150: return 1;
+    case architecture_t::gfx1151: return 1;
+    case architecture_t::gfx1152: return 1;
+    case architecture_t::gfx1153: return 1;
+    default:
+      throw std::runtime_error(
+          std::string("No default XCD count for architecture ") +
+          std::string(arch_enum_to_name(arch)) +
+          ". Use get_hardware_for_device() with a live GPU to query at runtime.");
+  }
 }
 
 void hardware_t::print() const {


### PR DESCRIPTION
## Motivation

The `num_xcds` field in `origami::hardware_t::architecture_constants` is hardcoded per architecture (e.g. gfx942 = 8, gfx950 = 8). This is fragile — different SKUs of the same architecture can have different XCD counts (e.g. a product with 4 XCDs vs 8). It also means every new architecture requires a hardcoded entry, with no enforcement that the value is correct.

This PR queries the XCC count at runtime via `hipDeviceGetAttribute(hipDeviceAttributeNumberOfXccs)` when a live device is available, and restructures the code so that future architectures are not required to have a hardcoded default.

AIGESOLSEL-133

## Technical Details

- **Removed `num_xcds` from `architecture_constants`** — the struct no longer carries an XCD count. This field was the only non-performance-tuning constant in the struct and varied by SKU, not just architecture.

- **Added `get_default_num_xcds(architecture_t)`** — a separate lookup that returns the known XCD count for existing architectures (gfx90a=1, gfx942=8, gfx950=8, gfx11xx/gfx12xx=1). Throws `std::runtime_error` for any architecture not in the table, with a message directing callers to use `get_hardware_for_device()`.

- **Modified `get_hardware_for_properties()`** — now accepts an optional `num_xcds_override` parameter. When non-zero, it uses the provided value; otherwise it falls back to `get_default_num_xcds()`. The public API is unchanged (default argument = 0).

- **Modified `get_hardware_for_device()`** — queries `hipDeviceAttributeNumberOfXccs` first (guarded by `#if HIP_VERSION_MAJOR >= 7`), then passes the result to `get_hardware_for_properties()`. For existing architectures on older HIP, the hardcoded table serves as fallback.

- **`get_hardware_for_arch()`** — uses `get_default_num_xcds()` directly, unchanged in behavior for known architectures. Throws for unknown architectures since no device is available for a runtime query.

- **`CU_per_L2`** is correctly derived from the resolved `NUM_XCD` in all paths (`N_CU / NUM_XCD`).

The design enforces that future architectures must rely on the runtime query via `get_hardware_for_device()`. Attempting to use `get_hardware_for_properties()` or `get_hardware_for_arch()` with an unlisted architecture produces a clear error.

## Test Plan

- Built origami with `-DORIGAMI_BUILD_TESTING=ON` inside the hipblaslt-dev Docker container (ROCm 7.13.0a, HIP 7.13, Ubuntu 24.04).
- Ran the full origami test suite (`ctest --output-on-failure`).
- Verified the runtime query path with a standalone test binary calling `get_hardware_for_device(0)` on a gfx1100 GPU — confirmed `hipDeviceGetAttribute(hipDeviceAttributeNumberOfXccs)` returns 1 with `hipSuccess`.

## Test Result

- 81/81 origami tests passed, 0 failures.
- Runtime query confirmed functional on gfx1100 (1 XCD queried, matches hardcoded default).

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
