### PR TITLE
[rocsparse] fix illegal kernels

### DIFF
--- a/projects/rocsparse/CHANGELOG.md
+++ b/projects/rocsparse/CHANGELOG.md
@@ -17,6 +17,7 @@ Documentation for rocSPARSE is available at
 * Significant performance improvement for `rocsparse_Xgtsv_no_pivot`.
 
 ### Resolved issues
+* Fixed incorrect usage of `__syncthreads` in `csx2dense`, `dense2csx`, `prune_dense2csr`, `csrcolor`, and `csrmm` (nnz_split)
 * Fix `rocsparse_[s|d|c|z]csric0` where `rocsparse_status_invalid_value` was being returned when the maximum number of non-zeros in any row is between 513 and 1024.
 * Fix compilation when using `--rocsparse_ILP64`
 

--- a/projects/rocsparse/library/src/conversion/csx2dense_device.h
+++ b/projects/rocsparse/library/src/conversion/csx2dense_device.h
@@ -1,6 +1,6 @@
 /*! \file */
 /* ************************************************************************
- * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2026 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -58,7 +58,6 @@ namespace rocsparse
             //
             for(I index = lane_index; index < size_row; index += WF_SIZE)
             {
-                __syncthreads();
                 const J column_index = csr_col_ind[shift + index] - base;
 
                 if(order == rocsparse_order_column)

--- a/projects/rocsparse/library/src/conversion/dense2csx_device.h
+++ b/projects/rocsparse/library/src/conversion/dense2csx_device.h
@@ -1,6 +1,6 @@
 /*! \file */
 /* ************************************************************************
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -57,11 +57,6 @@ namespace rocsparse
             //
             for(J column_index = lane_index; column_index < n; column_index += WF_SIZE)
             {
-                //
-                // Synchronize for cache considerations.
-                //
-                __syncthreads();
-
                 //
                 // Get value.
                 //
@@ -166,11 +161,6 @@ namespace rocsparse
 
                 // Get the number of non-zeros in the row.
                 const int count_total_nnzs = __popcll(wavefront_mask);
-
-                //
-                // Synchronize for cache considerations.
-                //
-                __syncthreads();
 
                 if(predicate)
                 {

--- a/projects/rocsparse/library/src/conversion/prune_dense2csr_device.h
+++ b/projects/rocsparse/library/src/conversion/prune_dense2csr_device.h
@@ -1,6 +1,6 @@
 /*! \file */
 /* ************************************************************************
-* Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights Reserved.
+* Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights Reserved.
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -144,9 +144,6 @@ namespace rocsparse
             // The warp handles the entire row.
             for(rocsparse_int column_index = lane_index; column_index < n; column_index += WF_SIZE)
             {
-                // Synchronize for cache considerations.
-                __syncthreads();
-
                 // Get value.
                 const T value = dense_val[row_index + column_index * ld];
 

--- a/projects/rocsparse/library/src/level3/csrmm_device_nnz_split.h
+++ b/projects/rocsparse/library/src/level3/csrmm_device_nnz_split.h
@@ -356,11 +356,14 @@ namespace rocsparse
 
         const I col = hipBlockIdx_x;
 
-        for(I i = tid; i < nblocks; i += BLOCKSIZE)
+        for(I i = 0; i < nblocks; i += BLOCKSIZE)
         {
+            const I idx = i + tid;
+
             // Copy data to reduction buffers
-            shared_row[tid] = row_block_red[i];
-            shared_val[tid] = val_block_red[i + nblocks * col];
+            shared_row[tid] = (idx < nblocks) ? row_block_red[idx] : -1;
+            shared_val[tid]
+                = (idx < nblocks) ? val_block_red[idx + nblocks * col] : static_cast<T>(0);
 
             __syncthreads();
 

--- a/projects/rocsparse/library/src/reordering/rocsparse_csrcolor.cpp
+++ b/projects/rocsparse/library/src/reordering/rocsparse_csrcolor.cpp
@@ -1,6 +1,6 @@
 /*! \file */
 /* ************************************************************************
- * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -139,11 +139,6 @@ namespace rocsparse
                 // Get the number of previous non-zero in the row.
                 //
                 const uint64_t count_previous_uncolored = __popcll(wavefront_mask & filter);
-
-                //
-                // Synchronize for cache considerations.
-                //
-                __syncthreads();
 
                 if(predicate)
                 {


### PR DESCRIPTION
The rocsparse library has a illegal usage of `__syncthreads();` this PR fixes that by either removing the unneeded ones or by changing the kernels to remove the need of using it.