### PR TITLE
[hip-kernel-provider] Fix hip-kernel-provider build

### DIFF
--- a/dnn-providers/hip-kernel-provider/src/HipKernelContainer.cpp
+++ b/dnn-providers/hip-kernel-provider/src/HipKernelContainer.cpp
@@ -4,7 +4,6 @@
 #include "HipKernelContainer.hpp"
 #include "CurrentDevicePropertyProvider.hpp"
 #include "engines/HipKernelEngine.hpp"
-#include "engines/plans/BatchnormPlanBuilder.hpp"
 #include "engines/plans/RMSnorm/RMSnormBwdPlanBuilder.hpp"
 #include "engines/plans/RMSnorm/RMSnormPlanBuilder.hpp"
 #include "engines/plans/batchnorm/BatchnormPlanBuilder.hpp"
@@ -40,6 +39,7 @@ const std::vector<HipKernelContainer::EngineDefinition>& HipKernelContainer::get
              engine->addPlanBuilder(std::make_unique<rmsnorm::RMSnormPlanBuilder>(
                  kernelCompiler, devicePropertyProvider));
              engine->addPlanBuilder(std::make_unique<rmsnorm::RMSnormBwdPlanBuilder>(
+                 kernelCompiler, devicePropertyProvider));
              engine->addPlanBuilder(std::make_unique<layernorm::LayernormPlanBuilder>(
                  kernelCompiler, devicePropertyProvider));
              return engine;


### PR DESCRIPTION
The PR https://github.com/ROCm/rocm-libraries/pull/5747 introduced some build failures from incorrect merge conflict resolution with https://github.com/ROCm/rocm-libraries/pull/5673

This PR fixes those build issues:
* First change is because the header got moved to a batchnorm directory and is already included a few lines below.
* Second chance is a malformed statement

