### PR TITLE
use explicit constructor for e8 and e5m3

### DIFF
--- a/projects/hipblaslt/library/include/hipblaslt/hipblaslt_e5m3.h
+++ b/projects/hipblaslt/library/include/hipblaslt/hipblaslt_e5m3.h
@@ -61,47 +61,52 @@ HIP_DEVICE static float hipblaslt_cast_to_f32_from_uf8(uint8_t v);
 #endif
 
 struct hipblaslt_e5m3 {
-  uint8_t data;
+    uint8_t data;
 
-  HIP_HOST_DEVICE hipblaslt_e5m3(const hipblaslt_e5m3&) = default;
+    HIP_HOST_DEVICE hipblaslt_e5m3() = default;
 
-  HIP_HOST_DEVICE hipblaslt_e5m3() = default;
+    HIP_HOST_DEVICE hipblaslt_e5m3(const hipblaslt_e5m3&) = default;
 
-  HIP_HOST_DEVICE hipblaslt_e5m3(const float f)
-  {
+    explicit HIP_HOST_DEVICE hipblaslt_e5m3(const float f)
+    {
 #if HIP_E5M3_CVT_FAST_PATH
-    data = hipblaslt_cast_to_uf8_from_f32(f, true);
+        data = hipblaslt_cast_to_uf8_from_f32(f, true);
 #else
-    data = hipblaslt_cast_to_uf8(f, 3, 5, true);
+        data = hipblaslt_cast_to_uf8(f, 3, 5, true);
 #endif
-  }
+    }
 
-  /*! convert fp8 e4m3 to float */
-  HIP_HOST_DEVICE operator float() const {
+    /*! convert fp8 e4m3 to float */
+    HIP_HOST_DEVICE operator float() const {
 // #if HIP_E5M3_CVT_FAST_PATH
-//    return hipblaslt_cast_to_f32_from_uf8(data);
+//        return hipblaslt_cast_to_f32_from_uf8(data);
 //#else
-    return hipblaslt_cast_from_uf8(data, 3, 5);
+        return hipblaslt_cast_from_uf8(data, 3, 5);
 //#endif
-  }
+    }
 
-  // check for zero
-  inline HIP_HOST_DEVICE bool is_zero() const
-  {
-      return data == 0;
-  }
+    // check for zero
+    inline HIP_HOST_DEVICE bool is_zero() const
+    {
+        return data == 0;
+    }
 
-  // check for nan
-  inline HIP_HOST_DEVICE bool is_nan() const
-  {
-      return data == 0xff;
-  }
+    // check for nan
+    inline HIP_HOST_DEVICE bool is_nan() const
+    {
+        return data == 0xff;
+    }
 
-  // check for inf
-  inline HIP_HOST_DEVICE bool is_inf() const
-  {
-      return false;
-  }
+    // check for inf
+    inline HIP_HOST_DEVICE bool is_inf() const
+    {
+        return false;
+    }
+
+    inline HIP_HOST_DEVICE hipblaslt_e5m3 operator-() const
+    {
+        return hipblaslt_e5m3(*this);
+    }
 };
 
 inline float operator*(hipblaslt_e5m3 a, float b)

--- a/projects/hipblaslt/library/include/hipblaslt/hipblaslt_e8.h
+++ b/projects/hipblaslt/library/include/hipblaslt/hipblaslt_e8.h
@@ -40,7 +40,9 @@ struct hipblaslt_e8
     // default constructor
     HIP_HOST_DEVICE hipblaslt_e8() = default;
 
-    HIP_HOST_DEVICE hipblaslt_e8(float v0)
+    HIP_HOST_DEVICE hipblaslt_e8(const hipblaslt_e8& other) = default;
+
+    explicit HIP_HOST_DEVICE hipblaslt_e8(float v0)
     {
         union {
             uint32_t x;
@@ -83,6 +85,11 @@ struct hipblaslt_e8
         }
 
         return v.f;
+    }
+
+    inline HIP_HOST_DEVICE hipblaslt_e8 operator-() const
+    {
+        return hipblaslt_e8(*this);
     }
 };
 


### PR DESCRIPTION
prevent ambiguous function in windows platform

## Motivation

hipblasltprovider met error of ambiguous function when call operator '<<' of hipblaslt_e8 and hipblaslt_e5m3 on Windows.
This patch is used to fix those errors.

## Technical Details

use explicit constructor with float paramter to prevent auto type conversion.

## Test Plan

> * [ ]  Verify hipblasltprovider build on Windows.
> * [ ]  CI build and test pass to confirm the Tensile logic loading path resolves the new file locations.

## Test Result

> * [ ]  Verify hipblasltprovider build on Windows.
> * [ ]  CI build and test pass to confirm the Tensile logic loading path resolves the new file locations.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
