### PR TITLE
[rocthrust] Fix THRUST_CUB_WRAPPED_NAMESPACE compile errors in headers

### DIFF
--- a/projects/rocthrust/thrust/detail/type_traits.h
+++ b/projects/rocthrust/thrust/detail/type_traits.h
@@ -273,7 +273,7 @@ struct promoted_numerical_type<
   typename _THRUST_STD::enable_if<_And<typename _THRUST_STD::is_floating_point<T1>::type,
                                        typename _THRUST_STD::is_floating_point<T2>::type>::value>::type>
 {
-  using type = typename ::thrust::detail::larger_type<T1, T2>::type;
+  using type = typename THRUST_NS_QUALIFIER::detail::larger_type<T1, T2>::type;
 };
 
 template <typename T1, typename T2>

--- a/projects/rocthrust/thrust/iterator/detail/tuple_of_iterator_references.h
+++ b/projects/rocthrust/thrust/iterator/detail/tuple_of_iterator_references.h
@@ -174,7 +174,7 @@ struct tuple_element<Id, THRUST_NS_QUALIFIER::detail::tuple_of_iterator_referenc
 #if _THRUST_HAS_DEVICE_SYSTEM_STD
     : _THRUST_STD::tuple_element<Id, _THRUST_STD::tuple<Ts...>>
 #else
-    : ::thrust::tuple_element<Id, ::thrust::tuple<Ts...>>
+    : THRUST_NS_QUALIFIER::tuple_element<Id, THRUST_NS_QUALIFIER::tuple<Ts...>>
 #endif
 {};
 
@@ -199,7 +199,7 @@ struct tuple_element<Id, THRUST_NS_QUALIFIER::detail::tuple_of_iterator_referenc
 #  if _THRUST_HAS_DEVICE_SYSTEM_STD
     : _THRUST_STD::tuple_element<Id, _THRUST_STD::tuple<Ts...>>
 #  else
-    : ::thrust::tuple_element<Id, ::thrust::tuple<Ts...>>
+    : THRUST_NS_QUALIFIER::tuple_element<Id, THRUST_NS_QUALIFIER::tuple<Ts...>>
 #  endif
 {};
 


### PR DESCRIPTION
## Motivation

Fixes #6309

When `THRUST_CUB_WRAPPED_NAMESPACE` is defined (e.g., `gko` for the [Ginkgo](https://github.com/ginkgo-project/ginkgo) project), the `thrust` namespace is wrapped:

```cpp
namespace gko { namespace thrust { ... } }
```

Several headers use hardcoded `::thrust::` references in `#else` branches (when `_THRUST_HAS_DEVICE_SYSTEM_STD` is false), which fail to resolve.

## Technical Details

Replaced hardcoded `::thrust::` with `THRUST_NS_QUALIFIER` in three locations across two files

`THRUST_NS_QUALIFIER` resolves to `::THRUST_WRAPPED_NAMESPACE::thrust` when a wrapped namespace is defined, and `::thrust` otherwise, so this is not an issue for unwrapped builds.

## Test Plan

- Make sure that rocThrust builds and tests pass

## Test Result

- Builds successfully and tests pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
