### PR TITLE
[CK_TILE] Skip padded k/n fragment work in qr_hpad FMHA fwd

### DIFF
--- a/projects/composablekernel/example/ck_tile/01_fmha/codegen/ops/fmha_fwd.py
+++ b/projects/composablekernel/example/ck_tile/01_fmha/codegen/ops/fmha_fwd.py
@@ -1194,6 +1194,11 @@ class KernelComponentFactoryGfx11(CompatibilityRuleFactory):
             if (problem_ctx.hdim, problem_ctx.hdim_v) != (128, 128):
                 return True
 
+            # For (128, 128) head dims, partial-fragment support in qr_hpad removes the need
+            # for the previous qr_hpad-specific handling that was added to avoid register spill.
+            # qr_hpad now reuses the regular 128x64 tile choice.
+            # The 64x64 tile remains disabled for qr_hpad because it is consistently slower
+            # in our measurements.
             if kernel_ctx.tile.F_bm0 == 64 and kernel_ctx.tile.F_bn0 == 64:
                 return kernel_ctx.pipeline.tag != "qr_hpad"
 

--- a/projects/composablekernel/example/ck_tile/01_fmha/codegen/ops/fmha_fwd.py
+++ b/projects/composablekernel/example/ck_tile/01_fmha/codegen/ops/fmha_fwd.py
@@ -1194,18 +1194,10 @@ class KernelComponentFactoryGfx11(CompatibilityRuleFactory):
             if (problem_ctx.hdim, problem_ctx.hdim_v) != (128, 128):
                 return True
 
-            is_64x32_tile = kernel_ctx.tile.F_bm0 == 64 and kernel_ctx.tile.F_bn0 == 32
-            pads_hdim = (
-                kernel_ctx.pipeline.F_dpad == "t" and kernel_ctx.pipeline.F_dvpad == "t"
-            )
-            exact_hdim = (
-                kernel_ctx.pipeline.F_dpad == "f" and kernel_ctx.pipeline.F_dvpad == "f"
-            )
+            if kernel_ctx.tile.F_bm0 == 64 and kernel_ctx.tile.F_bn0 == 64:
+                return kernel_ctx.pipeline.tag != "qr_hpad"
 
-            if is_64x32_tile:
-                return pads_hdim
-
-            return exact_hdim
+            return True
 
         rules.append(check_d128_tile_pipeline)
         return rules
@@ -1218,8 +1210,7 @@ class KernelComponentFactoryGfx11(CompatibilityRuleFactory):
                 ( 32,  32) : [FmhaFwdTileSize( 64,  64,  16,  32,  32,   32,  4, 1, 1,  4, 1, 1,  16, 16, 16,  16, 16, 16,  -1)],
                 ( 64,  64) : [FmhaFwdTileSize( 64,  64,  32,  64,  32,   64,  4, 1, 1,  4, 1, 1,  16, 16, 16,  16, 16, 16,  -1, CppConstraint("a.max_seqlen_q < 4096")),
                               FmhaFwdTileSize(128,  64,  32,  64,  32,   64,  8, 1, 1,  8, 1, 1,  16, 16, 16,  16, 16, 16,  -1)],
-                (128, 128) : [FmhaFwdTileSize( 64,  32,  32, 128,  32,  128,  4, 1, 1,  4, 1, 1,  16, 16, 16,  16, 16, 16,   6, CppConstraint("a.hdim_q != 128 || a.hdim_v != 128")),
-                              FmhaFwdTileSize( 64,  64,  32, 128,  32,  128,  4, 1, 1,  4, 1, 1,  16, 16, 16,  16, 16, 16,  -1, CppConstraint("a.max_seqlen_q < 4096")),
+                (128, 128) : [FmhaFwdTileSize( 64,  64,  32, 128,  32,  128,  4, 1, 1,  4, 1, 1,  16, 16, 16,  16, 16, 16,  -1, CppConstraint("a.max_seqlen_q < 2048")),
                               FmhaFwdTileSize(128,  64,  32, 128,  32,  128,  8, 1, 1,  8, 1, 1,  16, 16, 16,  16, 16, 16,   6)],
                 (192, 128) : [FmhaFwdTileSize( 64,  64,  32, 128,  32,  256,  4, 1, 1,  4, 1, 1,  16, 16, 16,  16, 16, 16,  -1)],
                 (256, 256) : [FmhaFwdTileSize(128,  64,  32, 256,  32,  256,  8, 1, 1,  8, 1, 1,  16, 16, 16,  16, 16, 16,   6)]

--- a/projects/composablekernel/include/ck_tile/ops/fmha/kernel/fmha_fwd_kernel.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/fmha/kernel/fmha_fwd_kernel.hpp
@@ -39,6 +39,9 @@ struct FmhaFwdKernel
     using EpiloguePipeline                       = ck_tile::remove_cvref_t<EpiloguePipeline_>;
     static constexpr ck_tile::index_t kBlockSize = FmhaPipeline::kBlockSize;
 
+    template <typename T>
+    using has_enable_tail_skip = decltype(T::kEnableTailSkip);
+
     static constexpr ck_tile::index_t kBlockPerCu = FmhaPipeline::kBlockPerCu;
     static_assert(kBlockPerCu > 0);
     static constexpr ck_tile::index_t kBlockPerCuInput = FmhaPipeline::Problem::kBlockPerCu;
@@ -1892,14 +1895,10 @@ struct FmhaFwdKernel
 
             BlockIndices block_indices{i_batch, i_nhead, i_nhead_k};
             constexpr bool kPassTailReqs = [] {
-                if constexpr(requires { FmhaPipeline::kEnableTailSkip; })
-                {
-                    return FmhaPipeline::kEnableTailSkip;
-                }
+                if constexpr(ck_tile::is_detected<has_enable_tail_skip, FmhaPipeline>::value)
+                    return static_cast<bool>(FmhaPipeline::kEnableTailSkip);
                 else
-                {
                     return false;
-                }
             }();
             auto invoke_fmha_pipeline = [&](auto&&... args) -> decltype(auto) {
                 if constexpr(kPassTailReqs)

--- a/projects/composablekernel/include/ck_tile/ops/fmha/kernel/fmha_fwd_kernel.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/fmha/kernel/fmha_fwd_kernel.hpp
@@ -40,7 +40,7 @@ struct FmhaFwdKernel
     static constexpr ck_tile::index_t kBlockSize = FmhaPipeline::kBlockSize;
 
     template <typename T>
-    using has_enable_tail_skip = decltype(T::kEnableTailSkip);
+    using has_head_dim_tail_args = decltype(T::kUseHeadDimTailArgs);
 
     static constexpr ck_tile::index_t kBlockPerCu = FmhaPipeline::kBlockPerCu;
     static_assert(kBlockPerCu > 0);
@@ -1894,20 +1894,20 @@ struct FmhaFwdKernel
             }();
 
             BlockIndices block_indices{i_batch, i_nhead, i_nhead_k};
-            constexpr bool kPassTailReqs = [] {
-                if constexpr(ck_tile::is_detected<has_enable_tail_skip, FmhaPipeline>::value)
-                    return static_cast<bool>(FmhaPipeline::kEnableTailSkip);
+            constexpr bool kPassHeadDimTailArgs = [] {
+                if constexpr(ck_tile::is_detected<has_head_dim_tail_args, FmhaPipeline>::value)
+                    return static_cast<bool>(FmhaPipeline::kUseHeadDimTailArgs);
                 else
                     return false;
             }();
             auto invoke_fmha_pipeline = [&](auto&&... args) -> decltype(auto) {
-                if constexpr(kPassTailReqs)
+                if constexpr(kPassHeadDimTailArgs)
                 {
                     const ck_tile::index_t valid_k0_loops =
                         ck_tile::integer_divide_ceil(kargs.hdim_q, FmhaPipeline::kK0);
-                    const ck_tile::index_t valid_last_k0_columns =
+                    const ck_tile::index_t valid_last_k0_length =
                         kargs.hdim_q - (valid_k0_loops - 1) * FmhaPipeline::kK0;
-                    const ck_tile::index_t valid_n1_columns = [&]() {
+                    const ck_tile::index_t valid_n1_length = [&]() {
                         const ck_tile::index_t remaining_n1 = kargs.hdim_v - i_n1;
                         return ck_tile::min(remaining_n1,
                                             static_cast<ck_tile::index_t>(FmhaPipeline::kN1));
@@ -1915,8 +1915,8 @@ struct FmhaFwdKernel
                     return FmhaPipeline{}(static_cast<decltype(args)&&>(args)...,
                                           sink_value,
                                           valid_k0_loops,
-                                          valid_last_k0_columns,
-                                          valid_n1_columns);
+                                          valid_last_k0_length,
+                                          valid_n1_length);
                 }
                 else
                 {

--- a/projects/composablekernel/include/ck_tile/ops/fmha/kernel/fmha_fwd_kernel.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/fmha/kernel/fmha_fwd_kernel.hpp
@@ -40,7 +40,7 @@ struct FmhaFwdKernel
     static constexpr ck_tile::index_t kBlockSize = FmhaPipeline::kBlockSize;
 
     template <typename T>
-    using has_head_dim_tail_args = decltype(T::kUseHeadDimTailArgs);
+    using has_hdim_tail_args = decltype(T::kUseHdimTailArgs);
 
     static constexpr ck_tile::index_t kBlockPerCu = FmhaPipeline::kBlockPerCu;
     static_assert(kBlockPerCu > 0);
@@ -1894,14 +1894,14 @@ struct FmhaFwdKernel
             }();
 
             BlockIndices block_indices{i_batch, i_nhead, i_nhead_k};
-            constexpr bool kPassHeadDimTailArgs = [] {
-                if constexpr(ck_tile::is_detected<has_head_dim_tail_args, FmhaPipeline>::value)
-                    return static_cast<bool>(FmhaPipeline::kUseHeadDimTailArgs);
+            constexpr bool kPassHdimTailArgs = [] {
+                if constexpr(ck_tile::is_detected<has_hdim_tail_args, FmhaPipeline>::value)
+                    return static_cast<bool>(FmhaPipeline::kUseHdimTailArgs);
                 else
                     return false;
             }();
             auto invoke_fmha_pipeline = [&](auto&&... args) -> decltype(auto) {
-                if constexpr(kPassHeadDimTailArgs)
+                if constexpr(kPassHdimTailArgs)
                 {
                     const ck_tile::index_t valid_k0_loops =
                         ck_tile::integer_divide_ceil(kargs.hdim_q, FmhaPipeline::kK0);

--- a/projects/composablekernel/include/ck_tile/ops/fmha/kernel/fmha_fwd_kernel.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/fmha/kernel/fmha_fwd_kernel.hpp
@@ -1906,6 +1906,8 @@ struct FmhaFwdKernel
                 {
                     const ck_tile::index_t valid_k0_loops =
                         ck_tile::integer_divide_ceil(kargs.hdim_q, FmhaPipeline::kK0);
+                    const ck_tile::index_t valid_last_k0_columns =
+                        kargs.hdim_q - (valid_k0_loops - 1) * FmhaPipeline::kK0;
                     const ck_tile::index_t valid_n1_columns = [&]() {
                         const ck_tile::index_t remaining_n1 = kargs.hdim_v - i_n1;
                         return ck_tile::min(remaining_n1,
@@ -1914,6 +1916,7 @@ struct FmhaFwdKernel
                     return FmhaPipeline{}(static_cast<decltype(args)&&>(args)...,
                                           sink_value,
                                           valid_k0_loops,
+                                          valid_last_k0_columns,
                                           valid_n1_columns);
                 }
                 else

--- a/projects/composablekernel/include/ck_tile/ops/fmha/kernel/fmha_fwd_kernel.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/fmha/kernel/fmha_fwd_kernel.hpp
@@ -1891,6 +1891,36 @@ struct FmhaFwdKernel
             }();
 
             BlockIndices block_indices{i_batch, i_nhead, i_nhead_k};
+            constexpr bool kPassTailReqs = [] {
+                if constexpr(requires { FmhaPipeline::kEnableTailSkip; })
+                {
+                    return FmhaPipeline::kEnableTailSkip;
+                }
+                else
+                {
+                    return false;
+                }
+            }();
+            auto invoke_fmha_pipeline = [&](auto&&... args) -> decltype(auto) {
+                if constexpr(kPassTailReqs)
+                {
+                    const ck_tile::index_t valid_k0_loops =
+                        ck_tile::integer_divide_ceil(kargs.hdim_q, FmhaPipeline::kK0);
+                    const ck_tile::index_t valid_n1_columns = [&]() {
+                        const ck_tile::index_t remaining_n1 = kargs.hdim_v - i_n1;
+                        return ck_tile::min(remaining_n1,
+                                            static_cast<ck_tile::index_t>(FmhaPipeline::kN1));
+                    }();
+                    return FmhaPipeline{}(static_cast<decltype(args)&&>(args)...,
+                                          sink_value,
+                                          valid_k0_loops,
+                                          valid_n1_columns);
+                }
+                else
+                {
+                    return FmhaPipeline{}(static_cast<decltype(args)&&>(args)..., sink_value);
+                }
+            };
 
             auto o_acc_tile = [&, i_nhead_ = i_nhead, i_nhead_k_ = i_nhead_k]() {
                 if constexpr(QScaleEnum == BlockAttentionQuantScaleEnum::PERTENSOR)
@@ -1910,36 +1940,35 @@ struct FmhaFwdKernel
                         else
                             return ck_tile::scales<remove_cvref_t<decltype(scale_o)>>{scale_o};
                     }();
-                    return FmhaPipeline{}(q_dram_window,
-                                          identity{}, // q_element_func
-                                          k_dram_window,
-                                          identity{}, // k_element_func
-                                          v_dram_window,
-                                          identity{}, // v_element_func
-                                          bias_dram_window,
-                                          identity{}, // bias_element_func
-                                          randval_dram_window,
-                                          lse_dram_window,
-                                          identity{}, // lse_element_func
-                                          identity{}, // s_acc_element_func
-                                          scales<remove_cvref_t<decltype(scale_p)>>{
-                                              scale_p},       // p_compute_element_func
-                                          o_acc_element_func, // o_acc_element_func
-                                          mask,
-                                          position_encoding,
-                                          variant_params.sm_scale,
-                                          variant,
-                                          variant_params,
-                                          block_indices,
-                                          smem_ptr,
-                                          dropout,
-                                          nullptr,
-                                          nullptr,
-                                          1,
-                                          make_null_tile_window(make_tuple()),
-                                          make_null_tile_window(make_tuple()),
-                                          make_null_tile_window(make_tuple()),
-                                          sink_value);
+                    return invoke_fmha_pipeline(q_dram_window,
+                                                identity{}, // q_element_func
+                                                k_dram_window,
+                                                identity{}, // k_element_func
+                                                v_dram_window,
+                                                identity{}, // v_element_func
+                                                bias_dram_window,
+                                                identity{}, // bias_element_func
+                                                randval_dram_window,
+                                                lse_dram_window,
+                                                identity{}, // lse_element_func
+                                                identity{}, // s_acc_element_func
+                                                scales<remove_cvref_t<decltype(scale_p)>>{
+                                                    scale_p},       // p_compute_element_func
+                                                o_acc_element_func, // o_acc_element_func
+                                                mask,
+                                                position_encoding,
+                                                variant_params.sm_scale,
+                                                variant,
+                                                variant_params,
+                                                block_indices,
+                                                smem_ptr,
+                                                dropout,
+                                                nullptr,
+                                                nullptr,
+                                                1,
+                                                make_null_tile_window(make_tuple()),
+                                                make_null_tile_window(make_tuple()),
+                                                make_null_tile_window(make_tuple()));
                 }
                 else if constexpr(QScaleEnum == BlockAttentionQuantScaleEnum::BLOCKSCALE)
                 {
@@ -1964,7 +1993,7 @@ struct FmhaFwdKernel
                     // Both P and rowsum are scaled by 2^shift, canceling in normalization
                     // No additional scaling needed in p_compute_element_func or o_acc_element_func
 
-                    return FmhaPipeline{}(
+                    return invoke_fmha_pipeline(
                         q_dram_window,
                         identity{}, // q_element_func
                         k_dram_window,
@@ -1992,8 +2021,7 @@ struct FmhaFwdKernel
                         kargs.block_scale_size_kv,
                         make_null_tile_window(make_tuple()),
                         make_null_tile_window(make_tuple()),
-                        make_null_tile_window(make_tuple()),
-                        sink_value);
+                        make_null_tile_window(make_tuple()));
                 }
                 else if constexpr(QScaleEnum == BlockAttentionQuantScaleEnum::MX)
                 {
@@ -2098,53 +2126,51 @@ struct FmhaFwdKernel
                                    number<FmhaPipeline::kK1 / kVScaleGranularity>{}),
                         {i_n1, 0});
 
-                    return FmhaPipeline{}(q_dram_window,
-                                          identity{}, // q_element_func
-                                          k_dram_window,
-                                          identity{}, // k_element_func
-                                          v_dram_window,
-                                          identity{}, // v_element_func
-                                          bias_dram_window,
-                                          identity{}, // bias_element_func
-                                          randval_dram_window,
-                                          lse_dram_window,
-                                          identity{}, // lse_element_func
-                                          identity{}, // s_acc_element_func
-                                          identity{}, // p_compute_element_func
-                                          identity{}, // o_acc_element_func
-                                          mask,
-                                          position_encoding,
-                                          kargs.scale_s,
-                                          variant,
-                                          variant_params,
-                                          block_indices,
-                                          smem_ptr,
-                                          dropout,
-                                          nullptr,
-                                          nullptr,
-                                          1,
-                                          q_scale_dram_window,
-                                          k_scale_dram_window,
-                                          v_scale_dram_window,
-                                          sink_value);
+                    return invoke_fmha_pipeline(q_dram_window,
+                                                identity{}, // q_element_func
+                                                k_dram_window,
+                                                identity{}, // k_element_func
+                                                v_dram_window,
+                                                identity{}, // v_element_func
+                                                bias_dram_window,
+                                                identity{}, // bias_element_func
+                                                randval_dram_window,
+                                                lse_dram_window,
+                                                identity{}, // lse_element_func
+                                                identity{}, // s_acc_element_func
+                                                identity{}, // p_compute_element_func
+                                                identity{}, // o_acc_element_func
+                                                mask,
+                                                position_encoding,
+                                                kargs.scale_s,
+                                                variant,
+                                                variant_params,
+                                                block_indices,
+                                                smem_ptr,
+                                                dropout,
+                                                nullptr,
+                                                nullptr,
+                                                1,
+                                                q_scale_dram_window,
+                                                k_scale_dram_window,
+                                                v_scale_dram_window);
                 }
                 else
                 {
-                    return FmhaPipeline{}(q_dram_window,
-                                          k_dram_window,
-                                          v_dram_window,
-                                          bias_dram_window,
-                                          randval_dram_window,
-                                          lse_dram_window,
-                                          mask,
-                                          position_encoding,
-                                          variant_params.sm_scale,
-                                          variant,
-                                          variant_params,
-                                          block_indices,
-                                          smem_ptr,
-                                          dropout,
-                                          sink_value);
+                    return invoke_fmha_pipeline(q_dram_window,
+                                                k_dram_window,
+                                                v_dram_window,
+                                                bias_dram_window,
+                                                randval_dram_window,
+                                                lse_dram_window,
+                                                mask,
+                                                position_encoding,
+                                                variant_params.sm_scale,
+                                                variant,
+                                                variant_params,
+                                                block_indices,
+                                                smem_ptr,
+                                                dropout);
                 }
             }();
 

--- a/projects/composablekernel/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs.hpp
@@ -71,7 +71,7 @@ struct BlockFmhaPipelineQRKSVS
     static constexpr auto QScaleEnum          = Problem::QScaleEnum;
     static constexpr bool kHasSink            = Problem::kHasSink;
     static constexpr bool kPaddedVecLoadStore = PaddedVecLoadStore_;
-    static constexpr bool kUseHeadDimTailArgs = kPadHeadDimQ || kPadHeadDimV;
+    static constexpr bool kUseHdimTailArgs = kPadHeadDimQ || kPadHeadDimV;
 
     static constexpr ck_tile::index_t kQKScaleGranularity = Problem::kQKScaleGranularity;
     static constexpr ck_tile::index_t kVScaleGranularity  = Problem::kVScaleGranularity;

--- a/projects/composablekernel/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs.hpp
@@ -275,7 +275,7 @@ struct BlockFmhaPipelineQRKSVS
         constexpr auto gemm_0_config =
             BlockGemm0::Policy::template GetWarpGemmMWarpNWarp<Problem>();
         using Gemm0WarpGemm           = remove_cvref_t<decltype(gemm_0_config.template at<0>())>;
-        constexpr index_t kGemm0WarpK = Gemm0WarpGemm::WarpGemmAttribute::Impl::kK;
+        constexpr index_t kGemm0WarpK = Gemm0WarpGemm::kK;
         constexpr index_t kGemm0KItersPerBlock = kK0 / kGemm0WarpK;
         constexpr bool kCanUsePartialGemm0Tail =
             kPadHeadDimQ && kIsQKGemm0V2 && (kGemm0KItersPerBlock > 1);

--- a/projects/composablekernel/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs.hpp
@@ -71,7 +71,7 @@ struct BlockFmhaPipelineQRKSVS
     static constexpr auto QScaleEnum          = Problem::QScaleEnum;
     static constexpr bool kHasSink            = Problem::kHasSink;
     static constexpr bool kPaddedVecLoadStore = PaddedVecLoadStore_;
-    static constexpr bool kUseHdimTailArgs = kPadHeadDimQ || kPadHeadDimV;
+    static constexpr bool kUseHdimTailArgs    = kPadHeadDimQ || kPadHeadDimV;
 
     static constexpr ck_tile::index_t kQKScaleGranularity = Problem::kQKScaleGranularity;
     static constexpr ck_tile::index_t kVScaleGranularity  = Problem::kVScaleGranularity;

--- a/projects/composablekernel/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs.hpp
@@ -41,6 +41,8 @@ struct BlockFmhaPipelineQRKSVS
 
     template <typename T>
     using has_partial_k_support = decltype(T::kSupportsPartialK);
+    template <typename T>
+    using has_partial_n_support = decltype(T::kSupportsPartialN);
 
     using BlockFmhaShape             = remove_cvref_t<typename Problem::BlockFmhaShape>;
     using VLayout                    = remove_cvref_t<typename BlockFmhaShape::VLayout>;
@@ -89,8 +91,6 @@ struct BlockFmhaPipelineQRKSVS
                   (!CK_TILE_FMHA_FWD_FAST_EXP2 && !kHasLogitsSoftCap));
     static_assert(!kPaddedVecLoadStore || (kPadHeadDimQ && kPadHeadDimV),
                   "padded vector load/store fast path only applies to padded head-dim kernels");
-    static_assert(!(kPadHeadDimV && QScaleEnum == BlockAttentionQuantScaleEnum::MX),
-                  "MX with padded hdim_v is not supported yet");
 
     // last dimension vector length used to create tensor view(and decide buffer_load vector length)
     // ... together with tensor distribution. tensor dist should able to overwrite this
@@ -273,9 +273,16 @@ struct BlockFmhaPipelineQRKSVS
         constexpr auto gemm_0                      = Policy::template GetQKBlockGemm<Problem>();
         constexpr auto gemm_1                      = Policy::template GetKVBlockGemm<Problem>();
         using BlockGemm0                           = remove_cvref_t<decltype(gemm_0)>;
+        using BlockGemm1                           = remove_cvref_t<decltype(gemm_1)>;
         constexpr bool kBlockGemm0SupportsPartialK = [] {
             if constexpr(ck_tile::is_detected<has_partial_k_support, BlockGemm0>::value)
                 return static_cast<bool>(BlockGemm0::kSupportsPartialK);
+            else
+                return false;
+        }();
+        constexpr bool kBlockGemm1SupportsPartialN = [] {
+            if constexpr(ck_tile::is_detected<has_partial_n_support, BlockGemm1>::value)
+                return static_cast<bool>(BlockGemm1::kSupportsPartialN);
             else
                 return false;
         }();
@@ -285,7 +292,7 @@ struct BlockFmhaPipelineQRKSVS
         using Gemm0WarpGemm           = remove_cvref_t<decltype(gemm_0_config.template at<0>())>;
         constexpr index_t kGemm0WarpK = Gemm0WarpGemm::kK;
         constexpr index_t kGemm0KItersPerBlock = kK0 / kGemm0WarpK;
-        constexpr bool kUsePartialKForTail =
+        constexpr bool kUsePartialKForGemm0Tail =
             kPadHeadDimQ && kBlockGemm0SupportsPartialK && (kGemm0KItersPerBlock > 1);
 
         auto q_dram_window = make_tile_window(q_dram_block_window_tmp.get_bottom_tensor_view(),
@@ -455,8 +462,8 @@ struct BlockFmhaPipelineQRKSVS
         // Number of k0 iterations prefetched ahead of the current compute iteration.
         // The skip decision must be made this many iterations before the last k0 loop.
         constexpr index_t kK0PrefetchDepth = 2;
-        const index_t tail_k_iters         = [&]() {
-            if constexpr(kUsePartialKForTail)
+        const index_t gemm0_tail_k_iters   = [&]() {
+            if constexpr(kUsePartialKForGemm0Tail)
             {
                 return ck_tile::integer_divide_ceil(valid_last_k0_length, kGemm0WarpK);
             }
@@ -563,16 +570,16 @@ struct BlockFmhaPipelineQRKSVS
             }
 
             auto run_gemm_0 = [&](auto i_k0) {
-                if constexpr(kUsePartialKForTail)
+                if constexpr(kUsePartialKForGemm0Tail)
                 {
                     if(static_cast<index_t>(i_k0.value) == (valid_k0_loops - 1) &&
-                       tail_k_iters < kGemm0KItersPerBlock)
+                       gemm0_tail_k_iters < kGemm0KItersPerBlock)
                     {
                         static_for<1, kGemm0KItersPerBlock, 1>{}([&](auto i_tail_k_iter) {
                             constexpr index_t kTailKIters = i_tail_k_iter;
                             constexpr index_t kTailK0     = kTailKIters * kGemm0WarpK;
 
-                            if(tail_k_iters == kTailKIters)
+                            if(gemm0_tail_k_iters == kTailKIters)
                             {
                                 using Gemm0TailProblem = BlockGemmProblem<
                                     QDataType,
@@ -1034,23 +1041,30 @@ struct BlockFmhaPipelineQRKSVS
             auto o_acc0 = decltype(o_acc){};
             clear_tile(o_acc0);
 
-            auto run_gemm_1_impl = [&](auto& o_acc_tensor, const auto& p_slice) {
-                if constexpr(kPadHeadDimV)
+            constexpr auto gemm_1_config =
+                BlockGemm1::Policy::template GetWarpGemmMWarpNWarp<Problem>();
+            using Gemm1WarpGemm = remove_cvref_t<decltype(gemm_1_config.template at<0>())>;
+            constexpr index_t kGemm1NWarp    = gemm_1_config.template at<2>();
+            constexpr index_t kGemm1NPerIter = kGemm1NWarp * Gemm1WarpGemm::kN;
+            const index_t valid_n_iters      = [&]() {
+                if constexpr(kPadHeadDimV && kBlockGemm1SupportsPartialN)
                 {
-                    constexpr auto gemm_1_config =
-                        decltype(gemm_1)::Policy::template GetWarpGemmMWarpNWarp<Problem>();
-                    using Gemm1WarpGemm = remove_cvref_t<decltype(gemm_1_config.template at<0>())>;
-                    constexpr index_t kGemm1NWarp    = gemm_1_config.template at<2>();
-                    constexpr index_t kGemm1NPerIter = kGemm1NWarp * Gemm1WarpGemm::kN;
-                    const index_t valid_n_iters =
-                        ck_tile::integer_divide_ceil(valid_n1_length, kGemm1NPerIter);
-                    gemm_1(o_acc_tensor, p_slice, v_lds_window, valid_n_iters);
+                    return ck_tile::integer_divide_ceil(valid_n1_length, kGemm1NPerIter);
                 }
-                else
-                {
-                    gemm_1(o_acc_tensor, p_slice, v_lds_window);
-                }
-            };
+                return static_cast<index_t>(0);
+            }();
+
+            auto run_gemm_1_impl =
+                [&](auto& o_acc_tensor, const auto& p_slice, const auto&... gemm_1_args) {
+                    if constexpr(kPadHeadDimV && kBlockGemm1SupportsPartialN)
+                    {
+                        gemm_1(o_acc_tensor, p_slice, gemm_1_args..., valid_n_iters);
+                    }
+                    else
+                    {
+                        gemm_1(o_acc_tensor, p_slice, gemm_1_args...);
+                    }
+                };
 
             auto run_gemm_1 = [&](auto i_k1) {
                 auto p_slice =
@@ -1061,17 +1075,18 @@ struct BlockFmhaPipelineQRKSVS
                         get_slice_tile(p_scale,
                                        sequence<0, i_k1*(kK1 / kVScaleGranularity)>{},
                                        sequence<kM0, (i_k1 + 1) * (kK1 / kVScaleGranularity)>{});
-                    gemm_1(o_acc, p_slice, p_scale_slice, v_lds_window, v_scale_block_tile);
+                    run_gemm_1_impl(
+                        o_acc, p_slice, p_scale_slice, v_lds_window, v_scale_block_tile);
                 }
                 else
                 {
                     if constexpr(QScaleEnum == BlockAttentionQuantScaleEnum::BLOCKSCALE)
                     {
-                        run_gemm_1_impl(o_acc0, p_slice);
+                        run_gemm_1_impl(o_acc0, p_slice, v_lds_window);
                     }
                     else
                     {
-                        run_gemm_1_impl(o_acc, p_slice);
+                        run_gemm_1_impl(o_acc, p_slice, v_lds_window);
                     }
                 }
             };

--- a/projects/composablekernel/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs.hpp
@@ -68,6 +68,7 @@ struct BlockFmhaPipelineQRKSVS
     static constexpr auto QScaleEnum          = Problem::QScaleEnum;
     static constexpr bool kHasSink            = Problem::kHasSink;
     static constexpr bool kPaddedVecLoadStore = PaddedVecLoadStore_;
+    static constexpr bool kEnableTailSkip     = kPadHeadDimQ || kPadHeadDimV;
 
     static constexpr ck_tile::index_t kQKScaleGranularity = Problem::kQKScaleGranularity;
     static constexpr ck_tile::index_t kVScaleGranularity  = Problem::kVScaleGranularity;
@@ -203,7 +204,9 @@ struct BlockFmhaPipelineQRKSVS
                    k_scale_dram_block_window_tmp, // N0*(K0/kQKScaleGranularity) tile
                const VScaleDramBlockWindowTmp&
                    v_scale_dram_block_window_tmp, // N1*(K1/kVScaleGranularity) tile
-               const float sink_v) const
+               const float sink_v,
+               const index_t valid_k0_loops = kQKHeaddim / kK0,
+               const index_t valid_n1_columns = kN1) const
     {
         static_assert(
             std::is_same_v<QDataType, remove_cvref_t<typename QDramBlockWindowTmp::DataType>> &&
@@ -428,6 +431,43 @@ struct BlockFmhaPipelineQRKSVS
         index_t i_total_loops      = 0;
         constexpr index_t k0_loops = kQKHeaddim / kK0;
         constexpr index_t k1_loops = kN0 / kK1;
+        const index_t clamped_valid_k0_loops = [&]() {
+            if constexpr(!kPadHeadDimQ)
+            {
+                return static_cast<index_t>(k0_loops);
+            }
+            if(valid_k0_loops < 1)
+            {
+                return index_t{1};
+            }
+            if(valid_k0_loops > k0_loops)
+            {
+                return static_cast<index_t>(k0_loops);
+            }
+            return valid_k0_loops;
+        }();
+        const index_t clamped_valid_n1_columns = [&]() {
+            if constexpr(!kPadHeadDimV)
+            {
+                return static_cast<index_t>(kN1);
+            }
+            if(valid_n1_columns < 1)
+            {
+                return index_t{1};
+            }
+            if(valid_n1_columns > kN1)
+            {
+                return static_cast<index_t>(kN1);
+            }
+            return valid_n1_columns;
+        }();
+        const bool skip_last_k0_loop = [&]() {
+            if constexpr(kPadHeadDimQ)
+            {
+                return clamped_valid_k0_loops == (k0_loops - 1);
+            }
+            return false;
+        }();
         // Use compile-time conditional for group barrier sequence
         // (No runtime lambda selection)
         auto schedule_gemm_0 = [] {
@@ -546,13 +586,31 @@ struct BlockFmhaPipelineQRKSVS
                     block_sync_lds();
                     run_gemm_0(number<i_k0>{});
                     block_sync_lds();
-                    move_tile_window(k_dram_window, {0, kK0});
+                    if constexpr(kPadHeadDimQ && i_k0 == (k0_loops - 3))
+                    {
+                        if(!skip_last_k0_loop)
+                        {
+                            move_tile_window(k_dram_window, {0, kK0});
+                        }
 
-                    store_tile(
-                        k_lds_window,
-                        tile_elementwise_in(k_element_func, k_block_tile)); // LDS write i + 1
-                    k_block_tile = load_tile(k_dram_window);                // global read i + 2
+                        store_tile(
+                            k_lds_window,
+                            tile_elementwise_in(k_element_func, k_block_tile)); // LDS write i + 1
 
+                        if(!skip_last_k0_loop)
+                        {
+                            k_block_tile = load_tile(k_dram_window); // global read i + 2
+                        }
+                    }
+                    else
+                    {
+                        move_tile_window(k_dram_window, {0, kK0});
+
+                        store_tile(
+                            k_lds_window,
+                            tile_elementwise_in(k_element_func, k_block_tile)); // LDS write i + 1
+                        k_block_tile = load_tile(k_dram_window);                // global read i + 2
+                    }
                     k_scale_block_tile = load_k_scale_block_tile();
                 });
             }
@@ -578,15 +636,18 @@ struct BlockFmhaPipelineQRKSVS
             { // tail
                 block_sync_lds();
                 run_gemm_0(number<k0_loops - 2>{});
-                block_sync_lds();
+                if(!skip_last_k0_loop)
+                {
+                    block_sync_lds();
 
-                store_tile(k_lds_window, tile_elementwise_in(k_element_func, k_block_tile));
+                    store_tile(k_lds_window, tile_elementwise_in(k_element_func, k_block_tile));
 
-                k_scale_block_tile = load_k_scale_block_tile();
+                    k_scale_block_tile = load_k_scale_block_tile();
 
-                block_sync_lds();
+                    block_sync_lds();
 
-                run_gemm_0(number<k0_loops - 1>{});
+                    run_gemm_0(number<k0_loops - 1>{});
+                }
             }
             if constexpr(kVPrefetch == VPrefetchPoint::AfterGemm0Tail)
             {
@@ -933,6 +994,25 @@ struct BlockFmhaPipelineQRKSVS
             auto o_acc0 = decltype(o_acc){};
             clear_tile(o_acc0);
 
+            auto run_gemm_1_impl = [&](auto& o_acc_tensor, const auto& p_slice) {
+                if constexpr(kPadHeadDimV)
+                {
+                    constexpr auto gemm_1_config =
+                        decltype(gemm_1)::Policy::template GetWarpGemmMWarpNWarp<Problem>();
+                    using Gemm1WarpGemm =
+                        remove_cvref_t<decltype(gemm_1_config.template at<0>())>;
+                    constexpr index_t kGemm1NWarp = gemm_1_config.template at<2>();
+                    constexpr index_t kGemm1NPerIter = kGemm1NWarp * Gemm1WarpGemm::kN;
+                    const index_t valid_gemm_1_n_iters =
+                        ck_tile::integer_divide_ceil(clamped_valid_n1_columns, kGemm1NPerIter);
+                    gemm_1(o_acc_tensor, p_slice, v_lds_window, valid_gemm_1_n_iters);
+                }
+                else
+                {
+                    gemm_1(o_acc_tensor, p_slice, v_lds_window);
+                }
+            };
+
             auto run_gemm_1 = [&](auto i_k1) {
                 auto p_slice =
                     get_slice_tile(p, sequence<0, i_k1 * kK1>{}, sequence<kM0, (i_k1 + 1) * kK1>{});
@@ -944,13 +1024,16 @@ struct BlockFmhaPipelineQRKSVS
                                        sequence<kM0, (i_k1 + 1) * (kK1 / kVScaleGranularity)>{});
                     gemm_1(o_acc, p_slice, p_scale_slice, v_lds_window, v_scale_block_tile);
                 }
-                else if constexpr(QScaleEnum == BlockAttentionQuantScaleEnum::BLOCKSCALE)
-                {
-                    gemm_1(o_acc0, p_slice, v_lds_window);
-                }
                 else
                 {
-                    gemm_1(o_acc, p_slice, v_lds_window);
+                    if constexpr(QScaleEnum == BlockAttentionQuantScaleEnum::BLOCKSCALE)
+                    {
+                        run_gemm_1_impl(o_acc0, p_slice);
+                    }
+                    else
+                    {
+                        run_gemm_1_impl(o_acc, p_slice);
+                    }
                 }
             };
 
@@ -1099,7 +1182,9 @@ struct BlockFmhaPipelineQRKSVS
                const BlockIndices& block_indices,
                void* smem_ptr,
                DropoutType& dropout,
-               const float sink_v) const
+               const float sink_v,
+               const index_t valid_k0_loops = kQKHeaddim / kK0,
+               const index_t valid_n1_columns = kN1) const
     {
         return operator()(q_dram_block_window_tmp,
                           identity{},
@@ -1129,7 +1214,9 @@ struct BlockFmhaPipelineQRKSVS
                           make_null_tile_window(make_tuple()),
                           make_null_tile_window(make_tuple()),
                           make_null_tile_window(make_tuple()),
-                          sink_v);
+                          sink_v,
+                          valid_k0_loops,
+                          valid_n1_columns);
     }
 };
 

--- a/projects/composablekernel/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs.hpp
@@ -205,9 +205,9 @@ struct BlockFmhaPipelineQRKSVS
                const VScaleDramBlockWindowTmp&
                    v_scale_dram_block_window_tmp, // N1*(K1/kVScaleGranularity) tile
                const float sink_v,
-               const index_t valid_k0_loops = kQKHeaddim / kK0,
+               const index_t valid_k0_loops        = kQKHeaddim / kK0,
                const index_t valid_last_k0_columns = kK0,
-               const index_t valid_n1_columns = kN1) const
+               const index_t valid_n1_columns      = kN1) const
     {
         static_assert(
             std::is_same_v<QDataType, remove_cvref_t<typename QDramBlockWindowTmp::DataType>> &&
@@ -265,18 +265,17 @@ struct BlockFmhaPipelineQRKSVS
             v_lds, Policy::template MakeVLdsBlockDescriptor<Problem>().get_lengths(), {0, 0});
 
         // Block GEMM
-        constexpr auto gemm_0 = Policy::template GetQKBlockGemm<Problem>();
-        constexpr auto gemm_1 = Policy::template GetKVBlockGemm<Problem>();
-        using BlockGemm0      = remove_cvref_t<decltype(gemm_0)>;
-        constexpr bool kIsQKGemm0V2 =
-            std::is_same_v<BlockGemm0,
-                           BlockGemmARegBSmemCRegV2<typename BlockGemm0::Problem,
-                                                    typename BlockGemm0::Policy>>;
+        constexpr auto gemm_0       = Policy::template GetQKBlockGemm<Problem>();
+        constexpr auto gemm_1       = Policy::template GetKVBlockGemm<Problem>();
+        using BlockGemm0            = remove_cvref_t<decltype(gemm_0)>;
+        constexpr bool kIsQKGemm0V2 = std::is_same_v<
+            BlockGemm0,
+            BlockGemmARegBSmemCRegV2<typename BlockGemm0::Problem, typename BlockGemm0::Policy>>;
 
-        constexpr auto gemm_0_config = BlockGemm0::Policy::template GetWarpGemmMWarpNWarp<Problem>();
-        using Gemm0WarpGemm          = remove_cvref_t<decltype(gemm_0_config.template at<0>())>;
-        constexpr index_t kGemm0WarpK =
-            Gemm0WarpGemm::WarpGemmAttribute::Impl::kK;
+        constexpr auto gemm_0_config =
+            BlockGemm0::Policy::template GetWarpGemmMWarpNWarp<Problem>();
+        using Gemm0WarpGemm           = remove_cvref_t<decltype(gemm_0_config.template at<0>())>;
+        constexpr index_t kGemm0WarpK = Gemm0WarpGemm::WarpGemmAttribute::Impl::kK;
         constexpr index_t kGemm0KItersPerBlock = kK0 / kGemm0WarpK;
         constexpr bool kCanUsePartialGemm0Tail =
             kPadHeadDimQ && kIsQKGemm0V2 && (kGemm0KItersPerBlock > 1);
@@ -442,9 +441,9 @@ struct BlockFmhaPipelineQRKSVS
         }();
 
         // prefetch K tile
-        index_t i_total_loops      = 0;
-        constexpr index_t k0_loops = kQKHeaddim / kK0;
-        constexpr index_t k1_loops = kN0 / kK1;
+        index_t i_total_loops                = 0;
+        constexpr index_t k0_loops           = kQKHeaddim / kK0;
+        constexpr index_t k1_loops           = kN0 / kK1;
         const index_t clamped_valid_k0_loops = [&]() {
             if constexpr(!kPadHeadDimQ)
             {
@@ -594,19 +593,17 @@ struct BlockFmhaPipelineQRKSVS
 
                             if(partial_gemm_0_k_iters == kTailKIters)
                             {
-                                using Gemm0TailProblem =
-                                    BlockGemmProblem<QDataType,
-                                                     KDataType,
-                                                     SaccDataType,
-                                                     Problem::kNumGemm0Warps * get_warp_size(),
-                                                     TileGemmShape<
-                                                         sequence<kM0, kN0, kTailK0>,
-                                                         typename BlockFmhaShape::Gemm0BlockWarps,
-                                                         sequence<BlockFmhaShape::Gemm0WarpTile::at(
-                                                                      number<0>{}),
-                                                                  BlockFmhaShape::Gemm0WarpTile::at(
-                                                                      number<1>{}),
-                                                                  kGemm0WarpK>>>;
+                                using Gemm0TailProblem = BlockGemmProblem<
+                                    QDataType,
+                                    KDataType,
+                                    SaccDataType,
+                                    Problem::kNumGemm0Warps * get_warp_size(),
+                                    TileGemmShape<
+                                        sequence<kM0, kN0, kTailK0>,
+                                        typename BlockFmhaShape::Gemm0BlockWarps,
+                                        sequence<BlockFmhaShape::Gemm0WarpTile::at(number<0>{}),
+                                                 BlockFmhaShape::Gemm0WarpTile::at(number<1>{}),
+                                                 kGemm0WarpK>>>;
                                 constexpr auto gemm_0_tail =
                                     BlockGemmARegBSmemCRegV2<Gemm0TailProblem,
                                                              typename BlockGemm0::Policy>{};
@@ -615,10 +612,8 @@ struct BlockFmhaPipelineQRKSVS
                                     get_slice_tile(q_tile,
                                                    sequence<0, i_k0 * kK0>{},
                                                    sequence<kM0, i_k0 * kK0 + kTailK0>{});
-                                auto k_tail_window =
-                                    make_tile_window(k_lds,
-                                                     make_tuple(number<kN0>{}, number<kTailK0>{}),
-                                                     {0, 0});
+                                auto k_tail_window = make_tile_window(
+                                    k_lds, make_tuple(number<kN0>{}, number<kTailK0>{}), {0, 0});
 
                                 gemm_0_tail(s_acc, q_slice, k_tail_window);
                             }
@@ -1063,9 +1058,8 @@ struct BlockFmhaPipelineQRKSVS
                 {
                     constexpr auto gemm_1_config =
                         decltype(gemm_1)::Policy::template GetWarpGemmMWarpNWarp<Problem>();
-                    using Gemm1WarpGemm =
-                        remove_cvref_t<decltype(gemm_1_config.template at<0>())>;
-                    constexpr index_t kGemm1NWarp = gemm_1_config.template at<2>();
+                    using Gemm1WarpGemm = remove_cvref_t<decltype(gemm_1_config.template at<0>())>;
+                    constexpr index_t kGemm1NWarp    = gemm_1_config.template at<2>();
                     constexpr index_t kGemm1NPerIter = kGemm1NWarp * Gemm1WarpGemm::kN;
                     const index_t valid_gemm_1_n_iters =
                         ck_tile::integer_divide_ceil(clamped_valid_n1_columns, kGemm1NPerIter);
@@ -1247,9 +1241,9 @@ struct BlockFmhaPipelineQRKSVS
                void* smem_ptr,
                DropoutType& dropout,
                const float sink_v,
-               const index_t valid_k0_loops = kQKHeaddim / kK0,
+               const index_t valid_k0_loops        = kQKHeaddim / kK0,
                const index_t valid_last_k0_columns = kK0,
-               const index_t valid_n1_columns = kN1) const
+               const index_t valid_n1_columns      = kN1) const
     {
         return operator()(q_dram_block_window_tmp,
                           identity{},

--- a/projects/composablekernel/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs.hpp
@@ -205,9 +205,9 @@ struct BlockFmhaPipelineQRKSVS
                const VScaleDramBlockWindowTmp&
                    v_scale_dram_block_window_tmp, // N1*(K1/kVScaleGranularity) tile
                const float sink_v,
-               const index_t valid_k0_loops        = kQKHeaddim / kK0,
-               const index_t valid_last_k0_columns = kK0,
-               const index_t valid_n1_columns      = kN1) const
+               const index_t valid_k0_loops,
+               const index_t valid_last_k0_columns,
+               const index_t valid_n1_columns) const
     {
         static_assert(
             std::is_same_v<QDataType, remove_cvref_t<typename QDramBlockWindowTmp::DataType>> &&
@@ -1222,6 +1222,94 @@ struct BlockFmhaPipelineQRKSVS
               typename BiasDramBlockWindowTmp,
               typename RandValDramBlockWindowTmp,
               typename LSEDramBlockWindowTmp,
+              typename QElementFunction,
+              typename KElementFunction,
+              typename VElementFunction,
+              typename BiasElementFunction,
+              typename LSEElementFunction,
+              typename SAccElementFunction,
+              typename PComputeElementFunction,
+              typename OAccElementFunction,
+              typename PositionEncoding,
+              typename AttentionVariantParams,
+              typename BlockIndices,
+              typename QScaleDramBlockWindowTmp,
+              typename KScaleDramBlockWindowTmp,
+              typename VScaleDramBlockWindowTmp>
+    CK_TILE_HOST_DEVICE auto
+    operator()(const QDramBlockWindowTmp& q_dram_block_window_tmp, // M0*K0 tile
+               const QElementFunction& q_element_func,
+               const KDramBlockWindowTmp& k_dram_block_window_tmp, // N0*K0 tile
+               const KElementFunction& k_element_func,
+               const VDramBlockWindowTmp& v_dram_block_window_tmp, // N1*K1 tile
+               const VElementFunction& v_element_func,
+               const BiasDramBlockWindowTmp& bias_dram_block_window_tmp, // M0*N0 tile
+               const BiasElementFunction& bias_element_func,
+               RandValDramBlockWindowTmp& randval_dram_block_window_tmp,
+               LSEDramBlockWindowTmp& lse_dram_window_tmp, // M0*1 tile
+               const LSEElementFunction& lse_element_func,
+               const SAccElementFunction& s_acc_element_func,
+               const PComputeElementFunction& p_compute_element_func,
+               const OAccElementFunction& o_acc_element_func,
+               FmhaMask mask,
+               PositionEncoding position_encoding,
+               float scale_s,
+               const AttentionVariant& variant,
+               const AttentionVariantParams& variant_params,
+               const BlockIndices& block_indices,
+               void* smem_ptr,
+               DropoutType& dropout,
+               const float* k_descale_ptr,
+               const float* v_descale_ptr,
+               const index_t block_scale_size_kv,
+               const QScaleDramBlockWindowTmp&
+                   q_scale_dram_block_window_tmp, // M0*(K0/kQKScaleGranularity) tile
+               const KScaleDramBlockWindowTmp&
+                   k_scale_dram_block_window_tmp, // N0*(K0/kQKScaleGranularity) tile
+               const VScaleDramBlockWindowTmp&
+                   v_scale_dram_block_window_tmp, // N1*(K1/kVScaleGranularity) tile
+               const float sink_v) const
+    {
+        return operator()(q_dram_block_window_tmp,
+                          q_element_func,
+                          k_dram_block_window_tmp,
+                          k_element_func,
+                          v_dram_block_window_tmp,
+                          v_element_func,
+                          bias_dram_block_window_tmp,
+                          bias_element_func,
+                          randval_dram_block_window_tmp,
+                          lse_dram_window_tmp,
+                          lse_element_func,
+                          s_acc_element_func,
+                          p_compute_element_func,
+                          o_acc_element_func,
+                          mask,
+                          position_encoding,
+                          scale_s,
+                          variant,
+                          variant_params,
+                          block_indices,
+                          smem_ptr,
+                          dropout,
+                          k_descale_ptr,
+                          v_descale_ptr,
+                          block_scale_size_kv,
+                          q_scale_dram_block_window_tmp,
+                          k_scale_dram_block_window_tmp,
+                          v_scale_dram_block_window_tmp,
+                          sink_v,
+                          kQKHeaddim / kK0,
+                          kK0,
+                          kN1);
+    }
+
+    template <typename QDramBlockWindowTmp,
+              typename KDramBlockWindowTmp,
+              typename VDramBlockWindowTmp,
+              typename BiasDramBlockWindowTmp,
+              typename RandValDramBlockWindowTmp,
+              typename LSEDramBlockWindowTmp,
               typename PositionEncoding,
               typename AttentionVariantParams,
               typename BlockIndices>
@@ -1241,9 +1329,9 @@ struct BlockFmhaPipelineQRKSVS
                void* smem_ptr,
                DropoutType& dropout,
                const float sink_v,
-               const index_t valid_k0_loops        = kQKHeaddim / kK0,
-               const index_t valid_last_k0_columns = kK0,
-               const index_t valid_n1_columns      = kN1) const
+               const index_t valid_k0_loops,
+               const index_t valid_last_k0_columns,
+               const index_t valid_n1_columns) const
     {
         return operator()(q_dram_block_window_tmp,
                           identity{},
@@ -1277,6 +1365,52 @@ struct BlockFmhaPipelineQRKSVS
                           valid_k0_loops,
                           valid_last_k0_columns,
                           valid_n1_columns);
+    }
+
+    template <typename QDramBlockWindowTmp,
+              typename KDramBlockWindowTmp,
+              typename VDramBlockWindowTmp,
+              typename BiasDramBlockWindowTmp,
+              typename RandValDramBlockWindowTmp,
+              typename LSEDramBlockWindowTmp,
+              typename PositionEncoding,
+              typename AttentionVariantParams,
+              typename BlockIndices>
+    CK_TILE_HOST_DEVICE auto
+    operator()(const QDramBlockWindowTmp& q_dram_block_window_tmp,       // M0*K0 tile
+               const KDramBlockWindowTmp& k_dram_block_window_tmp,       // N0*K0 tile
+               const VDramBlockWindowTmp& v_dram_block_window_tmp,       // N1*K1 tile
+               const BiasDramBlockWindowTmp& bias_dram_block_window_tmp, // M0*N0 tile
+               RandValDramBlockWindowTmp& randval_dram_block_window_tmp, // M0*N0 tile
+               LSEDramBlockWindowTmp& lse_dram_block_window_tmp,         // M0*1 tile
+               FmhaMask mask,
+               PositionEncoding position_encoding,
+               float scale_s,
+               const AttentionVariant& variant,
+               const AttentionVariantParams& variant_params,
+               const BlockIndices& block_indices,
+               void* smem_ptr,
+               DropoutType& dropout,
+               const float sink_v) const
+    {
+        return operator()(q_dram_block_window_tmp,
+                          k_dram_block_window_tmp,
+                          v_dram_block_window_tmp,
+                          bias_dram_block_window_tmp,
+                          randval_dram_block_window_tmp,
+                          lse_dram_block_window_tmp,
+                          mask,
+                          position_encoding,
+                          scale_s,
+                          variant,
+                          variant_params,
+                          block_indices,
+                          smem_ptr,
+                          dropout,
+                          sink_v,
+                          kQKHeaddim / kK0,
+                          kK0,
+                          kN1);
     }
 };
 

--- a/projects/composablekernel/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs.hpp
@@ -206,6 +206,7 @@ struct BlockFmhaPipelineQRKSVS
                    v_scale_dram_block_window_tmp, // N1*(K1/kVScaleGranularity) tile
                const float sink_v,
                const index_t valid_k0_loops = kQKHeaddim / kK0,
+               const index_t valid_last_k0_columns = kK0,
                const index_t valid_n1_columns = kN1) const
     {
         static_assert(
@@ -266,6 +267,19 @@ struct BlockFmhaPipelineQRKSVS
         // Block GEMM
         constexpr auto gemm_0 = Policy::template GetQKBlockGemm<Problem>();
         constexpr auto gemm_1 = Policy::template GetKVBlockGemm<Problem>();
+        using BlockGemm0      = remove_cvref_t<decltype(gemm_0)>;
+        constexpr bool kIsQKGemm0V2 =
+            std::is_same_v<BlockGemm0,
+                           BlockGemmARegBSmemCRegV2<typename BlockGemm0::Problem,
+                                                    typename BlockGemm0::Policy>>;
+
+        constexpr auto gemm_0_config = BlockGemm0::Policy::template GetWarpGemmMWarpNWarp<Problem>();
+        using Gemm0WarpGemm          = remove_cvref_t<decltype(gemm_0_config.template at<0>())>;
+        constexpr index_t kGemm0WarpK =
+            Gemm0WarpGemm::WarpGemmAttribute::Impl::kK;
+        constexpr index_t kGemm0KItersPerBlock = kK0 / kGemm0WarpK;
+        constexpr bool kCanUsePartialGemm0Tail =
+            kPadHeadDimQ && kIsQKGemm0V2 && (kGemm0KItersPerBlock > 1);
 
         auto q_dram_window = make_tile_window(q_dram_block_window_tmp.get_bottom_tensor_view(),
                                               q_dram_block_window_tmp.get_window_lengths(),
@@ -461,6 +475,13 @@ struct BlockFmhaPipelineQRKSVS
             }
             return valid_n1_columns;
         }();
+        const index_t partial_gemm_0_k_iters = [&]() {
+            if constexpr(kCanUsePartialGemm0Tail)
+            {
+                return ck_tile::integer_divide_ceil(valid_last_k0_columns, kGemm0WarpK);
+            }
+            return static_cast<index_t>(kGemm0KItersPerBlock);
+        }();
         const bool skip_last_k0_loop = [&]() {
             if constexpr(kPadHeadDimQ)
             {
@@ -471,7 +492,6 @@ struct BlockFmhaPipelineQRKSVS
         // Use compile-time conditional for group barrier sequence
         // (No runtime lambda selection)
         auto schedule_gemm_0 = [] {
-            using BlockGemm0 = remove_cvref_t<decltype(gemm_0)>;
             constexpr auto WarpGemmConfig =
                 BlockGemm0::Policy::template GetWarpGemmMWarpNWarp<Problem>();
             using WarpGemm0 = remove_cvref_t<decltype(WarpGemmConfig.template at<0>())>;
@@ -563,6 +583,50 @@ struct BlockFmhaPipelineQRKSVS
             }
 
             auto run_gemm_0 = [&](auto i_k0) {
+                if constexpr(kCanUsePartialGemm0Tail)
+                {
+                    if(static_cast<index_t>(i_k0.value) == (clamped_valid_k0_loops - 1) &&
+                       partial_gemm_0_k_iters < kGemm0KItersPerBlock)
+                    {
+                        static_for<1, kGemm0KItersPerBlock, 1>{}([&](auto i_tail_k_iter) {
+                            constexpr index_t kTailKIters = i_tail_k_iter;
+                            constexpr index_t kTailK0     = kTailKIters * kGemm0WarpK;
+
+                            if(partial_gemm_0_k_iters == kTailKIters)
+                            {
+                                using Gemm0TailProblem =
+                                    BlockGemmProblem<QDataType,
+                                                     KDataType,
+                                                     SaccDataType,
+                                                     Problem::kNumGemm0Warps * get_warp_size(),
+                                                     TileGemmShape<
+                                                         sequence<kM0, kN0, kTailK0>,
+                                                         typename BlockFmhaShape::Gemm0BlockWarps,
+                                                         sequence<BlockFmhaShape::Gemm0WarpTile::at(
+                                                                      number<0>{}),
+                                                                  BlockFmhaShape::Gemm0WarpTile::at(
+                                                                      number<1>{}),
+                                                                  kGemm0WarpK>>>;
+                                constexpr auto gemm_0_tail =
+                                    BlockGemmARegBSmemCRegV2<Gemm0TailProblem,
+                                                             typename BlockGemm0::Policy>{};
+
+                                auto q_slice =
+                                    get_slice_tile(q_tile,
+                                                   sequence<0, i_k0 * kK0>{},
+                                                   sequence<kM0, i_k0 * kK0 + kTailK0>{});
+                                auto k_tail_window =
+                                    make_tile_window(k_lds,
+                                                     make_tuple(number<kN0>{}, number<kTailK0>{}),
+                                                     {0, 0});
+
+                                gemm_0_tail(s_acc, q_slice, k_tail_window);
+                            }
+                        });
+                        return;
+                    }
+                }
+
                 auto q_slice = get_slice_tile(
                     q_tile, sequence<0, i_k0 * kK0>{}, sequence<kM0, (i_k0 + 1) * kK0>{});
                 if constexpr(QScaleEnum == BlockAttentionQuantScaleEnum::MX)
@@ -1184,6 +1248,7 @@ struct BlockFmhaPipelineQRKSVS
                DropoutType& dropout,
                const float sink_v,
                const index_t valid_k0_loops = kQKHeaddim / kK0,
+               const index_t valid_last_k0_columns = kK0,
                const index_t valid_n1_columns = kN1) const
     {
         return operator()(q_dram_block_window_tmp,
@@ -1216,6 +1281,7 @@ struct BlockFmhaPipelineQRKSVS
                           make_null_tile_window(make_tuple()),
                           sink_v,
                           valid_k0_loops,
+                          valid_last_k0_columns,
                           valid_n1_columns);
     }
 };

--- a/projects/composablekernel/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/fmha/pipeline/block_fmha_pipeline_qr_ks_vs.hpp
@@ -39,6 +39,9 @@ struct BlockFmhaPipelineQRKSVS
     using AttentionVariant      = remove_cvref_t<typename Problem::AttentionVariant>;
     using FmhaMask              = remove_cvref_t<typename Problem::FmhaMask>;
 
+    template <typename T>
+    using has_partial_k_support = decltype(T::kSupportsPartialK);
+
     using BlockFmhaShape             = remove_cvref_t<typename Problem::BlockFmhaShape>;
     using VLayout                    = remove_cvref_t<typename BlockFmhaShape::VLayout>;
     static constexpr bool kQLoadOnce = true; // if q_tile load whole block length (hdim) at once
@@ -68,7 +71,7 @@ struct BlockFmhaPipelineQRKSVS
     static constexpr auto QScaleEnum          = Problem::QScaleEnum;
     static constexpr bool kHasSink            = Problem::kHasSink;
     static constexpr bool kPaddedVecLoadStore = PaddedVecLoadStore_;
-    static constexpr bool kEnableTailSkip     = kPadHeadDimQ || kPadHeadDimV;
+    static constexpr bool kUseHeadDimTailArgs = kPadHeadDimQ || kPadHeadDimV;
 
     static constexpr ck_tile::index_t kQKScaleGranularity = Problem::kQKScaleGranularity;
     static constexpr ck_tile::index_t kVScaleGranularity  = Problem::kVScaleGranularity;
@@ -86,6 +89,8 @@ struct BlockFmhaPipelineQRKSVS
                   (!CK_TILE_FMHA_FWD_FAST_EXP2 && !kHasLogitsSoftCap));
     static_assert(!kPaddedVecLoadStore || (kPadHeadDimQ && kPadHeadDimV),
                   "padded vector load/store fast path only applies to padded head-dim kernels");
+    static_assert(!(kPadHeadDimV && QScaleEnum == BlockAttentionQuantScaleEnum::MX),
+                  "MX with padded hdim_v is not supported yet");
 
     // last dimension vector length used to create tensor view(and decide buffer_load vector length)
     // ... together with tensor distribution. tensor dist should able to overwrite this
@@ -206,8 +211,8 @@ struct BlockFmhaPipelineQRKSVS
                    v_scale_dram_block_window_tmp, // N1*(K1/kVScaleGranularity) tile
                const float sink_v,
                const index_t valid_k0_loops,
-               const index_t valid_last_k0_columns,
-               const index_t valid_n1_columns) const
+               const index_t valid_last_k0_length,
+               const index_t valid_n1_length) const
     {
         static_assert(
             std::is_same_v<QDataType, remove_cvref_t<typename QDramBlockWindowTmp::DataType>> &&
@@ -265,20 +270,23 @@ struct BlockFmhaPipelineQRKSVS
             v_lds, Policy::template MakeVLdsBlockDescriptor<Problem>().get_lengths(), {0, 0});
 
         // Block GEMM
-        constexpr auto gemm_0       = Policy::template GetQKBlockGemm<Problem>();
-        constexpr auto gemm_1       = Policy::template GetKVBlockGemm<Problem>();
-        using BlockGemm0            = remove_cvref_t<decltype(gemm_0)>;
-        constexpr bool kIsQKGemm0V2 = std::is_same_v<
-            BlockGemm0,
-            BlockGemmARegBSmemCRegV2<typename BlockGemm0::Problem, typename BlockGemm0::Policy>>;
+        constexpr auto gemm_0                      = Policy::template GetQKBlockGemm<Problem>();
+        constexpr auto gemm_1                      = Policy::template GetKVBlockGemm<Problem>();
+        using BlockGemm0                           = remove_cvref_t<decltype(gemm_0)>;
+        constexpr bool kBlockGemm0SupportsPartialK = [] {
+            if constexpr(ck_tile::is_detected<has_partial_k_support, BlockGemm0>::value)
+                return static_cast<bool>(BlockGemm0::kSupportsPartialK);
+            else
+                return false;
+        }();
 
         constexpr auto gemm_0_config =
             BlockGemm0::Policy::template GetWarpGemmMWarpNWarp<Problem>();
         using Gemm0WarpGemm           = remove_cvref_t<decltype(gemm_0_config.template at<0>())>;
         constexpr index_t kGemm0WarpK = Gemm0WarpGemm::kK;
         constexpr index_t kGemm0KItersPerBlock = kK0 / kGemm0WarpK;
-        constexpr bool kCanUsePartialGemm0Tail =
-            kPadHeadDimQ && kIsQKGemm0V2 && (kGemm0KItersPerBlock > 1);
+        constexpr bool kUsePartialKForTail =
+            kPadHeadDimQ && kBlockGemm0SupportsPartialK && (kGemm0KItersPerBlock > 1);
 
         auto q_dram_window = make_tile_window(q_dram_block_window_tmp.get_bottom_tensor_view(),
                                               q_dram_block_window_tmp.get_window_lengths(),
@@ -441,50 +449,23 @@ struct BlockFmhaPipelineQRKSVS
         }();
 
         // prefetch K tile
-        index_t i_total_loops                = 0;
-        constexpr index_t k0_loops           = kQKHeaddim / kK0;
-        constexpr index_t k1_loops           = kN0 / kK1;
-        const index_t clamped_valid_k0_loops = [&]() {
-            if constexpr(!kPadHeadDimQ)
+        index_t i_total_loops      = 0;
+        constexpr index_t k0_loops = kQKHeaddim / kK0;
+        constexpr index_t k1_loops = kN0 / kK1;
+        // Number of k0 iterations prefetched ahead of the current compute iteration.
+        // The skip decision must be made this many iterations before the last k0 loop.
+        constexpr index_t kK0PrefetchDepth = 2;
+        const index_t tail_k_iters         = [&]() {
+            if constexpr(kUsePartialKForTail)
             {
-                return static_cast<index_t>(k0_loops);
-            }
-            if(valid_k0_loops < 1)
-            {
-                return index_t{1};
-            }
-            if(valid_k0_loops > k0_loops)
-            {
-                return static_cast<index_t>(k0_loops);
-            }
-            return valid_k0_loops;
-        }();
-        const index_t clamped_valid_n1_columns = [&]() {
-            if constexpr(!kPadHeadDimV)
-            {
-                return static_cast<index_t>(kN1);
-            }
-            if(valid_n1_columns < 1)
-            {
-                return index_t{1};
-            }
-            if(valid_n1_columns > kN1)
-            {
-                return static_cast<index_t>(kN1);
-            }
-            return valid_n1_columns;
-        }();
-        const index_t partial_gemm_0_k_iters = [&]() {
-            if constexpr(kCanUsePartialGemm0Tail)
-            {
-                return ck_tile::integer_divide_ceil(valid_last_k0_columns, kGemm0WarpK);
+                return ck_tile::integer_divide_ceil(valid_last_k0_length, kGemm0WarpK);
             }
             return static_cast<index_t>(kGemm0KItersPerBlock);
         }();
         const bool skip_last_k0_loop = [&]() {
             if constexpr(kPadHeadDimQ)
             {
-                return clamped_valid_k0_loops == (k0_loops - 1);
+                return valid_k0_loops == (k0_loops - 1);
             }
             return false;
         }();
@@ -515,7 +496,7 @@ struct BlockFmhaPipelineQRKSVS
             }
         };
 
-        static_assert(2 <= k0_loops);
+        static_assert(kK0PrefetchDepth <= k0_loops);
         static_assert(1 <= k1_loops);
         do
         {
@@ -582,16 +563,16 @@ struct BlockFmhaPipelineQRKSVS
             }
 
             auto run_gemm_0 = [&](auto i_k0) {
-                if constexpr(kCanUsePartialGemm0Tail)
+                if constexpr(kUsePartialKForTail)
                 {
-                    if(static_cast<index_t>(i_k0.value) == (clamped_valid_k0_loops - 1) &&
-                       partial_gemm_0_k_iters < kGemm0KItersPerBlock)
+                    if(static_cast<index_t>(i_k0.value) == (valid_k0_loops - 1) &&
+                       tail_k_iters < kGemm0KItersPerBlock)
                     {
                         static_for<1, kGemm0KItersPerBlock, 1>{}([&](auto i_tail_k_iter) {
                             constexpr index_t kTailKIters = i_tail_k_iter;
                             constexpr index_t kTailK0     = kTailKIters * kGemm0WarpK;
 
-                            if(partial_gemm_0_k_iters == kTailKIters)
+                            if(tail_k_iters == kTailKIters)
                             {
                                 using Gemm0TailProblem = BlockGemmProblem<
                                     QDataType,
@@ -639,13 +620,13 @@ struct BlockFmhaPipelineQRKSVS
                 }
             };
 
-            if constexpr(k0_loops > 2)
+            if constexpr(k0_loops > kK0PrefetchDepth)
             {
-                static_for<0, k0_loops - 2, 1>{}([&](auto i_k0) {
+                static_for<0, k0_loops - kK0PrefetchDepth, 1>{}([&](auto i_k0) {
                     block_sync_lds();
                     run_gemm_0(number<i_k0>{});
                     block_sync_lds();
-                    if constexpr(kPadHeadDimQ && i_k0 == (k0_loops - 3))
+                    if constexpr(kPadHeadDimQ && i_k0 == (k0_loops - 1 - kK0PrefetchDepth))
                     {
                         if(!skip_last_k0_loop)
                         {
@@ -694,7 +675,7 @@ struct BlockFmhaPipelineQRKSVS
             }
             { // tail
                 block_sync_lds();
-                run_gemm_0(number<k0_loops - 2>{});
+                run_gemm_0(number<k0_loops - kK0PrefetchDepth>{});
                 if(!skip_last_k0_loop)
                 {
                     block_sync_lds();
@@ -1061,9 +1042,9 @@ struct BlockFmhaPipelineQRKSVS
                     using Gemm1WarpGemm = remove_cvref_t<decltype(gemm_1_config.template at<0>())>;
                     constexpr index_t kGemm1NWarp    = gemm_1_config.template at<2>();
                     constexpr index_t kGemm1NPerIter = kGemm1NWarp * Gemm1WarpGemm::kN;
-                    const index_t valid_gemm_1_n_iters =
-                        ck_tile::integer_divide_ceil(clamped_valid_n1_columns, kGemm1NPerIter);
-                    gemm_1(o_acc_tensor, p_slice, v_lds_window, valid_gemm_1_n_iters);
+                    const index_t valid_n_iters =
+                        ck_tile::integer_divide_ceil(valid_n1_length, kGemm1NPerIter);
+                    gemm_1(o_acc_tensor, p_slice, v_lds_window, valid_n_iters);
                 }
                 else
                 {
@@ -1330,8 +1311,8 @@ struct BlockFmhaPipelineQRKSVS
                DropoutType& dropout,
                const float sink_v,
                const index_t valid_k0_loops,
-               const index_t valid_last_k0_columns,
-               const index_t valid_n1_columns) const
+               const index_t valid_last_k0_length,
+               const index_t valid_n1_length) const
     {
         return operator()(q_dram_block_window_tmp,
                           identity{},
@@ -1363,8 +1344,8 @@ struct BlockFmhaPipelineQRKSVS
                           make_null_tile_window(make_tuple()),
                           sink_v,
                           valid_k0_loops,
-                          valid_last_k0_columns,
-                          valid_n1_columns);
+                          valid_last_k0_length,
+                          valid_n1_length);
     }
 
     template <typename QDramBlockWindowTmp,

--- a/projects/composablekernel/include/ck_tile/ops/gemm/block/block_gemm_areg_bsmem_creg_v2.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm/block/block_gemm_areg_bsmem_creg_v2.hpp
@@ -145,18 +145,16 @@ struct BlockGemmARegBSmemCRegV2
                 // read A warp tensor from A block tensor
                 AWarpTensor a_warp_tensor;
 
-                a_warp_tensor.get_thread_buffer() =
-                    a_block_tensor.get_y_sliced_thread_data(
-                        merge_sequences(sequence<mIter, kIter>{}, a_warp_y_index_zeros),
-                        merge_sequences(sequence<1, 1>{}, a_warp_y_lengths));
+                a_warp_tensor.get_thread_buffer() = a_block_tensor.get_y_sliced_thread_data(
+                    merge_sequences(sequence<mIter, kIter>{}, a_warp_y_index_zeros),
+                    merge_sequences(sequence<1, 1>{}, a_warp_y_lengths));
 
                 // read C warp tensor from C block tensor
                 CWarpTensor c_warp_tensor;
 
-                c_warp_tensor.get_thread_buffer() =
-                    c_block_tensor.get_y_sliced_thread_data(
-                        merge_sequences(sequence<mIter, nIter>{}, c_warp_y_index_zeros),
-                        merge_sequences(sequence<1, 1>{}, c_warp_y_lengths));
+                c_warp_tensor.get_thread_buffer() = c_block_tensor.get_y_sliced_thread_data(
+                    merge_sequences(sequence<mIter, nIter>{}, c_warp_y_index_zeros),
+                    merge_sequences(sequence<1, 1>{}, c_warp_y_lengths));
 
                 // warp GEMM
                 WG{}(c_warp_tensor, a_warp_tensor, b_warp_tensor);
@@ -197,9 +195,7 @@ struct BlockGemmARegBSmemCRegV2
         else
         {
             static_for<0, KIterPerWarp, 1>{}([&](auto kIter) {
-                static_for<0, NIterPerWarp, 1>{}([&](auto nIter) {
-                    run_n_iter(kIter, nIter);
-                });
+                static_for<0, NIterPerWarp, 1>{}([&](auto nIter) { run_n_iter(kIter, nIter); });
             });
         }
     }

--- a/projects/composablekernel/include/ck_tile/ops/gemm/block/block_gemm_areg_bsmem_creg_v2.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm/block/block_gemm_areg_bsmem_creg_v2.hpp
@@ -21,7 +21,8 @@ struct BlockGemmARegBSmemCRegV2
     using CDataType      = remove_cvref_t<typename Problem::CDataType>;
     using BlockGemmShape = remove_cvref_t<typename Problem::BlockGemmShape>;
 
-    static constexpr index_t kBlockSize = Problem::kBlockSize;
+    static constexpr index_t kBlockSize     = Problem::kBlockSize;
+    static constexpr bool kSupportsPartialK = true;
 
     template <bool UsePartialN,
               typename CBlockTensor,
@@ -171,21 +172,9 @@ struct BlockGemmARegBSmemCRegV2
         // hot loop:
         if constexpr(UsePartialN)
         {
-            const index_t clamped_valid_n_iters = [&]() {
-                if(valid_n_iters < 1)
-                {
-                    return index_t{1};
-                }
-                if(valid_n_iters > NIterPerWarp)
-                {
-                    return static_cast<index_t>(NIterPerWarp);
-                }
-                return valid_n_iters;
-            }();
-
             static_for<0, KIterPerWarp, 1>{}([&](auto kIter) {
                 static_for<0, NIterPerWarp, 1>{}([&](auto nIter) {
-                    if(static_cast<index_t>(nIter.value) < clamped_valid_n_iters)
+                    if(static_cast<index_t>(nIter.value) < valid_n_iters)
                     {
                         run_n_iter(kIter, nIter);
                     }
@@ -200,7 +189,7 @@ struct BlockGemmARegBSmemCRegV2
         }
     }
 
-    // C += A * B
+    // C += A * B (executing only the first valid_n_iters N sub-iterations)
     template <typename CBlockTensor, typename ABlockTensorTmp, typename BBlockWindowTmp>
     CK_TILE_DEVICE void operator()(CBlockTensor& c_block_tensor,
                                    const ABlockTensorTmp& a_block_tensor_tmp,
@@ -276,7 +265,7 @@ struct BlockGemmARegBSmemCRegV2
         return c_block_tensor;
     }
 
-    // C = A * B
+    // C = A * B (executing only the first valid_n_iters N sub-iterations)
     template <typename ABlockTensorTmp, typename BBlockWindowTmp>
     CK_TILE_DEVICE auto operator()(const ABlockTensorTmp& a_block_tensor_tmp,
                                    const BBlockWindowTmp& b_block_window_tmp,

--- a/projects/composablekernel/include/ck_tile/ops/gemm/block/block_gemm_areg_bsmem_creg_v2.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm/block/block_gemm_areg_bsmem_creg_v2.hpp
@@ -23,6 +23,7 @@ struct BlockGemmARegBSmemCRegV2
 
     static constexpr index_t kBlockSize     = Problem::kBlockSize;
     static constexpr bool kSupportsPartialK = true;
+    static constexpr bool kSupportsPartialN = true;
 
     template <bool UsePartialN,
               typename CBlockTensor,

--- a/projects/composablekernel/include/ck_tile/ops/gemm/block/block_gemm_areg_bsmem_creg_v2.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm/block/block_gemm_areg_bsmem_creg_v2.hpp
@@ -23,11 +23,14 @@ struct BlockGemmARegBSmemCRegV2
 
     static constexpr index_t kBlockSize = Problem::kBlockSize;
 
-    // C += A * B
-    template <typename CBlockTensor, typename ABlockTensorTmp, typename BBlockWindowTmp>
-    CK_TILE_DEVICE void operator()(CBlockTensor& c_block_tensor,
-                                   const ABlockTensorTmp& a_block_tensor_tmp,
-                                   const BBlockWindowTmp& b_block_window_tmp) const
+    template <bool UsePartialN,
+              typename CBlockTensor,
+              typename ABlockTensorTmp,
+              typename BBlockWindowTmp>
+    CK_TILE_DEVICE void Impl(CBlockTensor& c_block_tensor,
+                             const ABlockTensorTmp& a_block_tensor_tmp,
+                             const BBlockWindowTmp& b_block_window_tmp,
+                             [[maybe_unused]] const index_t valid_n_iters) const
     {
         static_assert(
             std::is_same_v<ADataType, remove_cv_t<typename ABlockTensorTmp::DataType>> &&
@@ -134,10 +137,7 @@ struct BlockGemmARegBSmemCRegV2
         constexpr auto a_warp_y_index_zeros = uniform_sequence_gen_t<AWarpDstr::NDimY, 0>{};
         constexpr auto c_warp_y_index_zeros = uniform_sequence_gen_t<CWarpDstr::NDimY, 0>{};
 
-        // hot loop:
-        static_ford<sequence<KIterPerWarp, NIterPerWarp>>{}([&](auto kn) {
-            constexpr auto kIter = number<kn[number<0>{}]>{};
-            constexpr auto nIter = number<kn[number<1>{}]>{};
+        auto run_n_iter = [&](auto kIter, auto nIter) {
             // read B warp tensor from B Block window
             const auto b_warp_tensor = load_tile(b_warp_windows(nIter)(kIter));
 
@@ -145,16 +145,18 @@ struct BlockGemmARegBSmemCRegV2
                 // read A warp tensor from A block tensor
                 AWarpTensor a_warp_tensor;
 
-                a_warp_tensor.get_thread_buffer() = a_block_tensor.get_y_sliced_thread_data(
-                    merge_sequences(sequence<mIter, kIter>{}, a_warp_y_index_zeros),
-                    merge_sequences(sequence<1, 1>{}, a_warp_y_lengths));
+                a_warp_tensor.get_thread_buffer() =
+                    a_block_tensor.get_y_sliced_thread_data(
+                        merge_sequences(sequence<mIter, kIter>{}, a_warp_y_index_zeros),
+                        merge_sequences(sequence<1, 1>{}, a_warp_y_lengths));
 
                 // read C warp tensor from C block tensor
                 CWarpTensor c_warp_tensor;
 
-                c_warp_tensor.get_thread_buffer() = c_block_tensor.get_y_sliced_thread_data(
-                    merge_sequences(sequence<mIter, nIter>{}, c_warp_y_index_zeros),
-                    merge_sequences(sequence<1, 1>{}, c_warp_y_lengths));
+                c_warp_tensor.get_thread_buffer() =
+                    c_block_tensor.get_y_sliced_thread_data(
+                        merge_sequences(sequence<mIter, nIter>{}, c_warp_y_index_zeros),
+                        merge_sequences(sequence<1, 1>{}, c_warp_y_lengths));
 
                 // warp GEMM
                 WG{}(c_warp_tensor, a_warp_tensor, b_warp_tensor);
@@ -166,7 +168,58 @@ struct BlockGemmARegBSmemCRegV2
                     merge_sequences(sequence<1, 1>{}, c_warp_y_lengths),
                     c_warp_tensor.get_thread_buffer());
             });
-        });
+        };
+
+        // hot loop:
+        if constexpr(UsePartialN)
+        {
+            const index_t clamped_valid_n_iters = [&]() {
+                if(valid_n_iters < 1)
+                {
+                    return index_t{1};
+                }
+                if(valid_n_iters > NIterPerWarp)
+                {
+                    return static_cast<index_t>(NIterPerWarp);
+                }
+                return valid_n_iters;
+            }();
+
+            static_for<0, KIterPerWarp, 1>{}([&](auto kIter) {
+                static_for<0, NIterPerWarp, 1>{}([&](auto nIter) {
+                    if(static_cast<index_t>(nIter.value) < clamped_valid_n_iters)
+                    {
+                        run_n_iter(kIter, nIter);
+                    }
+                });
+            });
+        }
+        else
+        {
+            static_for<0, KIterPerWarp, 1>{}([&](auto kIter) {
+                static_for<0, NIterPerWarp, 1>{}([&](auto nIter) {
+                    run_n_iter(kIter, nIter);
+                });
+            });
+        }
+    }
+
+    // C += A * B
+    template <typename CBlockTensor, typename ABlockTensorTmp, typename BBlockWindowTmp>
+    CK_TILE_DEVICE void operator()(CBlockTensor& c_block_tensor,
+                                   const ABlockTensorTmp& a_block_tensor_tmp,
+                                   const BBlockWindowTmp& b_block_window_tmp,
+                                   const index_t valid_n_iters) const
+    {
+        Impl<true>(c_block_tensor, a_block_tensor_tmp, b_block_window_tmp, valid_n_iters);
+    }
+
+    template <typename CBlockTensor, typename ABlockTensorTmp, typename BBlockWindowTmp>
+    CK_TILE_DEVICE void operator()(CBlockTensor& c_block_tensor,
+                                   const ABlockTensorTmp& a_block_tensor_tmp,
+                                   const BBlockWindowTmp& b_block_window_tmp) const
+    {
+        Impl<false>(c_block_tensor, a_block_tensor_tmp, b_block_window_tmp, 0);
     }
 
     template <index_t MPerBlock = BlockGemmShape::kM, index_t KPerBlock = BlockGemmShape::kK>
@@ -228,6 +281,16 @@ struct BlockGemmARegBSmemCRegV2
     }
 
     // C = A * B
+    template <typename ABlockTensorTmp, typename BBlockWindowTmp>
+    CK_TILE_DEVICE auto operator()(const ABlockTensorTmp& a_block_tensor_tmp,
+                                   const BBlockWindowTmp& b_block_window_tmp,
+                                   const index_t valid_n_iters) const
+    {
+        auto c_block_tensor = MakeCBlockTile();
+        operator()(c_block_tensor, a_block_tensor_tmp, b_block_window_tmp, valid_n_iters);
+        return c_block_tensor;
+    }
+
     template <typename ABlockTensorTmp, typename BBlockWindowTmp>
     CK_TILE_DEVICE auto operator()(const ABlockTensorTmp& a_block_tensor_tmp,
                                    const BBlockWindowTmp& b_block_window_tmp) const


### PR DESCRIPTION
## Motivation

`qr_hpad` currently executes work for padded head-dim fragments even when only a subset of the values are valid. This adds unnecessary computation for head dimensions that require padding, such as `hdim=72` and `hdim=80`, and hurts FMHA forward performance.

The goal of this PR is to make the padded-head-dim path skip invalid work based on the actual valid fragment count, while preserving the existing behavior for the non-padded path.

## Technical Details

This PR improves the `qr_hpad` FMHA forward path in three parts:

- Skip padded `k`/`n` fragments in the GEMM/pipeline path when only part of the fragment is valid.
- Add partial GEMM0 tail handling for `qr_hpad` so the kernel uses the valid fragment range instead of always computing over the padded extent.
- Retune the gfx11 `qr_hpad` kernel configuration after enabling the partial-fragment path.

To keep the existing path stable, the implementation adds overloads for the updated GEMM/pipeline interfaces. This allows existing full-tile callers to keep using the previous form, while the `qr_hpad` path can pass valid fragment counts when needed.

## Test Plan

./build/bin/tile_example_fmha_fwd -prec=bf16 -mode={0/1} -b=1 -h=16 -d={72/80} -s={seqlen} -s_k={seqlen} -lse=0 -iperm={0/1} -operm={0/1}

## Test Result

- On gfx11 and gfx12, for head dimensions that require padding, `tile_example_fmha_fwd` shows about 20-30% performance improvement at `hdim=72/80`.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
