### PR TITLE
Add miopen as a label for convolution changes in CK

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -68,6 +68,9 @@
 "project: miopen":
 - changed-files:
   - any-glob-to-any-file: 'projects/miopen/**/*'
+  - any-glob-to-any-file: 'projects/composablekernel/include/ck/tensor_operation/**/*conv*'
+  - any-glob-to-any-file: 'projects/composablekernel/include/ck/library/utility/*conv*'
+  - any-glob-to-any-file: 'projects/composablekernel/library/src/tensor_operation_instance/gpu/**/*conv*'
 
 "project: miopen-provider":
 - changed-files:


### PR DESCRIPTION
## Motivation

Convolution-related changes in the composablekernel project are relevant to MIOpen, but PRs touching those files were only receiving the project: composablekernel label — not project: miopen. This made it harder to filter and triage convolution PRs from a MIOpen perspective.

## Technical Details

Added path-based rules to the project: miopen entry in .github/labeler.yml so that PRs touching convolution files under projects/composablekernel/ are automatically labeled project: miopen by the existing labeler workflow.

The new rules cover:


- include/ck/tensor_operation/**/\*conv\* — convolution tensor operation headers
- include/ck/library/utility/\*conv\* — convolution utility headers
- library/src/utility/\*conv\* — convolution utility sources
- library/src/tensor_operation_instance/gpu/**/\*conv\* — GPU convolution kernel instances

No new workflow was introduced — the change hooks into the existing actions/labeler@v6 infrastructure.

## Test Plan

- Open a draft PR with changes to a file under projects/composablekernel/library/src/tensor_operation_instance/gpu/grouped_conv2d_fwd/ and verify that both project: composablekernel and project: miopen labels are applied automatically.
- Open a draft PR with changes only to a non-convolution composablekernel file (e.g. a GEMM kernel) and verify that project: miopen is not applied.

## Test Result

- Validated by manual inspection of the glob patterns against known convolution file paths in the repository.
- Will need to wait until this PR lands in order to test further.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
