### PR TITLE
bump the rock version in rocm-libraries

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       id-token: write
     container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:4443d9d710b9471e8ef658d509358bd92602498e67161b9280474bce0bb0decd
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:0e2c1b31f7e1661a3895508962f6c4e740a2dfd4575b9bfac87d538e3af20079
       options: -v /runner/config:/home/awsconfig/
     strategy:
       fail-fast: true

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: b68757b3461145b85eabec29cea1223027a56da0 # 2026-04-01
+          ref: 1d1b030e280f2d7a44105958f622c846a79c6cb0 # 2026-04-14
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Setup ccache
         run: |
           ./TheRock/build_tools/setup_ccache.py \
-            --config-preset "github-oss-presubmit" \
+            --config-preset "github-oss-dev" \
             --dir "$(dirname $CCACHE_CONFIGPATH)" \
             --local-path "$CACHE_DIR/ccache"
 

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 1d1b030e280f2d7a44105958f622c846a79c6cb0 # 2026-04-14
+          ref: de1255d3ffd3e4f17f8069c972cf6a4e2e1736e2 # 2026-04-14
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-nightly.yml
+++ b/.github/workflows/therock-ci-nightly.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 1d1b030e280f2d7a44105958f622c846a79c6cb0 # 2026-04-14
+          ref: de1255d3ffd3e4f17f8069c972cf6a4e2e1736e2 # 2026-04-14
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/therock-ci-nightly.yml
+++ b/.github/workflows/therock-ci-nightly.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: b68757b3461145b85eabec29cea1223027a56da0 # 2026-04-01
+          ref: 1d1b030e280f2d7a44105958f622c846a79c6cb0 # 2026-04-14
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 1d1b030e280f2d7a44105958f622c846a79c6cb0 # 2026-04-14
+          ref: de1255d3ffd3e4f17f8069c972cf6a4e2e1736e2 # 2026-04-14
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: b68757b3461145b85eabec29cea1223027a56da0 # 2026-04-01
+          ref: 1d1b030e280f2d7a44105958f622c846a79c6cb0 # 2026-04-14
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: b68757b3461145b85eabec29cea1223027a56da0 # 2026-04-01
+          ref: 1d1b030e280f2d7a44105958f622c846a79c6cb0 # 2026-04-14
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 1d1b030e280f2d7a44105958f622c846a79c6cb0 # 2026-04-14
+          ref: de1255d3ffd3e4f17f8069c972cf6a4e2e1736e2 # 2026-04-14
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: 1d1b030e280f2d7a44105958f622c846a79c6cb0 # 2026-04-14
+          ref: de1255d3ffd3e4f17f8069c972cf6a4e2e1736e2 # 2026-04-14
 
       - name: Configure git for long paths on Windows
         if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: b68757b3461145b85eabec29cea1223027a56da0 # 2026-04-01
+          ref: 1d1b030e280f2d7a44105958f622c846a79c6cb0 # 2026-04-14
 
       - name: Configure git for long paths on Windows
         if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: 1d1b030e280f2d7a44105958f622c846a79c6cb0 # 2026-04-14
+          ref: de1255d3ffd3e4f17f8069c972cf6a4e2e1736e2 # 2026-04-14
 
       - name: Setting up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: b68757b3461145b85eabec29cea1223027a56da0 # 2026-04-01
+          ref: 1d1b030e280f2d7a44105958f622c846a79c6cb0 # 2026-04-14
 
       - name: Setting up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0


### PR DESCRIPTION
## Motivation

I want to see if I can bump the rock back to rocm-libraries and have things build correctly.  My other PR(https://github.com/ROCm/rocm-libraries/pull/6382) where I added a new custom feature to the rock failed on a library I didn't expect so I want to see if I broke something or if the bumps are broken in general at the moment 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
