### PR TITLE
[miopen] Remove excessive integer conversions in ConvBinWinogradRxS

### DIFF
--- a/projects/miopen/src/solver/conv/conv_winoRxS.cpp
+++ b/projects/miopen/src/solver/conv/conv_winoRxS.cpp
@@ -214,35 +214,25 @@ inline bool IsWinogradV21Preferred(const std::string& asic, const ProblemDescrip
 }
 
 inline bool IsShaderConstraintsMetV21(const ProblemDescription& problem,
-                                      const int R,
-                                      const int S,
-                                      const int C,
-                                      const int K,
-                                      const int H,
-                                      const int W,
-                                      const int OH,
-                                      const int OW,
-                                      const int N)
+                                      const uint64_t R,
+                                      const uint64_t S,
+                                      const uint64_t C,
+                                      const uint64_t K,
+                                      const uint64_t H,
+                                      const uint64_t W,
+                                      const uint64_t OH,
+                                      const uint64_t OW,
+                                      const uint64_t N)
 {
-    // Convert arguments to uint64_t
-    uint64_t N_    = N;
-    uint64_t C_    = C;
-    uint64_t H_    = H;
-    uint64_t W_    = W;
-    uint64_t K_    = K;
-    uint64_t S_    = S;
-    uint64_t R_    = R;
-    uint64_t OH_   = OH;
-    uint64_t OW_   = OW;
-    uint64_t padW_ = problem.GetPadW();
-    uint64_t padH_ = problem.GetPadH();
+    uint64_t padW = problem.GetPadW();
+    uint64_t padH = problem.GetPadH();
 
-    uint64_t o_K_stride      = OH_ * OW_;
-    uint64_t o_N_stride      = o_K_stride * K_;
+    uint64_t o_K_stride      = OH * OW;
+    uint64_t o_N_stride      = o_K_stride * K;
     uint64_t o_N_stride_OHOW = o_N_stride + o_K_stride;
 
-    uint64_t d_C_stride    = H_ * W_;
-    uint64_t d_N_stride    = d_C_stride * C_;
+    uint64_t d_C_stride    = H * W;
+    uint64_t d_N_stride    = d_C_stride * C;
     uint64_t d_N_stride_HW = d_N_stride + d_C_stride;
 
     auto num_tiles  = Ceil(OH, 2) * Ceil(OW, 2);
@@ -251,84 +241,77 @@ inline bool IsShaderConstraintsMetV21(const ProblemDescription& problem,
 
     // clang-format off
     // Check implementation limits.
-    return N_           < (uint64_t{1} << 16)
-        && C_           < (uint64_t{1} << 16)
-        && H_           < (uint64_t{1} << 16)
-        && W_           < (uint64_t{1} << 16)
-        && K_           < (uint64_t{1} << 16)
-        && S_           < (uint64_t{1} << 16)
-        && R_           < (uint64_t{1} << 16)
-        && OH_          < (uint64_t{1} << 16)
-        && OW_          < (uint64_t{1} << 16)
-        && padW_        < (uint64_t{1} << 16)
-        && padH_        < (uint64_t{1} << 16)
-        && C_ * R_ * S_ < (uint64_t{1} << 22)
-        && K_ * R_ * S_ < (uint64_t{1} << 28)
+    return N         < (uint64_t{1} << 16)
+        && C         < (uint64_t{1} << 16)
+        && H         < (uint64_t{1} << 16)
+        && W         < (uint64_t{1} << 16)
+        && K         < (uint64_t{1} << 16)
+        && S         < (uint64_t{1} << 16)
+        && R         < (uint64_t{1} << 16)
+        && OH        < (uint64_t{1} << 16)
+        && OW        < (uint64_t{1} << 16)
+        && padW      < (uint64_t{1} << 16)
+        && padH      < (uint64_t{1} << 16)
+        && C * R * S < (uint64_t{1} << 22)
+        && K * R * S < (uint64_t{1} << 28)
         && ((o_N_stride_OHOW < (uint64_t{1} << 29) && d_N_stride_HW < (uint64_t{1} << 29))
            || (stride_one && o_N_stride < (uint64_t{1} << 30) && d_N_stride < (uint64_t{1} << 30)
-           && (N == 1 || num_tiles % 16 == 0)));
+           && (N == 1 || num_tiles % 16 == 0)))
+        && (!problem.IsDirectionBackwardWrW()
+          || C == 1
+          || N * H * W < (uint64_t{1} << 28));
     // clang-format on
 }
 
 inline bool IsShaderConstraintsMetV30(const ProblemDescription& problem,
-                                      const int R,
-                                      const int S,
-                                      const int C,
-                                      const int K,
-                                      const int H,
-                                      const int W,
-                                      const int OH,
-                                      const int OW,
-                                      const int N)
+                                      const uint64_t R,
+                                      const uint64_t S,
+                                      const uint64_t C,
+                                      const uint64_t K,
+                                      const uint64_t H,
+                                      const uint64_t W,
+                                      const uint64_t OH,
+                                      const uint64_t OW,
+                                      const uint64_t N)
 {
-    // Convert arguments to uint64_t
-    uint64_t N_    = N;
-    uint64_t C_    = C;
-    uint64_t H_    = H;
-    uint64_t W_    = W;
-    uint64_t K_    = K;
-    uint64_t S_    = S;
-    uint64_t R_    = R;
-    uint64_t OH_   = OH;
-    uint64_t OW_   = OW;
-    uint64_t padW_ = problem.GetPadW();
-    uint64_t padH_ = problem.GetPadH();
+    uint64_t padW = problem.GetPadW();
+    uint64_t padH = problem.GetPadH();
 
     // clang-format off
     // Check implementation limits.
-    return N_    < (uint64_t{1} << 16)
-        && C_    < (uint64_t{1} << 16)
-        && H_    < (uint64_t{1} << 16)
-        && W_    < (uint64_t{1} << 16)
-        && K_    < (uint64_t{1} << 16)
-        && S_    < (uint64_t{1} << 16)
-        && R_    < (uint64_t{1} << 16)
-        && OH_   < (uint64_t{1} << 16)
-        && OW_   < (uint64_t{1} << 16)
-        && padW_ < (uint64_t{1} << 16)
-        && padH_ < (uint64_t{1} << 16)
-        && H_ * W_              < (uint64_t{1} << 29)
-        && K_ * R_ * S_         < (uint64_t{1} << 28)
-        && (C_ + 1) * H_ * W_   < (uint64_t{1} << 30)
-        && (C_ + 1) * R_ * S_   < (uint64_t{1} << 22)
-        && (K_ + 1) * OH_ * OW_ < (uint64_t{1} << 30)
+    return N    < (uint64_t{1} << 16)
+        && C    < (uint64_t{1} << 16)
+        && H    < (uint64_t{1} << 16)
+        && W    < (uint64_t{1} << 16)
+        && K    < (uint64_t{1} << 16)
+        && S    < (uint64_t{1} << 16)
+        && R    < (uint64_t{1} << 16)
+        && OH   < (uint64_t{1} << 16)
+        && OW   < (uint64_t{1} << 16)
+        && padW < (uint64_t{1} << 16)
+        && padH < (uint64_t{1} << 16)
+        && H * W             < (uint64_t{1} << 29)
+        && K * R * S         < (uint64_t{1} << 28)
+        && (C + 1) * H * W   < (uint64_t{1} << 30)
+        && (C + 1) * R * S   < (uint64_t{1} << 22)
+        && (K + 1) * OH * OW < (uint64_t{1} << 30)
         && (!problem.IsDirectionBackwardWrW()
-          || C_ == 1
-          || N_ * H_ * W_       < (uint64_t{1} << 28));
+          || C == 1
+          || N * H * W       < (uint64_t{1} << 28));
     // clang-format on
 }
 
 template <int Winodata, int Winofilter>
 inline bool IsShaderConstraintsMet(const ProblemDescription& problem,
-                                   const int R,
-                                   const int S,
-                                   const int C,
-                                   const int K,
-                                   const int H,
-                                   const int W,
-                                   const int OH,
-                                   const int OW,
-                                   const int N,
+                                   const uint64_t R,
+                                   const uint64_t S,
+                                   const uint64_t C,
+                                   const uint64_t K,
+                                   const uint64_t H,
+                                   const uint64_t W,
+                                   const uint64_t OH,
+                                   const uint64_t OW,
+                                   const uint64_t N,
                                    const std::string& asic)
 {
     // Padding for bwd data shall not be negative.


### PR DESCRIPTION
## Motivation

The follow-up PR of #6298 addressing the review comments.

## Technical Details

- Function signatures have been changed to accept `uint64_t` to avoid conversion blocks
- The fix is propagated to v21 kernel

## Test Plan

### Should pass

```bash
MIOPEN_DEBUG_FIND_ONLY_SOLVER=ConvBinWinogradRxSf3x2 MIOpenDriver conv -n 1 -c 256 -H 1024 -W 1024 -k 128 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 4 -t 1
MIOPEN_DEBUG_FIND_ONLY_SOLVER=ConvBinWinogradRxSf3x2 MIOpenDriver conv -n 2 -c 256 -H 1024 -W 1023 -k 128 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 4 -t 1
MIOPEN_DEBUG_FIND_ONLY_SOLVER=ConvBinWinogradRxSf3x2 MIOpenDriver conv -n 3 -c 256 -H 1024 -W 1023 -k 128 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 4 -t 1
MIOPEN_FIND_MODE=3 MIOPEN_FIND_ENFORCE=3 MIOpenDriver conv -n 2 -c 256 -H 1024 -W 1024 -k 128 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 4 -t 1
```

### Solver-restricted shape that should report "no suitable algorithm found"

```bash
MIOPEN_DEBUG_FIND_ONLY_SOLVER=ConvBinWinogradRxSf3x2 MIOpenDriver conv -n 2 -c 256 -H 1024 -W 1024 -k 128 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 4 -t 1
```

### CI

CI should pass.

## Test Results

- [X] Shapes pass
- [X] Solver-restricted shape reports `No suitable algorithm was found to execute the required convolution`
- [x] CI

On gfx906 failure disappears as well but the target shape causes an issue with resources allocation in other solvers. This is out of scope of this PR and can be addressed separately.

### Relevant Outputs Excerpts

#### Passing shapes

```text
MIOpenDriver conv -n 1 -c 256 -H 1024 -W 1024 -k 128 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 4 -t 1
MIOpen Backward Weights Conv. Algorithm: 3, Solution: 37/ConvBinWinogradRxSf3x2
Backward Convolution Weights Verifies OK on GPU reference (7.3594e-06 < 3e-05)

MIOpenDriver conv -n 2 -c 256 -H 1024 -W 1023 -k 128 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 4 -t 1
MIOpen Backward Weights Conv. Algorithm: 3, Solution: 37/ConvBinWinogradRxSf3x2
Backward Convolution Weights Verifies OK on GPU reference (1.05197e-05 < 3e-05)

MIOpenDriver conv -n 3 -c 256 -H 1024 -W 1023 -k 128 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 4 -t 1
MIOpen Backward Weights Conv. Algorithm: 3, Solution: 37/ConvBinWinogradRxSf3x2
Backward Convolution Weights Verifies OK on GPU reference (1.3601e-05 < 3e-05)

MIOpenDriver conv -n 2 -c 256 -H 1024 -W 1024 -k 128 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 4 -t 1
MIOpen Backward Weights Conv. Algorithm: 5, Solution: 110/ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC
Backward Convolution Weights Verifies OK on GPU reference (2.67907e-07 < 0.01)
```

#### Shape restricted by the new constraint

```text
MIOpenDriver conv -n 2 -c 256 -H 1024 -W 1024 -k 128 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 4 -t 1
MIOpen Error: ctr-cx63-mi300x-12.amd.com:/home/AMD/grsergei/rocm-libraries/projects/miopen/src/ocl/convolutionocl.cpp:1394: No suitable algorithm was found to execute the required convolution
```

## Submission Checklist

- [x] Looked over the [contributing guidelines](https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests).