### PR TITLE
[hipDNN] Fix windows integration tests

### DIFF
--- a/dnn-providers/integration-tests/CMakeLists.txt
+++ b/dnn-providers/integration-tests/CMakeLists.txt
@@ -125,6 +125,7 @@ target_link_libraries(${INTEGRATION_TESTS_EXE}
         hipdnn_plugin_sdk
         GTest::gtest
         Threads::Threads
+        $<$<PLATFORM_ID:Windows>:shlwapi>
 )
 
 target_compile_options(${INTEGRATION_TESTS_EXE} PRIVATE ${INTEGRATION_TESTS_WARNING_COMPILE_OPTIONS})

--- a/dnn-providers/integration-tests/cmake/scripts/test_name_validator.py
+++ b/dnn-providers/integration-tests/cmake/scripts/test_name_validator.py
@@ -32,7 +32,7 @@ class TestNameValidator:
     )
 
     FULL_NAME_RE: Pattern[str] = re.compile(
-        r"^(?:(?P<prefix>[A-Z][A-Za-z0-9]*)/)?"
+        r"^(?:(?P<prefix>(?:DISABLED_)?[A-Z][A-Za-z0-9]*)/)?"
         r"(?P<suite>[A-Z][A-Za-z0-9]*)"
         r"(?:/\d+)?"
         r"\.(?P<case>(?:DISABLED_[A-Z][A-Za-z0-9]+|[A-Z][A-Za-z0-9]*))"
@@ -424,6 +424,9 @@ class TestTestNameValidator(unittest.TestCase):
         valid_names = [
             "TestMyClass.DISABLED_Something",
             "IntegrationGpuConvolutionFp32.DISABLED_Forward",
+            "DISABLED_Medium2d/TestGpuConvRefShapesFp32.MatchesCpuRef/Basic3x3",
+            "DISABLED_Large2d/TestGpuConvRefShapesFp32.MatchesCpuRef/ResNet",
+            "DISABLED_Nhwc2dMedium/TestGpuConvRefShapesFp16.MatchesCpuRef/Stride2",
         ]
 
         for name in valid_names:

--- a/dnn-providers/integration-tests/gpu_ref/kernels/convolution/GpuRefConvWrw.cpp
+++ b/dnn-providers/integration-tests/gpu_ref/kernels/convolution/GpuRefConvWrw.cpp
@@ -8,6 +8,8 @@
 
 #include "GpuRefTypes.h"
 
+using namespace gpu_ref;
+
 extern "C" __global__ void convWrwRef1d(ConvWrwArgs1d args)
 {
     auto* dw = static_cast<W_TYPE*>(args.dw);

--- a/dnn-providers/integration-tests/src/common/PlatformUtils.hpp
+++ b/dnn-providers/integration-tests/src/common/PlatformUtils.hpp
@@ -1,0 +1,46 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <string_view>
+
+#ifdef _WIN32
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
+// clang-format off
+#include <windows.h>
+#include <shlwapi.h>
+// clang-format on
+
+#elif defined(__linux__)
+
+#include <fnmatch.h>
+
+#else
+
+#error "Unsupported platform"
+
+#endif
+
+namespace hipdnn_integration_tests
+{
+
+/// Cross-platform glob match supporting '*' and '?' wildcards.
+/// Returns true if @p text matches @p pattern.
+inline bool globMatch(std::string_view pattern, std::string_view text)
+{
+    const std::string patternStr(pattern);
+    const std::string textStr(text);
+
+#ifdef _WIN32
+    return PathMatchSpecA(textStr.c_str(), patternStr.c_str()) != FALSE;
+#elif defined(__linux__)
+    return fnmatch(patternStr.c_str(), textStr.c_str(), 0) == 0;
+#endif
+}
+
+} // namespace hipdnn_integration_tests

--- a/dnn-providers/integration-tests/src/harness/TestSettings.hpp
+++ b/dnn-providers/integration-tests/src/harness/TestSettings.hpp
@@ -3,14 +3,14 @@
 
 #pragma once
 
-#include <fnmatch.h>
-
 #include <filesystem>
 #include <optional>
 #include <stdexcept>
 #include <string>
 #include <string_view>
 #include <vector>
+
+#include "common/PlatformUtils.hpp"
 
 // HIP's host_defines.h redefines __noinline__ as either
 // __attribute__((noinline)) or empty, which collides with tomlplusplus's
@@ -48,7 +48,7 @@ struct ToleranceOverride
 //   atol = 1e-3
 //   rtol = 1e-2
 //
-// Filters use GTest-style globs (fnmatch with * wildcards).
+// Filters use GTest-style globs (globMatch with * wildcards).
 // Later entries take precedence over earlier ones when multiple filters match.
 class TestSettings
 {
@@ -137,7 +137,7 @@ public:
         {
             for(const auto& filter : entry.filters)
             {
-                if(fnmatch(filter.c_str(), testNameStr.c_str(), 0) == 0)
+                if(globMatch(filter, testNameStr))
                 {
                     result = ToleranceOverride{entry.atol, entry.rtol};
                     break; // matched this entry, continue to next for precedence

--- a/dnn-providers/integration-tests/tests/CMakeLists.txt
+++ b/dnn-providers/integration-tests/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 add_executable(hipdnn_integration_tests_unit_tests
     main.cpp
+    TestPlatformUtils.cpp
     TestTestConfig.cpp
     TestTestSettings.cpp
     TestGpuReferenceGraphExecutor.cpp
@@ -20,6 +21,7 @@ target_link_libraries(hipdnn_integration_tests_unit_tests
         hipdnn_plugin_sdk
         GTest::gtest
         Threads::Threads
+        $<$<PLATFORM_ID:Windows>:shlwapi>
 )
 
 target_compile_options(hipdnn_integration_tests_unit_tests

--- a/dnn-providers/integration-tests/tests/TestPlatformUtils.cpp
+++ b/dnn-providers/integration-tests/tests/TestPlatformUtils.cpp
@@ -1,0 +1,121 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <gtest/gtest.h>
+
+#include "common/PlatformUtils.hpp"
+
+using hipdnn_integration_tests::globMatch;
+
+// NOLINTBEGIN(readability-identifier-naming) -- gtest macro-generated names
+
+// ---------------------------------------------------------------------------
+// Exact match
+// ---------------------------------------------------------------------------
+
+TEST(TestGlobMatch, ExactMatchReturnsTrue)
+{
+    EXPECT_TRUE(globMatch("hello", "hello"));
+}
+
+TEST(TestGlobMatch, ExactMismatchReturnsFalse)
+{
+    EXPECT_FALSE(globMatch("hello", "world"));
+}
+
+// ---------------------------------------------------------------------------
+// Star wildcard
+// ---------------------------------------------------------------------------
+
+TEST(TestGlobMatch, StarMatchesEverything)
+{
+    EXPECT_TRUE(globMatch("*", "anything"));
+}
+
+TEST(TestGlobMatch, StarMatchesEmptyString)
+{
+    EXPECT_TRUE(globMatch("*", ""));
+}
+
+TEST(TestGlobMatch, LeadingStar)
+{
+    EXPECT_TRUE(globMatch("*world", "hello world"));
+    EXPECT_FALSE(globMatch("*world", "hello world!"));
+}
+
+TEST(TestGlobMatch, TrailingStar)
+{
+    EXPECT_TRUE(globMatch("hello*", "hello world"));
+    EXPECT_FALSE(globMatch("hello*", "hi world"));
+}
+
+TEST(TestGlobMatch, MiddleStar)
+{
+    EXPECT_TRUE(globMatch("he*ld", "hello world"));
+    EXPECT_FALSE(globMatch("he*ld", "hello worlds"));
+}
+
+TEST(TestGlobMatch, MultipleStars)
+{
+    EXPECT_TRUE(globMatch("*Conv*Fp16*", "IntegrationGpuConvFwd2dFp16/Smoke"));
+    EXPECT_FALSE(globMatch("*Conv*Fp16*", "IntegrationGpuConvFwd2dFp32/Smoke"));
+}
+
+// ---------------------------------------------------------------------------
+// Question-mark wildcard
+// ---------------------------------------------------------------------------
+
+TEST(TestGlobMatch, QuestionMarkMatchesSingleChar)
+{
+    EXPECT_TRUE(globMatch("h?llo", "hello"));
+    EXPECT_TRUE(globMatch("h?llo", "hallo"));
+}
+
+TEST(TestGlobMatch, QuestionMarkDoesNotMatchEmpty)
+{
+    EXPECT_FALSE(globMatch("h?llo", "hllo"));
+}
+
+TEST(TestGlobMatch, QuestionMarkDoesNotMatchMultiple)
+{
+    EXPECT_FALSE(globMatch("h?o", "hello"));
+}
+
+// ---------------------------------------------------------------------------
+// Empty inputs
+// ---------------------------------------------------------------------------
+
+TEST(TestGlobMatch, BothEmptyMatches)
+{
+    EXPECT_TRUE(globMatch("", ""));
+}
+
+TEST(TestGlobMatch, StarMatchesEmptyText)
+{
+    EXPECT_TRUE(globMatch("*", ""));
+}
+
+TEST(TestGlobMatch, LiteralDoesNotMatchEmptyText)
+{
+    EXPECT_FALSE(globMatch("a", ""));
+}
+
+// ---------------------------------------------------------------------------
+// Practical patterns from integration tests
+// ---------------------------------------------------------------------------
+
+TEST(TestGlobMatch, IntegrationStyleConvFwdFp16)
+{
+    EXPECT_TRUE(
+        globMatch("*ConvFwd*Fp16*", "IntegrationGpuConvFwd2dFp16/Smoke.Correctness/NCHW_params"));
+    EXPECT_FALSE(
+        globMatch("*ConvFwd*Fp16*", "IntegrationGpuConvFwd2dFp32/Smoke.Correctness/NCHW_params"));
+}
+
+TEST(TestGlobMatch, IntegrationStyleBroadWildcard)
+{
+    EXPECT_TRUE(globMatch("*convolution*fp16*", "test_convolution_fwd_fp16_nchw"));
+    EXPECT_FALSE(globMatch("*convolution*fp16*", "test_convolution_fwd_fp32_nchw"));
+}
+
+// NOLINTEND(readability-identifier-naming)


### PR DESCRIPTION
## Motivation
Develop for rocm-libraries (specifically dnn-providers/integration-tests) was broken.  This PR fixes a few issues.

## Technical Details
- Fixed test validator script
- Fixed gpu conv wrw not using the right namespace for toAccum / fromAccum
- Added a cross platform glob function

## Test Plan
- All unit tests and integration tests pass

## Test Result
- [x] Tests passing

## Submission Checklist
- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
