### PR TITLE
[hipDNN] Migrate hipdnn backend tests to use hipdnn_flatbuffers_sdk

### DIFF
--- a/projects/hipdnn/tests/backend/CMakeLists.txt
+++ b/projects/hipdnn/tests/backend/CMakeLists.txt
@@ -38,6 +38,7 @@ target_link_libraries(
         GTest::gtest_main
         Threads::Threads
         hipdnn_test_sdk
+        hipdnn_flatbuffers_sdk
         hipdnn_plugin_sdk
         hipdnn_backend
         hip::host

--- a/projects/hipdnn/tests/backend/IntegrationConvOperationDescriptorApi.cpp
+++ b/projects/hipdnn/tests/backend/IntegrationConvOperationDescriptorApi.cpp
@@ -4,7 +4,7 @@
 #include "BackendTestHelpers.hpp"
 #include "hipdnn_backend.h"
 #include <gtest/gtest.h>
-#include <hipdnn_data_sdk/data_objects/convolution_common_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/convolution_common_generated.h>
 #include <hipdnn_test_sdk/constants/ConvFpropConstants.hpp>
 #include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
 #include <test_plugins/TestPluginConstants.hpp>

--- a/projects/hipdnn/tests/backend/IntegrationGraphDescriptorApi.cpp
+++ b/projects/hipdnn/tests/backend/IntegrationGraphDescriptorApi.cpp
@@ -4,9 +4,9 @@
 #include "BackendTestHelpers.hpp"
 #include "hipdnn_backend.h"
 #include <gtest/gtest.h>
-#include <hipdnn_data_sdk/data_objects/convolution_common_generated.h>
-#include <hipdnn_data_sdk/data_objects/data_types_generated.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/convolution_common_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/data_types_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_test_sdk/constants/ConvFpropConstants.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 #include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
@@ -15,7 +15,7 @@
 
 using namespace backend_test;
 using namespace hipdnn_tests::constants;
-using DataTypeSdk = hipdnn_data_sdk::data_objects::DataType;
+using DataTypeSdk = hipdnn_flatbuffers_sdk::data_objects::DataType;
 
 class IntegrationGraphDescriptorApi : public ::testing::Test
 {
@@ -155,7 +155,7 @@ TEST_F(IntegrationGraphDescriptorApi, GetSerializedGraphSizeQueryMatchesCopySize
     EXPECT_EQ(copySize, queriedSize);
 
     // Verify data is valid FlatBuffer
-    auto graphFb = hipdnn_data_sdk::data_objects::GetGraph(buffer.data());
+    auto graphFb = hipdnn_flatbuffers_sdk::data_objects::GetGraph(buffer.data());
     ASSERT_NE(graphFb, nullptr);
 
     hipdnnBackendDestroyDescriptor(desc);
@@ -195,9 +195,9 @@ TEST_F(IntegrationGraphDescriptorApi, SerializedGraphRoundTripPreservesGraphProp
               HIPDNN_STATUS_SUCCESS);
 
     // Verify graph properties match what we set
-    auto graphFb = hipdnn_data_sdk::data_objects::GetGraph(buffer.data());
+    auto graphFb = hipdnn_flatbuffers_sdk::data_objects::GetGraph(buffer.data());
     ASSERT_NE(graphFb, nullptr);
-    hipdnn_data_sdk::data_objects::GraphT graphT;
+    hipdnn_flatbuffers_sdk::data_objects::GraphT graphT;
     graphFb->UnPackTo(&graphT);
 
     EXPECT_EQ(graphT.name, "test");
@@ -285,7 +285,7 @@ TEST_F(IntegrationGraphDescriptorApi, GetSerializedGraphSucceedsWithOversizedBuf
     EXPECT_EQ(reportedSize, queriedSize);
 
     // Verify data is valid
-    auto graphFb = hipdnn_data_sdk::data_objects::GetGraph(buffer.data());
+    auto graphFb = hipdnn_flatbuffers_sdk::data_objects::GetGraph(buffer.data());
     ASSERT_NE(graphFb, nullptr);
 
     hipdnnBackendDestroyDescriptor(desc);

--- a/projects/hipdnn/tests/backend/IntegrationKnobsApi.cpp
+++ b/projects/hipdnn/tests/backend/IntegrationKnobsApi.cpp
@@ -15,6 +15,11 @@
 #include <unordered_set>
 #include <vector>
 
+using hipdnn_flatbuffers_sdk::data_objects::Knob;
+using hipdnn_flatbuffers_sdk::data_objects::KnobConstraint;
+using hipdnn_flatbuffers_sdk::data_objects::KnobValue;
+using hipdnn_plugin_sdk::KnobSettingFactory;
+
 class IntegrationKnobsApi : public ::testing::Test
 {
 protected:
@@ -229,8 +234,9 @@ TEST_F(IntegrationKnobsApi, GetKnobInfoValidateIntKnob)
     bool foundIntKnob = false;
     for(size_t i = 0; i < static_cast<size_t>(returnedCount); ++i)
     {
-        flatbuffers::Verifier verifier(static_cast<const uint8_t*>(knobData[i].ptr),
-                                       knobData[i].size);
+        flatbuffers::Verifier verifier( // NOLINT(misc-const-correctness)
+            static_cast<const uint8_t*>(knobData[i].ptr),
+            knobData[i].size);
         ASSERT_TRUE(verifier.VerifyBuffer<Knob>());
 
         auto knob = flatbuffers::GetRoot<Knob>(knobData[i].ptr);
@@ -466,11 +472,6 @@ TEST_F(IntegrationKnobsApi, GetKnobInfoNotFinalizedEngine)
 // =============================================================================
 // EngineConfig Knob Choice Tests (via HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE)
 // =============================================================================
-
-using hipdnn_flatbuffers_sdk::data_objects::Knob;
-using hipdnn_flatbuffers_sdk::data_objects::KnobConstraint;
-using hipdnn_flatbuffers_sdk::data_objects::KnobValue;
-using hipdnn_plugin_sdk::KnobSettingFactory;
 
 TEST_F(IntegrationKnobsApi, SetKnobChoiceIntValue)
 {

--- a/projects/hipdnn/tests/backend/IntegrationKnobsApi.cpp
+++ b/projects/hipdnn/tests/backend/IntegrationKnobsApi.cpp
@@ -8,8 +8,8 @@
 #include <array>
 #include <cstring>
 #include <gtest/gtest.h>
-#include <hipdnn_data_sdk/data_objects/engine_config_generated.h>
-#include <hipdnn_data_sdk/data_objects/knob_value_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/engine_config_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/knob_value_generated.h>
 #include <hipdnn_plugin_sdk/KnobSettingFactory.hpp>
 #include <test_plugins/TestPluginConstants.hpp>
 #include <unordered_set>
@@ -231,9 +231,10 @@ TEST_F(IntegrationKnobsApi, GetKnobInfoValidateIntKnob)
     {
         flatbuffers::Verifier verifier(static_cast<const uint8_t*>(knobData[i].ptr),
                                        knobData[i].size);
-        ASSERT_TRUE(verifier.VerifyBuffer<hipdnn_data_sdk::data_objects::Knob>());
+        ASSERT_TRUE(verifier.VerifyBuffer<hipdnn_flatbuffers_sdk::data_objects::Knob>());
 
-        auto knob = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(knobData[i].ptr);
+        auto knob
+            = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::Knob>(knobData[i].ptr);
 
         if(knob->knob_id()->str() == "test.int_knob")
         {
@@ -244,14 +245,14 @@ TEST_F(IntegrationKnobsApi, GetKnobInfoValidateIntKnob)
 
             // Verify default value type and value
             EXPECT_EQ(knob->default_value_type(),
-                      hipdnn_data_sdk::data_objects::KnobValue::IntValue);
+                      hipdnn_flatbuffers_sdk::data_objects::KnobValue::IntValue);
             auto intValue = knob->default_value_as_IntValue();
             ASSERT_NE(intValue, nullptr);
             EXPECT_EQ(intValue->value(), 50);
 
             // Verify constraint
             EXPECT_EQ(knob->constraint_type(),
-                      hipdnn_data_sdk::data_objects::KnobConstraint::IntConstraint);
+                      hipdnn_flatbuffers_sdk::data_objects::KnobConstraint::IntConstraint);
             auto constraint = knob->constraint_as_IntConstraint();
             ASSERT_NE(constraint, nullptr);
             EXPECT_EQ(constraint->min_value(), 0);
@@ -294,7 +295,8 @@ TEST_F(IntegrationKnobsApi, GetKnobInfoValidateFloatKnob)
     bool foundFloatKnob = false;
     for(size_t i = 0; i < static_cast<size_t>(returnedCount); ++i)
     {
-        auto knob = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(knobData[i].ptr);
+        auto knob
+            = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::Knob>(knobData[i].ptr);
 
         if(knob->knob_id()->str() == "test.float_knob")
         {
@@ -305,14 +307,14 @@ TEST_F(IntegrationKnobsApi, GetKnobInfoValidateFloatKnob)
 
             // Verify default value type and value
             EXPECT_EQ(knob->default_value_type(),
-                      hipdnn_data_sdk::data_objects::KnobValue::FloatValue);
+                      hipdnn_flatbuffers_sdk::data_objects::KnobValue::FloatValue);
             auto floatValue = knob->default_value_as_FloatValue();
             ASSERT_NE(floatValue, nullptr);
             EXPECT_DOUBLE_EQ(floatValue->value(), 0.5);
 
             // Verify constraint
             EXPECT_EQ(knob->constraint_type(),
-                      hipdnn_data_sdk::data_objects::KnobConstraint::FloatConstraint);
+                      hipdnn_flatbuffers_sdk::data_objects::KnobConstraint::FloatConstraint);
             auto constraint = knob->constraint_as_FloatConstraint();
             ASSERT_NE(constraint, nullptr);
             EXPECT_DOUBLE_EQ(constraint->min_value(), 0.0);
@@ -354,7 +356,8 @@ TEST_F(IntegrationKnobsApi, GetKnobInfoValidateStringKnob)
     bool foundStringKnob = false;
     for(size_t i = 0; i < static_cast<size_t>(returnedCount); ++i)
     {
-        auto knob = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(knobData[i].ptr);
+        auto knob
+            = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::Knob>(knobData[i].ptr);
 
         if(knob->knob_id()->str() == "test.string_knob")
         {
@@ -365,14 +368,14 @@ TEST_F(IntegrationKnobsApi, GetKnobInfoValidateStringKnob)
 
             // Verify default value type and value
             EXPECT_EQ(knob->default_value_type(),
-                      hipdnn_data_sdk::data_objects::KnobValue::StringValue);
+                      hipdnn_flatbuffers_sdk::data_objects::KnobValue::StringValue);
             auto stringValue = knob->default_value_as_StringValue();
             ASSERT_NE(stringValue, nullptr);
             EXPECT_STREQ(stringValue->value()->c_str(), "fast");
 
             // Verify constraint
             EXPECT_EQ(knob->constraint_type(),
-                      hipdnn_data_sdk::data_objects::KnobConstraint::StringConstraint);
+                      hipdnn_flatbuffers_sdk::data_objects::KnobConstraint::StringConstraint);
             auto constraint = knob->constraint_as_StringConstraint();
             ASSERT_NE(constraint, nullptr);
             // Note: KnobFactory uses max_length=0 (no length limit) for string knobs
@@ -424,7 +427,8 @@ TEST_F(IntegrationKnobsApi, GetKnobInfoValidateDeprecatedKnob)
     bool foundDeprecatedKnob = false;
     for(size_t i = 0; i < static_cast<size_t>(returnedCount); ++i)
     {
-        auto knob = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(knobData[i].ptr);
+        auto knob
+            = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::Knob>(knobData[i].ptr);
 
         if(knob->knob_id()->str() == "test.deprecated_knob")
         {

--- a/projects/hipdnn/tests/backend/IntegrationKnobsApi.cpp
+++ b/projects/hipdnn/tests/backend/IntegrationKnobsApi.cpp
@@ -231,10 +231,9 @@ TEST_F(IntegrationKnobsApi, GetKnobInfoValidateIntKnob)
     {
         flatbuffers::Verifier verifier(static_cast<const uint8_t*>(knobData[i].ptr),
                                        knobData[i].size);
-        ASSERT_TRUE(verifier.VerifyBuffer<hipdnn_flatbuffers_sdk::data_objects::Knob>());
+        ASSERT_TRUE(verifier.VerifyBuffer<Knob>());
 
-        auto knob
-            = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::Knob>(knobData[i].ptr);
+        auto knob = flatbuffers::GetRoot<Knob>(knobData[i].ptr);
 
         if(knob->knob_id()->str() == "test.int_knob")
         {
@@ -244,15 +243,13 @@ TEST_F(IntegrationKnobsApi, GetKnobInfoValidateIntKnob)
             EXPECT_STREQ(knob->description()->c_str(), "Test integer knob with range 0-100");
 
             // Verify default value type and value
-            EXPECT_EQ(knob->default_value_type(),
-                      hipdnn_flatbuffers_sdk::data_objects::KnobValue::IntValue);
+            EXPECT_EQ(knob->default_value_type(), KnobValue::IntValue);
             auto intValue = knob->default_value_as_IntValue();
             ASSERT_NE(intValue, nullptr);
             EXPECT_EQ(intValue->value(), 50);
 
             // Verify constraint
-            EXPECT_EQ(knob->constraint_type(),
-                      hipdnn_flatbuffers_sdk::data_objects::KnobConstraint::IntConstraint);
+            EXPECT_EQ(knob->constraint_type(), KnobConstraint::IntConstraint);
             auto constraint = knob->constraint_as_IntConstraint();
             ASSERT_NE(constraint, nullptr);
             EXPECT_EQ(constraint->min_value(), 0);
@@ -295,8 +292,7 @@ TEST_F(IntegrationKnobsApi, GetKnobInfoValidateFloatKnob)
     bool foundFloatKnob = false;
     for(size_t i = 0; i < static_cast<size_t>(returnedCount); ++i)
     {
-        auto knob
-            = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::Knob>(knobData[i].ptr);
+        auto knob = flatbuffers::GetRoot<Knob>(knobData[i].ptr);
 
         if(knob->knob_id()->str() == "test.float_knob")
         {
@@ -306,15 +302,13 @@ TEST_F(IntegrationKnobsApi, GetKnobInfoValidateFloatKnob)
             EXPECT_STREQ(knob->description()->c_str(), "Test float knob with range 0.0-1.0");
 
             // Verify default value type and value
-            EXPECT_EQ(knob->default_value_type(),
-                      hipdnn_flatbuffers_sdk::data_objects::KnobValue::FloatValue);
+            EXPECT_EQ(knob->default_value_type(), KnobValue::FloatValue);
             auto floatValue = knob->default_value_as_FloatValue();
             ASSERT_NE(floatValue, nullptr);
             EXPECT_DOUBLE_EQ(floatValue->value(), 0.5);
 
             // Verify constraint
-            EXPECT_EQ(knob->constraint_type(),
-                      hipdnn_flatbuffers_sdk::data_objects::KnobConstraint::FloatConstraint);
+            EXPECT_EQ(knob->constraint_type(), KnobConstraint::FloatConstraint);
             auto constraint = knob->constraint_as_FloatConstraint();
             ASSERT_NE(constraint, nullptr);
             EXPECT_DOUBLE_EQ(constraint->min_value(), 0.0);
@@ -356,8 +350,7 @@ TEST_F(IntegrationKnobsApi, GetKnobInfoValidateStringKnob)
     bool foundStringKnob = false;
     for(size_t i = 0; i < static_cast<size_t>(returnedCount); ++i)
     {
-        auto knob
-            = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::Knob>(knobData[i].ptr);
+        auto knob = flatbuffers::GetRoot<Knob>(knobData[i].ptr);
 
         if(knob->knob_id()->str() == "test.string_knob")
         {
@@ -367,15 +360,13 @@ TEST_F(IntegrationKnobsApi, GetKnobInfoValidateStringKnob)
             EXPECT_STREQ(knob->description()->c_str(), "Test string knob with enum values");
 
             // Verify default value type and value
-            EXPECT_EQ(knob->default_value_type(),
-                      hipdnn_flatbuffers_sdk::data_objects::KnobValue::StringValue);
+            EXPECT_EQ(knob->default_value_type(), KnobValue::StringValue);
             auto stringValue = knob->default_value_as_StringValue();
             ASSERT_NE(stringValue, nullptr);
             EXPECT_STREQ(stringValue->value()->c_str(), "fast");
 
             // Verify constraint
-            EXPECT_EQ(knob->constraint_type(),
-                      hipdnn_flatbuffers_sdk::data_objects::KnobConstraint::StringConstraint);
+            EXPECT_EQ(knob->constraint_type(), KnobConstraint::StringConstraint);
             auto constraint = knob->constraint_as_StringConstraint();
             ASSERT_NE(constraint, nullptr);
             // Note: KnobFactory uses max_length=0 (no length limit) for string knobs
@@ -427,8 +418,7 @@ TEST_F(IntegrationKnobsApi, GetKnobInfoValidateDeprecatedKnob)
     bool foundDeprecatedKnob = false;
     for(size_t i = 0; i < static_cast<size_t>(returnedCount); ++i)
     {
-        auto knob
-            = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::Knob>(knobData[i].ptr);
+        auto knob = flatbuffers::GetRoot<Knob>(knobData[i].ptr);
 
         if(knob->knob_id()->str() == "test.deprecated_knob")
         {
@@ -477,6 +467,9 @@ TEST_F(IntegrationKnobsApi, GetKnobInfoNotFinalizedEngine)
 // EngineConfig Knob Choice Tests (via HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE)
 // =============================================================================
 
+using hipdnn_flatbuffers_sdk::data_objects::Knob;
+using hipdnn_flatbuffers_sdk::data_objects::KnobConstraint;
+using hipdnn_flatbuffers_sdk::data_objects::KnobValue;
 using hipdnn_plugin_sdk::KnobSettingFactory;
 
 TEST_F(IntegrationKnobsApi, SetKnobChoiceIntValue)
@@ -812,8 +805,7 @@ TEST_F(IntegrationConstraintValidationApi, IntValueToFloatConstraint)
 {
     setupEngineConfig();
 
-    auto knobBuffer
-        = hipdnn_plugin_sdk::KnobSettingFactory::createIntKnobSetting("constraint.float_knob", 5);
+    auto knobBuffer = KnobSettingFactory::createIntKnobSetting("constraint.float_knob", 5);
     hipdnnBackendFlatbufferData_t knobData = {knobBuffer.data(), knobBuffer.size()};
 
     EXPECT_EQ(hipdnnBackendSetAttribute(_engineConfig,
@@ -831,8 +823,7 @@ TEST_F(IntegrationConstraintValidationApi, FloatValueToIntConstraint)
 {
     setupEngineConfig();
 
-    auto knobBuffer = hipdnn_plugin_sdk::KnobSettingFactory::createFloatKnobSetting(
-        "constraint.int_knob", 50.0);
+    auto knobBuffer = KnobSettingFactory::createFloatKnobSetting("constraint.int_knob", 50.0);
     hipdnnBackendFlatbufferData_t knobData = {knobBuffer.data(), knobBuffer.size()};
 
     EXPECT_EQ(hipdnnBackendSetAttribute(_engineConfig,
@@ -850,8 +841,7 @@ TEST_F(IntegrationConstraintValidationApi, StringValueToIntConstraint)
 {
     setupEngineConfig();
 
-    auto knobBuffer = hipdnn_plugin_sdk::KnobSettingFactory::createStringKnobSetting(
-        "constraint.int_knob", "50");
+    auto knobBuffer = KnobSettingFactory::createStringKnobSetting("constraint.int_knob", "50");
     hipdnnBackendFlatbufferData_t knobData = {knobBuffer.data(), knobBuffer.size()};
 
     EXPECT_EQ(hipdnnBackendSetAttribute(_engineConfig,
@@ -869,8 +859,7 @@ TEST_F(IntegrationConstraintValidationApi, IntValueToStringConstraint)
 {
     setupEngineConfig();
 
-    auto knobBuffer
-        = hipdnn_plugin_sdk::KnobSettingFactory::createIntKnobSetting("constraint.string_knob", 0);
+    auto knobBuffer = KnobSettingFactory::createIntKnobSetting("constraint.string_knob", 0);
     hipdnnBackendFlatbufferData_t knobData = {knobBuffer.data(), knobBuffer.size()};
 
     EXPECT_EQ(hipdnnBackendSetAttribute(_engineConfig,
@@ -888,8 +877,7 @@ TEST_F(IntegrationConstraintValidationApi, FloatValueToStringConstraint)
 {
     setupEngineConfig();
 
-    auto knobBuffer = hipdnn_plugin_sdk::KnobSettingFactory::createFloatKnobSetting(
-        "constraint.string_knob", 1.5);
+    auto knobBuffer = KnobSettingFactory::createFloatKnobSetting("constraint.string_knob", 1.5);
     hipdnnBackendFlatbufferData_t knobData = {knobBuffer.data(), knobBuffer.size()};
 
     EXPECT_EQ(hipdnnBackendSetAttribute(_engineConfig,
@@ -907,8 +895,7 @@ TEST_F(IntegrationConstraintValidationApi, StringValueToFloatConstraint)
 {
     setupEngineConfig();
 
-    auto knobBuffer = hipdnn_plugin_sdk::KnobSettingFactory::createStringKnobSetting(
-        "constraint.float_knob", "5.0");
+    auto knobBuffer = KnobSettingFactory::createStringKnobSetting("constraint.float_knob", "5.0");
     hipdnnBackendFlatbufferData_t knobData = {knobBuffer.data(), knobBuffer.size()};
 
     EXPECT_EQ(hipdnnBackendSetAttribute(_engineConfig,
@@ -926,12 +913,10 @@ TEST_F(IntegrationConstraintValidationApi, CorrectTypesSucceed)
 {
     setupEngineConfig();
 
-    auto intKnobBuffer
-        = hipdnn_plugin_sdk::KnobSettingFactory::createIntKnobSetting("constraint.int_knob", 50);
-    auto floatKnobBuffer = hipdnn_plugin_sdk::KnobSettingFactory::createFloatKnobSetting(
-        "constraint.float_knob", 5.0);
-    auto stringKnobBuffer = hipdnn_plugin_sdk::KnobSettingFactory::createStringKnobSetting(
-        "constraint.string_knob", "beta");
+    auto intKnobBuffer = KnobSettingFactory::createIntKnobSetting("constraint.int_knob", 50);
+    auto floatKnobBuffer = KnobSettingFactory::createFloatKnobSetting("constraint.float_knob", 5.0);
+    auto stringKnobBuffer
+        = KnobSettingFactory::createStringKnobSetting("constraint.string_knob", "beta");
 
     std::vector<hipdnnBackendFlatbufferData_t> knobDataArray
         = {{intKnobBuffer.data(), intKnobBuffer.size()},
@@ -953,8 +938,7 @@ TEST_F(IntegrationConstraintValidationApi, UnknownKnobIsIgnored)
 {
     setupEngineConfig();
 
-    auto knobBuffer
-        = hipdnn_plugin_sdk::KnobSettingFactory::createIntKnobSetting("unknown.knob", 123);
+    auto knobBuffer = KnobSettingFactory::createIntKnobSetting("unknown.knob", 123);
     hipdnnBackendFlatbufferData_t knobData = {knobBuffer.data(), knobBuffer.size()};
 
     EXPECT_EQ(hipdnnBackendSetAttribute(_engineConfig,
@@ -972,10 +956,8 @@ TEST_F(IntegrationConstraintValidationApi, MixedValidAndInvalidKnobs)
 {
     setupEngineConfig();
 
-    auto validKnobBuffer
-        = hipdnn_plugin_sdk::KnobSettingFactory::createIntKnobSetting("constraint.int_knob", 50);
-    auto invalidKnobBuffer
-        = hipdnn_plugin_sdk::KnobSettingFactory::createIntKnobSetting("constraint.float_knob", 5);
+    auto validKnobBuffer = KnobSettingFactory::createIntKnobSetting("constraint.int_knob", 50);
+    auto invalidKnobBuffer = KnobSettingFactory::createIntKnobSetting("constraint.float_knob", 5);
 
     std::vector<hipdnnBackendFlatbufferData_t> knobDataArray
         = {{validKnobBuffer.data(), validKnobBuffer.size()},

--- a/projects/hipdnn/tests/backend/IntegrationSetPluginPathsExt.cpp
+++ b/projects/hipdnn/tests/backend/IntegrationSetPluginPathsExt.cpp
@@ -6,8 +6,8 @@
 #include <array>
 #include <filesystem>
 #include <gtest/gtest.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
 #include <hipdnn_data_sdk/utilities/PlatformUtils.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_test_sdk/utilities/ScopedEnvironmentVariableSetter.hpp>
 #include <vector>
 

--- a/projects/hipdnn/tests/backend/TestUtil.cpp
+++ b/projects/hipdnn/tests/backend/TestUtil.cpp
@@ -5,9 +5,9 @@
 #include "hipdnn_backend.h"
 #include <filesystem>
 #include <gtest/gtest.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
 #include <hipdnn_data_sdk/logging/Logger.hpp>
 #include <hipdnn_data_sdk/utilities/PlatformUtils.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 #include <span>
 #include <stdexcept>
@@ -271,7 +271,8 @@ void extractTensorInfoFromGraph(const flatbuffers::DetachedBuffer& serializedGra
     nameToUidMap.clear();
     uidToDimsMap.clear();
 
-    auto deserializedGraph = hipdnn_data_sdk::data_objects::UnPackGraph(serializedGraph.data());
+    auto deserializedGraph
+        = hipdnn_flatbuffers_sdk::data_objects::UnPackGraph(serializedGraph.data());
     ASSERT_NE(deserializedGraph, nullptr);
 
     // Extract all tensor information from the deserialized graph

--- a/projects/hipdnn/tests/backend/TestUtil.hpp
+++ b/projects/hipdnn/tests/backend/TestUtil.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "hipdnn_backend.h"
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 
 namespace test_util
 {


### PR DESCRIPTION
## Summary
- Migrate hipdnn backend integration tests to use `hipdnn_flatbuffers_sdk` for FlatBuffers type deserialization
- Add `hipdnn_flatbuffers_sdk` link dependency to backend test CMakeLists.txt
- Backend tests deserialize raw FlatBuffer bytes directly, so they can use `hipdnn_flatbuffers_sdk` schema independently of the backend's internal namespace

## Test plan
- [x] hipdnn core builds successfully
- [x] All 9 hipdnn test suites pass (100%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)