### PR TITLE
[hipDNN] Migrate plugin_sdk, test_sdk, dnn-providers, and test_plugins to hipdnn_flatbuffers_sdk

### DIFF
--- a/dnn-providers/fusilli-provider/CMakeLists.txt
+++ b/dnn-providers/fusilli-provider/CMakeLists.txt
@@ -51,7 +51,7 @@ FetchContent_MakeAvailable(IREERuntime)
 
 # Other dependencies
 find_package(hip CONFIG REQUIRED)
-find_package(hipdnn_data_sdk CONFIG REQUIRED)
+find_package(hipdnn_flatbuffers_sdk CONFIG REQUIRED)
 find_package(hipdnn_plugin_sdk CONFIG REQUIRED)
 find_package(hipdnn_frontend CONFIG REQUIRED)
 find_package(hipdnn_test_sdk CONFIG REQUIRED)
@@ -107,7 +107,7 @@ add_library(${FUSILLI_PLUGIN_TARGET} SHARED
   src/fusilli_plugin.cpp
 )
 target_compile_options(${FUSILLI_PLUGIN_TARGET} PRIVATE ${FUSILLI_PLUGIN_WARNING_COMPILE_OPTIONS})
-target_link_libraries(${FUSILLI_PLUGIN_TARGET} PRIVATE hipdnn_plugin_sdk hipdnn_data_sdk hip::host fusilli::fusilli)
+target_link_libraries(${FUSILLI_PLUGIN_TARGET} PRIVATE hipdnn_plugin_sdk hipdnn_flatbuffers_sdk hip::host fusilli::fusilli)
 set_target_properties(${FUSILLI_PLUGIN_TARGET} PROPERTIES
   C_VISIBILITY_PRESET hidden
   CXX_VISIBILITY_PRESET hidden

--- a/dnn-providers/fusilli-provider/include/custom_ops.h
+++ b/dnn-providers/fusilli-provider/include/custom_ops.h
@@ -24,7 +24,7 @@
 #define FUSILLI_PLUGIN_CUSTOM_OPS_H
 
 #include <fusilli.h>
-#include <hipdnn_data_sdk/data_objects/sdpa_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/sdpa_attributes_generated.h>
 
 #include <format>
 #include <memory>
@@ -94,8 +94,8 @@ static constexpr std::string_view kSdpaWithMask = R"mlir(
 namespace SdpaImport {
 // Check if the SDPA attributes use only features supported by the MLIR
 // template. Returns NotImplemented for unsupported configurations.
-inline fusilli::ErrorObject
-validateTemplate(const hipdnn_data_sdk::data_objects::SdpaAttributes *attrs) {
+inline fusilli::ErrorObject validateTemplate(
+    const hipdnn_flatbuffers_sdk::data_objects::SdpaAttributes *attrs) {
   if (attrs->dropout_probability().has_value() &&
       *attrs->dropout_probability() > 0.0f)
     return fusilli::error(fusilli::ErrorCode::NotImplemented,
@@ -137,14 +137,14 @@ validateTemplate(const hipdnn_data_sdk::data_objects::SdpaAttributes *attrs) {
     return fusilli::error(fusilli::ErrorCode::NotImplemented,
                           "SDPA with FP8 quantization not supported.");
   if (attrs->diagonal_alignment() !=
-      hipdnn_data_sdk::data_objects::DiagonalAlignment::TOP_LEFT)
+      hipdnn_flatbuffers_sdk::data_objects::DiagonalAlignment::TOP_LEFT)
     return fusilli::error(
         fusilli::ErrorCode::NotImplemented,
         "SDPA with non-TOP_LEFT diagonal alignment not supported.");
   // This is out of an over-abundance of caution, IREE doesn't need a backend
   // implementation hit.
   if (attrs->implementation() !=
-      hipdnn_data_sdk::data_objects::AttentionImplementation::AUTO)
+      hipdnn_flatbuffers_sdk::data_objects::AttentionImplementation::AUTO)
     return fusilli::error(
         fusilli::ErrorCode::NotImplemented,
         "SDPA with explicit implementation strategy not supported.");

--- a/dnn-providers/fusilli-provider/include/graph_import.h
+++ b/dnn-providers/fusilli-provider/include/graph_import.h
@@ -15,18 +15,18 @@
 #define FUSILLI_PLUGIN_SRC_GRAPH_IMPORT_H
 
 #include <fusilli.h>
-#include <hipdnn_data_sdk/data_objects/convolution_bwd_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/convolution_wrw_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/custom_op_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/data_types_generated.h>
-#include <hipdnn_data_sdk/data_objects/matmul_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/norm_common_generated.h>
-#include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/reduction_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/rmsnorm_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/sdpa_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/convolution_bwd_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/convolution_wrw_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/custom_op_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/data_types_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/matmul_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/norm_common_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/pointwise_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/reduction_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/rmsnorm_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/sdpa_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
 
 #include <format>
@@ -39,25 +39,25 @@
 
 // Convert from hipDNN DataType to fusilli DataType.
 inline fusilli::ErrorOr<fusilli::DataType> hipDnnDataTypeToFusilliDataType(
-    hipdnn_data_sdk::data_objects::DataType hipdnnType) {
+    hipdnn_flatbuffers_sdk::data_objects::DataType hipdnnType) {
   switch (hipdnnType) {
-  case hipdnn_data_sdk::data_objects::DataType::HALF:
+  case hipdnn_flatbuffers_sdk::data_objects::DataType::HALF:
     return ok(fusilli::DataType::Half);
-  case hipdnn_data_sdk::data_objects::DataType::BFLOAT16:
+  case hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16:
     return ok(fusilli::DataType::BFloat16);
-  case hipdnn_data_sdk::data_objects::DataType::FLOAT:
+  case hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT:
     return ok(fusilli::DataType::Float);
-  case hipdnn_data_sdk::data_objects::DataType::DOUBLE:
+  case hipdnn_flatbuffers_sdk::data_objects::DataType::DOUBLE:
     return ok(fusilli::DataType::Double);
-  case hipdnn_data_sdk::data_objects::DataType::INT8:
+  case hipdnn_flatbuffers_sdk::data_objects::DataType::INT8:
     return ok(fusilli::DataType::Int8);
-  case hipdnn_data_sdk::data_objects::DataType::UINT8:
+  case hipdnn_flatbuffers_sdk::data_objects::DataType::UINT8:
     return ok(fusilli::DataType::Uint8);
-  case hipdnn_data_sdk::data_objects::DataType::INT32:
+  case hipdnn_flatbuffers_sdk::data_objects::DataType::INT32:
     return ok(fusilli::DataType::Int32);
-  case hipdnn_data_sdk::data_objects::DataType::INT4:
+  case hipdnn_flatbuffers_sdk::data_objects::DataType::INT4:
     return ok(fusilli::DataType::Int4);
-  case hipdnn_data_sdk::data_objects::DataType::UNSET:
+  case hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET:
     return ok(fusilli::DataType::NotSet);
   default:
     return error(fusilli::ErrorCode::RuntimeFailure,
@@ -66,13 +66,13 @@ inline fusilli::ErrorOr<fusilli::DataType> hipDnnDataTypeToFusilliDataType(
 }
 
 #define FUSILLI_PLUGIN_POINTWISE_CASE(CASE)                                    \
-  case hipdnn_data_sdk::data_objects::PointwiseMode::CASE:                     \
+  case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::CASE:              \
     return fusilli::PointwiseAttr::Mode::CASE;
 
 // Convert from hipDNN PointwiseMode to fusilli PointwiseAttr::Mode.
 inline fusilli::ErrorOr<fusilli::PointwiseAttr::Mode>
 hipDnnPointwiseModeToFusilliMode(
-    hipdnn_data_sdk::data_objects::PointwiseMode hipdnnMode) {
+    hipdnn_flatbuffers_sdk::data_objects::PointwiseMode hipdnnMode) {
   switch (hipdnnMode) {
     FUSILLI_POINTWISE_OPS(FUSILLI_PLUGIN_POINTWISE_CASE)
   default:
@@ -83,11 +83,11 @@ hipDnnPointwiseModeToFusilliMode(
 
 // Convert from hipDNN NormFwdPhase to fusilli NormFwdPhase.
 inline fusilli::ErrorOr<fusilli::NormFwdPhase> hipDnnNormFwdPhaseToFusilliPhase(
-    hipdnn_data_sdk::data_objects::NormFwdPhase hipdnnPhase) {
+    hipdnn_flatbuffers_sdk::data_objects::NormFwdPhase hipdnnPhase) {
   switch (hipdnnPhase) {
-  case hipdnn_data_sdk::data_objects::NormFwdPhase::TRAINING:
+  case hipdnn_flatbuffers_sdk::data_objects::NormFwdPhase::TRAINING:
     return ok(fusilli::NormFwdPhase::TRAINING);
-  case hipdnn_data_sdk::data_objects::NormFwdPhase::INFERENCE:
+  case hipdnn_flatbuffers_sdk::data_objects::NormFwdPhase::INFERENCE:
     return ok(fusilli::NormFwdPhase::INFERENCE);
   default:
     return error(fusilli::ErrorCode::NotImplemented,
@@ -98,13 +98,13 @@ inline fusilli::ErrorOr<fusilli::NormFwdPhase> hipDnnNormFwdPhaseToFusilliPhase(
 // Convert from hipDNN ReductionMode to fusilli ReductionAttr::Mode.
 inline fusilli::ErrorOr<fusilli::ReductionAttr::Mode>
 hipDnnReductionModeToFusilliMode(
-    hipdnn_data_sdk::data_objects::ReductionMode hipdnnMode) {
+    hipdnn_flatbuffers_sdk::data_objects::ReductionMode hipdnnMode) {
   switch (hipdnnMode) {
-  case hipdnn_data_sdk::data_objects::ReductionMode::ADD:
+  case hipdnn_flatbuffers_sdk::data_objects::ReductionMode::ADD:
     return ok(fusilli::ReductionAttr::Mode::SUM);
-  case hipdnn_data_sdk::data_objects::ReductionMode::MIN_OP:
+  case hipdnn_flatbuffers_sdk::data_objects::ReductionMode::MIN_OP:
     return ok(fusilli::ReductionAttr::Mode::MIN);
-  case hipdnn_data_sdk::data_objects::ReductionMode::MAX_OP:
+  case hipdnn_flatbuffers_sdk::data_objects::ReductionMode::MAX_OP:
     return ok(fusilli::ReductionAttr::Mode::MAX);
   default:
     return error(fusilli::ErrorCode::NotImplemented,
@@ -150,7 +150,7 @@ private:
       : opGraphWrapper(opGraph->ptr, opGraph->size) {}
 
   fusilli::ErrorObject importGraph() {
-    const hipdnn_data_sdk::data_objects::Graph &hipDnnGraph =
+    const hipdnn_flatbuffers_sdk::data_objects::Graph &hipDnnGraph =
         opGraphWrapper.getGraph();
 
     // Import graph level properties.
@@ -176,7 +176,7 @@ private:
   // Import all graph nodes.
   fusilli::ErrorObject importNodes() {
     for (uint32_t i = 0; i < opGraphWrapper.nodeCount(); ++i) {
-      const hipdnn_data_sdk::data_objects::Node &node =
+      const hipdnn_flatbuffers_sdk::data_objects::Node &node =
           opGraphWrapper.getNode(i);
       FUSILLI_CHECK_ERROR(importNode(node));
     }
@@ -186,43 +186,47 @@ private:
 
   // Import single graph node.
   fusilli::ErrorObject
-  importNode(const hipdnn_data_sdk::data_objects::Node &node) {
+  importNode(const hipdnn_flatbuffers_sdk::data_objects::Node &node) {
     switch (node.attributes_type()) {
-    case hipdnn_data_sdk::data_objects::NodeAttributes::
+    case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::
         ConvolutionFwdAttributes:
       FUSILLI_CHECK_ERROR(
           importConvFPropAttr(node.attributes_as_ConvolutionFwdAttributes()));
       break;
-    case hipdnn_data_sdk::data_objects::NodeAttributes::
+    case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::
         ConvolutionWrwAttributes:
       FUSILLI_CHECK_ERROR(
           importConvWGradAttr(node.attributes_as_ConvolutionWrwAttributes()));
       break;
-    case hipdnn_data_sdk::data_objects::NodeAttributes::
+    case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::
         ConvolutionBwdAttributes:
       FUSILLI_CHECK_ERROR(
           importConvDGradAttr(node.attributes_as_ConvolutionBwdAttributes()));
       break;
-    case hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes:
+    case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::
+        PointwiseAttributes:
       FUSILLI_CHECK_ERROR(
           importPointwiseAttr(node.attributes_as_PointwiseAttributes()));
       break;
-    case hipdnn_data_sdk::data_objects::NodeAttributes::MatmulAttributes:
+    case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::MatmulAttributes:
       FUSILLI_CHECK_ERROR(
           importMatmulAttr(node.attributes_as_MatmulAttributes()));
       break;
-    case hipdnn_data_sdk::data_objects::NodeAttributes::SdpaAttributes:
+    case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::SdpaAttributes:
       FUSILLI_CHECK_ERROR(importSdpaAttr(node.attributes_as_SdpaAttributes()));
       break;
-    case hipdnn_data_sdk::data_objects::NodeAttributes::ReductionAttributes:
+    case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::
+        ReductionAttributes:
       FUSILLI_CHECK_ERROR(
           importReductionAttr(node.attributes_as_ReductionAttributes()));
       break;
-    case hipdnn_data_sdk::data_objects::NodeAttributes::RMSNormAttributes:
+    case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::
+        RMSNormAttributes:
       FUSILLI_CHECK_ERROR(
           importRmsnormAttr(node.attributes_as_RMSNormAttributes()));
       break;
-    case hipdnn_data_sdk::data_objects::NodeAttributes::CustomOpAttributes:
+    case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::
+        CustomOpAttributes:
       FUSILLI_CHECK_ERROR(
           importCustomOpAttr(node.attributes_as_CustomOpAttributes()));
       break;
@@ -234,7 +238,7 @@ private:
   }
 
   fusilli::ErrorObject importConvFPropAttr(
-      const hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes
+      const hipdnn_flatbuffers_sdk::data_objects::ConvolutionFwdAttributes
           *hipDnnConvFwdAttr) {
     // Import node inputs.
     FUSILLI_ASSIGN_OR_RETURN(
@@ -266,7 +270,7 @@ private:
   }
 
   fusilli::ErrorObject importConvWGradAttr(
-      const hipdnn_data_sdk::data_objects::ConvolutionWrwAttributes
+      const hipdnn_flatbuffers_sdk::data_objects::ConvolutionWrwAttributes
           *hipDnnConvWrwAttr) {
     // Import node inputs.
     FUSILLI_ASSIGN_OR_RETURN(
@@ -298,7 +302,7 @@ private:
   }
 
   fusilli::ErrorObject importConvDGradAttr(
-      const hipdnn_data_sdk::data_objects::ConvolutionBwdAttributes
+      const hipdnn_flatbuffers_sdk::data_objects::ConvolutionBwdAttributes
           *hipDnnConvBwdAttr) {
     // Import node inputs.
     FUSILLI_ASSIGN_OR_RETURN(
@@ -330,7 +334,8 @@ private:
   }
 
   fusilli::ErrorObject importPointwiseAttr(
-      const hipdnn_data_sdk::data_objects::PointwiseAttributes *hipDnnPwAttr) {
+      const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes
+          *hipDnnPwAttr) {
     // Get mode and determine input count.
     FUSILLI_ASSIGN_OR_RETURN(
         fusilli::PointwiseAttr::Mode mode,
@@ -375,8 +380,9 @@ private:
     return fusilli::ok();
   }
 
-  fusilli::ErrorObject importMatmulAttr(
-      const hipdnn_data_sdk::data_objects::MatmulAttributes *hipDnnMatmulAttr) {
+  fusilli::ErrorObject
+  importMatmulAttr(const hipdnn_flatbuffers_sdk::data_objects::MatmulAttributes
+                       *hipDnnMatmulAttr) {
     // Import node inputs.
     FUSILLI_ASSIGN_OR_RETURN(
         std::shared_ptr<fusilli::TensorAttr> a,
@@ -397,8 +403,9 @@ private:
     return fusilli::ok();
   }
 
-  fusilli::ErrorObject importSdpaAttr(
-      const hipdnn_data_sdk::data_objects::SdpaAttributes *hipDnnSdpaAttr) {
+  fusilli::ErrorObject
+  importSdpaAttr(const hipdnn_flatbuffers_sdk::data_objects::SdpaAttributes
+                     *hipDnnSdpaAttr) {
     // Are available SDPA templates applicable?
     FUSILLI_CHECK_ERROR(SdpaImport::validateTemplate(hipDnnSdpaAttr));
 
@@ -406,7 +413,7 @@ private:
     // accumulates in the query element type, so reject if the requested mode
     // doesn't match. UNSET (the default) is always fine.
     auto mmaCoreMode = hipDnnSdpaAttr->mma_core_mode();
-    if (mmaCoreMode != hipdnn_data_sdk::data_objects::DataType::UNSET) {
+    if (mmaCoreMode != hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET) {
       auto qDataType = opGraphWrapper.getTensorMap()
                            .at(hipDnnSdpaAttr->q_tensor_uid())
                            ->data_type();
@@ -459,7 +466,7 @@ private:
                               "SDPA scale must be a pass-by-value scalar, "
                               "not a device tensor.");
       if (scaleTensor->value_type() !=
-          hipdnn_data_sdk::data_objects::TensorValue::Float32Value)
+          hipdnn_flatbuffers_sdk::data_objects::TensorValue::Float32Value)
         return fusilli::error(fusilli::ErrorCode::NotImplemented,
                               "SDPA scale tensor must be Float32.");
       scaleValue = scaleTensor->value_as_Float32Value()->value();
@@ -484,7 +491,8 @@ private:
   }
 
   fusilli::ErrorObject importReductionAttr(
-      const hipdnn_data_sdk::data_objects::ReductionAttributes *hipDnnRedAttr) {
+      const hipdnn_flatbuffers_sdk::data_objects::ReductionAttributes
+          *hipDnnRedAttr) {
     // Import node input.
     FUSILLI_ASSIGN_OR_RETURN(
         std::shared_ptr<fusilli::TensorAttr> x,
@@ -507,9 +515,9 @@ private:
     return fusilli::ok();
   }
 
-  fusilli::ErrorObject
-  importRmsnormAttr(const hipdnn_data_sdk::data_objects::RMSNormAttributes
-                        *hipDnnRmsnormAttr) {
+  fusilli::ErrorObject importRmsnormAttr(
+      const hipdnn_flatbuffers_sdk::data_objects::RMSNormAttributes
+          *hipDnnRmsnormAttr) {
     // Fusilli's rmsnorm does not support the optional bias input.
     if (hipDnnRmsnormAttr->bias_tensor_uid().has_value())
       return fusilli::error(fusilli::ErrorCode::NotImplemented,
@@ -564,7 +572,8 @@ private:
   }
 
   fusilli::ErrorObject importCustomOpAttr(
-      const hipdnn_data_sdk::data_objects::CustomOpAttributes *hipDnnAttr) {
+      const hipdnn_flatbuffers_sdk::data_objects::CustomOpAttributes
+          *hipDnnAttr) {
     // Only import custom ops targeting this plugin.
     std::string customOpId = hipDnnAttr->custom_op_id()->str();
     if (!customOpId.starts_with("fusilli.")) {
@@ -614,8 +623,8 @@ private:
   importNodeInput(int64_t uid, const char *name) {
     // Get hipDNN tensor. TensorMap is created from the graph that uid variable
     // is read from, so .at() call should be safe.
-    const hipdnn_data_sdk::data_objects::TensorAttributes *hipDnnTensorAttr =
-        opGraphWrapper.getTensorMap().at(uid);
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes
+        *hipDnnTensorAttr = opGraphWrapper.getTensorMap().at(uid);
 
     // A virtual tensor indicates an intermediate (non-boundary) tensor.
     if (hipDnnTensorAttr->virtual_()) {
@@ -631,15 +640,15 @@ private:
     fusilli::TensorAttr fusilliTensorAttr;
     if (isPassByValue(hipDnnTensorAttr)) { // handle scalar tensors
       switch (hipDnnTensorAttr->value_type()) {
-      case hipdnn_data_sdk::data_objects::TensorValue::Float32Value:
+      case hipdnn_flatbuffers_sdk::data_objects::TensorValue::Float32Value:
         fusilliTensorAttr = fusilli::TensorAttr(
             hipDnnTensorAttr->value_as_Float32Value()->value());
         break;
-      case hipdnn_data_sdk::data_objects::TensorValue::Float64Value:
+      case hipdnn_flatbuffers_sdk::data_objects::TensorValue::Float64Value:
         fusilliTensorAttr = fusilli::TensorAttr(
             hipDnnTensorAttr->value_as_Float64Value()->value());
         break;
-      case hipdnn_data_sdk::data_objects::TensorValue::Int32Value:
+      case hipdnn_flatbuffers_sdk::data_objects::TensorValue::Int32Value:
         fusilliTensorAttr = fusilli::TensorAttr(
             hipDnnTensorAttr->value_as_Int32Value()->value());
         break;
@@ -669,8 +678,8 @@ private:
                    const std::shared_ptr<fusilli::TensorAttr> &nodeOutput) {
     // Get hipDNN tensor. TensorMap is created from the graph that uid variable
     // is read from, so .at() call should be safe.
-    const hipdnn_data_sdk::data_objects::TensorAttributes *hipDnnTensorAttr =
-        opGraphWrapper.getTensorMap().at(uid);
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes
+        *hipDnnTensorAttr = opGraphWrapper.getTensorMap().at(uid);
 
     // Import attrs.
     nodeOutput->setName(std::format("{}_{}", name, uid)); // C++20
@@ -696,16 +705,16 @@ private:
 
   // Whether the hipDNN tensor carries a pass-by-value scalar (equivalent to
   // hipDNN frontend's TensorAttributes::get_pass_by_value()).
-  static bool
-  isPassByValue(const hipdnn_data_sdk::data_objects::TensorAttributes *src) {
+  static bool isPassByValue(
+      const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes *src) {
     return src->value_type() !=
-           hipdnn_data_sdk::data_objects::TensorValue::NONE;
+           hipdnn_flatbuffers_sdk::data_objects::TensorValue::NONE;
   }
 
   // Import tensor attrs (dims, strides, datatype) from hipDNN to fusilli.
-  fusilli::ErrorObject
-  importAttrs(fusilli::TensorAttr &dest,
-              const hipdnn_data_sdk::data_objects::TensorAttributes *src) {
+  fusilli::ErrorObject importAttrs(
+      fusilli::TensorAttr &dest,
+      const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes *src) {
     FUSILLI_ASSIGN_OR_RETURN(auto dataType,
                              hipDnnDataTypeToFusilliDataType(src->data_type()));
     dest.setIsVirtual(src->virtual_())

--- a/dnn-providers/fusilli-provider/src/fusilli_plugin.cpp
+++ b/dnn-providers/fusilli-provider/src/fusilli_plugin.cpp
@@ -15,14 +15,14 @@
 #include <flatbuffers/vector.h>
 #include <fusilli.h>
 #include <hip/hip_runtime.h>
-#include <hipdnn_data_sdk/data_objects/data_types_generated.h>
-#include <hipdnn_data_sdk/data_objects/engine_details_generated.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
-#include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
 #include <hipdnn_data_sdk/logging/Logger.hpp>
 #include <hipdnn_data_sdk/utilities/EngineNames.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/data_types_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/engine_details_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
 #include <hipdnn_plugin_sdk/EnginePluginApi.h>
 #include <hipdnn_plugin_sdk/PluginApi.h>
 #include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
@@ -305,7 +305,8 @@ hipdnnEnginePluginGetEngineDetails(hipdnnEnginePluginHandle_t handle,
   // being.
   flatbuffers::FlatBufferBuilder builder;
   auto engineDetailsObj =
-      hipdnn_data_sdk::data_objects::CreateEngineDetails(builder, engineId);
+      hipdnn_flatbuffers_sdk::data_objects::CreateEngineDetails(builder,
+                                                                engineId);
   builder.Finish(engineDetailsObj);
 
   // Populate out parameter.
@@ -388,8 +389,8 @@ hipdnnPluginStatus_t hipdnnEnginePluginCreateExecutionContext(
   FUSILLI_PLUGIN_CHECK_NULL(executionContext);
 
   // Ensure that config contains expected engine id.
-  hipdnn_plugin_sdk::EngineConfigWrapper engineConfigWrapper(
-      engineConfig->ptr, engineConfig->size);
+  hipdnn_flatbuffers_sdk::flatbuffer_utilities::EngineConfigWrapper
+      engineConfigWrapper(engineConfig->ptr, engineConfig->size);
   if (engineConfigWrapper.engineId() !=
       hipdnn_data_sdk::utilities::FUSILLI_ENGINE_ID) {
     return hipdnn_plugin_sdk::PluginLastErrorManager::setLastError(

--- a/dnn-providers/fusilli-provider/test/test_fusilli_plugin_api.cpp
+++ b/dnn-providers/fusilli-provider/test/test_fusilli_plugin_api.cpp
@@ -7,11 +7,11 @@
 #include <flatbuffers/flatbuffer_builder.h>
 #include <fusilli.h>
 #include <gtest/gtest.h>
-#include <hipdnn_data_sdk/data_objects/data_types_generated.h>
-#include <hipdnn_data_sdk/data_objects/engine_config_generated.h>
-#include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
 #include <hipdnn_data_sdk/logging/LogLevel.hpp>
 #include <hipdnn_data_sdk/utilities/EngineNames.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/data_types_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/engine_config_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/pointwise_attributes_generated.h>
 #include <hipdnn_frontend/Graph.hpp>
 #include <hipdnn_frontend/Utilities.hpp>
 #include <hipdnn_frontend/attributes/MatmulAttributes.hpp>
@@ -477,11 +477,12 @@ TEST(TestFusilliPluginApi, GetApplicableEngineIdsConvPointwise) {
   // Test conv + unary pointwise activation for various modes.
   // (conv -> binary -> pointwise covered in
   // GetApplicableEngineIdsConvBiasActiv)
-  for (auto mode : {hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
-                    hipdnn_data_sdk::data_objects::PointwiseMode::SIGMOID_FWD,
-                    hipdnn_data_sdk::data_objects::PointwiseMode::TANH_FWD,
-                    hipdnn_data_sdk::data_objects::PointwiseMode::GELU_FWD,
-                    hipdnn_data_sdk::data_objects::PointwiseMode::ELU_FWD}) {
+  for (auto mode :
+       {hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SIGMOID_FWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::TANH_FWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::GELU_FWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::ELU_FWD}) {
     auto builder = hipdnn_test_sdk::utilities::createValidConvFwdActivGraph(
         /*xDims=*/{4, 4, 4, 4}, /*xStrides=*/{64, 16, 4, 1},
         /*wDims=*/{4, 4, 1, 1}, /*wStrides=*/{4, 1, 1, 1},
@@ -519,9 +520,9 @@ TEST(TestFusilliPluginApi, GetApplicableEngineIdsConvBiasActiv) {
 
   // Graph structure: conv -> bias (ADD) -> activation
   for (auto activMode :
-       {hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
-        hipdnn_data_sdk::data_objects::PointwiseMode::SIGMOID_FWD,
-        hipdnn_data_sdk::data_objects::PointwiseMode::TANH_FWD}) {
+       {hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SIGMOID_FWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::TANH_FWD}) {
     auto builder = hipdnn_test_sdk::utilities::createValidConvFwdBiasActivGraph(
         /*xDims=*/{4, 4, 4, 4}, /*xStrides=*/{64, 16, 4, 1},
         /*wDims=*/{4, 4, 1, 1}, /*wStrides=*/{4, 1, 1, 1},
@@ -588,31 +589,36 @@ TEST(TestFusilliPluginApi, GetApplicableEngineIdsInt4NonBatchedMatmul) {
   // Non-batched (2D) mixed-precision int4 x fp16 matmul is not supported —
   // mixed element types require rank-3 tensors (torch.bmm). The plugin should
   // report 0 engines.
-  using DT = hipdnn_data_sdk::data_objects::DataType;
+  using DT = hipdnn_flatbuffers_sdk::data_objects::DataType;
   flatbuffers::FlatBufferBuilder builder;
   std::vector<int64_t> aDims = {4, 8}, aStrides = {8, 1};
   std::vector<int64_t> bDims = {8, 4}, bStrides = {4, 1};
   std::vector<int64_t> cDims = {4, 4}, cStrides = {4, 1};
 
-  std::vector<
-      ::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+  std::vector<::flatbuffers::Offset<
+      hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
       tensors;
-  tensors.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-      builder, 1, "A", DT::INT4, &aStrides, &aDims));
-  tensors.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-      builder, 2, "B", DT::HALF, &bStrides, &bDims));
-  tensors.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-      builder, 3, "C", DT::HALF, &cStrides, &cDims));
+  tensors.push_back(
+      hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+          builder, 1, "A", DT::INT4, &aStrides, &aDims));
+  tensors.push_back(
+      hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+          builder, 2, "B", DT::HALF, &bStrides, &bDims));
+  tensors.push_back(
+      hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+          builder, 3, "C", DT::HALF, &cStrides, &cDims));
 
   auto matmulAttr =
-      hipdnn_data_sdk::data_objects::CreateMatmulAttributes(builder, 1, 2, 3);
-  std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-  nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+      hipdnn_flatbuffers_sdk::data_objects::CreateMatmulAttributes(builder, 1,
+                                                                   2, 3);
+  std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>>
+      nodes;
+  nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
       builder, "matmul", DT::FLOAT,
-      hipdnn_data_sdk::data_objects::NodeAttributes::MatmulAttributes,
+      hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::MatmulAttributes,
       matmulAttr.Union()));
 
-  auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+  auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
       builder, "test", DT::HALF, DT::HALF, DT::FLOAT, &tensors, &nodes);
   builder.Finish(graphOffset);
 
@@ -648,8 +654,8 @@ TEST(TestFusilliPluginApi, CreateExecutionContext) {
   const std::vector<int64_t> expectedWStrides = {4, 1, 1, 1};
   const std::vector<int64_t> expectedYDims = {4, 4, 4, 4};
   const std::vector<int64_t> expectedYStrides = {64, 16, 4, 1};
-  const hipdnn_data_sdk::data_objects::DataType dataType =
-      hipdnn_data_sdk::data_objects::DataType::FLOAT;
+  const hipdnn_flatbuffers_sdk::data_objects::DataType dataType =
+      hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT;
   FUSILLI_PLUGIN_EXPECT_OR_ASSIGN(fusilli::DataType expectedDataType,
                                   hipDnnDataTypeToFusilliDataType(dataType));
 
@@ -666,7 +672,7 @@ TEST(TestFusilliPluginApi, CreateExecutionContext) {
 
   // Create engine config.
   flatbuffers::FlatBufferBuilder configBuilder;
-  auto engineConfig = hipdnn_data_sdk::data_objects::CreateEngineConfig(
+  auto engineConfig = hipdnn_flatbuffers_sdk::data_objects::CreateEngineConfig(
       configBuilder, hipdnn_data_sdk::utilities::FUSILLI_ENGINE_ID);
   configBuilder.Finish(engineConfig);
   hipdnnPluginConstData_t engineConfigData;
@@ -791,7 +797,7 @@ TEST(TestFusilliPluginApi, GetApplicableEngineIdsSdpa) {
   // SDPA with attn_mask should be supported.
   builder = hipdnn_test_sdk::utilities::createValidSdpaFwdGraph(
       qkvDims, qkvStrides, qkvDims, qkvStrides, qkvDims, qkvStrides, qkvDims,
-      qkvStrides, hipdnn_data_sdk::data_objects::DataType::HALF,
+      qkvStrides, hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
       /*withAttnMask=*/true);
   opGraph.ptr = builder.GetBufferPointer();
   opGraph.size = builder.GetSize();
@@ -804,7 +810,7 @@ TEST(TestFusilliPluginApi, GetApplicableEngineIdsSdpa) {
   // SDPA with stats output is NOT supported (yet).
   builder = hipdnn_test_sdk::utilities::createValidSdpaFwdGraph(
       qkvDims, qkvStrides, qkvDims, qkvStrides, qkvDims, qkvStrides, qkvDims,
-      qkvStrides, hipdnn_data_sdk::data_objects::DataType::HALF,
+      qkvStrides, hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
       /*withAttnMask=*/false, /*withScale=*/false, /*withStats=*/true);
   opGraph.ptr = builder.GetBufferPointer();
   opGraph.size = builder.GetSize();

--- a/dnn-providers/fusilli-provider/test/test_graph_import.cpp
+++ b/dnn-providers/fusilli-provider/test/test_graph_import.cpp
@@ -9,7 +9,7 @@
 
 #include <fusilli.h>
 #include <gtest/gtest.h>
-#include <hipdnn_data_sdk/data_objects/data_types_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/data_types_generated.h>
 #include <hipdnn_frontend/Graph.hpp>
 #include <hipdnn_frontend/attributes/CustomOpAttributes.hpp>
 #include <hipdnn_frontend/attributes/TensorAttributes.hpp>
@@ -17,43 +17,45 @@
 TEST(TestGraphImport, ConvertHipDnnToFusilli) {
   FUSILLI_PLUGIN_EXPECT_OR_ASSIGN(
       auto halfDt, hipDnnDataTypeToFusilliDataType(
-                       hipdnn_data_sdk::data_objects::DataType::HALF));
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF));
   EXPECT_EQ(halfDt, fusilli::DataType::Half);
   FUSILLI_PLUGIN_EXPECT_OR_ASSIGN(
-      auto bfloat16Dt, hipDnnDataTypeToFusilliDataType(
-                           hipdnn_data_sdk::data_objects::DataType::BFLOAT16));
+      auto bfloat16Dt,
+      hipDnnDataTypeToFusilliDataType(
+          hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16));
   EXPECT_EQ(bfloat16Dt, fusilli::DataType::BFloat16);
   FUSILLI_PLUGIN_EXPECT_OR_ASSIGN(
       auto floatDt, hipDnnDataTypeToFusilliDataType(
-                        hipdnn_data_sdk::data_objects::DataType::FLOAT));
+                        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT));
   EXPECT_EQ(floatDt, fusilli::DataType::Float);
   FUSILLI_PLUGIN_EXPECT_OR_ASSIGN(
-      auto doubleDt, hipDnnDataTypeToFusilliDataType(
-                         hipdnn_data_sdk::data_objects::DataType::DOUBLE));
+      auto doubleDt,
+      hipDnnDataTypeToFusilliDataType(
+          hipdnn_flatbuffers_sdk::data_objects::DataType::DOUBLE));
   EXPECT_EQ(doubleDt, fusilli::DataType::Double);
   FUSILLI_PLUGIN_EXPECT_OR_ASSIGN(
       auto uint8Dt, hipDnnDataTypeToFusilliDataType(
-                        hipdnn_data_sdk::data_objects::DataType::UINT8));
+                        hipdnn_flatbuffers_sdk::data_objects::DataType::UINT8));
   EXPECT_EQ(uint8Dt, fusilli::DataType::Uint8);
   FUSILLI_PLUGIN_EXPECT_OR_ASSIGN(
       auto int8Dt, hipDnnDataTypeToFusilliDataType(
-                       hipdnn_data_sdk::data_objects::DataType::INT8));
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::INT8));
   EXPECT_EQ(int8Dt, fusilli::DataType::Int8);
   FUSILLI_PLUGIN_EXPECT_OR_ASSIGN(
       auto int32Dt, hipDnnDataTypeToFusilliDataType(
-                        hipdnn_data_sdk::data_objects::DataType::INT32));
+                        hipdnn_flatbuffers_sdk::data_objects::DataType::INT32));
   EXPECT_EQ(int32Dt, fusilli::DataType::Int32);
   FUSILLI_PLUGIN_EXPECT_OR_ASSIGN(
       auto int4Dt, hipDnnDataTypeToFusilliDataType(
-                       hipdnn_data_sdk::data_objects::DataType::INT4));
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::INT4));
   EXPECT_EQ(int4Dt, fusilli::DataType::Int4);
   FUSILLI_PLUGIN_EXPECT_OR_ASSIGN(
       auto unsetDt, hipDnnDataTypeToFusilliDataType(
-                        hipdnn_data_sdk::data_objects::DataType::UNSET));
+                        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET));
   EXPECT_EQ(unsetDt, fusilli::DataType::NotSet);
 
   auto invalidResult = hipDnnDataTypeToFusilliDataType(
-      static_cast<hipdnn_data_sdk::data_objects::DataType>(42));
+      static_cast<hipdnn_flatbuffers_sdk::data_objects::DataType>(42));
   EXPECT_TRUE(isError(invalidResult));
 }
 

--- a/dnn-providers/hip-kernel-provider/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/CMakeLists.txt
@@ -83,7 +83,7 @@ list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/llvm ${ROCM_PATH} ${ROCM_PATH}/hip)
 
 find_package(hip REQUIRED)
 find_package(hiprtc REQUIRED)
-find_package(hipdnn_data_sdk CONFIG REQUIRED)
+find_package(hipdnn_flatbuffers_sdk CONFIG REQUIRED)
 find_package(hipdnn_plugin_sdk CONFIG REQUIRED)
 
 include(CheckToolVersion)

--- a/dnn-providers/hip-kernel-provider/src/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/src/CMakeLists.txt
@@ -36,7 +36,7 @@ target_include_directories(hip_kernel_provider_impl PUBLIC
     ${CMAKE_BINARY_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}/../kernels
 )
-target_link_libraries(hip_kernel_provider_impl PUBLIC hip::host hipdnn_data_sdk hipdnn_plugin_sdk hiprtc::hiprtc)
+target_link_libraries(hip_kernel_provider_impl PUBLIC hip::host hipdnn_flatbuffers_sdk hipdnn_plugin_sdk hiprtc::hiprtc)
 
 target_compile_options(hip_kernel_provider_impl PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
 set_target_properties(hip_kernel_provider_impl PROPERTIES
@@ -49,14 +49,14 @@ add_clang_tidy_custom_target()
 # Static library for unit tests to link against (provides access to internal implementation)
 add_library(hip_kernel_provider_private STATIC $<TARGET_OBJECTS:hip_kernel_provider_impl>)
 target_include_directories(hip_kernel_provider_private PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(hip_kernel_provider_private PUBLIC hipdnn_data_sdk hipdnn_plugin_sdk hiprtc::hiprtc)
+target_link_libraries(hip_kernel_provider_private PUBLIC hipdnn_flatbuffers_sdk hipdnn_plugin_sdk hiprtc::hiprtc)
 if(ENABLE_ASM_SDPA_ENGINE)
     target_compile_definitions(hip_kernel_provider_private PUBLIC HIPDNN_ENGINE_ASM_SDPA=1)
 endif()
 
 # hip_kernel_provider - SHARED library (the actual plugin)
 add_library(hip_kernel_provider SHARED $<TARGET_OBJECTS:hip_kernel_provider_impl>)
-target_link_libraries(hip_kernel_provider PRIVATE hipdnn_data_sdk hipdnn_plugin_sdk hiprtc::hiprtc hip::host)
+target_link_libraries(hip_kernel_provider PRIVATE hipdnn_flatbuffers_sdk hipdnn_plugin_sdk hiprtc::hiprtc hip::host)
 
 if(NOT WIN32)
     target_link_libraries(hip_kernel_provider PRIVATE "-Xlinker --exclude-libs=ALL")

--- a/dnn-providers/hip-kernel-provider/src/HipKernelUtils.cpp
+++ b/dnn-providers/hip-kernel-provider/src/HipKernelUtils.cpp
@@ -9,9 +9,10 @@
 namespace hip_kernel_provider::hip_kernel_utils
 {
 
-ActivationParams parseActivation(const hipdnn_data_sdk::data_objects::PointwiseAttributes& attrs)
+ActivationParams
+    parseActivation(const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& attrs)
 {
-    using PM = hipdnn_data_sdk::data_objects::PointwiseMode;
+    using PM = hipdnn_flatbuffers_sdk::data_objects::PointwiseMode;
 
     switch(attrs.operation())
     {
@@ -98,8 +99,9 @@ hipdnnPluginDeviceBuffer_t findDeviceBuffer(int64_t uid,
             + " not found in the provided device buffers.");
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes& findTensorAttributes(
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& findTensorAttributes(
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     int64_t uid)
 {
@@ -113,7 +115,7 @@ const hipdnn_data_sdk::data_objects::TensorAttributes& findTensorAttributes(
                                                        + std::to_string(uid));
 }
 
-bool isChannelLastLayout(const hipdnn_data_sdk::data_objects::TensorAttributes* tensor)
+bool isChannelLastLayout(const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* tensor)
 {
     const auto* strides = tensor->strides();
     const auto* dims = tensor->dims();

--- a/dnn-providers/hip-kernel-provider/src/HipKernelUtils.hpp
+++ b/dnn-providers/hip-kernel-provider/src/HipKernelUtils.hpp
@@ -5,8 +5,8 @@
 
 #include <unordered_map>
 
-#include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/pointwise_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/tensor_attributes_generated.h>
 #include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
 
 /**
@@ -50,17 +50,19 @@ struct ActivationParams
     double gamma;
 };
 
-ActivationParams parseActivation(const hipdnn_data_sdk::data_objects::PointwiseAttributes& attrs);
+ActivationParams
+    parseActivation(const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& attrs);
 
 hipdnnPluginDeviceBuffer_t findDeviceBuffer(int64_t uid,
                                             const hipdnnPluginDeviceBuffer_t* deviceBuffers,
                                             uint32_t numDeviceBuffers);
 
-const hipdnn_data_sdk::data_objects::TensorAttributes& findTensorAttributes(
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& findTensorAttributes(
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     int64_t uid);
 
-bool isChannelLastLayout(const hipdnn_data_sdk::data_objects::TensorAttributes* tensor);
+bool isChannelLastLayout(const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* tensor);
 
 }

--- a/dnn-providers/hip-kernel-provider/src/engines/HipKernelEngine.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/HipKernelEngine.cpp
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier:  MIT
 
 #include "HipKernelEngine.hpp"
-#include "hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp"
+#include "hipdnn_flatbuffers_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp"
 
-#include <hipdnn_data_sdk/data_objects/engine_details_generated.h>
 #include <hipdnn_data_sdk/logging/Logger.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/engine_details_generated.h>
 #include <hipdnn_plugin_sdk/KnobFactory.hpp>
 
 namespace hip_kernel_provider
@@ -22,13 +22,15 @@ int64_t HipKernelEngine::id() const
 }
 
 void initializeHipKernelSettings(
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig&
+        engineConfig,
     [[maybe_unused]] HipKernelSettings& executionSettings)
 {
 }
 
 bool HipKernelEngine::isApplicable(
-    HipKernelHandle& handle, const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+    HipKernelHandle& handle,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
 {
     // This is wrong if we ever have more than 1 plan builder thats applicable.
     // If this is the case, we should split plan builders accross multiple engines.
@@ -42,13 +44,14 @@ bool HipKernelEngine::isApplicable(
     return false;
 }
 
-void HipKernelEngine::getDetails(HipKernelHandle& handle,
-                                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-                                 hipdnnPluginConstData_t& detailsOut) const
+void HipKernelEngine::getDetails(
+    HipKernelHandle& handle,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    hipdnnPluginConstData_t& detailsOut) const
 {
     flatbuffers::FlatBufferBuilder builder;
 
-    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::Knob>> knobsVector;
+    std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Knob>> knobsVector;
 
     // Collect custom knobs from plan builders
     for(const auto& planBuilder : _planBuilders)
@@ -62,7 +65,7 @@ void HipKernelEngine::getDetails(HipKernelHandle& handle,
 
         for(const auto& knobT : customKnobs)
         {
-            auto knobOffset = hipdnn_data_sdk::data_objects::Knob::Pack(builder, &knobT);
+            auto knobOffset = hipdnn_flatbuffers_sdk::data_objects::Knob::Pack(builder, &knobT);
             knobsVector.push_back(knobOffset);
         }
 
@@ -73,7 +76,8 @@ void HipKernelEngine::getDetails(HipKernelHandle& handle,
 
     auto knobs = builder.CreateVector(knobsVector);
 
-    auto engineDetails = hipdnn_data_sdk::data_objects::CreateEngineDetails(builder, _id, knobs);
+    auto engineDetails
+        = hipdnn_flatbuffers_sdk::data_objects::CreateEngineDetails(builder, _id, knobs);
     builder.Finish(engineDetails);
     auto detachedBuffer = std::make_unique<flatbuffers::DetachedBuffer>(builder.Release());
     detailsOut.ptr = detachedBuffer->data();
@@ -84,8 +88,8 @@ void HipKernelEngine::getDetails(HipKernelHandle& handle,
 
 size_t HipKernelEngine::getMaxWorkspaceSize(
     const HipKernelHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-    const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig) const
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig) const
 {
     HipKernelSettings baseExecutionSettings;
     initializeHipKernelSettings(engineConfig, baseExecutionSettings);
@@ -107,8 +111,8 @@ size_t HipKernelEngine::getMaxWorkspaceSize(
 
 void HipKernelEngine::initializeExecutionContext(
     const HipKernelHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-    const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
     HipKernelContext& executionContext) const
 {
     HipKernelSettings executionSettings;

--- a/dnn-providers/hip-kernel-provider/src/engines/HipKernelEngine.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/HipKernelEngine.hpp
@@ -22,20 +22,21 @@ public:
 
     int64_t id() const override;
 
-    bool isApplicable(HipKernelHandle& handle,
-                      const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+    bool isApplicable(
+        HipKernelHandle& handle,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
     void getDetails(HipKernelHandle& handle,
-                    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                     hipdnnPluginConstData_t& detailsOut) const override;
-    size_t getMaxWorkspaceSize(
-        const HipKernelHandle& handle,
-        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-        const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig) const override;
+    size_t getMaxWorkspaceSize(const HipKernelHandle& handle,
+                               const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+                               const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig&
+                                   engineConfig) const override;
 
     void initializeExecutionContext(
         const HipKernelHandle& handle,
-        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-        const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
         HipKernelContext& executionContext) const override;
 
     void addPlanBuilder(

--- a/dnn-providers/hip-kernel-provider/src/engines/asm_sdpa_engine/AsmSdpaEngine.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/asm_sdpa_engine/AsmSdpaEngine.cpp
@@ -3,8 +3,8 @@
 
 #include "AsmSdpaEngine.hpp"
 
-#include <hipdnn_data_sdk/data_objects/engine_details_generated.h>
 #include <hipdnn_data_sdk/utilities/EngineNames.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/engine_details_generated.h>
 
 namespace asm_sdpa_engine
 {
@@ -26,8 +26,9 @@ int64_t AsmSdpaEngine::staticId()
     return hipdnn_data_sdk::utilities::ASM_SDPA_ENGINE_ID;
 }
 
-bool AsmSdpaEngine::isApplicable(HipKernelHandle& handle,
-                                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+bool AsmSdpaEngine::isApplicable(
+    HipKernelHandle& handle,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
 {
     for(const auto& pb : _planBuilders)
     {
@@ -39,14 +40,15 @@ bool AsmSdpaEngine::isApplicable(HipKernelHandle& handle,
     return false;
 }
 
-void AsmSdpaEngine::getDetails(HipKernelHandle& handle,
-                               const hipdnn_data_sdk::flatbuffer_utilities::IGraph& /*opGraph*/,
-                               hipdnnPluginConstData_t& detailsOut) const
+void AsmSdpaEngine::getDetails(
+    HipKernelHandle& handle,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& /*opGraph*/,
+    hipdnnPluginConstData_t& detailsOut) const
 {
     flatbuffers::FlatBufferBuilder builder;
 
     auto engineDetails
-        = hipdnn_data_sdk::data_objects::CreateEngineDetailsDirect(builder, id(), nullptr);
+        = hipdnn_flatbuffers_sdk::data_objects::CreateEngineDetailsDirect(builder, id(), nullptr);
     builder.Finish(engineDetails);
     auto detachedBuffer = std::make_unique<flatbuffers::DetachedBuffer>(builder.Release());
     detailsOut.ptr = detachedBuffer->data();
@@ -57,8 +59,8 @@ void AsmSdpaEngine::getDetails(HipKernelHandle& handle,
 
 size_t AsmSdpaEngine::getMaxWorkspaceSize(
     const HipKernelHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-    const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& /*engineConfig*/) const
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& /*engineConfig*/) const
 {
     for(const auto& pb : _planBuilders)
     {
@@ -74,8 +76,8 @@ size_t AsmSdpaEngine::getMaxWorkspaceSize(
 
 void AsmSdpaEngine::initializeExecutionContext(
     const HipKernelHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-    const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
     HipKernelContext& executionContext) const
 {
     executionContext.setExecutionSettings(HipKernelSettings{});

--- a/dnn-providers/hip-kernel-provider/src/engines/asm_sdpa_engine/AsmSdpaEngine.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/asm_sdpa_engine/AsmSdpaEngine.hpp
@@ -36,25 +36,26 @@ public:
 
     int64_t id() const override;
 
-    bool isApplicable(HipKernelHandle& handle,
-                      const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+    bool isApplicable(
+        HipKernelHandle& handle,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
 
     void getDetails(HipKernelHandle& handle,
-                    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                     hipdnnPluginConstData_t& detailsOut) const override;
 
     size_t
         // NOLINTNEXTLINE(portability-template-virtual-member-function)
         getMaxWorkspaceSize(const HipKernelHandle& handle,
-                            const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-                            const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig&
+                            const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+                            const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig&
                                 engineConfig) const override;
 
     // NOLINTNEXTLINE(portability-template-virtual-member-function)
     void initializeExecutionContext(
         const HipKernelHandle& handle,
-        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-        const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
         HipKernelContext& executionContext) const override;
 
 private:

--- a/dnn-providers/hip-kernel-provider/src/engines/asm_sdpa_engine/plans/SdpaFwdPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/asm_sdpa_engine/plans/SdpaFwdPlanBuilder.cpp
@@ -16,9 +16,9 @@ namespace asm_sdpa_engine
 
 bool SdpaFwdPlanBuilder::isApplicable(
     const HipKernelHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
 {
-    using namespace hipdnn_data_sdk::data_objects;
+    using namespace hipdnn_flatbuffers_sdk::data_objects;
     // NOLINTNEXTLINE(readability-identifier-naming)
     static const char* HIP_KERNEL_LOG_PREFIX = "[SdpaFwdPlanBuilder::isApplicable] ";
 
@@ -103,7 +103,7 @@ bool SdpaFwdPlanBuilder::isApplicable(
 
 size_t SdpaFwdPlanBuilder::getMaxWorkspaceSize(
     const HipKernelHandle& /* handle */,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& /* opGraph */,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& /* opGraph */,
     const HipKernelSettings& /* executionSettings */) const
 {
     // Forward-only kernel uses 64KB LDS internally, no external workspace needed
@@ -113,8 +113,8 @@ size_t SdpaFwdPlanBuilder::getMaxWorkspaceSize(
 
 void SdpaFwdPlanBuilder::initializeExecutionSettings(
     const HipKernelHandle& /* handle */,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& /* opGraph */,
-    const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& /* engineConfig */,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& /* opGraph */,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& /* engineConfig */,
     HipKernelSettings& /* executionSettings */) const
 {
     HIPDNN_PLUGIN_LOG_ERROR("SdpaFwdPlanBuilder::initializeExecutionContext not implemented");
@@ -122,8 +122,8 @@ void SdpaFwdPlanBuilder::initializeExecutionSettings(
 
 void SdpaFwdPlanBuilder::buildPlan(
     const HipKernelHandle& /* handle */,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-    const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& /* engineConfig */,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& /* engineConfig */,
     HipKernelContext& executionContext) const
 {
     // Load kernel module
@@ -155,7 +155,7 @@ void SdpaFwdPlanBuilder::buildPlan(
 
     // Extract SDPA attributes and tensor metadata
     auto& sdpaNode = opGraph.getNodeWrapper(0);
-    auto& sdpaAttrs = sdpaNode.attributesAs<hipdnn_data_sdk::data_objects::SdpaAttributes>();
+    auto& sdpaAttrs = sdpaNode.attributesAs<hipdnn_flatbuffers_sdk::data_objects::SdpaAttributes>();
     auto& tensorMap = opGraph.getTensorMap();
 
     // Get tensor UIDs
@@ -250,9 +250,9 @@ void SdpaFwdPlanBuilder::buildPlan(
     executionContext.setPlan(std::make_unique<SdpaFwdPlan>(module, function, params));
 }
 
-std::vector<hipdnn_data_sdk::data_objects::KnobT> SdpaFwdPlanBuilder::getCustomKnobs(
+std::vector<hipdnn_flatbuffers_sdk::data_objects::KnobT> SdpaFwdPlanBuilder::getCustomKnobs(
     const HipKernelHandle& /* handle */,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& /* opGraph */) const
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& /* opGraph */) const
 {
     return {};
 }

--- a/dnn-providers/hip-kernel-provider/src/engines/asm_sdpa_engine/plans/SdpaFwdPlanBuilder.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/asm_sdpa_engine/plans/SdpaFwdPlanBuilder.hpp
@@ -16,28 +16,30 @@ class SdpaFwdPlanBuilder
     : public hipdnn_plugin_sdk::IPlanBuilder<HipKernelHandle, HipKernelSettings, HipKernelContext>
 {
 public:
-    bool isApplicable(const HipKernelHandle& handle,
-                      const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+    bool isApplicable(
+        const HipKernelHandle& handle,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
 
     size_t getMaxWorkspaceSize(const HipKernelHandle& handle,
-                               const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                               const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                                const HipKernelSettings& executionSettings) const override;
 
     void initializeExecutionSettings(
         const HipKernelHandle& handle,
-        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-        const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
         HipKernelSettings& executionSettings) const override;
 
     void buildPlan(const HipKernelHandle& handle,
-                   const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-                   const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+                   const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+                   const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
                    HipKernelContext& executionContext) const override;
 
-    std::vector<hipdnn_data_sdk::data_objects::KnobT>
+    std::vector<hipdnn_flatbuffers_sdk::data_objects::KnobT>
         // NOLINTNEXTLINE(portability-template-virtual-member-function)
-        getCustomKnobs(const HipKernelHandle& handle,
-                       const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+        getCustomKnobs(
+            const HipKernelHandle& handle,
+            const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
 };
 
 } // namespace asm_sdpa_engine

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/PlanUtils.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/PlanUtils.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "hipdnn_data_sdk/data_objects/data_types_generated.h"
+#include "hipdnn_flatbuffers_sdk/data_objects/data_types_generated.h"
 #include "hipdnn_plugin_sdk/PluginException.hpp"
 #include <cstddef>
 
@@ -15,21 +15,21 @@ namespace hip_kernel_provider
 * it as a kernel argument. Intended to be used when kernel source code supports
 * multiple tensors type which are instantiated via a preprocessor definition.
 */
-inline const char* getKernelParamTypeString(hipdnn_data_sdk::data_objects::DataType type)
+inline const char* getKernelParamTypeString(hipdnn_flatbuffers_sdk::data_objects::DataType type)
 {
     switch(type)
     {
-    case hipdnn_data_sdk::data_objects::DataType::HALF:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::HALF:
         return "half";
-    case hipdnn_data_sdk::data_objects::DataType::BFLOAT16:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16:
         return "ushort";
-    case hipdnn_data_sdk::data_objects::DataType::FLOAT:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT:
         return "float";
     default:
         throw hipdnn_plugin_sdk::HipdnnPluginException(
             HIPDNN_PLUGIN_STATUS_BAD_PARAM,
             std::string("Unsupported data type: ")
-                + hipdnn_data_sdk::data_objects::EnumNameDataType(type));
+                + hipdnn_flatbuffers_sdk::data_objects::EnumNameDataType(type));
     }
 }
 

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormApplicabilityChecks.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormApplicabilityChecks.cpp
@@ -17,7 +17,7 @@ namespace hip_kernel_provider::rmsnorm
 
 // --- Tensor Descriptor Implementation ---
 RMSnormTensorDescriptor::RMSnormTensorDescriptor(
-    const hipdnn_data_sdk::data_objects::TensorAttributes* attr)
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* attr)
     : dims(attr->dims()->begin(), attr->dims()->end())
     , strides(attr->strides()->begin(), attr->strides()->end())
     , strideOrder(hipdnn_data_sdk::utilities::extractStrideOrder(strides))
@@ -141,8 +141,8 @@ void validateConsistentLayouts(const std::vector<RMSnormTensorDescriptor>& tenso
 }
 
 void validateDataTypeIsSupported(
-    hipdnn_data_sdk::data_objects::DataType dataType,
-    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
+    hipdnn_flatbuffers_sdk::data_objects::DataType dataType,
+    const std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType>& allowedTypes,
     const std::string& errorMessage)
 {
     if(allowedTypes.count(dataType) > 0)
@@ -154,9 +154,10 @@ void validateDataTypeIsSupported(
 
 void validateConsistentDataTypes(
     const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
-    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
+    const std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType>& allowedTypes,
     const std::string& typeErrorMessage,
     const std::string& consistencyErrorMessage)
 {
@@ -183,7 +184,8 @@ void validateConsistentDataTypes(
 
 void validateConsistentShapes(
     const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     const std::vector<int64_t>& referenceShape,
     const std::string& errorMessage)
@@ -203,7 +205,8 @@ void validateConsistentShapes(
 // --- Component Validators ---
 
 void checkTensorLayoutsAndDimsSupported(
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     // Skip tensors with embedded scalar values (epsilon) - they don't have layouts or dimensions to validate
@@ -212,7 +215,7 @@ void checkTensorLayoutsAndDimsSupported(
 
     for(const auto& [id, attr] : tensorMap)
     {
-        if(attr->value_type() != hipdnn_data_sdk::data_objects::TensorValue::NONE)
+        if(attr->value_type() != hipdnn_flatbuffers_sdk::data_objects::TensorValue::NONE)
         {
             continue;
         }
@@ -228,13 +231,14 @@ void checkTensorDataTypesSupported(
     const std::vector<int64_t>& ioTensorIds,
     const std::vector<int64_t>& affineTensorIds,
     const std::vector<int64_t>& statTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
-    std::unordered_set<hipdnn_data_sdk::data_objects::DataType> allowedIOTypes{
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-        hipdnn_data_sdk::data_objects::DataType::HALF};
+    std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> allowedIOTypes{
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF};
 
     validateConsistentDataTypes(ioTensorIds,
                                 tensorMap,
@@ -244,8 +248,8 @@ void checkTensorDataTypesSupported(
                                 "All IO tensors for RMSnorm must have the same data type.");
 
     // Only fp32 compute type is supported for now
-    std::unordered_set<hipdnn_data_sdk::data_objects::DataType> allowedComputeTypes{
-        hipdnn_data_sdk::data_objects::DataType::FLOAT
+    std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> allowedComputeTypes{
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT
 
     };
     validateConsistentDataTypes(affineTensorIds,
@@ -265,7 +269,8 @@ void checkTensorShapesSupported(
     const std::vector<int64_t>& ioTensorIds,
     const std::vector<int64_t>& affineTensorIds,
     const std::vector<int64_t>& statTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     if(ioTensorIds.empty())
@@ -301,8 +306,9 @@ void checkTensorShapesSupported(
 
 // --- High-Level Configuration Validators ---
 void checkRMSnormTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::RMSNormAttributes& rmsNormAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::RMSNormAttributes& rmsNormAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     std::vector<int64_t> ioTensorIds = {rmsNormAttr.x_tensor_uid(), rmsNormAttr.y_tensor_uid()};
@@ -324,8 +330,9 @@ void checkRMSnormTensorConfigSupported(
 }
 
 void checkRMSNormBwdTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::RMSNormBackwardAttributes& rmsNormBwdAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::RMSNormBackwardAttributes& rmsNormBwdAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     std::vector<int64_t> ioTensorIds = {rmsNormBwdAttr.dy_tensor_uid(),

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormApplicabilityChecks.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormApplicabilityChecks.hpp
@@ -6,9 +6,9 @@
 #include <unordered_map>
 #include <vector>
 
-#include <hipdnn_data_sdk/data_objects/rmsnorm_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/rmsnorm_backward_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/rmsnorm_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/rmsnorm_backward_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/tensor_attributes_generated.h>
 
 namespace hip_kernel_provider::rmsnorm
 {
@@ -21,7 +21,8 @@ struct RMSnormTensorDescriptor
     std::vector<int64_t> strides;
     std::vector<int64_t> strideOrder;
 
-    explicit RMSnormTensorDescriptor(const hipdnn_data_sdk::data_objects::TensorAttributes* attr);
+    explicit RMSnormTensorDescriptor(
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* attr);
 
     size_t numDims() const
     {
@@ -32,14 +33,16 @@ struct RMSnormTensorDescriptor
 
 // --- High-Level Configuration Validators ---
 void checkRMSnormTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::RMSNormAttributes& rmsNormAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::RMSNormAttributes& rmsNormAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
 // Backward-specific validator
 void checkRMSNormBwdTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::RMSNormBackwardAttributes& rmsNormBwdAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::RMSNormBackwardAttributes& rmsNormBwdAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
 } // namespace hip_kernel_provider::rmsnorm

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormBwdPlan.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormBwdPlan.cpp
@@ -18,8 +18,9 @@ namespace hip_kernel_provider::rmsnorm
 {
 
 RMSnormBwdParams::RMSnormBwdParams(
-    const hipdnn_data_sdk::data_objects::RMSNormBackwardAttributes& attributes,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::RMSNormBackwardAttributes& attributes,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
     : _dy(tensorMap.at(attributes.dy_tensor_uid()))
     , _x(tensorMap.at(attributes.x_tensor_uid()))
@@ -35,37 +36,37 @@ RMSnormBwdParams::RMSnormBwdParams(
 {
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes* RMSnormBwdParams::dy() const
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* RMSnormBwdParams::dy() const
 {
     return _dy;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes* RMSnormBwdParams::x() const
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* RMSnormBwdParams::x() const
 {
     return _x;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes* RMSnormBwdParams::scale() const
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* RMSnormBwdParams::scale() const
 {
     return _scale;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes* RMSnormBwdParams::invRMS() const
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* RMSnormBwdParams::invRMS() const
 {
     return _invRMS;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes* RMSnormBwdParams::dx() const
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* RMSnormBwdParams::dx() const
 {
     return _dx;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes* RMSnormBwdParams::dscale() const
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* RMSnormBwdParams::dscale() const
 {
     return _dscale;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes* RMSnormBwdParams::dbias() const
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* RMSnormBwdParams::dbias() const
 {
     return _dbias;
 }

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormBwdPlan.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormBwdPlan.hpp
@@ -24,8 +24,9 @@ class RMSnormBwdParams
 {
 public:
     RMSnormBwdParams(
-        const hipdnn_data_sdk::data_objects::RMSNormBackwardAttributes& attributes,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::RMSNormBackwardAttributes& attributes,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap);
 
     RMSnormBwdParams(const RMSnormBwdParams&) = delete;
@@ -34,22 +35,22 @@ public:
     RMSnormBwdParams(RMSnormBwdParams&&) = default;
     RMSnormBwdParams& operator=(RMSnormBwdParams&&) = default;
 
-    const hipdnn_data_sdk::data_objects::TensorAttributes* dy() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* x() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* scale() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* invRMS() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* dx() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* dscale() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* dbias() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* dy() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* x() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* scale() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* invRMS() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* dx() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* dscale() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* dbias() const;
 
 private:
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _dy;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _x;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _scale;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _invRMS;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _dx;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _dscale;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _dbias;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _dy;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _x;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _scale;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _invRMS;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _dx;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _dscale;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _dbias;
 };
 
 class RMSnormBwdPlan : public hipdnn_plugin_sdk::IPlan<HipKernelHandle>

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormBwdPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormBwdPlanBuilder.cpp
@@ -3,7 +3,7 @@
 
 #include <algorithm>
 #include <exception>
-#include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
 #include <hipdnn_plugin_sdk/PluginLogging.hpp>
 #include <set>
 #include <string>
@@ -24,12 +24,13 @@ RMSnormBwdPlanBuilder::RMSnormBwdPlanBuilder(const IKernelCompiler& kernelCompil
 
 bool RMSnormBwdPlanBuilder::isApplicable(
     [[maybe_unused]] const HipKernelHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
 {
     auto anyNodeIsNotF32Compute = [&]() {
         return !std::all_of(
             opGraph.nodeWrappers().begin(), opGraph.nodeWrappers().end(), [](const auto& node) {
-                return node->computeDataType() == hipdnn_data_sdk::data_objects::DataType::FLOAT;
+                return node->computeDataType()
+                       == hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT;
             });
     };
 
@@ -46,8 +47,9 @@ bool RMSnormBwdPlanBuilder::isApplicable(
         }
 
         if(!opGraph.hasOnlySupportedAttributes(
-               std::set<hipdnn_data_sdk::data_objects::NodeAttributes>{
-                   hipdnn_data_sdk::data_objects::NodeAttributes::RMSNormBackwardAttributes}))
+               std::set<hipdnn_flatbuffers_sdk::data_objects::NodeAttributes>{
+                   hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::
+                       RMSNormBackwardAttributes}))
         {
             HIPDNN_PLUGIN_LOG_INFO(
                 "RMSnorm backward plan builder is not applicable for this graph");
@@ -82,7 +84,7 @@ bool RMSnormBwdPlanBuilder::isApplicable(
 
 size_t RMSnormBwdPlanBuilder::getMaxWorkspaceSize(
     [[maybe_unused]] const HipKernelHandle& handle,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
     [[maybe_unused]] const HipKernelSettings& executionSettings) const
 {
     // RMSnorm backward plan currently does not require any workspace.
@@ -91,8 +93,9 @@ size_t RMSnormBwdPlanBuilder::getMaxWorkspaceSize(
 
 void RMSnormBwdPlanBuilder::initializeExecutionSettings(
     [[maybe_unused]] const HipKernelHandle& handle,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig&
+        engineConfig,
     [[maybe_unused]] HipKernelSettings& executionSettings) const
 {
 }
@@ -100,15 +103,17 @@ void RMSnormBwdPlanBuilder::initializeExecutionSettings(
 namespace
 {
 
-void buildPlanSingleNode([[maybe_unused]] const HipKernelHandle& handle,
-                         const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-                         const hipdnn_data_sdk::flatbuffer_utilities::INodeWrapper& nodeWrapper,
-                         const IKernelCompiler& kernelCompiler,
-                         const IDevicePropertyProvider& devicePropertyProvider,
-                         HipKernelContext& executionContext)
+void buildPlanSingleNode(
+    [[maybe_unused]] const HipKernelHandle& handle,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::INodeWrapper& nodeWrapper,
+    const IKernelCompiler& kernelCompiler,
+    const IDevicePropertyProvider& devicePropertyProvider,
+    HipKernelContext& executionContext)
 {
     const auto& attr
-        = nodeWrapper.attributesAs<hipdnn_data_sdk::data_objects::RMSNormBackwardAttributes>();
+        = nodeWrapper
+              .attributesAs<hipdnn_flatbuffers_sdk::data_objects::RMSNormBackwardAttributes>();
 
     RMSnormBwdParams params(attr, opGraph.getTensorMap());
     auto plan = std::make_unique<RMSnormBwdPlan>(std::move(params));
@@ -120,8 +125,9 @@ void buildPlanSingleNode([[maybe_unused]] const HipKernelHandle& handle,
 
 void RMSnormBwdPlanBuilder::buildPlan(
     const HipKernelHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig&
+        engineConfig,
     HipKernelContext& executionContext) const
 {
     const auto& nodeWrapper = opGraph.getNodeWrapper(0);
@@ -132,9 +138,9 @@ void RMSnormBwdPlanBuilder::buildPlan(
         handle, opGraph, nodeWrapper, _kernelCompiler, _devicePropertyProvider, executionContext);
 }
 
-std::vector<hipdnn_data_sdk::data_objects::KnobT> RMSnormBwdPlanBuilder::getCustomKnobs(
+std::vector<hipdnn_flatbuffers_sdk::data_objects::KnobT> RMSnormBwdPlanBuilder::getCustomKnobs(
     [[maybe_unused]] const HipKernelHandle& handle,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
 {
     return {};
 }

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormBwdPlanBuilder.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormBwdPlanBuilder.hpp
@@ -10,7 +10,7 @@
 #include "HipKernelSettings.hpp"
 #include "IDevicePropertyProvider.hpp"
 #include "hip/IKernelCompiler.hpp"
-#include "hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp"
+#include "hipdnn_flatbuffers_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp"
 
 namespace hip_kernel_provider::rmsnorm
 {
@@ -26,27 +26,28 @@ public:
     RMSnormBwdPlanBuilder(const RMSnormBwdPlanBuilder&) = delete;
     RMSnormBwdPlanBuilder& operator=(const RMSnormBwdPlanBuilder&) = delete;
 
-    bool isApplicable(const HipKernelHandle& handle,
-                      const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+    bool isApplicable(
+        const HipKernelHandle& handle,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
 
     size_t getMaxWorkspaceSize(const HipKernelHandle& handle,
-                               const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                               const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                                const HipKernelSettings& executionSettings) const override;
 
     void initializeExecutionSettings(
         const HipKernelHandle& handle,
-        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-        const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
         HipKernelSettings& executionSettings) const override;
 
     void buildPlan(const HipKernelHandle& handle,
-                   const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-                   const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+                   const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+                   const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
                    HipKernelContext& executionContext) const override;
 
-    std::vector<hipdnn_data_sdk::data_objects::KnobT>
-        getCustomKnobs(const HipKernelHandle& handle,
-                       const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+    std::vector<hipdnn_flatbuffers_sdk::data_objects::KnobT> getCustomKnobs(
+        const HipKernelHandle& handle,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
 
 private:
     const IKernelCompiler& _kernelCompiler;

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormFwdPlan.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormFwdPlan.cpp
@@ -10,8 +10,8 @@
 #include <cstdint>
 #include <hipdnn_data_sdk/logging/Logger.hpp>
 #include <hipdnn_data_sdk/utilities/Constants.hpp>
-#include <hipdnn_data_sdk/utilities/FlatbufferUtils.hpp>
 #include <hipdnn_data_sdk/utilities/PlatformUtils.hpp>
+#include <hipdnn_flatbuffers_sdk/utilities/FlatbufferUtils.hpp>
 
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 
@@ -19,8 +19,9 @@ namespace hip_kernel_provider::rmsnorm
 {
 
 RMSnormFwdParams::RMSnormFwdParams(
-    const hipdnn_data_sdk::data_objects::RMSNormAttributes& attributes,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::RMSNormAttributes& attributes,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
     : _x(tensorMap.at(attributes.x_tensor_uid()))
     , _scale(tensorMap.at(attributes.scale_tensor_uid()))
@@ -36,32 +37,32 @@ RMSnormFwdParams::RMSnormFwdParams(
 {
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes* RMSnormFwdParams::x() const
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* RMSnormFwdParams::x() const
 {
     return _x;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes* RMSnormFwdParams::scale() const
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* RMSnormFwdParams::scale() const
 {
     return _scale;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes* RMSnormFwdParams::epsilon() const
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* RMSnormFwdParams::epsilon() const
 {
     return _epsilon;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes* RMSnormFwdParams::bias() const
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* RMSnormFwdParams::bias() const
 {
     return _bias;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes* RMSnormFwdParams::y() const
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* RMSnormFwdParams::y() const
 {
     return _y;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes* RMSnormFwdParams::invRMS() const
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* RMSnormFwdParams::invRMS() const
 {
     return _invRMS;
 }
@@ -122,8 +123,8 @@ void RMSnormFwdPlan::compile(const IKernelCompiler& kernelCompiler,
 
     // Determine input/output data type configuration
     auto ioDataType = _params.x()->data_type();
-    const bool useFp16 = ioDataType == hipdnn_data_sdk::data_objects::DataType::HALF;
-    const bool useBfp16 = ioDataType == hipdnn_data_sdk::data_objects::DataType::BFLOAT16;
+    const bool useFp16 = ioDataType == hipdnn_flatbuffers_sdk::data_objects::DataType::HALF;
+    const bool useBfp16 = ioDataType == hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16;
     const bool useFp32 = !useFp16 && !useBfp16;
     std::string ioTypeString = getKernelParamTypeString(ioDataType);
 
@@ -176,10 +177,10 @@ void RMSnormFwdPlan::execute(const HipKernelHandle& handle,
                                       _params.invRMS()->uid(), deviceBuffers, numDeviceBuffers)
                                       .ptr;
 
-    hipdnn_data_sdk::data_objects::TensorAttributesT epsilonTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT epsilonTensor;
     _params.epsilon()->UnPackTo(&epsilonTensor);
     double epsilon
-        = hipdnn_data_sdk::utilities::extractDoubleFromTensorValue(epsilonTensor, "Epsilon");
+        = hipdnn_flatbuffers_sdk::utilities::extractDoubleFromTensorValue(epsilonTensor, "Epsilon");
 
     _runnableKernel->launch(handle.getStream(),
                             xBuffer.ptr,

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormFwdPlan.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormFwdPlan.hpp
@@ -24,8 +24,9 @@ class RMSnormFwdParams
 {
 public:
     RMSnormFwdParams(
-        const hipdnn_data_sdk::data_objects::RMSNormAttributes& attributes,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::RMSNormAttributes& attributes,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap);
 
     RMSnormFwdParams(const RMSnormFwdParams&) = delete;
@@ -34,20 +35,20 @@ public:
     RMSnormFwdParams(RMSnormFwdParams&&) = default;
     RMSnormFwdParams& operator=(RMSnormFwdParams&&) = default;
 
-    const hipdnn_data_sdk::data_objects::TensorAttributes* x() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* scale() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* bias() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* y() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* invRMS() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* epsilon() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* x() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* scale() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* bias() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* y() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* invRMS() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* epsilon() const;
 
 private:
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _x;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _scale;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _bias;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _y;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _invRMS;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _epsilon;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _x;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _scale;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _bias;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _y;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _invRMS;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _epsilon;
 };
 
 class RMSnormFwdPlan : public hipdnn_plugin_sdk::IPlan<HipKernelHandle>

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormPlanBuilder.cpp
@@ -1,7 +1,7 @@
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier:  MIT
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
 #include <hipdnn_plugin_sdk/PluginLogging.hpp>
 
 #include "RMSnormApplicabilityChecks.hpp"
@@ -23,13 +23,14 @@ RMSnormPlanBuilder::RMSnormPlanBuilder(const IKernelCompiler& kernelCompiler,
 
 bool RMSnormPlanBuilder::isApplicable(
     [[maybe_unused]] const HipKernelHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
 {
 
     auto anyNodeIsNotF32Compute = [&]() {
         return !std::all_of(
             opGraph.nodeWrappers().begin(), opGraph.nodeWrappers().end(), [](const auto& node) {
-                return node->computeDataType() == hipdnn_data_sdk::data_objects::DataType::FLOAT;
+                return node->computeDataType()
+                       == hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT;
             });
     };
 
@@ -46,8 +47,8 @@ bool RMSnormPlanBuilder::isApplicable(
         }
 
         if(!opGraph.hasOnlySupportedAttributes(
-               std::set<hipdnn_data_sdk::data_objects::NodeAttributes>{
-                   hipdnn_data_sdk::data_objects::NodeAttributes::RMSNormAttributes}))
+               std::set<hipdnn_flatbuffers_sdk::data_objects::NodeAttributes>{
+                   hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::RMSNormAttributes}))
         {
             HIPDNN_PLUGIN_LOG_INFO("RMSnorm plan builder is not applicable for this graph");
             return false;
@@ -80,7 +81,7 @@ bool RMSnormPlanBuilder::isApplicable(
 
 size_t RMSnormPlanBuilder::getMaxWorkspaceSize(
     [[maybe_unused]] const HipKernelHandle& handle,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
     [[maybe_unused]] const HipKernelSettings& executionSettings) const
 {
     // RMS norm plan builder does not require workspace size
@@ -90,14 +91,16 @@ size_t RMSnormPlanBuilder::getMaxWorkspaceSize(
 namespace
 {
 
-void buildPlanFwdSingleNode([[maybe_unused]] const HipKernelHandle& handle,
-                            const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-                            const hipdnn_data_sdk::flatbuffer_utilities::INodeWrapper& nodeWrapper,
-                            const IKernelCompiler& kernelCompiler,
-                            const IDevicePropertyProvider& devicePropertyProvider,
-                            HipKernelContext& executionContext)
+void buildPlanFwdSingleNode(
+    [[maybe_unused]] const HipKernelHandle& handle,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::INodeWrapper& nodeWrapper,
+    const IKernelCompiler& kernelCompiler,
+    const IDevicePropertyProvider& devicePropertyProvider,
+    HipKernelContext& executionContext)
 {
-    const auto& attr = nodeWrapper.attributesAs<hipdnn_data_sdk::data_objects::RMSNormAttributes>();
+    const auto& attr
+        = nodeWrapper.attributesAs<hipdnn_flatbuffers_sdk::data_objects::RMSNormAttributes>();
 
     RMSnormFwdParams params(attr, opGraph.getTensorMap());
     auto plan = std::make_unique<RMSnormFwdPlan>(std::move(params));
@@ -109,16 +112,18 @@ void buildPlanFwdSingleNode([[maybe_unused]] const HipKernelHandle& handle,
 
 void RMSnormPlanBuilder::initializeExecutionSettings(
     [[maybe_unused]] const HipKernelHandle& handle,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig&
+        engineConfig,
     [[maybe_unused]] HipKernelSettings& executionSettings) const
 {
 }
 
 void RMSnormPlanBuilder::buildPlan(
     const HipKernelHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig&
+        engineConfig,
     HipKernelContext& executionContext) const
 {
     const auto& nodeWrapper = opGraph.getNodeWrapper(0);
@@ -129,9 +134,9 @@ void RMSnormPlanBuilder::buildPlan(
         handle, opGraph, nodeWrapper, _kernelCompiler, _devicePropertyProvider, executionContext);
 }
 
-std::vector<hipdnn_data_sdk::data_objects::KnobT> RMSnormPlanBuilder::getCustomKnobs(
+std::vector<hipdnn_flatbuffers_sdk::data_objects::KnobT> RMSnormPlanBuilder::getCustomKnobs(
     [[maybe_unused]] const HipKernelHandle& handle,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
 {
     return {};
 }

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormPlanBuilder.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/RMSnorm/RMSnormPlanBuilder.hpp
@@ -10,7 +10,7 @@
 #include "HipKernelSettings.hpp"
 #include "IDevicePropertyProvider.hpp"
 #include "hip/IKernelCompiler.hpp"
-#include "hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp"
+#include "hipdnn_flatbuffers_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp"
 
 namespace hip_kernel_provider::rmsnorm
 {
@@ -27,27 +27,28 @@ public:
     RMSnormPlanBuilder(const RMSnormPlanBuilder&) = delete;
     RMSnormPlanBuilder& operator=(const RMSnormPlanBuilder&) = delete;
 
-    bool isApplicable(const HipKernelHandle& handle,
-                      const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+    bool isApplicable(
+        const HipKernelHandle& handle,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
 
     size_t getMaxWorkspaceSize(const HipKernelHandle& handle,
-                               const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                               const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                                const HipKernelSettings& executionSettings) const override;
 
     void initializeExecutionSettings(
         const HipKernelHandle& handle,
-        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-        const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
         HipKernelSettings& executionSettings) const override;
 
     void buildPlan(const HipKernelHandle& handle,
-                   const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-                   const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+                   const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+                   const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
                    HipKernelContext& executionContext) const override;
 
-    std::vector<hipdnn_data_sdk::data_objects::KnobT>
-        getCustomKnobs(const HipKernelHandle& handle,
-                       const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+    std::vector<hipdnn_flatbuffers_sdk::data_objects::KnobT> getCustomKnobs(
+        const HipKernelHandle& handle,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
 
 private:
     const IKernelCompiler& _kernelCompiler;

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormApplicabilityChecks.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormApplicabilityChecks.cpp
@@ -16,9 +16,9 @@ namespace hip_kernel_provider::batchnorm
 
 // --- Type Configuration Helpers ---
 
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType> type_configs::getAllowedIoTypes()
+std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> type_configs::getAllowedIoTypes()
 {
-    std::unordered_set<hipdnn_data_sdk::data_objects::DataType> types;
+    std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> types;
     for(const auto& config : VALID)
     {
         types.insert(config.io);
@@ -26,9 +26,10 @@ std::unordered_set<hipdnn_data_sdk::data_objects::DataType> type_configs::getAll
     return types;
 }
 
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType> type_configs::getAllowedAffineTypes()
+std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType>
+    type_configs::getAllowedAffineTypes()
 {
-    std::unordered_set<hipdnn_data_sdk::data_objects::DataType> types;
+    std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> types;
     for(const auto& config : VALID)
     {
         types.insert(config.affine);
@@ -36,9 +37,10 @@ std::unordered_set<hipdnn_data_sdk::data_objects::DataType> type_configs::getAll
     return types;
 }
 
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType> type_configs::getAllowedStatTypes()
+std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType>
+    type_configs::getAllowedStatTypes()
 {
-    std::unordered_set<hipdnn_data_sdk::data_objects::DataType> types;
+    std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> types;
     for(const auto& config : VALID)
     {
         types.insert(config.stat);
@@ -46,10 +48,10 @@ std::unordered_set<hipdnn_data_sdk::data_objects::DataType> type_configs::getAll
     return types;
 }
 
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType>
+std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType>
     type_configs::getAllowedIntermediateTypes()
 {
-    std::unordered_set<hipdnn_data_sdk::data_objects::DataType> types;
+    std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> types;
     for(const auto& config : VALID)
     {
         types.insert(config.intermediate);
@@ -60,7 +62,7 @@ std::unordered_set<hipdnn_data_sdk::data_objects::DataType>
 // --- Tensor Descriptor Implementation ---
 
 BatchnormTensorDescriptor::BatchnormTensorDescriptor(
-    const hipdnn_data_sdk::data_objects::TensorAttributes* attr)
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* attr)
     : dims(attr->dims()->begin(), attr->dims()->end())
     , strides(attr->strides()->begin(), attr->strides()->end())
     , strideOrder(hipdnn_data_sdk::utilities::extractStrideOrder(strides))
@@ -187,8 +189,8 @@ void validateConsistentLayouts(const std::vector<BatchnormTensorDescriptor>& ten
 }
 
 void validateDataTypeIsSupported(
-    hipdnn_data_sdk::data_objects::DataType dataType,
-    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
+    hipdnn_flatbuffers_sdk::data_objects::DataType dataType,
+    const std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType>& allowedTypes,
     const std::string& errorMessage)
 {
     if(allowedTypes.count(dataType) > 0)
@@ -200,9 +202,10 @@ void validateDataTypeIsSupported(
 
 void validateConsistentDataTypes(
     const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
-    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
+    const std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType>& allowedTypes,
     const std::string& typeErrorMessage,
     const std::string& consistencyErrorMessage)
 {
@@ -229,9 +232,10 @@ void validateConsistentDataTypes(
 
 void validateFixedDataType(
     const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
-    hipdnn_data_sdk::data_objects::DataType expectedType,
+    hipdnn_flatbuffers_sdk::data_objects::DataType expectedType,
     const std::string& errorMessage)
 {
     for(const auto tensorId : tensorIds)
@@ -247,7 +251,8 @@ void validateFixedDataType(
 
 void validateConsistentShapes(
     const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     const std::vector<int64_t>& referenceShape,
     const std::string& errorMessage)
@@ -300,7 +305,8 @@ void validatePeerStatsNotPopulated(const flatbuffers::Vector<int64_t>* peerStats
 // --- Component Validators ---
 
 void checkTensorLayoutsAndDimsSupported(
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     // Skip tensors with embedded scalar values (epsilon, momentum) - they don't have layouts or dimensions to validate
@@ -309,7 +315,7 @@ void checkTensorLayoutsAndDimsSupported(
 
     for(const auto& [id, attr] : tensorMap)
     {
-        if(attr->value_type() != hipdnn_data_sdk::data_objects::TensorValue::NONE)
+        if(attr->value_type() != hipdnn_flatbuffers_sdk::data_objects::TensorValue::NONE)
         {
             continue;
         }
@@ -326,7 +332,8 @@ void checkTensorDataTypesSupported(
     const std::vector<int64_t>& affineTensorIds,
     const std::vector<int64_t>& statTensorIds,
     const std::vector<int64_t>& intermediateTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     validators::validateConsistentDataTypes(
@@ -399,7 +406,8 @@ void checkTensorShapesSupported(
     const std::vector<int64_t>& ioTensorIds,
     const std::vector<int64_t>& affineTensorIds,
     const std::vector<int64_t>& statTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     bool isTraining)
 {
@@ -444,7 +452,8 @@ void checkBatchnormTensorConfigSupported(
     const std::vector<int64_t>& affineTensorIds,
     const std::vector<int64_t>& statTensorIds,
     const std::vector<int64_t>& intermediateTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     bool isTraining)
 {
@@ -457,8 +466,9 @@ void checkBatchnormTensorConfigSupported(
 } // namespace
 
 void checkBatchnormInferenceTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     std::vector<int64_t> ioTensorIds = {bnInfAttr.x_tensor_uid(), bnInfAttr.y_tensor_uid()};
@@ -472,8 +482,9 @@ void checkBatchnormInferenceTensorConfigSupported(
 }
 
 void checkBatchnormInferenceVarianceExtTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     std::vector<int64_t> ioTensorIds = {bnInfAttr.x_tensor_uid(), bnInfAttr.y_tensor_uid()};
@@ -487,9 +498,10 @@ void checkBatchnormInferenceVarianceExtTensorConfigSupported(
 }
 
 void checkBatchnormInferenceActivationTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     checkBatchnormFwdActivationModeSupported(actAttr);
@@ -507,9 +519,10 @@ void checkBatchnormInferenceActivationTensorConfigSupported(
 }
 
 void checkBatchnormInferenceVarianceExtActivationTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     checkBatchnormFwdActivationModeSupported(actAttr);
@@ -532,18 +545,18 @@ namespace
 {
 
 void checkBatchnormActivationModeSupported(
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& activAttr, bool isBwd)
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& activAttr, bool isBwd)
 {
     // hip-kernel-provider batchnorm supports: PASSTHRU, RELU, CLIPPEDREU, CLAMP (no Leaky ReLU)
 
-    if(activAttr.operation() == hipdnn_data_sdk::data_objects::PointwiseMode::IDENTITY)
+    if(activAttr.operation() == hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::IDENTITY)
     {
         return;
     }
 
     if(activAttr.operation()
-       == (isBwd ? hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD
-                 : hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD))
+       == (isBwd ? hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD
+                 : hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD))
     {
         if(!activAttr.relu_lower_clip_slope())
         {
@@ -561,20 +574,21 @@ void checkBatchnormActivationModeSupported(
 } // namespace
 
 void checkBatchnormFwdActivationModeSupported(
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& activAttr)
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& activAttr)
 {
     checkBatchnormActivationModeSupported(activAttr, false);
 }
 
 void checkBatchnormBwdActivationModeSupported(
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& activAttr)
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& activAttr)
 {
     checkBatchnormActivationModeSupported(activAttr, true);
 }
 
 void checkBatchnormFwdTrainingTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormAttributes& bnAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormAttributes& bnAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     validators::validatePeerStatsNotPopulated(

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormApplicabilityChecks.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormApplicabilityChecks.hpp
@@ -8,11 +8,11 @@
 #include <unordered_set>
 #include <vector>
 
-#include <hipdnn_data_sdk/data_objects/batchnorm_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/batchnorm_inference_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/batchnorm_inference_attributes_variance_ext_generated.h>
-#include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/batchnorm_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/batchnorm_inference_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/batchnorm_inference_attributes_variance_ext_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/pointwise_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/tensor_attributes_generated.h>
 
 namespace hip_kernel_provider::batchnorm
 {
@@ -25,7 +25,8 @@ struct BatchnormTensorDescriptor
     std::vector<int64_t> strides;
     std::vector<int64_t> strideOrder;
 
-    explicit BatchnormTensorDescriptor(const hipdnn_data_sdk::data_objects::TensorAttributes* attr);
+    explicit BatchnormTensorDescriptor(
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* attr);
 
     size_t numDims() const
     {
@@ -49,28 +50,31 @@ void validateSupportedLayout(const std::vector<int64_t>& strideOrder, size_t num
 void validateConsistentLayouts(const std::vector<BatchnormTensorDescriptor>& tensors);
 
 void validateDataTypeIsSupported(
-    hipdnn_data_sdk::data_objects::DataType dataType,
-    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
+    hipdnn_flatbuffers_sdk::data_objects::DataType dataType,
+    const std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType>& allowedTypes,
     const std::string& errorMessage);
 
 void validateConsistentDataTypes(
     const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
-    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
+    const std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType>& allowedTypes,
     const std::string& typeErrorMessage,
     const std::string& consistencyErrorMessage);
 
 void validateFixedDataType(
     const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
-    hipdnn_data_sdk::data_objects::DataType expectedType,
+    hipdnn_flatbuffers_sdk::data_objects::DataType expectedType,
     const std::string& errorMessage);
 
 void validateConsistentShapes(
     const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     const std::vector<int64_t>& referenceShape,
     const std::string& errorMessage);
@@ -82,7 +86,8 @@ void validateSpatialDimensions(const std::vector<int64_t>& ioDims);
 // --- Component Validators ---
 
 void checkTensorLayoutsAndDimsSupported(
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
 void checkTensorDataTypesSupported(
@@ -90,50 +95,57 @@ void checkTensorDataTypesSupported(
     const std::vector<int64_t>& affineTensorIds,
     const std::vector<int64_t>& statTensorIds,
     const std::vector<int64_t>& intermediateTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
 void checkTensorShapesSupported(
     const std::vector<int64_t>& ioTensorIds,
     const std::vector<int64_t>& affineTensorIds,
     const std::vector<int64_t>& statTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     bool isTraining);
 
 // --- High-Level Configuration Validators ---
 
 void checkBatchnormInferenceTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
 void checkBatchnormInferenceVarianceExtTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
 void checkBatchnormInferenceActivationTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
 void checkBatchnormInferenceVarianceExtActivationTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
 void checkBatchnormFwdActivationModeSupported(
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& activAttr);
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& activAttr);
 
 void checkBatchnormBwdActivationModeSupported(
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& activAttr);
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& activAttr);
 
 void checkBatchnormFwdTrainingTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormAttributes& bnAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormAttributes& bnAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
 // --- Batchnorm Type Configuration ---
@@ -143,15 +155,15 @@ void checkBatchnormFwdTrainingTensorConfigSupported(
 // - Affine/Stat/Intermediate tensors: FLOAT only
 struct TensorTypes
 {
-    hipdnn_data_sdk::data_objects::DataType io;
-    hipdnn_data_sdk::data_objects::DataType affine;
-    hipdnn_data_sdk::data_objects::DataType stat;
-    hipdnn_data_sdk::data_objects::DataType intermediate;
+    hipdnn_flatbuffers_sdk::data_objects::DataType io;
+    hipdnn_flatbuffers_sdk::data_objects::DataType affine;
+    hipdnn_flatbuffers_sdk::data_objects::DataType stat;
+    hipdnn_flatbuffers_sdk::data_objects::DataType intermediate;
 };
 
 namespace type_configs
 {
-using DT = hipdnn_data_sdk::data_objects::DataType;
+using DT = hipdnn_flatbuffers_sdk::data_objects::DataType;
 
 inline constexpr TensorTypes ALL_FLOAT = {DT::FLOAT, DT::FLOAT, DT::FLOAT, DT::FLOAT};
 inline constexpr TensorTypes HALF_IO = {DT::HALF, DT::FLOAT, DT::FLOAT, DT::FLOAT};
@@ -159,10 +171,10 @@ inline constexpr TensorTypes BFLOAT16_IO = {DT::BFLOAT16, DT::FLOAT, DT::FLOAT, 
 
 inline constexpr std::array<TensorTypes, 3> VALID = {ALL_FLOAT, HALF_IO, BFLOAT16_IO};
 
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType> getAllowedIoTypes();
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType> getAllowedAffineTypes();
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType> getAllowedStatTypes();
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType> getAllowedIntermediateTypes();
+std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> getAllowedIoTypes();
+std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> getAllowedAffineTypes();
+std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> getAllowedStatTypes();
+std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> getAllowedIntermediateTypes();
 
 } // namespace type_configs
 

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormFwdInferencePlan.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormFwdInferencePlan.cpp
@@ -15,8 +15,9 @@ namespace hip_kernel_provider::batchnorm
 {
 
 BatchnormFwdInferenceParams::BatchnormFwdInferenceParams(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& attributes,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes& attributes,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
     : _x(tensorMap.at(attributes.x_tensor_uid()))
     , _y(tensorMap.at(attributes.y_tensor_uid()))
@@ -29,9 +30,10 @@ BatchnormFwdInferenceParams::BatchnormFwdInferenceParams(
 }
 
 BatchnormFwdInferenceParams::BatchnormFwdInferenceParams(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& inferenceAttributes,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& pointwiseAttributes,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes& inferenceAttributes,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& pointwiseAttributes,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
     : _x(tensorMap.at(inferenceAttributes.x_tensor_uid()))
     , _y(tensorMap.at(inferenceAttributes.y_tensor_uid()))
@@ -44,32 +46,35 @@ BatchnormFwdInferenceParams::BatchnormFwdInferenceParams(
 {
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes* BatchnormFwdInferenceParams::x() const
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* BatchnormFwdInferenceParams::x() const
 {
     return _x;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes* BatchnormFwdInferenceParams::y() const
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* BatchnormFwdInferenceParams::y() const
 {
     return _y;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes* BatchnormFwdInferenceParams::scale() const
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*
+    BatchnormFwdInferenceParams::scale() const
 {
     return _scale;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes* BatchnormFwdInferenceParams::bias() const
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*
+    BatchnormFwdInferenceParams::bias() const
 {
     return _bias;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes* BatchnormFwdInferenceParams::estMean() const
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*
+    BatchnormFwdInferenceParams::estMean() const
 {
     return _estMean;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes*
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*
     BatchnormFwdInferenceParams::invVariance() const
 {
     return _invVariance;
@@ -81,7 +86,7 @@ const std::optional<hip_kernel_utils::ActivationParams>&
     return _optActivation;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes*
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*
     BatchnormFwdInferenceParams::activationOut() const
 {
     return _activationOut;
@@ -106,10 +111,10 @@ void BatchnormFwdInferencePlan::compile(const IKernelCompiler& kernelCompiler,
     auto xDataType = _inferenceParams.x()->data_type();
     auto scaleDataType = _inferenceParams.scale()->data_type();
 
-    bool useFp16Mix = (xDataType == hipdnn_data_sdk::data_objects::DataType::HALF
-                       && scaleDataType == hipdnn_data_sdk::data_objects::DataType::FLOAT);
-    bool useBfp16Mix = (xDataType == hipdnn_data_sdk::data_objects::DataType::BFLOAT16
-                        && scaleDataType == hipdnn_data_sdk::data_objects::DataType::FLOAT);
+    bool useFp16Mix = (xDataType == hipdnn_flatbuffers_sdk::data_objects::DataType::HALF
+                       && scaleDataType == hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT);
+    bool useBfp16Mix = (xDataType == hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16
+                        && scaleDataType == hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT);
     bool useFp32 = !useFp16Mix && !useBfp16Mix;
 
     // Extract dimensions from x tensor

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormFwdInferencePlan.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormFwdInferencePlan.hpp
@@ -26,14 +26,17 @@ class BatchnormFwdInferenceParams
 {
 public:
     BatchnormFwdInferenceParams(
-        const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& attributes,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes& attributes,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap);
 
     BatchnormFwdInferenceParams(
-        const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& inferenceAttributes,
-        const hipdnn_data_sdk::data_objects::PointwiseAttributes& pointwiseAttributes,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes&
+            inferenceAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& pointwiseAttributes,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap);
 
     BatchnormFwdInferenceParams(const BatchnormFwdInferenceParams&) = delete;
@@ -42,26 +45,26 @@ public:
     BatchnormFwdInferenceParams(BatchnormFwdInferenceParams&&) = default;
     BatchnormFwdInferenceParams& operator=(BatchnormFwdInferenceParams&&) = default;
 
-    const hipdnn_data_sdk::data_objects::TensorAttributes* x() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* y() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* scale() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* bias() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* estMean() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* invVariance() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* x() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* y() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* scale() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* bias() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* estMean() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* invVariance() const;
 
     const std::optional<hip_kernel_utils::ActivationParams>& optActivation() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* activationOut() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* activationOut() const;
 
 private:
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _x;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _y;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _scale;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _bias;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _estMean;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _invVariance;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _x;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _y;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _scale;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _bias;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _estMean;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _invVariance;
 
     std::optional<hip_kernel_utils::ActivationParams> _optActivation;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _activationOut;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _activationOut;
 };
 
 class BatchnormFwdInferencePlan : public hipdnn_plugin_sdk::IPlan<HipKernelHandle>

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormFwdInferenceWithVariancePlan.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormFwdInferenceWithVariancePlan.cpp
@@ -8,16 +8,17 @@
 
 #include <hipdnn_data_sdk/logging/Logger.hpp>
 #include <hipdnn_data_sdk/utilities/Constants.hpp>
-#include <hipdnn_data_sdk/utilities/FlatbufferUtils.hpp>
 #include <hipdnn_data_sdk/utilities/PlatformUtils.hpp>
+#include <hipdnn_flatbuffers_sdk/utilities/FlatbufferUtils.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 
 namespace hip_kernel_provider::batchnorm
 {
 
 BatchnormFwdInferenceWithVarianceParams::BatchnormFwdInferenceWithVarianceParams(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& attributes,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& attributes,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
     : _x(tensorMap.at(attributes.x_tensor_uid()))
     , _y(tensorMap.at(attributes.y_tensor_uid()))
@@ -29,15 +30,16 @@ BatchnormFwdInferenceWithVarianceParams::BatchnormFwdInferenceWithVarianceParams
 {
     // Extract epsilon value from pass-by-value tensor (cast to double for kernel compatibility)
     auto epsilonTensorAttr = tensorMap.at(attributes.epsilon_tensor_uid());
-    _epsilonValue
-        = hipdnn_data_sdk::utilities::extractDoubleFromTensorValue(epsilonTensorAttr, "Epsilon");
+    _epsilonValue = hipdnn_flatbuffers_sdk::utilities::extractDoubleFromTensorValue(
+        epsilonTensorAttr, "Epsilon");
 }
 
 BatchnormFwdInferenceWithVarianceParams::BatchnormFwdInferenceWithVarianceParams(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributesVarianceExt&
         inferenceAttributes,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& pointwiseAttributes,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& pointwiseAttributes,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
     : _x(tensorMap.at(inferenceAttributes.x_tensor_uid()))
     , _y(tensorMap.at(inferenceAttributes.y_tensor_uid()))
@@ -50,41 +52,41 @@ BatchnormFwdInferenceWithVarianceParams::BatchnormFwdInferenceWithVarianceParams
 {
     // Extract epsilon value from pass-by-value tensor (cast to double for kernel compatibility)
     auto epsilonTensorAttr = tensorMap.at(inferenceAttributes.epsilon_tensor_uid());
-    _epsilonValue
-        = hipdnn_data_sdk::utilities::extractDoubleFromTensorValue(epsilonTensorAttr, "Epsilon");
+    _epsilonValue = hipdnn_flatbuffers_sdk::utilities::extractDoubleFromTensorValue(
+        epsilonTensorAttr, "Epsilon");
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes*
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*
     BatchnormFwdInferenceWithVarianceParams::x() const
 {
     return _x;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes*
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*
     BatchnormFwdInferenceWithVarianceParams::y() const
 {
     return _y;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes*
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*
     BatchnormFwdInferenceWithVarianceParams::scale() const
 {
     return _scale;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes*
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*
     BatchnormFwdInferenceWithVarianceParams::bias() const
 {
     return _bias;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes*
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*
     BatchnormFwdInferenceWithVarianceParams::estMean() const
 {
     return _estMean;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes*
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*
     BatchnormFwdInferenceWithVarianceParams::estVariance() const
 {
     return _estVariance;
@@ -101,7 +103,7 @@ const std::optional<hip_kernel_utils::ActivationParams>&
     return _optActivation;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes*
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*
     BatchnormFwdInferenceWithVarianceParams::activationOut() const
 {
     return _activationOut;
@@ -127,10 +129,10 @@ void BatchnormFwdInferenceWithVariancePlan::compile(const IKernelCompiler& kerne
     auto xDataType = _inferenceParams.x()->data_type();
     auto scaleDataType = _inferenceParams.scale()->data_type();
 
-    bool useFp16Mix = (xDataType == hipdnn_data_sdk::data_objects::DataType::HALF
-                       && scaleDataType == hipdnn_data_sdk::data_objects::DataType::FLOAT);
-    bool useBfp16Mix = (xDataType == hipdnn_data_sdk::data_objects::DataType::BFLOAT16
-                        && scaleDataType == hipdnn_data_sdk::data_objects::DataType::FLOAT);
+    bool useFp16Mix = (xDataType == hipdnn_flatbuffers_sdk::data_objects::DataType::HALF
+                       && scaleDataType == hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT);
+    bool useBfp16Mix = (xDataType == hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16
+                        && scaleDataType == hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT);
     bool useFp32 = !useFp16Mix && !useBfp16Mix;
 
     // Extract dimensions from x tensor

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormFwdInferenceWithVariancePlan.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormFwdInferenceWithVariancePlan.hpp
@@ -26,15 +26,18 @@ class BatchnormFwdInferenceWithVarianceParams
 {
 public:
     BatchnormFwdInferenceWithVarianceParams(
-        const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& attributes,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributesVarianceExt&
+            attributes,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap);
 
     BatchnormFwdInferenceWithVarianceParams(
-        const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt&
+        const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributesVarianceExt&
             inferenceAttributes,
-        const hipdnn_data_sdk::data_objects::PointwiseAttributes& pointwiseAttributes,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& pointwiseAttributes,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap);
 
     BatchnormFwdInferenceWithVarianceParams(const BatchnormFwdInferenceWithVarianceParams&)
@@ -47,28 +50,28 @@ public:
     BatchnormFwdInferenceWithVarianceParams& operator=(BatchnormFwdInferenceWithVarianceParams&&)
         = default;
 
-    const hipdnn_data_sdk::data_objects::TensorAttributes* x() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* y() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* scale() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* bias() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* estMean() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* estVariance() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* x() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* y() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* scale() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* bias() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* estMean() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* estVariance() const;
     double epsilonValue() const;
 
     const std::optional<hip_kernel_utils::ActivationParams>& optActivation() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* activationOut() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* activationOut() const;
 
 private:
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _x;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _y;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _scale;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _bias;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _estMean;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _estVariance;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _x;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _y;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _scale;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _bias;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _estMean;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _estVariance;
     double _epsilonValue;
 
     std::optional<hip_kernel_utils::ActivationParams> _optActivation;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _activationOut;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _activationOut;
 };
 
 class BatchnormFwdInferenceWithVariancePlan : public hipdnn_plugin_sdk::IPlan<HipKernelHandle>

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormFwdTrainingPlan.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormFwdTrainingPlan.cpp
@@ -9,16 +9,17 @@
 
 #include <hipdnn_data_sdk/logging/Logger.hpp>
 #include <hipdnn_data_sdk/utilities/Constants.hpp>
-#include <hipdnn_data_sdk/utilities/FlatbufferUtils.hpp>
 #include <hipdnn_data_sdk/utilities/PlatformUtils.hpp>
+#include <hipdnn_flatbuffers_sdk/utilities/FlatbufferUtils.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 
 namespace hip_kernel_provider::batchnorm
 {
 
 BatchnormFwdTrainingParams::BatchnormFwdTrainingParams(
-    const hipdnn_data_sdk::data_objects::BatchnormAttributes& attributes,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormAttributes& attributes,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
     : _x(&(hip_kernel_utils::findTensorAttributes(tensorMap, attributes.x_tensor_uid())))
     , _y(&(hip_kernel_utils::findTensorAttributes(tensorMap, attributes.y_tensor_uid())))
@@ -27,8 +28,8 @@ BatchnormFwdTrainingParams::BatchnormFwdTrainingParams(
 {
     // Extract epsilon value from pass-by-value tensor (cast to double for kernel compatibility)
     auto epsilonTensorAttr = tensorMap.at(attributes.epsilon_tensor_uid());
-    _epsilonValue
-        = hipdnn_data_sdk::utilities::extractDoubleFromTensorValue(epsilonTensorAttr, "Epsilon");
+    _epsilonValue = hipdnn_flatbuffers_sdk::utilities::extractDoubleFromTensorValue(
+        epsilonTensorAttr, "Epsilon");
 
     // Save mean and inv_variance are optional
     if(attributes.mean_tensor_uid().has_value())
@@ -51,7 +52,7 @@ BatchnormFwdTrainingParams::BatchnormFwdTrainingParams(
     {
         // Extract momentum value from pass-by-value tensor (cast to double for kernel compatibility)
         auto momentumTensorAttr = tensorMap.at(attributes.momentum_tensor_uid().value());
-        _momentumValue = hipdnn_data_sdk::utilities::extractDoubleFromTensorValue(
+        _momentumValue = hipdnn_flatbuffers_sdk::utilities::extractDoubleFromTensorValue(
             momentumTensorAttr, "Momentum");
 
         _prevRunningMean = &(hip_kernel_utils::findTensorAttributes(
@@ -66,22 +67,24 @@ BatchnormFwdTrainingParams::BatchnormFwdTrainingParams(
     }
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes* BatchnormFwdTrainingParams::x() const
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* BatchnormFwdTrainingParams::x() const
 {
     return _x;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes* BatchnormFwdTrainingParams::y() const
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* BatchnormFwdTrainingParams::y() const
 {
     return _y;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes* BatchnormFwdTrainingParams::scale() const
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*
+    BatchnormFwdTrainingParams::scale() const
 {
     return _scale;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes* BatchnormFwdTrainingParams::bias() const
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*
+    BatchnormFwdTrainingParams::bias() const
 {
     return _bias;
 }
@@ -96,12 +99,13 @@ bool BatchnormFwdTrainingParams::hasSaveMeanVariance() const
     return (_mean != nullptr) && (_invVariance != nullptr);
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes* BatchnormFwdTrainingParams::mean() const
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*
+    BatchnormFwdTrainingParams::mean() const
 {
     return _mean;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes*
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*
     BatchnormFwdTrainingParams::invVariance() const
 {
     return _invVariance;
@@ -112,13 +116,13 @@ bool BatchnormFwdTrainingParams::hasRunningStats() const
     return _hasRunningStats;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes*
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*
     BatchnormFwdTrainingParams::prevRunningMean() const
 {
     return _prevRunningMean;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes*
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*
     BatchnormFwdTrainingParams::prevRunningVariance() const
 {
     return _prevRunningVariance;
@@ -129,13 +133,13 @@ double BatchnormFwdTrainingParams::momentumValue() const
     return _momentumValue.value();
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes*
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*
     BatchnormFwdTrainingParams::nextRunningMean() const
 {
     return _nextRunningMean;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes*
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*
     BatchnormFwdTrainingParams::nextRunningVariance() const
 {
     return _nextRunningVariance;
@@ -164,10 +168,10 @@ void BatchnormFwdTrainingPlan::compile(const IKernelCompiler& kernelCompiler,
     // FP16 IO and FP16 scale/bias data types, the hip kernel plugin
     // applicability checks require the scale and bias tensors to be FP32.
     // So we are not using the USE_FP16 path in the kernel for now.
-    bool useFp16Mix = (xDataType == hipdnn_data_sdk::data_objects::DataType::HALF
-                       && scaleDataType == hipdnn_data_sdk::data_objects::DataType::FLOAT);
-    bool useBfp16Mix = (xDataType == hipdnn_data_sdk::data_objects::DataType::BFLOAT16
-                        && scaleDataType == hipdnn_data_sdk::data_objects::DataType::FLOAT);
+    bool useFp16Mix = (xDataType == hipdnn_flatbuffers_sdk::data_objects::DataType::HALF
+                       && scaleDataType == hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT);
+    bool useBfp16Mix = (xDataType == hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16
+                        && scaleDataType == hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT);
     bool useFp32 = !useFp16Mix && !useBfp16Mix;
 
     // Extract dimensions from x tensor

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormFwdTrainingPlan.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormFwdTrainingPlan.hpp
@@ -25,8 +25,9 @@ class BatchnormFwdTrainingParams
 {
 public:
     BatchnormFwdTrainingParams(
-        const hipdnn_data_sdk::data_objects::BatchnormAttributes& attributes,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::BatchnormAttributes& attributes,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap);
 
     BatchnormFwdTrainingParams(const BatchnormFwdTrainingParams&) = delete;
@@ -35,39 +36,39 @@ public:
     BatchnormFwdTrainingParams(BatchnormFwdTrainingParams&&) = default;
     BatchnormFwdTrainingParams& operator=(BatchnormFwdTrainingParams&&) = default;
 
-    const hipdnn_data_sdk::data_objects::TensorAttributes* x() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* y() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* scale() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* bias() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* x() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* y() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* scale() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* bias() const;
     double epsilonValue() const;
 
     bool hasSaveMeanVariance() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* mean() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* invVariance() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* mean() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* invVariance() const;
 
     bool hasRunningStats() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* prevRunningMean() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* prevRunningVariance() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* prevRunningMean() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* prevRunningVariance() const;
     double momentumValue() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* nextRunningMean() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* nextRunningVariance() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* nextRunningMean() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* nextRunningVariance() const;
 
 private:
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _x;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _y;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _scale;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _bias;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _x;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _y;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _scale;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _bias;
     double _epsilonValue;
 
     // Save mean/variance
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _mean = nullptr;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _invVariance = nullptr;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _mean = nullptr;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _invVariance = nullptr;
 
     // Running statistics
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _prevRunningMean = nullptr;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _prevRunningVariance = nullptr;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _nextRunningMean = nullptr;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _nextRunningVariance = nullptr;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _prevRunningMean = nullptr;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _prevRunningVariance = nullptr;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _nextRunningMean = nullptr;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _nextRunningVariance = nullptr;
     std::optional<double> _momentumValue;
     bool _hasRunningStats{false};
 };

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormPlanBuilder.cpp
@@ -1,7 +1,7 @@
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier:  MIT
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
 #include <hipdnn_plugin_sdk/PluginLogging.hpp>
 
 #include "BatchnormPlanBuilder.hpp"
@@ -16,9 +16,10 @@ namespace hip_kernel_provider::batchnorm
 namespace
 {
 void batchnormFwdFusionCheckTensors(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     // in_0 must be the batchnorm inference output (forward path)
@@ -64,9 +65,10 @@ void batchnormFwdFusionCheckTensors(
     }
 }
 bool batchnormFwdFusionCheckTensorsLogErrors(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     try
@@ -82,9 +84,10 @@ bool batchnormFwdFusionCheckTensorsLogErrors(
 }
 
 void batchnormFwdWithVarianceFusionCheckTensors(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     // in_0 must be the batchnorm inference output (forward path)
@@ -131,9 +134,10 @@ void batchnormFwdWithVarianceFusionCheckTensors(
 }
 
 bool batchnormFwdWithVarianceFusionCheckTensorsLogErrors(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     try
@@ -159,12 +163,13 @@ BatchnormPlanBuilder::BatchnormPlanBuilder(const IKernelCompiler& kernelCompiler
 
 bool BatchnormPlanBuilder::isApplicable(
     [[maybe_unused]] const HipKernelHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
 {
     auto anyNodeIsNotF32Compute = [&]() {
         return !std::all_of(
             opGraph.nodeWrappers().begin(), opGraph.nodeWrappers().end(), [](const auto& node) {
-                return node->computeDataType() == hipdnn_data_sdk::data_objects::DataType::FLOAT;
+                return node->computeDataType()
+                       == hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT;
             });
     };
 
@@ -180,10 +185,11 @@ bool BatchnormPlanBuilder::isApplicable(
         }
 
         if(!opGraph.hasOnlySupportedAttributes(
-               std::set<hipdnn_data_sdk::data_objects::NodeAttributes>{
-                   hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes,
-                   hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
-                   hipdnn_data_sdk::data_objects::NodeAttributes::
+               std::set<hipdnn_flatbuffers_sdk::data_objects::NodeAttributes>{
+                   hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes,
+                   hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::
+                       BatchnormInferenceAttributes,
+                   hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::
                        BatchnormInferenceAttributesVarianceExt}))
         {
             HIPDNN_PLUGIN_LOG_INFO("Batchnorm plan builder is not applicable for this graph");
@@ -196,15 +202,15 @@ bool BatchnormPlanBuilder::isApplicable(
         {
             switch(node.attributes_type())
             {
-            case hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes:
+            case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes:
                 checkBatchnormFwdTrainingTensorConfigSupported(
                     *node.attributes_as_BatchnormAttributes(), opGraph.getTensorMap());
                 break;
-            case hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes:
+            case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes:
                 checkBatchnormInferenceTensorConfigSupported(
                     *node.attributes_as_BatchnormInferenceAttributes(), opGraph.getTensorMap());
                 break;
-            case hipdnn_data_sdk::data_objects::NodeAttributes::
+            case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::
                 BatchnormInferenceAttributesVarianceExt:
                 checkBatchnormInferenceVarianceExtTensorConfigSupported(
                     *node.attributes_as_BatchnormInferenceAttributesVarianceExt(),
@@ -237,13 +243,14 @@ bool BatchnormPlanBuilder::isApplicable(
 
         bool isFwdInferenceFirst
             = node0.attributesType()
-              == hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes;
-        bool isFwdInferenceWithVarianceFirst = node0.attributesType()
-                                               == hipdnn_data_sdk::data_objects::NodeAttributes::
-                                                   BatchnormInferenceAttributesVarianceExt;
+              == hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes;
+        bool isFwdInferenceWithVarianceFirst
+            = node0.attributesType()
+              == hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::
+                  BatchnormInferenceAttributesVarianceExt;
         bool isPointwiseSecond
             = node1.attributesType()
-              == hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes;
+              == hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes;
 
         if(!((isFwdInferenceFirst || isFwdInferenceWithVarianceFirst) && isPointwiseSecond))
         {
@@ -254,10 +261,10 @@ bool BatchnormPlanBuilder::isApplicable(
 
         if(isFwdInferenceFirst)
         {
-            const auto& bnInfAttr
-                = node0.attributesAs<hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes>();
+            const auto& bnInfAttr = node0.attributesAs<
+                hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes>();
             const auto& actAttr
-                = node1.attributesAs<hipdnn_data_sdk::data_objects::PointwiseAttributes>();
+                = node1.attributesAs<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>();
             if(!batchnormFwdFusionCheckTensorsLogErrors(bnInfAttr, actAttr, opGraph.getTensorMap()))
             {
                 return false;
@@ -277,9 +284,9 @@ bool BatchnormPlanBuilder::isApplicable(
         else
         {
             const auto& bnInfAttr = node0.attributesAs<
-                hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt>();
+                hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributesVarianceExt>();
             const auto& actAttr
-                = node1.attributesAs<hipdnn_data_sdk::data_objects::PointwiseAttributes>();
+                = node1.attributesAs<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>();
 
             if(!batchnormFwdWithVarianceFusionCheckTensorsLogErrors(
                    bnInfAttr, actAttr, opGraph.getTensorMap()))
@@ -315,7 +322,7 @@ bool BatchnormPlanBuilder::isApplicable(
 
 size_t BatchnormPlanBuilder::getMaxWorkspaceSize(
     [[maybe_unused]] const HipKernelHandle& handle,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
     [[maybe_unused]] const HipKernelSettings& executionSettings) const
 {
     //batchnorm plan builder does not require workspace size
@@ -327,14 +334,15 @@ namespace
 
 void buildPlanInferenceSingleNode(
     [[maybe_unused]] const HipKernelHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-    const hipdnn_data_sdk::flatbuffer_utilities::INodeWrapper& nodeWrapper,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::INodeWrapper& nodeWrapper,
     const IKernelCompiler& kernelCompiler,
     const IDevicePropertyProvider& devicePropertyProvider,
     HipKernelContext& executionContext)
 {
     const auto& attr
-        = nodeWrapper.attributesAs<hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes>();
+        = nodeWrapper
+              .attributesAs<hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes>();
 
     BatchnormFwdInferenceParams params(attr, opGraph.getTensorMap());
     auto plan = std::make_unique<BatchnormFwdInferencePlan>(std::move(params));
@@ -344,14 +352,14 @@ void buildPlanInferenceSingleNode(
 
 void buildPlanInferenceWithVarianceSingleNode(
     [[maybe_unused]] const HipKernelHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-    const hipdnn_data_sdk::flatbuffer_utilities::INodeWrapper& nodeWrapper,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::INodeWrapper& nodeWrapper,
     const IKernelCompiler& kernelCompiler,
     const IDevicePropertyProvider& devicePropertyProvider,
     HipKernelContext& executionContext)
 {
     const auto& attr = nodeWrapper.attributesAs<
-        hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt>();
+        hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributesVarianceExt>();
 
     BatchnormFwdInferenceWithVarianceParams params(attr, opGraph.getTensorMap());
     auto plan = std::make_unique<BatchnormFwdInferenceWithVariancePlan>(std::move(params));
@@ -361,7 +369,7 @@ void buildPlanInferenceWithVarianceSingleNode(
 
 void buildPlanFusedFwdInferenceActivation(
     [[maybe_unused]] const HipKernelHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
     const IKernelCompiler& kernelCompiler,
     const IDevicePropertyProvider& devicePropertyProvider,
     HipKernelContext& executionContext)
@@ -370,9 +378,9 @@ void buildPlanFusedFwdInferenceActivation(
     const auto& node1 = opGraph.getNodeWrapper(1);
 
     const auto& fwdInference
-        = node0.attributesAs<hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes>();
+        = node0.attributesAs<hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes>();
     const auto& activation
-        = node1.attributesAs<hipdnn_data_sdk::data_objects::PointwiseAttributes>();
+        = node1.attributesAs<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>();
 
     BatchnormFwdInferenceParams params(fwdInference, activation, opGraph.getTensorMap());
     auto plan = std::make_unique<BatchnormFwdInferencePlan>(std::move(params));
@@ -382,7 +390,7 @@ void buildPlanFusedFwdInferenceActivation(
 
 void buildPlanFusedFwdInferenceWithVarianceActivation(
     [[maybe_unused]] const HipKernelHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
     const IKernelCompiler& kernelCompiler,
     const IDevicePropertyProvider& devicePropertyProvider,
     HipKernelContext& executionContext)
@@ -391,9 +399,9 @@ void buildPlanFusedFwdInferenceWithVarianceActivation(
     const auto& node1 = opGraph.getNodeWrapper(1);
 
     const auto& fwdInference = node0.attributesAs<
-        hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt>();
+        hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributesVarianceExt>();
     const auto& activation
-        = node1.attributesAs<hipdnn_data_sdk::data_objects::PointwiseAttributes>();
+        = node1.attributesAs<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>();
 
     BatchnormFwdInferenceWithVarianceParams params(
         fwdInference, activation, opGraph.getTensorMap());
@@ -404,14 +412,14 @@ void buildPlanFusedFwdInferenceWithVarianceActivation(
 
 void buildPlanFwdTrainingSingleNode(
     [[maybe_unused]] const HipKernelHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-    const hipdnn_data_sdk::flatbuffer_utilities::INodeWrapper& nodeWrapper,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::INodeWrapper& nodeWrapper,
     const IKernelCompiler& kernelCompiler,
     const IDevicePropertyProvider& devicePropertyProvider,
     HipKernelContext& executionContext)
 {
     const auto& attr
-        = nodeWrapper.attributesAs<hipdnn_data_sdk::data_objects::BatchnormAttributes>();
+        = nodeWrapper.attributesAs<hipdnn_flatbuffers_sdk::data_objects::BatchnormAttributes>();
 
     BatchnormFwdTrainingParams params(attr, opGraph.getTensorMap());
     auto plan = std::make_unique<BatchnormFwdTrainingPlan>(std::move(params));
@@ -423,30 +431,32 @@ void buildPlanFwdTrainingSingleNode(
 
 void BatchnormPlanBuilder::initializeExecutionSettings(
     [[maybe_unused]] const HipKernelHandle& handle,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig&
+        engineConfig,
     [[maybe_unused]] HipKernelSettings& executionSettings) const
 {
 }
 
 void BatchnormPlanBuilder::buildPlan(
     const HipKernelHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig&
+        engineConfig,
     HipKernelContext& executionContext) const
 {
     if(opGraph.nodeCount() == 2)
     {
         const auto& node0 = opGraph.getNodeWrapper(0);
         if(node0.attributesType()
-           == hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes)
+           == hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes)
         {
             HIPDNN_PLUGIN_LOG_INFO("Building batchnorm inference + activation fusion plan");
             buildPlanFusedFwdInferenceActivation(
                 handle, opGraph, _kernelCompiler, _devicePropertyProvider, executionContext);
         }
         else if(node0.attributesType()
-                == hipdnn_data_sdk::data_objects::NodeAttributes::
+                == hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::
                     BatchnormInferenceAttributesVarianceExt)
         {
             HIPDNN_PLUGIN_LOG_INFO(
@@ -462,7 +472,7 @@ void BatchnormPlanBuilder::buildPlan(
 
     switch(nodeWrapper.attributesType())
     {
-    case hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes:
+    case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes:
         HIPDNN_PLUGIN_LOG_INFO("Building batchnorm fwd training plan for node: " << nodeName);
         buildPlanFwdTrainingSingleNode(handle,
                                        opGraph,
@@ -471,7 +481,7 @@ void BatchnormPlanBuilder::buildPlan(
                                        _devicePropertyProvider,
                                        executionContext);
         break;
-    case hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes:
+    case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes:
         HIPDNN_PLUGIN_LOG_INFO("Building batchnorm fwd inference plan for node: " << nodeName);
         buildPlanInferenceSingleNode(handle,
                                      opGraph,
@@ -480,7 +490,8 @@ void BatchnormPlanBuilder::buildPlan(
                                      _devicePropertyProvider,
                                      executionContext);
         break;
-    case hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributesVarianceExt:
+    case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::
+        BatchnormInferenceAttributesVarianceExt:
         HIPDNN_PLUGIN_LOG_INFO(
             "Building batchnorm fwd inference with variance plan for node: " << nodeName);
         buildPlanInferenceWithVarianceSingleNode(handle,
@@ -495,13 +506,13 @@ void BatchnormPlanBuilder::buildPlan(
             HIPDNN_PLUGIN_STATUS_BAD_PARAM,
             "Unsupported node type for batchnorm plan builder: "
                 + std::string(
-                    hipdnn_data_sdk::data_objects::toString(nodeWrapper.attributesType())));
+                    hipdnn_flatbuffers_sdk::data_objects::toString(nodeWrapper.attributesType())));
     }
 }
 
-std::vector<hipdnn_data_sdk::data_objects::KnobT> BatchnormPlanBuilder::getCustomKnobs(
+std::vector<hipdnn_flatbuffers_sdk::data_objects::KnobT> BatchnormPlanBuilder::getCustomKnobs(
     [[maybe_unused]] const HipKernelHandle& handle,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
 {
     return {};
 }

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormPlanBuilder.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/batchnorm/BatchnormPlanBuilder.hpp
@@ -10,7 +10,7 @@
 #include "HipKernelSettings.hpp"
 #include "IDevicePropertyProvider.hpp"
 #include "hip/IKernelCompiler.hpp"
-#include "hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp"
+#include "hipdnn_flatbuffers_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp"
 
 namespace hip_kernel_provider::batchnorm
 {
@@ -27,27 +27,28 @@ public:
     BatchnormPlanBuilder(const BatchnormPlanBuilder&) = delete;
     BatchnormPlanBuilder& operator=(const BatchnormPlanBuilder&) = delete;
 
-    bool isApplicable(const HipKernelHandle& handle,
-                      const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+    bool isApplicable(
+        const HipKernelHandle& handle,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
 
     size_t getMaxWorkspaceSize(const HipKernelHandle& handle,
-                               const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                               const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                                const HipKernelSettings& executionSettings) const override;
 
     void initializeExecutionSettings(
         const HipKernelHandle& handle,
-        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-        const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
         HipKernelSettings& executionSettings) const override;
 
     void buildPlan(const HipKernelHandle& handle,
-                   const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-                   const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+                   const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+                   const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
                    HipKernelContext& executionContext) const override;
 
-    std::vector<hipdnn_data_sdk::data_objects::KnobT>
-        getCustomKnobs(const HipKernelHandle& handle,
-                       const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+    std::vector<hipdnn_flatbuffers_sdk::data_objects::KnobT> getCustomKnobs(
+        const HipKernelHandle& handle,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
 
 private:
     const IKernelCompiler& _kernelCompiler;

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormApplicabilityChecks.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormApplicabilityChecks.cpp
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier:  MIT
 
 #include "engines/plans/layernorm/LayernormUtilities.hpp"
-#include "hipdnn_data_sdk/data_objects/data_types_generated.h"
-#include "hipdnn_data_sdk/data_objects/tensor_attributes_generated.h"
+#include "hipdnn_flatbuffers_sdk/data_objects/data_types_generated.h"
+#include "hipdnn_flatbuffers_sdk/data_objects/tensor_attributes_generated.h"
 #include "hipdnn_plugin_sdk/PluginApiDataTypes.h"
 #include "hipdnn_plugin_sdk/PluginException.hpp"
 #include <cstdint>
@@ -20,9 +20,9 @@ namespace hip_kernel_provider::layernorm
 
 // --- Type Configuration Helpers ---
 
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType> type_configs::getAllowedIoTypes()
+std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> type_configs::getAllowedIoTypes()
 {
-    std::unordered_set<hipdnn_data_sdk::data_objects::DataType> types;
+    std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> types;
     for(const auto& config : VALID)
     {
         types.insert(config.io);
@@ -30,9 +30,10 @@ std::unordered_set<hipdnn_data_sdk::data_objects::DataType> type_configs::getAll
     return types;
 }
 
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType> type_configs::getAllowedAffineTypes()
+std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType>
+    type_configs::getAllowedAffineTypes()
 {
-    std::unordered_set<hipdnn_data_sdk::data_objects::DataType> types;
+    std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> types;
     for(const auto& config : VALID)
     {
         types.insert(config.affine);
@@ -40,9 +41,10 @@ std::unordered_set<hipdnn_data_sdk::data_objects::DataType> type_configs::getAll
     return types;
 }
 
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType> type_configs::getAllowedStatTypes()
+std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType>
+    type_configs::getAllowedStatTypes()
 {
-    std::unordered_set<hipdnn_data_sdk::data_objects::DataType> types;
+    std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> types;
     for(const auto& config : VALID)
     {
         types.insert(config.stat);
@@ -50,9 +52,10 @@ std::unordered_set<hipdnn_data_sdk::data_objects::DataType> type_configs::getAll
     return types;
 }
 
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType> type_configs::getAllowedEpsilonTypes()
+std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType>
+    type_configs::getAllowedEpsilonTypes()
 {
-    std::unordered_set<hipdnn_data_sdk::data_objects::DataType> types;
+    std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> types;
     for(const auto& config : VALID)
     {
         types.insert(config.epsilon);
@@ -63,7 +66,7 @@ std::unordered_set<hipdnn_data_sdk::data_objects::DataType> type_configs::getAll
 // --- Tensor Descriptor Implementation ---
 
 LayernormTensorDescriptor::LayernormTensorDescriptor(
-    const hipdnn_data_sdk::data_objects::TensorAttributes* attr)
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* attr)
     : dims(attr->dims()->begin(), attr->dims()->end())
     , strides(attr->strides()->begin(), attr->strides()->end())
     , strideOrder(hipdnn_data_sdk::utilities::extractStrideOrder(strides))
@@ -190,8 +193,8 @@ void validateConsistentLayouts(const std::vector<LayernormTensorDescriptor>& ten
 }
 
 void validateDataTypeIsSupported(
-    hipdnn_data_sdk::data_objects::DataType dataType,
-    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
+    hipdnn_flatbuffers_sdk::data_objects::DataType dataType,
+    const std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType>& allowedTypes,
     const std::string& errorMessage)
 {
     if(allowedTypes.count(dataType) > 0)
@@ -203,9 +206,10 @@ void validateDataTypeIsSupported(
 
 void validateConsistentDataTypes(
     const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
-    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
+    const std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType>& allowedTypes,
     const std::string& typeErrorMessage,
     const std::string& consistencyErrorMessage)
 {
@@ -232,9 +236,10 @@ void validateConsistentDataTypes(
 
 void validateConsistentDataTypes(
     const std::vector<std::optional<int64_t>>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
-    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
+    const std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType>& allowedTypes,
     const std::string& typeErrorMessage,
     const std::string& consistencyErrorMessage)
 {
@@ -253,9 +258,10 @@ void validateConsistentDataTypes(
 
 void validateFixedDataType(
     const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
-    hipdnn_data_sdk::data_objects::DataType expectedType,
+    hipdnn_flatbuffers_sdk::data_objects::DataType expectedType,
     const std::string& errorMessage)
 {
     for(const auto tensorId : tensorIds)
@@ -271,7 +277,8 @@ void validateFixedDataType(
 
 void validateConsistentShapes(
     const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     const std::vector<int64_t>& referenceShape,
     const std::string& errorMessage)
@@ -290,7 +297,8 @@ void validateConsistentShapes(
 
 void validateConsistentShapes(
     const std::vector<std::optional<int64_t>>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     const std::vector<int64_t>& referenceShape,
     const std::string& errorMessage)
@@ -311,7 +319,8 @@ void validateNormalizedDim(
     const std::vector<int64_t>& ioTensorIds,
     const std::vector<int64_t>& affineTensorIds,
     const std::vector<std::optional<int64_t>>& statTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     if(ioTensorIds.empty())
@@ -367,7 +376,8 @@ void validateNormalizedDim(
 
 void checkTensorLayoutsAndDimsSupported(
     const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     std::vector<LayernormTensorDescriptor> tensors;
@@ -376,7 +386,7 @@ void checkTensorLayoutsAndDimsSupported(
     for(const auto& id : tensorIds)
     {
         auto attr = tensorMap.at(id);
-        if(attr->value_type() == hipdnn_data_sdk::data_objects::TensorValue::NONE)
+        if(attr->value_type() == hipdnn_flatbuffers_sdk::data_objects::TensorValue::NONE)
         {
             tensors.emplace_back(attr);
         }
@@ -388,7 +398,8 @@ void checkTensorLayoutsAndDimsSupported(
 }
 
 void checkTensorLayoutsAndDimsSupported(
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     // Skip tensors with embedded scalar values (epsilon, momentum) - they don't have layouts or dimensions to validate
@@ -396,7 +407,7 @@ void checkTensorLayoutsAndDimsSupported(
     tensorIds.reserve(tensorMap.size());
     for(const auto& [id, attr] : tensorMap)
     {
-        if(attr->value_type() != hipdnn_data_sdk::data_objects::TensorValue::NONE)
+        if(attr->value_type() != hipdnn_flatbuffers_sdk::data_objects::TensorValue::NONE)
         {
             continue;
         }
@@ -411,7 +422,8 @@ void checkTensorDataTypesSupported(
     const std::vector<int64_t>& affineTensorIds,
     const std::vector<std::optional<int64_t>>& statTensorIds,
     const std::vector<int64_t>& epsilonTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     const auto allowedIoTypes = type_configs::getAllowedIoTypes();
@@ -451,7 +463,7 @@ void checkTensorDataTypesSupported(
             allTensorIds.emplace_back(tensorId.value());
         }
     }
-    std::unordered_set<hipdnn_data_sdk::data_objects::DataType> allAllowedTypes;
+    std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> allAllowedTypes;
     allAllowedTypes.insert(allowedIoTypes.begin(), allowedIoTypes.end());
     allAllowedTypes.insert(allowedAffineTypes.begin(), allowedAffineTypes.end());
     allAllowedTypes.insert(allowedStatTypes.begin(), allowedStatTypes.end());
@@ -486,7 +498,8 @@ void checkTensorShapesSupported(
     const std::vector<int64_t>& ioTensorIds,
     const std::vector<int64_t>& affineTensorIds,
     const std::vector<std::optional<int64_t>>& statTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     if(ioTensorIds.empty())
@@ -536,8 +549,9 @@ void checkTensorShapesSupported(
 // --- High-level Configuration Validators ---
 
 void checkLayernormTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::LayernormAttributes& lnAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::LayernormAttributes& lnAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     std::vector<int64_t> ioTensorIds = {lnAttr.x_tensor_uid(), lnAttr.y_tensor_uid()};

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormApplicabilityChecks.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormApplicabilityChecks.hpp
@@ -10,9 +10,9 @@
 #include <unordered_set>
 #include <vector>
 
-#include <hipdnn_data_sdk/data_objects/layernorm_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/layernorm_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/pointwise_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/tensor_attributes_generated.h>
 
 namespace hip_kernel_provider::layernorm
 {
@@ -25,7 +25,8 @@ struct LayernormTensorDescriptor
     std::vector<int64_t> strides;
     std::vector<int64_t> strideOrder;
 
-    explicit LayernormTensorDescriptor(const hipdnn_data_sdk::data_objects::TensorAttributes* attr);
+    explicit LayernormTensorDescriptor(
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* attr);
 
     size_t numDims() const
     {
@@ -50,43 +51,48 @@ void validateSupportedLayout(const std::vector<int64_t>& strideOrder, size_t num
 void validateConsistentLayouts(const std::vector<LayernormTensorDescriptor>& tensors);
 
 void validateDataTypeIsSupported(
-    hipdnn_data_sdk::data_objects::DataType dataType,
-    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
+    hipdnn_flatbuffers_sdk::data_objects::DataType dataType,
+    const std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType>& allowedTypes,
     const std::string& errorMessage);
 
 void validateConsistentDataTypes(
     const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
-    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
+    const std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType>& allowedTypes,
     const std::string& typeErrorMessage,
     const std::string& consistencyErrorMessage);
 
 void validateConsistentDataTypes(
     const std::vector<std::optional<int64_t>>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
-    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
+    const std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType>& allowedTypes,
     const std::string& typeErrorMessage,
     const std::string& consistencyErrorMessage);
 
 void validateFixedDataType(
     const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
-    hipdnn_data_sdk::data_objects::DataType expectedType,
+    hipdnn_flatbuffers_sdk::data_objects::DataType expectedType,
     const std::string& errorMessage);
 
 void validateConsistentShapes(
     const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     const std::vector<int64_t>& referenceShape,
     const std::string& errorMessage);
 
 void validateConsistentShapes(
     const std::vector<std::optional<int64_t>>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     const std::vector<int64_t>& referenceShape,
     const std::string& errorMessage);
@@ -95,7 +101,8 @@ void validateNormalizedDim(
     const std::vector<int64_t>& ioTensorIds,
     const std::vector<int64_t>& affineTensorIds,
     const std::vector<std::optional<int64_t>>& statTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
 } // namespace validators
@@ -104,11 +111,13 @@ void validateNormalizedDim(
 
 void checkTensorLayoutsAndDimsSupported(
     const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
 void checkTensorLayoutsAndDimsSupported(
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
 void checkTensorDataTypesSupported(
@@ -116,21 +125,24 @@ void checkTensorDataTypesSupported(
     const std::vector<int64_t>& affineTensorIds,
     const std::vector<std::optional<int64_t>>& statTensorIds,
     const std::vector<int64_t>& epsilonTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
 void checkTensorShapesSupported(
     const std::vector<int64_t>& ioTensorIds,
     const std::vector<int64_t>& affineTensorIds,
     const std::vector<std::optional<int64_t>>& statTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
 // --- High-level Configuration Validators ---
 
 void checkLayernormTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::LayernormAttributes& lnAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::LayernormAttributes& lnAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
 // Layernorm Type Configuration ---
@@ -140,15 +152,15 @@ void checkLayernormTensorConfigSupported(
 // - Epsilon tensors: FLOAT only
 struct TensorTypes
 {
-    hipdnn_data_sdk::data_objects::DataType io;
-    hipdnn_data_sdk::data_objects::DataType affine;
-    hipdnn_data_sdk::data_objects::DataType stat;
-    hipdnn_data_sdk::data_objects::DataType epsilon;
+    hipdnn_flatbuffers_sdk::data_objects::DataType io;
+    hipdnn_flatbuffers_sdk::data_objects::DataType affine;
+    hipdnn_flatbuffers_sdk::data_objects::DataType stat;
+    hipdnn_flatbuffers_sdk::data_objects::DataType epsilon;
 };
 
 namespace type_configs
 {
-using DT = hipdnn_data_sdk::data_objects::DataType;
+using DT = hipdnn_flatbuffers_sdk::data_objects::DataType;
 
 inline constexpr TensorTypes FLOAT = {DT::FLOAT, DT::FLOAT, DT::FLOAT, DT::FLOAT};
 inline constexpr TensorTypes HALF = {DT::HALF, DT::HALF, DT::HALF, DT::FLOAT};
@@ -156,10 +168,10 @@ inline constexpr TensorTypes BFLOAT16 = {DT::BFLOAT16, DT::BFLOAT16, DT::BFLOAT1
 
 inline constexpr std::array<TensorTypes, 3> VALID = {FLOAT, HALF, BFLOAT16};
 
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType> getAllowedIoTypes();
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType> getAllowedAffineTypes();
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType> getAllowedStatTypes();
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType> getAllowedEpsilonTypes();
+std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> getAllowedIoTypes();
+std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> getAllowedAffineTypes();
+std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> getAllowedStatTypes();
+std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> getAllowedEpsilonTypes();
 
 } // namespace type_configs
 

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormFwdPlan.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormFwdPlan.cpp
@@ -9,10 +9,10 @@
 
 #include <hipdnn_data_sdk/logging/Logger.hpp>
 #include <hipdnn_data_sdk/utilities/Constants.hpp>
-#include <hipdnn_data_sdk/utilities/FlatbufferUtils.hpp>
 #include <hipdnn_data_sdk/utilities/PlatformUtils.hpp>
 #include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_flatbuffers_sdk/utilities/FlatbufferUtils.hpp>
 #include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 
@@ -20,8 +20,9 @@ namespace hip_kernel_provider::layernorm
 {
 
 LayernormFwdParams::LayernormFwdParams(
-    const hipdnn_data_sdk::data_objects::LayernormAttributes& attributes,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::LayernormAttributes& attributes,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
     : _x(tensorMap.at(attributes.x_tensor_uid()))
     , _y(tensorMap.at(attributes.y_tensor_uid()))
@@ -37,37 +38,38 @@ LayernormFwdParams::LayernormFwdParams(
 {
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes* LayernormFwdParams::x() const
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* LayernormFwdParams::x() const
 {
     return _x;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes* LayernormFwdParams::y() const
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* LayernormFwdParams::y() const
 {
     return _y;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes* LayernormFwdParams::scale() const
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* LayernormFwdParams::scale() const
 {
     return _scale;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes* LayernormFwdParams::bias() const
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* LayernormFwdParams::bias() const
 {
     return _bias;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes* LayernormFwdParams::mean() const
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* LayernormFwdParams::mean() const
 {
     return _mean;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes* LayernormFwdParams::invVariance() const
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*
+    LayernormFwdParams::invVariance() const
 {
     return _invVariance;
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes* LayernormFwdParams::epsilon() const
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* LayernormFwdParams::epsilon() const
 {
     return _epsilon;
 }
@@ -144,13 +146,13 @@ void LayernormFwdPlan::compile(const IKernelCompiler& kernelCompiler,
     }
     options.emplace_back(
         std::string("-DHIP_PLUGIN_USE_FP32=")
-        + (xDataType == hipdnn_data_sdk::data_objects::DataType::FLOAT ? "1" : "0"));
+        + (xDataType == hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT ? "1" : "0"));
     options.emplace_back(
         std::string("-DHIP_PLUGIN_USE_FP16=")
-        + (xDataType == hipdnn_data_sdk::data_objects::DataType::HALF ? "1" : "0"));
+        + (xDataType == hipdnn_flatbuffers_sdk::data_objects::DataType::HALF ? "1" : "0"));
     options.emplace_back(
         std::string("-DHIP_PLUGIN_USE_BFP16=")
-        + (xDataType == hipdnn_data_sdk::data_objects::DataType::BFLOAT16 ? "1" : "0"));
+        + (xDataType == hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16 ? "1" : "0"));
     options.emplace_back(std::string("-DOUTER_SIZE=") + std::to_string(outerSize));
     options.emplace_back(std::string("-DINNER_SIZE=") + std::to_string(innerSize));
     options.emplace_back(std::string("-DSTRIDE=") + std::to_string(stride));
@@ -199,10 +201,10 @@ void LayernormFwdPlan::execute(const HipKernelHandle& handle,
                                                                       numDeviceBuffers)
                                  : hipdnnPluginDeviceBuffer_t{-1, nullptr};
 
-    hipdnn_data_sdk::data_objects::TensorAttributesT epsilonTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT epsilonTensor;
     _params.epsilon()->UnPackTo(&epsilonTensor);
     double epsilon
-        = hipdnn_data_sdk::utilities::extractDoubleFromTensorValue(epsilonTensor, "Epsilon");
+        = hipdnn_flatbuffers_sdk::utilities::extractDoubleFromTensorValue(epsilonTensor, "Epsilon");
 
     // Launch kernel
     _runnableKernel->launch(handle.getStream(),

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormFwdPlan.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormFwdPlan.hpp
@@ -25,8 +25,9 @@ class LayernormFwdParams
 {
 public:
     LayernormFwdParams(
-        const hipdnn_data_sdk::data_objects::LayernormAttributes& attributes,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::LayernormAttributes& attributes,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap);
 
     LayernormFwdParams(const LayernormFwdParams&) = delete;
@@ -35,22 +36,22 @@ public:
     LayernormFwdParams(LayernormFwdParams&&) = default;
     LayernormFwdParams& operator=(LayernormFwdParams&&) = default;
 
-    const hipdnn_data_sdk::data_objects::TensorAttributes* x() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* y() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* scale() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* bias() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* mean() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* invVariance() const;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* epsilon() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* x() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* y() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* scale() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* bias() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* mean() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* invVariance() const;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* epsilon() const;
 
 private:
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _x;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _y;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _scale;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _bias;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _mean;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _invVariance;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* _epsilon;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _x;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _y;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _scale;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _bias;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _mean;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _invVariance;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* _epsilon;
 };
 
 class LayernormFwdPlan : public hipdnn_plugin_sdk::IPlan<HipKernelHandle>

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormPlanBuilder.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier:  MIT
 
 #include <cstdio>
-#include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 #include <hipdnn_plugin_sdk/PluginLogging.hpp>
 #include <string>
@@ -25,12 +25,13 @@ LayernormPlanBuilder::LayernormPlanBuilder(const IKernelCompiler& kernelCompiler
 
 bool LayernormPlanBuilder::isApplicable(
     [[maybe_unused]] const HipKernelHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
 {
     auto anyNodeIsNotF32Compute = [&]() {
         return !std::all_of(
             opGraph.nodeWrappers().begin(), opGraph.nodeWrappers().end(), [](const auto& node) {
-                return node->computeDataType() == hipdnn_data_sdk::data_objects::DataType::FLOAT;
+                return node->computeDataType()
+                       == hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT;
             });
     };
 
@@ -46,8 +47,8 @@ bool LayernormPlanBuilder::isApplicable(
         }
 
         if(!opGraph.hasOnlySupportedAttributes(
-               std::set<hipdnn_data_sdk::data_objects::NodeAttributes>{
-                   hipdnn_data_sdk::data_objects::NodeAttributes::LayernormAttributes}))
+               std::set<hipdnn_flatbuffers_sdk::data_objects::NodeAttributes>{
+                   hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::LayernormAttributes}))
         {
             HIPDNN_PLUGIN_LOG_INFO("Layernorm plan builder is not applicable for this graph");
             return false;
@@ -59,7 +60,7 @@ bool LayernormPlanBuilder::isApplicable(
         {
             switch(node.attributes_type())
             {
-            case hipdnn_data_sdk::data_objects::NodeAttributes::LayernormAttributes:
+            case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::LayernormAttributes:
                 checkLayernormTensorConfigSupported(*node.attributes_as_LayernormAttributes(),
                                                     opGraph.getTensorMap());
                 break;
@@ -88,7 +89,7 @@ bool LayernormPlanBuilder::isApplicable(
 
 size_t LayernormPlanBuilder::getMaxWorkspaceSize(
     [[maybe_unused]] const HipKernelHandle& handle,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
     [[maybe_unused]] const HipKernelSettings& executionSettings) const
 {
     // Layernorm plan builder does not require workspace size
@@ -99,14 +100,14 @@ namespace
 {
 
 void buildPlanFwd([[maybe_unused]] const HipKernelHandle& handle,
-                  const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-                  const hipdnn_data_sdk::flatbuffer_utilities::INodeWrapper& nodeWrapper,
+                  const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+                  const hipdnn_flatbuffers_sdk::flatbuffer_utilities::INodeWrapper& nodeWrapper,
                   const IKernelCompiler& kernelCompiler,
                   const IDevicePropertyProvider& devicePropertyProvider,
                   HipKernelContext& executionContext)
 {
     const auto& attr
-        = nodeWrapper.attributesAs<hipdnn_data_sdk::data_objects::LayernormAttributes>();
+        = nodeWrapper.attributesAs<hipdnn_flatbuffers_sdk::data_objects::LayernormAttributes>();
 
     LayernormFwdParams params(attr, opGraph.getTensorMap());
     auto plan = std::make_unique<LayernormFwdPlan>(std::move(params));
@@ -119,16 +120,18 @@ void buildPlanFwd([[maybe_unused]] const HipKernelHandle& handle,
 
 void LayernormPlanBuilder::initializeExecutionSettings(
     [[maybe_unused]] const HipKernelHandle& handle,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig&
+        engineConfig,
     [[maybe_unused]] HipKernelSettings& executionSettings) const
 {
 }
 
 void LayernormPlanBuilder::buildPlan(
     const HipKernelHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig&
+        engineConfig,
     HipKernelContext& executionContext) const
 {
     const auto& nodeWrapper = opGraph.getNodeWrapper(0);
@@ -139,9 +142,9 @@ void LayernormPlanBuilder::buildPlan(
         handle, opGraph, nodeWrapper, _kernelCompiler, _devicePropertyProvider, executionContext);
 }
 
-std::vector<hipdnn_data_sdk::data_objects::KnobT> LayernormPlanBuilder::getCustomKnobs(
+std::vector<hipdnn_flatbuffers_sdk::data_objects::KnobT> LayernormPlanBuilder::getCustomKnobs(
     [[maybe_unused]] const HipKernelHandle& handle,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
 {
     return {};
 }

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormPlanBuilder.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormPlanBuilder.hpp
@@ -10,7 +10,7 @@
 #include "HipKernelSettings.hpp"
 #include "IDevicePropertyProvider.hpp"
 #include "hip/IKernelCompiler.hpp"
-#include "hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp"
+#include "hipdnn_flatbuffers_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp"
 
 namespace hip_kernel_provider::layernorm
 {
@@ -27,27 +27,28 @@ public:
     LayernormPlanBuilder(const LayernormPlanBuilder&) = delete;
     LayernormPlanBuilder& operator=(const LayernormPlanBuilder&) = delete;
 
-    bool isApplicable(const HipKernelHandle& handle,
-                      const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+    bool isApplicable(
+        const HipKernelHandle& handle,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
 
     size_t getMaxWorkspaceSize(const HipKernelHandle& handle,
-                               const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                               const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                                const HipKernelSettings& executionSettings) const override;
 
     void initializeExecutionSettings(
         const HipKernelHandle& handle,
-        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-        const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
         HipKernelSettings& executionSettings) const override;
 
     void buildPlan(const HipKernelHandle& handle,
-                   const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-                   const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+                   const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+                   const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
                    HipKernelContext& executionContext) const override;
 
-    std::vector<hipdnn_data_sdk::data_objects::KnobT>
-        getCustomKnobs(const HipKernelHandle& handle,
-                       const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+    std::vector<hipdnn_flatbuffers_sdk::data_objects::KnobT> getCustomKnobs(
+        const HipKernelHandle& handle,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
 
 private:
     const IKernelCompiler& _kernelCompiler;

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormUtilities.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormUtilities.cpp
@@ -10,9 +10,9 @@
 namespace hip_kernel_provider::layernorm
 {
 
-size_t
-    getMinNormalizedDimFromAffine(const hipdnn_data_sdk::data_objects::TensorAttributes* ioAttr,
-                                  const hipdnn_data_sdk::data_objects::TensorAttributes* affineAttr)
+size_t getMinNormalizedDimFromAffine(
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* ioAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* affineAttr)
 {
     const std::vector<int64_t> ioDims(ioAttr->dims()->begin(), ioAttr->dims()->end());
     const std::vector<int64_t> affineDims(affineAttr->dims()->begin(), affineAttr->dims()->end());
@@ -36,7 +36,8 @@ size_t
 size_t getMinNormalizedDimFromAffine(
     const int64_t ioTensorId,
     const int64_t affineTensorId,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     const auto* ioAttr = &hip_kernel_utils::findTensorAttributes(tensorMap, ioTensorId);
@@ -45,9 +46,9 @@ size_t getMinNormalizedDimFromAffine(
     return getMinNormalizedDimFromAffine(ioAttr, affineAttr);
 }
 
-size_t
-    getMaxNormalizedDimFromAffine(const hipdnn_data_sdk::data_objects::TensorAttributes* ioAttr,
-                                  const hipdnn_data_sdk::data_objects::TensorAttributes* affineAttr)
+size_t getMaxNormalizedDimFromAffine(
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* ioAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* affineAttr)
 {
     const std::vector<int64_t> ioDims(ioAttr->dims()->begin(), ioAttr->dims()->end());
     const std::vector<int64_t> affineDims(affineAttr->dims()->begin(), affineAttr->dims()->end());
@@ -71,7 +72,8 @@ size_t
 size_t getMaxNormalizedDimFromAffine(
     const int64_t ioTensorId,
     const int64_t affineTensorId,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     const auto* ioAttr = &hip_kernel_utils::findTensorAttributes(tensorMap, ioTensorId);
@@ -80,8 +82,9 @@ size_t getMaxNormalizedDimFromAffine(
     return getMaxNormalizedDimFromAffine(ioAttr, affineAttr);
 }
 
-size_t getMinNormalizedDimFromStat(const hipdnn_data_sdk::data_objects::TensorAttributes* ioAttr,
-                                   const hipdnn_data_sdk::data_objects::TensorAttributes* statAttr)
+size_t getMinNormalizedDimFromStat(
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* ioAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* statAttr)
 {
     if(ioAttr == nullptr || statAttr == nullptr)
     {
@@ -110,7 +113,8 @@ size_t getMinNormalizedDimFromStat(const hipdnn_data_sdk::data_objects::TensorAt
 size_t getMinNormalizedDimFromStat(
     const int64_t ioTensorId,
     const int64_t statTensorId,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     const auto* ioAttr = &hip_kernel_utils::findTensorAttributes(tensorMap, ioTensorId);
@@ -119,8 +123,9 @@ size_t getMinNormalizedDimFromStat(
     return getMinNormalizedDimFromStat(ioAttr, statAttr);
 }
 
-size_t getMaxNormalizedDimFromStat(const hipdnn_data_sdk::data_objects::TensorAttributes* ioAttr,
-                                   const hipdnn_data_sdk::data_objects::TensorAttributes* statAttr)
+size_t getMaxNormalizedDimFromStat(
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* ioAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* statAttr)
 {
     const std::vector<int64_t> ioDims(ioAttr->dims()->begin(), ioAttr->dims()->end());
     if(statAttr == nullptr)
@@ -148,7 +153,8 @@ size_t getMaxNormalizedDimFromStat(const hipdnn_data_sdk::data_objects::TensorAt
 size_t getMaxNormalizedDimFromStat(
     const int64_t ioTensorId,
     const int64_t statTensorId,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     const auto* ioAttr = &hip_kernel_utils::findTensorAttributes(tensorMap, ioTensorId);
@@ -158,9 +164,9 @@ size_t getMaxNormalizedDimFromStat(
 }
 
 size_t guessNormalizedDim(
-    const hipdnn_data_sdk::data_objects::TensorAttributes* ioAttr,
-    const std::optional<const hipdnn_data_sdk::data_objects::TensorAttributes*> affineAttr,
-    const std::optional<const hipdnn_data_sdk::data_objects::TensorAttributes*> statAttr)
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* ioAttr,
+    const std::optional<const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*> affineAttr,
+    const std::optional<const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*> statAttr)
 {
     size_t affineNormalizedDimMin
         = affineAttr.has_value() ? getMinNormalizedDimFromAffine(ioAttr, affineAttr.value()) : 0;
@@ -182,15 +188,16 @@ size_t guessNormalizedDim(
     const int64_t ioTensorId,
     const std::optional<int64_t> affineTensorId,
     const std::optional<int64_t> statTensorId,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     const auto* ioAttr = &hip_kernel_utils::findTensorAttributes(tensorMap, ioTensorId);
-    const std::optional<const hipdnn_data_sdk::data_objects::TensorAttributes*> affineAttr
+    const std::optional<const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*> affineAttr
         = affineTensorId.has_value() ? std::optional(&hip_kernel_utils::findTensorAttributes(
                                            tensorMap, affineTensorId.value()))
                                      : std::nullopt;
-    const std::optional<const hipdnn_data_sdk::data_objects::TensorAttributes*> statAttr
+    const std::optional<const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*> statAttr
         = statTensorId.has_value() ? std::optional(&hip_kernel_utils::findTensorAttributes(
                                          tensorMap, statTensorId.value()))
                                    : std::nullopt;

--- a/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormUtilities.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/plans/layernorm/LayernormUtilities.hpp
@@ -7,59 +7,66 @@
 #include <optional>
 #include <unordered_map>
 
-#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/tensor_attributes_generated.h>
 
 namespace hip_kernel_provider::layernorm
 {
 
 size_t getMinNormalizedDimFromAffine(
-    const hipdnn_data_sdk::data_objects::TensorAttributes* ioAttr,
-    const hipdnn_data_sdk::data_objects::TensorAttributes* affineAttr);
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* ioAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* affineAttr);
 
 size_t getMinNormalizedDimFromAffine(
     int64_t ioTensorId,
     int64_t affineTensorId,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
 size_t getMaxNormalizedDimFromAffine(
-    const hipdnn_data_sdk::data_objects::TensorAttributes* ioAttr,
-    const hipdnn_data_sdk::data_objects::TensorAttributes* affineAttr);
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* ioAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* affineAttr);
 
 size_t getMaxNormalizedDimFromAffine(
     int64_t ioTensorId,
     int64_t affineTensorId,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
-size_t getMinNormalizedDimFromStat(const hipdnn_data_sdk::data_objects::TensorAttributes* ioAttr,
-                                   const hipdnn_data_sdk::data_objects::TensorAttributes* statAttr);
+size_t getMinNormalizedDimFromStat(
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* ioAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* statAttr);
 
 size_t getMinNormalizedDimFromStat(
     int64_t ioTensorId,
     int64_t statTensorId,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
-size_t getMaxNormalizedDimFromStat(const hipdnn_data_sdk::data_objects::TensorAttributes* ioAttr,
-                                   const hipdnn_data_sdk::data_objects::TensorAttributes* statAttr);
+size_t getMaxNormalizedDimFromStat(
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* ioAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* statAttr);
 
 size_t getMaxNormalizedDimFromStat(
     int64_t ioTensorId,
     int64_t statTensorId,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
 size_t guessNormalizedDim(
-    const hipdnn_data_sdk::data_objects::TensorAttributes* ioAttr,
-    std::optional<const hipdnn_data_sdk::data_objects::TensorAttributes*> affineAttr,
-    std::optional<const hipdnn_data_sdk::data_objects::TensorAttributes*> statAttr);
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* ioAttr,
+    std::optional<const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*> affineAttr,
+    std::optional<const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*> statAttr);
 
 size_t guessNormalizedDim(
     int64_t ioTensorId,
     std::optional<int64_t> affineTensorId,
     std::optional<int64_t> statTensorId,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
 } // namespace hip_kernel_provider::layernorm

--- a/dnn-providers/hip-kernel-provider/src/integration_tests/Common/ActivationCommon.hpp
+++ b/dnn-providers/hip-kernel-provider/src/integration_tests/Common/ActivationCommon.hpp
@@ -3,15 +3,15 @@
 
 #pragma once
 
-#include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/pointwise_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
 
 namespace test_activation_common
 {
 
 struct ActivTestCase
 {
-    hipdnn_data_sdk::data_objects::PointwiseMode mode;
+    hipdnn_flatbuffers_sdk::data_objects::PointwiseMode mode;
     std::optional<float> reluLowerClip;
     std::optional<float> reluUpperClip;
     std::optional<float> reluLowerClipSlope;
@@ -19,7 +19,7 @@ struct ActivTestCase
     std::optional<float> eluAlpha;
     std::optional<float> softplusBeta;
 
-    ActivTestCase(hipdnn_data_sdk::data_objects::PointwiseMode modeLocal,
+    ActivTestCase(hipdnn_flatbuffers_sdk::data_objects::PointwiseMode modeLocal,
                   std::optional<float> reluLowerClipLocal = std::nullopt,
                   std::optional<float> reluUpperClipLocal = std::nullopt,
                   std::optional<float> reluLowerClipSlopeLocal = std::nullopt,
@@ -34,7 +34,7 @@ struct ActivTestCase
         , eluAlpha(eluAlphaLocal)
         , softplusBeta(softplusBetaLocal)
     {
-        using PointwiseMode = hipdnn_data_sdk::data_objects::PointwiseMode;
+        using PointwiseMode = hipdnn_flatbuffers_sdk::data_objects::PointwiseMode;
 
         switch(mode)
         {
@@ -93,7 +93,7 @@ struct ActivTestCase
 
 inline std::vector<ActivTestCase> createFwdActivationSmokeCases()
 {
-    using PM = hipdnn_data_sdk::data_objects::PointwiseMode;
+    using PM = hipdnn_flatbuffers_sdk::data_objects::PointwiseMode;
 
     std::vector<ActivTestCase> cases;
 
@@ -112,7 +112,7 @@ inline std::vector<ActivTestCase> createFwdActivationSmokeCases()
 
 inline std::vector<ActivTestCase> createFwdActivationFullCases()
 {
-    using PM = hipdnn_data_sdk::data_objects::PointwiseMode;
+    using PM = hipdnn_flatbuffers_sdk::data_objects::PointwiseMode;
 
     std::vector<ActivTestCase> cases;
 

--- a/dnn-providers/hip-kernel-provider/src/integration_tests/IntegrationGraphVerificationHarness.hpp
+++ b/dnn-providers/hip-kernel-provider/src/integration_tests/IntegrationGraphVerificationHarness.hpp
@@ -4,8 +4,8 @@
 #pragma once
 
 #include <gtest/gtest.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_data_sdk/utilities/Workspace.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_frontend/Graph.hpp>
 #include <hipdnn_frontend/Utilities.hpp>
 #include <hipdnn_frontend/attributes/TensorAttributes.hpp>

--- a/dnn-providers/hip-kernel-provider/src/tests/TestHipKernelContainer.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/TestHipKernelContainer.cpp
@@ -57,7 +57,7 @@ TEST(TestHipKernelContainer, GetEngineManagerReturnsValidReference)
 
 TEST(TestHipKernelContainer, GetApplicableEngineIdsSdpaGraph)
 {
-    using namespace hipdnn_data_sdk::data_objects;
+    using namespace hipdnn_flatbuffers_sdk::data_objects;
 
     HipKernelHandle handle;
     if(hip_kernel_provider_common::getDeviceString(handle.getStream()) != "gfx942")
@@ -73,8 +73,8 @@ TEST(TestHipKernelContainer, GetApplicableEngineIdsSdpaGraph)
         dims, strides, dims, strides, dims, strides, dims, strides, DataType::BFLOAT16);
     auto graphBuffer = graph.Release();
 
-    auto graphWrapper = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(graphBuffer.data(),
-                                                                            graphBuffer.size());
+    auto graphWrapper = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        graphBuffer.data(), graphBuffer.size());
 
     auto applicableEngines = engineManager.getApplicableEngineIds(handle, graphWrapper);
 

--- a/dnn-providers/hip-kernel-provider/src/tests/TestHipKernelUtils.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/TestHipKernelUtils.cpp
@@ -7,8 +7,8 @@
 
 #include "HipKernelUtils.hpp"
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 
@@ -23,19 +23,24 @@ flatbuffers::FlatBufferBuilder createSingleTensorGraph(const std::vector<int64_t
                                                        const std::vector<int64_t>& strides)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 1, "tensor", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        1,
+        "tensor",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &strides,
+        &dims));
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
@@ -43,8 +48,8 @@ flatbuffers::FlatBufferBuilder createSingleTensorGraph(const std::vector<int64_t
 }
 
 /// Extracts the TensorAttributes pointer (UID 1) from a single-tensor graph.
-const hipdnn_data_sdk::data_objects::TensorAttributes*
-    getTensor(const hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper& graph)
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*
+    getTensor(const hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper& graph)
 {
     return graph.getTensorMap().at(1);
 }
@@ -110,8 +115,8 @@ TEST(TestFindDeviceBuffer, FindsFirstMatchWhenDuplicateUidsExist)
 TEST(TestFindTensorAttributes, FindsTensorWithMatchingUid)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& tensorMap = graph.getTensorMap();
 
@@ -123,8 +128,8 @@ TEST(TestFindTensorAttributes, FindsTensorWithMatchingUid)
 TEST(TestFindTensorAttributes, ThrowsWhenUidNotFound)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& tensorMap = graph.getTensorMap();
 
@@ -133,7 +138,8 @@ TEST(TestFindTensorAttributes, ThrowsWhenUidNotFound)
 
 TEST(TestFindTensorAttributes, ThrowsWhenMapIsEmpty)
 {
-    std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*> emptyMap;
+    std::unordered_map<int64_t, const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>
+        emptyMap;
 
     EXPECT_THROW(findTensorAttributes(emptyMap, 1), hipdnn_plugin_sdk::HipdnnPluginException);
 }
@@ -149,8 +155,8 @@ TEST(TestIsChannelLastLayout, ReturnsTrueForNhwc4D)
         dims, hipdnn_data_sdk::utilities::TensorLayout::NHWC.strideOrder);
 
     auto builder = createSingleTensorGraph(dims, strides);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_TRUE(isChannelLastLayout(getTensor(graph)));
 }
@@ -162,8 +168,8 @@ TEST(TestIsChannelLastLayout, ReturnsFalseForNchw4D)
         dims, hipdnn_data_sdk::utilities::TensorLayout::NCHW.strideOrder);
 
     auto builder = createSingleTensorGraph(dims, strides);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_FALSE(isChannelLastLayout(getTensor(graph)));
 }
@@ -179,8 +185,8 @@ TEST(TestIsChannelLastLayout, ReturnsTrueForNdhwc5D)
         dims, hipdnn_data_sdk::utilities::TensorLayout::NDHWC.strideOrder);
 
     auto builder = createSingleTensorGraph(dims, strides);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_TRUE(isChannelLastLayout(getTensor(graph)));
 }
@@ -192,8 +198,8 @@ TEST(TestIsChannelLastLayout, ReturnsFalseForNcdhw5D)
         dims, hipdnn_data_sdk::utilities::TensorLayout::NCDHW.strideOrder);
 
     auto builder = createSingleTensorGraph(dims, strides);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_FALSE(isChannelLastLayout(getTensor(graph)));
 }
@@ -208,8 +214,8 @@ TEST(TestIsChannelLastLayout, ThrowsFor3DTensor)
     std::vector<int64_t> strides = {672, 224, 1};
 
     auto builder = createSingleTensorGraph(dims, strides);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_THROW(isChannelLastLayout(getTensor(graph)), hipdnn_plugin_sdk::HipdnnPluginException);
 }
@@ -220,8 +226,8 @@ TEST(TestIsChannelLastLayout, ThrowsFor6DTensor)
     std::vector<int64_t> strides = {4816896, 1605632, 401408, 50176, 224, 1};
 
     auto builder = createSingleTensorGraph(dims, strides);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_THROW(isChannelLastLayout(getTensor(graph)), hipdnn_plugin_sdk::HipdnnPluginException);
 }
@@ -234,8 +240,8 @@ namespace
 {
 
 // Helper function to create PointwiseAttributes
-const hipdnn_data_sdk::data_objects::PointwiseAttributes*
-    createPointwiseAttributes(hipdnn_data_sdk::data_objects::PointwiseMode mode,
+const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes*
+    createPointwiseAttributes(hipdnn_flatbuffers_sdk::data_objects::PointwiseMode mode,
                               flatbuffers::Optional<float> reluLowerClip = flatbuffers::nullopt,
                               flatbuffers::Optional<float> reluUpperClip = flatbuffers::nullopt,
                               flatbuffers::Optional<float> reluLowerClipSlope
@@ -244,21 +250,22 @@ const hipdnn_data_sdk::data_objects::PointwiseAttributes*
                               flatbuffers::Optional<float> softplusBeta = flatbuffers::nullopt)
 {
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(builder,
-                                                                               mode,
-                                                                               reluLowerClip,
-                                                                               reluUpperClip,
-                                                                               reluLowerClipSlope,
-                                                                               flatbuffers::nullopt,
-                                                                               0,
-                                                                               flatbuffers::nullopt,
-                                                                               flatbuffers::nullopt,
-                                                                               1,
-                                                                               flatbuffers::nullopt,
-                                                                               eluAlpha,
-                                                                               softplusBeta);
+    auto attrOffset
+        = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(builder,
+                                                                          mode,
+                                                                          reluLowerClip,
+                                                                          reluUpperClip,
+                                                                          reluLowerClipSlope,
+                                                                          flatbuffers::nullopt,
+                                                                          0,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          1,
+                                                                          flatbuffers::nullopt,
+                                                                          eluAlpha,
+                                                                          softplusBeta);
     builder.Finish(attrOffset);
-    return flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
+    return flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
         builder.GetBufferPointer());
 }
 
@@ -266,7 +273,8 @@ const hipdnn_data_sdk::data_objects::PointwiseAttributes*
 
 TEST(TestParseActivation, ReluDefault)
 {
-    auto attrs = createPointwiseAttributes(hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD);
+    auto attrs
+        = createPointwiseAttributes(hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD);
 
     auto params = parseActivation(*attrs);
 
@@ -277,7 +285,7 @@ TEST(TestParseActivation, ReluDefault)
 TEST(TestParseActivation, ReluClippedUpperOnly)
 {
     auto attrs = createPointwiseAttributes(
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD, flatbuffers::nullopt, 5.0f);
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD, flatbuffers::nullopt, 5.0f);
 
     auto params = parseActivation(*attrs);
 
@@ -288,7 +296,7 @@ TEST(TestParseActivation, ReluClippedUpperOnly)
 TEST(TestParseActivation, ReluClampLowerAndUpper)
 {
     auto attrs = createPointwiseAttributes(
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD, 0.5f, 10.0f);
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD, 0.5f, 10.0f);
 
     auto params = parseActivation(*attrs);
 
@@ -299,10 +307,11 @@ TEST(TestParseActivation, ReluClampLowerAndUpper)
 
 TEST(TestParseActivation, ReluLeaky)
 {
-    auto attrs = createPointwiseAttributes(hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
-                                           flatbuffers::nullopt,
-                                           flatbuffers::nullopt,
-                                           0.01f);
+    auto attrs
+        = createPointwiseAttributes(hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD,
+                                    flatbuffers::nullopt,
+                                    flatbuffers::nullopt,
+                                    0.01f);
 
     auto params = parseActivation(*attrs);
 
@@ -314,18 +323,19 @@ TEST(TestParseActivation, ThrowsOnReluUnsupportedLowerClipOnly)
 {
     // lower clip without upper clip is not supported
     auto attrs = createPointwiseAttributes(
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD, 0.5f, flatbuffers::nullopt);
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD, 0.5f, flatbuffers::nullopt);
 
     EXPECT_THROW(parseActivation(*attrs), hipdnn_plugin_sdk::HipdnnPluginException);
 }
 
 TEST(TestParseActivation, EluCustomAlpha)
 {
-    auto attrs = createPointwiseAttributes(hipdnn_data_sdk::data_objects::PointwiseMode::ELU_FWD,
-                                           flatbuffers::nullopt,
-                                           flatbuffers::nullopt,
-                                           flatbuffers::nullopt,
-                                           1.50f);
+    auto attrs
+        = createPointwiseAttributes(hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::ELU_FWD,
+                                    flatbuffers::nullopt,
+                                    flatbuffers::nullopt,
+                                    flatbuffers::nullopt,
+                                    1.50f);
 
     auto params = parseActivation(*attrs);
 
@@ -335,13 +345,13 @@ TEST(TestParseActivation, EluCustomAlpha)
 
 TEST(TestParseActivation, SoftplusValidBeta)
 {
-    auto attrs
-        = createPointwiseAttributes(hipdnn_data_sdk::data_objects::PointwiseMode::SOFTPLUS_FWD,
-                                    flatbuffers::nullopt,
-                                    flatbuffers::nullopt,
-                                    flatbuffers::nullopt,
-                                    flatbuffers::nullopt,
-                                    1.0f);
+    auto attrs = createPointwiseAttributes(
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SOFTPLUS_FWD,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        1.0f);
 
     auto params = parseActivation(*attrs);
 
@@ -350,21 +360,21 @@ TEST(TestParseActivation, SoftplusValidBeta)
 
 TEST(TestParseActivation, SoftplusInvalidBeta)
 {
-    auto attrs
-        = createPointwiseAttributes(hipdnn_data_sdk::data_objects::PointwiseMode::SOFTPLUS_FWD,
-                                    flatbuffers::nullopt,
-                                    flatbuffers::nullopt,
-                                    flatbuffers::nullopt,
-                                    flatbuffers::nullopt,
-                                    2.0f);
+    auto attrs = createPointwiseAttributes(
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SOFTPLUS_FWD,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        2.0f);
 
     EXPECT_THROW(parseActivation(*attrs), hipdnn_plugin_sdk::HipdnnPluginException);
 }
 
 TEST(TestParseActivation, Sigmoid)
 {
-    auto attrs
-        = createPointwiseAttributes(hipdnn_data_sdk::data_objects::PointwiseMode::SIGMOID_FWD);
+    auto attrs = createPointwiseAttributes(
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SIGMOID_FWD);
 
     auto params = parseActivation(*attrs);
     EXPECT_EQ(params.mode, ActivationMode::LOGISTIC);
@@ -372,7 +382,8 @@ TEST(TestParseActivation, Sigmoid)
 
 TEST(TestParseActivation, TanhWithDefaults)
 {
-    auto attrs = createPointwiseAttributes(hipdnn_data_sdk::data_objects::PointwiseMode::TANH_BWD);
+    auto attrs
+        = createPointwiseAttributes(hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::TANH_BWD);
 
     auto params = parseActivation(*attrs);
 
@@ -383,7 +394,8 @@ TEST(TestParseActivation, TanhWithDefaults)
 
 TEST(TestParseActivation, Passthru)
 {
-    auto attrs = createPointwiseAttributes(hipdnn_data_sdk::data_objects::PointwiseMode::IDENTITY);
+    auto attrs
+        = createPointwiseAttributes(hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::IDENTITY);
 
     auto params = parseActivation(*attrs);
 

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/TestHipKernelEngine.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/TestHipKernelEngine.cpp
@@ -4,8 +4,8 @@
 #include <gtest/gtest.h>
 #include <memory>
 
-#include <hipdnn_data_sdk/data_objects/engine_config_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/EngineDetailsWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/engine_config_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/EngineDetailsWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/MockEngineConfig.hpp>
 #include <hipdnn_test_sdk/utilities/MockGraph.hpp>
 #include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
@@ -15,7 +15,7 @@
 
 using namespace hip_kernel_provider;
 using namespace hipdnn_test_sdk::utilities;
-using namespace hipdnn_data_sdk::flatbuffer_utilities;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 
 TEST(TestHipKernelEngine, ConstructorAndId)
 {
@@ -190,14 +190,14 @@ TEST(TestHipKernelEngine, GetDetailsOnlyUsesFirstPlanBuilderCustomKnobs)
     auto mockPlanBuilder2 = std::make_unique<MockPlanBuilder>();
 
     // Set up first plan builder to return a custom knob
-    hipdnn_data_sdk::data_objects::KnobT knob1;
+    hipdnn_flatbuffers_sdk::data_objects::KnobT knob1;
     knob1.knob_id = "custom.knob1";
     knob1.description = "First custom knob";
-    hipdnn_data_sdk::data_objects::IntValueT defaultValue1;
+    hipdnn_flatbuffers_sdk::data_objects::IntValueT defaultValue1;
     defaultValue1.value = 1;
     knob1.default_value.Set(defaultValue1);
 
-    std::vector<hipdnn_data_sdk::data_objects::KnobT> customKnobs1;
+    std::vector<hipdnn_flatbuffers_sdk::data_objects::KnobT> customKnobs1;
     customKnobs1.push_back(knob1);
 
     EXPECT_CALL(*mockPlanBuilder1, getCustomKnobs(::testing::_, ::testing::_))

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/asm_sdpa_engine/TestAsmSdpaEngine.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/asm_sdpa_engine/TestAsmSdpaEngine.cpp
@@ -4,8 +4,8 @@
 #include <gtest/gtest.h>
 
 #include <hip_kernel_provider_common/HipDeviceUtils.hpp>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_frontend/Types.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 
@@ -35,8 +35,8 @@ TEST_F(TestAsmSdpaEngine, IsApplicableReturnsFalseForNonSdpaGraph)
     // Create a batchnorm inference graph - this does not use SDPA attributes
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graphWrapper(builder.GetBufferPointer(),
-                                                                     builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graphWrapper(
+        builder.GetBufferPointer(), builder.GetSize());
 
     EXPECT_FALSE(_engine.isApplicable(_handle, graphWrapper));
 }
@@ -59,10 +59,10 @@ TEST_F(TestAsmSdpaEngine, IsApplicableReturnsTrueForSdpaGraph)
         strides,
         dims,
         strides,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16);
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graphWrapper(builder.GetBufferPointer(),
-                                                                     builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graphWrapper(
+        builder.GetBufferPointer(), builder.GetSize());
 
     EXPECT_TRUE(_engine.isApplicable(_handle, graphWrapper));
 }

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/asm_sdpa_engine/TestSdpaFwdPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/asm_sdpa_engine/TestSdpaFwdPlanBuilder.cpp
@@ -3,8 +3,8 @@
 
 #include <gtest/gtest.h>
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 
 #include "HipKernelHandle.hpp"
@@ -29,8 +29,8 @@ TEST_F(TestSdpaFwdPlanBuilder, IsApplicableReturnsFalseForNonSdpaGraph)
     // Create a batchnorm inference graph - this does not use SDPA attributes
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graphWrapper(builder.GetBufferPointer(),
-                                                                     builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graphWrapper(
+        builder.GetBufferPointer(), builder.GetSize());
 
     EXPECT_FALSE(_planBuilder.isApplicable(_handle, graphWrapper));
 }
@@ -46,15 +46,16 @@ struct GraphTest
     {
     }
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graphWrapper() const
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graphWrapper() const
     {
-        return hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(buffer->data(), buffer->size());
+        return hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(buffer->data(),
+                                                                          buffer->size());
     }
 };
 
 auto createSdpaFwdGraph(const std::vector<int64_t>& dims = {4, 8, 256, 128},
-                        hipdnn_data_sdk::data_objects::DataType dataType
-                        = hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+                        hipdnn_flatbuffers_sdk::data_objects::DataType dataType
+                        = hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
                         bool withAttnMask = false,
                         bool withScale = false,
                         bool withStats = false,
@@ -82,7 +83,7 @@ auto createSdpaFwdGraph(const std::vector<int64_t>& dims = {4, 8, 256, 128},
 
 TEST_F(TestSdpaFwdPlanBuilder, IsApplicableSdpaVariations)
 {
-    using namespace hipdnn_data_sdk::data_objects;
+    using namespace hipdnn_flatbuffers_sdk::data_objects;
 
     if(hip_kernel_provider_common::getDeviceString(_handle.getStream()) != "gfx942")
     {
@@ -127,8 +128,8 @@ TEST_F(TestSdpaFwdPlanBuilder, GetMaxWorkspaceSizeCalculatesCorrectly)
     // Create an SDPA graph with known dimensions (withStats = false by default)
     auto builder = hipdnn_test_sdk::utilities::createValidSdpaFwdGraph();
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graphWrapper(builder.GetBufferPointer(),
-                                                                     builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graphWrapper(
+        builder.GetBufferPointer(), builder.GetSize());
 
     // Get the workspace size from the plan builder
     HipKernelSettings settings;

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Batchnorm/TestBatchnormFwdInferencePlan.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Batchnorm/TestBatchnormFwdInferencePlan.cpp
@@ -9,7 +9,7 @@
 #include "mocks/MockKernelCompiler.hpp"
 #include "mocks/MockRunnableKernel.hpp"
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 #include <hipdnn_plugin_sdk/interfaces/IPlan.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
@@ -24,8 +24,8 @@ namespace hip_kernel_provider::batchnorm::test
 TEST(TestBatchnormFwdInferenceParams, ConstructsFromSingleNodeGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_BatchnormInferenceAttributes();
@@ -36,8 +36,8 @@ TEST(TestBatchnormFwdInferenceParams, ConstructsFromSingleNodeGraph)
 TEST(TestBatchnormFwdInferenceParams, HasCorrectTensorPointersForSingleNode)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_BatchnormInferenceAttributes();
@@ -59,8 +59,8 @@ TEST(TestBatchnormFwdInferenceParams, HasCorrectTensorPointersForSingleNode)
 TEST(TestBatchnormFwdInferenceParams, TensorPointersMatchExpectedUids)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_BatchnormInferenceAttributes();
@@ -78,8 +78,8 @@ TEST(TestBatchnormFwdInferenceParams, TensorPointersMatchExpectedUids)
 TEST(TestBatchnormFwdInferenceParams, IsMoveConstructible)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_BatchnormInferenceAttributes();
@@ -94,8 +94,8 @@ TEST(TestBatchnormFwdInferenceParams, IsMoveConstructible)
 TEST(TestBatchnormFwdInferenceParams, ConstructGraphWithActivation)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdInferActGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_BatchnormInferenceAttributes();
@@ -109,8 +109,8 @@ TEST(TestBatchnormFwdInferenceParams, ConstructGraphWithActivation)
 TEST(TestBatchnormFwdInferenceParams, HasCorrectTensorPointersForGraphWithActivation)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdInferActGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_BatchnormInferenceAttributes();
@@ -133,8 +133,8 @@ TEST(TestBatchnormFwdInferenceParams, HasCorrectTensorPointersForGraphWithActiva
 TEST(TestBatchnormFwdInferenceParams, TensorPointersMatchExpectedUidsForGraphWithActivation)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdInferActGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_BatchnormInferenceAttributes();
@@ -165,16 +165,16 @@ TEST(TestBatchnormFwdInferenceParams, IsNotCopyConstructible)
 namespace
 {
 
-BatchnormFwdInferencePlan createPlanFromGraph(const std::vector<int64_t>& strides
-                                              = {150528, 50176, 224, 1},
-                                              const std::vector<int64_t>& dims = {1, 3, 224, 224},
-                                              hipdnn_data_sdk::data_objects::DataType inputDataType
-                                              = hipdnn_data_sdk::data_objects::DataType::FLOAT)
+BatchnormFwdInferencePlan
+    createPlanFromGraph(const std::vector<int64_t>& strides = {150528, 50176, 224, 1},
+                        const std::vector<int64_t>& dims = {1, 3, 224, 224},
+                        hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType
+                        = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph(
         strides, dims, inputDataType);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_BatchnormInferenceAttributes();
@@ -322,8 +322,9 @@ TEST(TestBatchnormFwdInferencePlan, CompileFp16SetsCorrectDefines)
             return program;
         });
 
-    auto plan = createPlanFromGraph(
-        {150528, 50176, 224, 1}, {1, 3, 224, 224}, hipdnn_data_sdk::data_objects::DataType::HALF);
+    auto plan = createPlanFromGraph({150528, 50176, 224, 1},
+                                    {1, 3, 224, 224},
+                                    hipdnn_flatbuffers_sdk::data_objects::DataType::HALF);
     auto deviceProps = createTestDeviceProps();
 
     plan.compile(mockCompiler, deviceProps);
@@ -358,7 +359,7 @@ TEST(TestBatchnormFwdInferencePlan, CompileBfp16SetsCorrectDefines)
 
     auto plan = createPlanFromGraph({150528, 50176, 224, 1},
                                     {1, 3, 224, 224},
-                                    hipdnn_data_sdk::data_objects::DataType::BFLOAT16);
+                                    hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16);
     auto deviceProps = createTestDeviceProps();
 
     plan.compile(mockCompiler, deviceProps);
@@ -442,9 +443,9 @@ TEST(TestBatchnormFwdInferencePlan, CompileWithUnsupportedDimensionThrows)
 
     // 3D tensor is not supported
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph(
-        {12, 4, 1}, {1, 3, 4}, hipdnn_data_sdk::data_objects::DataType::FLOAT);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+        {12, 4, 1}, {1, 3, 4}, hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT);
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_BatchnormInferenceAttributes();

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Batchnorm/TestBatchnormFwdInferenceWithVariancePlan.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Batchnorm/TestBatchnormFwdInferenceWithVariancePlan.cpp
@@ -9,7 +9,7 @@
 #include "mocks/MockKernelCompiler.hpp"
 #include "mocks/MockRunnableKernel.hpp"
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 #include <hipdnn_plugin_sdk/interfaces/IPlan.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
@@ -24,8 +24,8 @@ namespace hip_kernel_provider::batchnorm::test
 TEST(TestBatchnormFwdInferenceWithVarianceParams, ConstructsFromSingleNodeGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormWithVarianceInferenceGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_BatchnormInferenceAttributesVarianceExt();
@@ -36,8 +36,8 @@ TEST(TestBatchnormFwdInferenceWithVarianceParams, ConstructsFromSingleNodeGraph)
 TEST(TestBatchnormFwdInferenceWithVarianceParams, HasCorrectTensorPointersForSingleNode)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormWithVarianceInferenceGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_BatchnormInferenceAttributesVarianceExt();
@@ -60,8 +60,8 @@ TEST(TestBatchnormFwdInferenceWithVarianceParams, HasCorrectTensorPointersForSin
 TEST(TestBatchnormFwdInferenceWithVarianceParams, TensorPointersMatchExpectedUids)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormWithVarianceInferenceGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_BatchnormInferenceAttributesVarianceExt();
@@ -79,8 +79,8 @@ TEST(TestBatchnormFwdInferenceWithVarianceParams, TensorPointersMatchExpectedUid
 TEST(TestBatchnormFwdInferenceWithVarianceParams, IsMoveConstructible)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormWithVarianceInferenceGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_BatchnormInferenceAttributesVarianceExt();
@@ -101,8 +101,8 @@ TEST(TestBatchnormFwdInferenceWithVarianceParams, ConstructGraphWithActivation)
 {
     auto builder
         = hipdnn_test_sdk::utilities::createValidBatchnormWithVarianceInferenceActivGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_BatchnormInferenceAttributesVarianceExt();
@@ -118,8 +118,8 @@ TEST(TestBatchnormFwdInferenceWithVarianceParams, HasCorrectTensorPointersForGra
 {
     auto builder
         = hipdnn_test_sdk::utilities::createValidBatchnormWithVarianceInferenceActivGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_BatchnormInferenceAttributesVarianceExt();
@@ -144,8 +144,8 @@ TEST(TestBatchnormFwdInferenceWithVarianceParams,
 {
     auto builder
         = hipdnn_test_sdk::utilities::createValidBatchnormWithVarianceInferenceActivGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_BatchnormInferenceAttributesVarianceExt();
@@ -174,13 +174,13 @@ namespace
 BatchnormFwdInferenceWithVariancePlan
     createPlanFromGraph(const std::vector<int64_t>& strides = {150528, 50176, 224, 1},
                         const std::vector<int64_t>& dims = {1, 3, 224, 224},
-                        hipdnn_data_sdk::data_objects::DataType inputDataType
-                        = hipdnn_data_sdk::data_objects::DataType::FLOAT)
+                        hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType
+                        = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormWithVarianceInferenceGraph(
         strides, dims, inputDataType);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_BatchnormInferenceAttributesVarianceExt();
@@ -328,8 +328,9 @@ TEST(TestBatchnormFwdInferenceWithVariancePlan, CompileFp16SetsCorrectDefines)
             return program;
         });
 
-    auto plan = createPlanFromGraph(
-        {150528, 50176, 224, 1}, {1, 3, 224, 224}, hipdnn_data_sdk::data_objects::DataType::HALF);
+    auto plan = createPlanFromGraph({150528, 50176, 224, 1},
+                                    {1, 3, 224, 224},
+                                    hipdnn_flatbuffers_sdk::data_objects::DataType::HALF);
     auto deviceProps = createTestDeviceProps();
 
     plan.compile(mockCompiler, deviceProps);
@@ -364,7 +365,7 @@ TEST(TestBatchnormFwdInferenceWithVariancePlan, CompileBfp16SetsCorrectDefines)
 
     auto plan = createPlanFromGraph({150528, 50176, 224, 1},
                                     {1, 3, 224, 224},
-                                    hipdnn_data_sdk::data_objects::DataType::BFLOAT16);
+                                    hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16);
     auto deviceProps = createTestDeviceProps();
 
     plan.compile(mockCompiler, deviceProps);
@@ -448,9 +449,9 @@ TEST(TestBatchnormFwdInferenceWithVariancePlan, CompileWithUnsupportedDimensionT
 
     // 3D tensor is not supported
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormWithVarianceInferenceGraph(
-        {12, 4, 1}, {1, 3, 4}, hipdnn_data_sdk::data_objects::DataType::FLOAT);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+        {12, 4, 1}, {1, 3, 4}, hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT);
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_BatchnormInferenceAttributesVarianceExt();

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Batchnorm/TestBatchnormFwdTrainingPlan.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Batchnorm/TestBatchnormFwdTrainingPlan.cpp
@@ -9,7 +9,7 @@
 #include "mocks/MockKernelCompiler.hpp"
 #include "mocks/MockRunnableKernel.hpp"
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 #include <hipdnn_plugin_sdk/interfaces/IPlan.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
@@ -24,8 +24,8 @@ using namespace hip_kernel_provider::batchnorm;
 TEST(TestBatchnormFwdTrainingParams, ConstructsFromSingleNodeGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_BatchnormAttributes();
@@ -36,8 +36,8 @@ TEST(TestBatchnormFwdTrainingParams, ConstructsFromSingleNodeGraph)
 TEST(TestBatchnormFwdTrainingParams, HasCorrectTensorPointersForSingleNode)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_BatchnormAttributes();
@@ -55,8 +55,8 @@ TEST(TestBatchnormFwdTrainingParams, HasCorrectTensorPointersForSingleNode)
 TEST(TestBatchnormFwdTrainingParams, TensorPointersMatchExpectedUids)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_BatchnormAttributes();
@@ -74,8 +74,8 @@ TEST(TestBatchnormFwdTrainingParams, TensorPointersMatchExpectedUids)
 TEST(TestBatchnormFwdTrainingParams, IsMoveConstructible)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_BatchnormAttributes();
@@ -90,8 +90,8 @@ TEST(TestBatchnormFwdTrainingParams, IsMoveConstructible)
 TEST(TestBatchnormFwdTrainingParams, ExtractsEpsilonValueCorrectly)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     auto* attrs = node.attributes_as_BatchnormAttributes();
@@ -107,8 +107,8 @@ TEST(TestBatchnormFwdTrainingParams, HandlesMeanVariancePresent)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph(
         {1, 3, 14, 14}, {1, 3, 14, 14}, true);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     auto* attrs = node.attributes_as_BatchnormAttributes();
@@ -125,8 +125,8 @@ TEST(TestBatchnormFwdTrainingParams, HandlesMeanVarianceMissing)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph(
         {1, 3, 14, 14}, {1, 3, 14, 14}, false);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     auto* attrs = node.attributes_as_BatchnormAttributes();
@@ -140,8 +140,8 @@ TEST(TestBatchnormFwdTrainingParams, HandlesMeanVarianceMissing)
 TEST(TestBatchnormFwdTrainingParams, HasRunningStatsReturnsFalseWhenNotProvided)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     auto* attrs = node.attributes_as_BatchnormAttributes();
@@ -171,8 +171,8 @@ BatchnormFwdTrainingPlan createPlanFromGraph(const std::vector<int64_t>& strides
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph(
         strides, dims, withMeanVariance);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_BatchnormAttributes();

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Batchnorm/TestBatchnormPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Batchnorm/TestBatchnormPlanBuilder.cpp
@@ -12,7 +12,7 @@
 #include "mocks/MockKernelCompiler.hpp"
 #include "mocks/MockRunnableKernel.hpp"
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 #include <hipdnn_test_sdk/utilities/MockEngineConfig.hpp>
 #include <hipdnn_test_sdk/utilities/MockGraph.hpp>
@@ -62,8 +62,8 @@ protected:
 TEST_F(TestBatchnormPlanBuilder, IsApplicableReturnsTrueForValidInferenceGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_TRUE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -71,8 +71,8 @@ TEST_F(TestBatchnormPlanBuilder, IsApplicableReturnsTrueForValidInferenceGraph)
 TEST_F(TestBatchnormPlanBuilder, IsApplicableReturnsTrueForValidFwdTrainingGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_TRUE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -84,8 +84,8 @@ TEST_F(TestBatchnormPlanBuilder, IsApplicableReturnsTrueForValidFwdTrainingGraph
 TEST_F(TestBatchnormPlanBuilder, IsApplicableReturnsFalseForThreeNodeGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferActBwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -99,8 +99,8 @@ TEST_F(TestBatchnormPlanBuilder, BuildPlanSetsPlanForSingleNodeInference)
     setupMockCompileChain();
 
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     HipKernelContext ctx;
 
     EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx));
@@ -112,8 +112,8 @@ TEST_F(TestBatchnormPlanBuilder, BuildPlanSetsPlanForSingleNodeFwdTraining)
     setupMockCompileChain();
 
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     HipKernelContext ctx;
 
     EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx));
@@ -127,8 +127,8 @@ TEST_F(TestBatchnormPlanBuilder, BuildPlanSetsPlanForSingleNodeFwdTraining)
 TEST_F(TestBatchnormPlanBuilder, GetMaxWorkspaceSizeReturnsZero)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     HipKernelSettings settings;
 
     EXPECT_EQ(_planBuilder.getMaxWorkspaceSize(_dummyHandle, graph, settings), 0u);
@@ -137,8 +137,8 @@ TEST_F(TestBatchnormPlanBuilder, GetMaxWorkspaceSizeReturnsZero)
 TEST_F(TestBatchnormPlanBuilder, GetMaxWorkspaceSizeReturnsZeroForFwdTrainingGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     HipKernelSettings settings;
 
     EXPECT_EQ(_planBuilder.getMaxWorkspaceSize(_dummyHandle, graph, settings), 0u);
@@ -151,8 +151,8 @@ TEST_F(TestBatchnormPlanBuilder, GetMaxWorkspaceSizeReturnsZeroForFwdTrainingGra
 TEST_F(TestBatchnormPlanBuilder, GetCustomKnobsReturnsEmpty)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     auto knobs = _planBuilder.getCustomKnobs(_dummyHandle, graph);
     EXPECT_TRUE(knobs.empty());
@@ -161,8 +161,8 @@ TEST_F(TestBatchnormPlanBuilder, GetCustomKnobsReturnsEmpty)
 TEST_F(TestBatchnormPlanBuilder, GetCustomKnobsReturnsEmptyForFwdTrainingGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     auto knobs = _planBuilder.getCustomKnobs(_dummyHandle, graph);
     EXPECT_TRUE(knobs.empty());

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Layernorm/TestLayernormFwdPlan.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Layernorm/TestLayernormFwdPlan.cpp
@@ -3,7 +3,7 @@
 
 #include "engines/plans/layernorm/LayernormFwdPlan.hpp"
 #include <gtest/gtest.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 
 using namespace hip_kernel_provider::layernorm;
@@ -12,8 +12,8 @@ TEST(TestLayernormFwdParams, InitializesAllTensorsFromValidGraph)
 {
     // Create a valid layernorm graph
     auto builder = hipdnn_test_sdk::utilities::createValidLayernormFpropGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the layernorm node and attributes
     const auto& node = graph.getNode(0);

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Layernorm/TestLayernormPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/plans/Layernorm/TestLayernormPlanBuilder.cpp
@@ -5,7 +5,7 @@
 #include <gtest/gtest.h>
 #include <hipdnn_frontend/Types.hpp>
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_plugin_sdk/EnginePluginApi.h>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 #include <hipdnn_test_sdk/utilities/MockEngineConfig.hpp>
@@ -22,7 +22,7 @@
 #include "mocks/MockRunnableKernel.hpp"
 
 using namespace hipdnn_test_sdk::utilities;
-using namespace hipdnn_data_sdk::flatbuffer_utilities;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 
 namespace hip_kernel_provider::layernorm::test
 {
@@ -66,8 +66,8 @@ protected:
 TEST_F(TestLayernormPlanBuilder, IsApplicableReturnsTrueForValidInferenceGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidLayernormFpropGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_TRUE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -98,8 +98,8 @@ TEST_F(TestLayernormPlanBuilder, BuildPlanSetsPlanForSingleNode)
     setupMockCompileChain();
 
     auto builder = hipdnn_test_sdk::utilities::createValidLayernormFpropGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     HipKernelContext ctx;
 
     EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx));
@@ -113,8 +113,8 @@ TEST_F(TestLayernormPlanBuilder, BuildPlanSetsPlanForSingleNode)
 TEST_F(TestLayernormPlanBuilder, GetMaxWorkspaceSizeReturnsZero)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidLayernormFpropGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     HipKernelSettings settings;
 
     EXPECT_EQ(_planBuilder.getMaxWorkspaceSize(_dummyHandle, graph, settings), 0u);
@@ -127,8 +127,8 @@ TEST_F(TestLayernormPlanBuilder, GetMaxWorkspaceSizeReturnsZero)
 TEST_F(TestLayernormPlanBuilder, GetCustomKnobsReturnsEmpty)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidLayernormFpropGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     auto knobs = _planBuilder.getCustomKnobs(_dummyHandle, graph);
     EXPECT_TRUE(knobs.empty());

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/plans/RMSnorm/TestRMSnormBwdPlan.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/plans/RMSnorm/TestRMSnormBwdPlan.cpp
@@ -5,7 +5,7 @@
 
 #include "engines/plans/RMSnorm/RMSnormBwdPlan.hpp"
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_plugin_sdk/interfaces/IPlan.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 
@@ -19,8 +19,8 @@ using namespace hip_kernel_provider::rmsnorm;
 TEST(TestRMSnormBwdParams, ConstructsFromSingleNodeGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidRMSNormBwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_RMSNormBackwardAttributes();
@@ -32,8 +32,8 @@ TEST(TestRMSnormBwdParams, HasCorrectTensorPointersWithOptionalAttributes)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidRMSNormBwdGraph(
         {150528, 50176, 224, 1}, {1, 3, 224, 224}, true);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_RMSNormBackwardAttributes();
@@ -53,8 +53,8 @@ TEST(TestRMSnormBwdParams, TensorPointersMatchExpectedUids)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidRMSNormBwdGraph(
         {150528, 50176, 224, 1}, {1, 3, 224, 224}, true);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_RMSNormBackwardAttributes();
@@ -74,8 +74,8 @@ TEST(TestRMSnormBwdParams, OptionalTensorsAreNullWhenNotProvided)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidRMSNormBwdGraph(
         {150528, 50176, 224, 1}, {1, 3, 224, 224}, false);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_RMSNormBackwardAttributes();
@@ -94,8 +94,8 @@ TEST(TestRMSnormBwdParams, OptionalTensorsAreNullWhenNotProvided)
 TEST(TestRMSnormBwdParams, IsMoveConstructible)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidRMSNormBwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_RMSNormBackwardAttributes();
@@ -123,8 +123,8 @@ RMSnormBwdPlan createPlanFromGraph(bool hasOptionalAttributes = true)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidRMSNormBwdGraph(
         {150528, 50176, 224, 1}, {1, 3, 224, 224}, hasOptionalAttributes);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_RMSNormBackwardAttributes();

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/plans/RMSnorm/TestRMSnormBwdPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/plans/RMSnorm/TestRMSnormBwdPlanBuilder.cpp
@@ -11,7 +11,7 @@
 #include "mocks/MockKernelCompiler.hpp"
 #include "mocks/MockRunnableKernel.hpp"
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 #include <hipdnn_test_sdk/utilities/MockEngineConfig.hpp>
@@ -37,8 +37,8 @@ protected:
 TEST_F(TestRMSnormBwdPlanBuilder, IsApplicableReturnsTrueForValidSingleNodeGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidRMSNormBwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_TRUE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -47,8 +47,8 @@ TEST_F(TestRMSnormBwdPlanBuilder, IsApplicableReturnsTrueWithoutOptionalAttribut
 {
     auto builder = hipdnn_test_sdk::utilities::createValidRMSNormBwdGraph(
         {150528, 50176, 224, 1}, {1, 3, 224, 224}, false);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_TRUE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -60,8 +60,8 @@ TEST_F(TestRMSnormBwdPlanBuilder, IsApplicableReturnsTrueWithoutOptionalAttribut
 TEST_F(TestRMSnormBwdPlanBuilder, IsNotApplicableForBatchnormGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -72,10 +72,10 @@ TEST_F(TestRMSnormBwdPlanBuilder, IsNotApplicableForNonF32ComputeType)
         {150528, 50176, 224, 1},
         {1, 3, 224, 224},
         true,
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF);
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -87,8 +87,8 @@ TEST_F(TestRMSnormBwdPlanBuilder, IsNotApplicableForNonF32ComputeType)
 TEST_F(TestRMSnormBwdPlanBuilder, BuildPlanSetsPlanForSingleNodeGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidRMSNormBwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     HipKernelContext ctx;
 
     EXPECT_CALL(_mockDevicePropertyProvider, getDeviceProperties())
@@ -105,8 +105,8 @@ TEST_F(TestRMSnormBwdPlanBuilder, BuildPlanSetsPlanForSingleNodeGraph)
 TEST_F(TestRMSnormBwdPlanBuilder, GetMaxWorkspaceSizeReturnsZero)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidRMSNormBwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     HipKernelSettings settings;
 
     EXPECT_EQ(_planBuilder.getMaxWorkspaceSize(_dummyHandle, graph, settings), 0u);
@@ -119,8 +119,8 @@ TEST_F(TestRMSnormBwdPlanBuilder, GetMaxWorkspaceSizeReturnsZero)
 TEST_F(TestRMSnormBwdPlanBuilder, GetCustomKnobsReturnsEmpty)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidRMSNormBwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     auto knobs = _planBuilder.getCustomKnobs(_dummyHandle, graph);
     EXPECT_TRUE(knobs.empty());

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/plans/RMSnorm/TestRMSnormFwdPlan.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/plans/RMSnorm/TestRMSnormFwdPlan.cpp
@@ -10,7 +10,7 @@
 #include "mocks/MockKernelCompiler.hpp"
 #include "mocks/MockRunnableKernel.hpp"
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 #include <hipdnn_plugin_sdk/interfaces/IPlan.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
@@ -24,8 +24,8 @@ using namespace hip_kernel_provider::rmsnorm;
 TEST(TestRMSnormFwdParams, ConstructsFromSingleNodeGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidRMSNormGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_RMSNormAttributes();
@@ -36,8 +36,8 @@ TEST(TestRMSnormFwdParams, ConstructsFromSingleNodeGraph)
 TEST(TestRMSnormFwdParams, HasCorrectTensorPointersForSingleNode)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidRMSNormGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_RMSNormAttributes();
@@ -54,8 +54,8 @@ TEST(TestRMSnormFwdParams, HasCorrectTensorPointersForSingleNode)
 TEST(TestRMSnormFwdParams, TensorPointersMatchExpectedUids)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidRMSNormGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_RMSNormAttributes();
@@ -70,8 +70,8 @@ TEST(TestRMSnormFwdParams, TensorPointersMatchExpectedUids)
 TEST(TestRMSnormFwdParams, IsMoveConstructible)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidRMSNormGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_RMSNormAttributes();
@@ -96,13 +96,13 @@ namespace
 
 RMSnormFwdPlan createPlanFromGraph(const std::vector<int64_t>& strides = {150528, 50176, 224, 1},
                                    const std::vector<int64_t>& dims = {1, 3, 224, 224},
-                                   hipdnn_data_sdk::data_objects::DataType inputDataType
-                                   = hipdnn_data_sdk::data_objects::DataType::FLOAT)
+                                   hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType
+                                   = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT)
 {
     auto builder
         = hipdnn_test_sdk::utilities::createValidRMSNormGraph(strides, dims, inputDataType);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_RMSNormAttributes();
@@ -251,8 +251,9 @@ TEST(TestRMSnormFwdPlan, CompileFp16SetsCorrectDefines)
             return program;
         });
 
-    auto plan = createPlanFromGraph(
-        {150528, 50176, 224, 1}, {1, 3, 224, 224}, hipdnn_data_sdk::data_objects::DataType::HALF);
+    auto plan = createPlanFromGraph({150528, 50176, 224, 1},
+                                    {1, 3, 224, 224},
+                                    hipdnn_flatbuffers_sdk::data_objects::DataType::HALF);
     auto deviceProps = createTestDeviceProps();
 
     plan.compile(mockCompiler, deviceProps);
@@ -287,7 +288,7 @@ TEST(TestRMSnormFwdPlan, CompileBfp16SetsCorrectDefines)
 
     auto plan = createPlanFromGraph({150528, 50176, 224, 1},
                                     {1, 3, 224, 224},
-                                    hipdnn_data_sdk::data_objects::DataType::BFLOAT16);
+                                    hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16);
     auto deviceProps = createTestDeviceProps();
 
     plan.compile(mockCompiler, deviceProps);
@@ -309,9 +310,9 @@ TEST(TestRMSnormFwdPlan, CompileWithUnsupportedDimensionThrows)
 
     // 3D tensor is not supported
     auto builder = hipdnn_test_sdk::utilities::createValidRMSNormGraph(
-        {12, 4, 1}, {1, 3, 4}, hipdnn_data_sdk::data_objects::DataType::FLOAT);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+        {12, 4, 1}, {1, 3, 4}, hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT);
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_RMSNormAttributes();
@@ -330,9 +331,9 @@ TEST(TestRMSnormFwdPlan, CompileWithUnsupportedWorkgroupsThrows)
 
     // Number of workgroups exeeds UINT32_MAX
     auto builder = hipdnn_test_sdk::utilities::createValidRMSNormGraph(
-        {4, 4, 2, 1}, {UINT32_MAX, 1, 2, 2}, hipdnn_data_sdk::data_objects::DataType::FLOAT);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+        {4, 4, 2, 1}, {UINT32_MAX, 1, 2, 2}, hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT);
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     const auto& attr = *node.attributes_as_RMSNormAttributes();

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/plans/RMSnorm/TestRMSnormPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/plans/RMSnorm/TestRMSnormPlanBuilder.cpp
@@ -12,7 +12,7 @@
 #include "mocks/MockKernelCompiler.hpp"
 #include "mocks/MockRunnableKernel.hpp"
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 #include <hipdnn_test_sdk/utilities/MockEngineConfig.hpp>
 #include <hipdnn_test_sdk/utilities/MockGraph.hpp>
@@ -61,8 +61,8 @@ protected:
 TEST_F(TestRMSnormPlanBuilder, IsApplicableReturnsTrueForValidInferenceGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidRMSNormGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_TRUE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -73,8 +73,8 @@ TEST_F(TestRMSnormPlanBuilder, IsApplicableReturnsTrueForValidInferenceGraph)
 TEST_F(TestRMSnormPlanBuilder, IsApplicableReturnsFalseForThreeNodeGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -88,8 +88,8 @@ TEST_F(TestRMSnormPlanBuilder, BuildPlanSetsPlanForSingleNodeInference)
     setupMockCompileChain();
 
     auto builder = hipdnn_test_sdk::utilities::createValidRMSNormGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     HipKernelContext ctx;
 
     EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx));
@@ -103,8 +103,8 @@ TEST_F(TestRMSnormPlanBuilder, BuildPlanSetsPlanForSingleNodeInference)
 TEST_F(TestRMSnormPlanBuilder, GetMaxWorkspaceSizeReturnsZero)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidRMSNormGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     HipKernelSettings settings;
 
     EXPECT_EQ(_planBuilder.getMaxWorkspaceSize(_dummyHandle, graph, settings), 0u);
@@ -117,8 +117,8 @@ TEST_F(TestRMSnormPlanBuilder, GetMaxWorkspaceSizeReturnsZero)
 TEST_F(TestRMSnormPlanBuilder, GetCustomKnobsReturnsEmpty)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidRMSNormGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     auto knobs = _planBuilder.getCustomKnobs(_dummyHandle, graph);
     EXPECT_TRUE(knobs.empty());

--- a/dnn-providers/hip-kernel-provider/src/tests/mocks/MockPlanBuilder.hpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/mocks/MockPlanBuilder.hpp
@@ -5,7 +5,7 @@
 
 #include <gmock/gmock.h>
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_plugin_sdk/interfaces/IPlanBuilder.hpp>
 
 #include "HipKernelContext.hpp"
@@ -22,35 +22,35 @@ public:
     MOCK_METHOD(bool,
                 isApplicable,
                 (const HipKernelHandle& handle,
-                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph),
+                 const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph),
                 (const, override));
     MOCK_METHOD(size_t,
                 getMaxWorkspaceSize,
                 (const HipKernelHandle& handle,
-                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                 const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                  const HipKernelSettings& executionSettings),
                 (const, override));
 
     MOCK_METHOD(void,
                 initializeExecutionSettings,
                 (const HipKernelHandle& handle,
-                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-                 const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+                 const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+                 const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
                  HipKernelSettings& executionSettings),
                 (const, override));
 
     MOCK_METHOD(void,
                 buildPlan,
                 (const HipKernelHandle& handle,
-                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-                 const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+                 const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+                 const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
                  HipKernelContext& executionContext),
                 (const, override));
 
-    MOCK_METHOD((std::vector<hipdnn_data_sdk::data_objects::KnobT>),
+    MOCK_METHOD((std::vector<hipdnn_flatbuffers_sdk::data_objects::KnobT>),
                 getCustomKnobs,
                 (const HipKernelHandle& handle,
-                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph),
+                 const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph),
                 (const, override));
 };
 

--- a/dnn-providers/hipblaslt-provider/CMakeLists.txt
+++ b/dnn-providers/hipblaslt-provider/CMakeLists.txt
@@ -70,8 +70,8 @@ list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/llvm ${ROCM_PATH} ${ROCM_PATH}/hip)
 find_package(hip REQUIRED)
 
 # SDK dependencies - use targets directly in superbuild, find_package otherwise
-if(NOT TARGET hipdnn_data_sdk)
-    find_package(hipdnn_data_sdk CONFIG REQUIRED)
+if(NOT TARGET hipdnn_flatbuffers_sdk)
+    find_package(hipdnn_flatbuffers_sdk CONFIG REQUIRED)
 endif()
 
 if(NOT TARGET hipdnn_plugin_sdk)
@@ -122,7 +122,7 @@ target_include_directories(hipblaslt_plugin_private PUBLIC ${CMAKE_CURRENT_SOURC
 # hip::host triggers a hard ambiguous operator<< error in upstream hipBLASLt
 # headers (hipblaslt_e5m3.h / hipblaslt_e8.h) due to missing MSVC ABI flags.
 # See: https://github.com/ROCm/rocm-libraries/issues/6404
-target_link_libraries(hipblaslt_plugin_private PUBLIC roc::hipblaslt hipdnn_data_sdk hipdnn_plugin_sdk hip::device)
+target_link_libraries(hipblaslt_plugin_private PUBLIC roc::hipblaslt hipdnn_flatbuffers_sdk hipdnn_plugin_sdk hip::device)
 
 target_compile_options(hipblaslt_plugin_private PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
 

--- a/dnn-providers/hipblaslt-provider/EngineManager.cpp
+++ b/dnn-providers/hipblaslt-provider/EngineManager.cpp
@@ -3,13 +3,14 @@
 
 #include <algorithm>
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 
 #include "EngineManager.hpp"
 #include "engines/HipblasltEngine.hpp"
 
 using namespace hipdnn_plugin_sdk;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 
 namespace hipblaslt_plugin
 {
@@ -20,7 +21,8 @@ void EngineManager::addEngine(std::unique_ptr<IEngine> engine)
 }
 
 std::vector<int64_t> EngineManager::getApplicableEngineIds(
-    HipdnnEnginePluginHandle& handle, const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph)
+    HipdnnEnginePluginHandle& handle,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph)
 {
     std::vector<int64_t> applicable;
     for(const auto& engine : _engines)
@@ -35,7 +37,7 @@ std::vector<int64_t> EngineManager::getApplicableEngineIds(
 
 void EngineManager::getEngineDetails(
     HipdnnEnginePluginHandle& handle,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
     int64_t engineId,
     hipdnnPluginConstData_t& engineDetailsOut)
 {
@@ -46,7 +48,7 @@ void EngineManager::getEngineDetails(
 size_t EngineManager::getWorkspaceSize(
     const HipdnnEnginePluginHandle& handle,
     int64_t engineId,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
 {
     auto& engine = getEngine(engineId);
     return engine.getWorkspaceSize(handle, opGraph);
@@ -54,8 +56,8 @@ size_t EngineManager::getWorkspaceSize(
 
 void EngineManager::initializeExecutionContext(
     const HipdnnEnginePluginHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-    const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
     HipdnnEnginePluginExecutionContext& executionContext) const
 {
     auto& engine = getEngine(engineConfig.engineId());

--- a/dnn-providers/hipblaslt-provider/EngineManager.hpp
+++ b/dnn-providers/hipblaslt-provider/EngineManager.hpp
@@ -7,7 +7,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
 #include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
 
 #include "engines/EngineInterface.hpp"
@@ -29,21 +29,22 @@ public:
 
     std::vector<int64_t>
         getApplicableEngineIds(HipdnnEnginePluginHandle& handle,
-                               const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph);
+                               const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph);
 
     void getEngineDetails(HipdnnEnginePluginHandle& handle,
-                          const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                          const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                           int64_t engineId,
                           hipdnnPluginConstData_t& engineDetailsOut);
 
-    size_t getWorkspaceSize(const HipdnnEnginePluginHandle& handle,
-                            int64_t engineId,
-                            const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const;
+    size_t
+        getWorkspaceSize(const HipdnnEnginePluginHandle& handle,
+                         int64_t engineId,
+                         const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const;
 
     void initializeExecutionContext(
         const HipdnnEnginePluginHandle& handle,
-        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-        const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
         HipdnnEnginePluginExecutionContext& executionContext) const;
 
 private:

--- a/dnn-providers/hipblaslt-provider/HipblasltMatrixLayout.cpp
+++ b/dnn-providers/hipblaslt-provider/HipblasltMatrixLayout.cpp
@@ -9,7 +9,7 @@ namespace hipblaslt_plugin
 {
 
 HipblasltMatrixLayout::HipblasltMatrixLayout(
-    const hipdnn_data_sdk::flatbuffer_utilities::TensorAttributesWrapper& tensor)
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::TensorAttributesWrapper& tensor)
     : _uid(tensor.uid())
 {
     const auto& dims = tensor.dims();

--- a/dnn-providers/hipblaslt-provider/HipblasltMatrixLayout.hpp
+++ b/dnn-providers/hipblaslt-provider/HipblasltMatrixLayout.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <hipblaslt/hipblaslt.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/TensorAttributesWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/TensorAttributesWrapper.hpp>
 
 namespace hipblaslt_plugin
 {
@@ -14,7 +14,7 @@ class HipblasltMatrixLayout
 public:
     HipblasltMatrixLayout() = default;
     HipblasltMatrixLayout(
-        const hipdnn_data_sdk::flatbuffer_utilities::TensorAttributesWrapper& tensor);
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::TensorAttributesWrapper& tensor);
 
     HipblasltMatrixLayout(const HipblasltMatrixLayout&) = delete;
     HipblasltMatrixLayout& operator=(const HipblasltMatrixLayout&) = delete;

--- a/dnn-providers/hipblaslt-provider/HipblasltPlugin.cpp
+++ b/dnn-providers/hipblaslt-provider/HipblasltPlugin.cpp
@@ -3,9 +3,9 @@
 
 #include <iostream>
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_data_sdk/utilities/EngineNames.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_plugin_sdk/EnginePluginApi.h>
 #include <hipdnn_plugin_sdk/PluginApi.h>
 #include <hipdnn_plugin_sdk/PluginDataTypeHelpers.hpp>
@@ -24,6 +24,7 @@ static const char* pluginName = "hipblaslt_plugin";
 static const char* pluginVersion = "1.0.0";
 
 using namespace hipdnn_plugin_sdk;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 using namespace hipblaslt_plugin;
 
 // NOLINTNEXTLINE

--- a/dnn-providers/hipblaslt-provider/HipblasltUtils.cpp
+++ b/dnn-providers/hipblaslt-provider/HipblasltUtils.cpp
@@ -7,7 +7,7 @@ namespace hipblaslt_plugin::hipblaslt_utils
 {
 
 EpilogueParams mapPointwiseModeToHipblasLtEpilogue(
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes* attrs, bool withBias)
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes* attrs, bool withBias)
 {
     if(!attrs)
     {
@@ -15,7 +15,7 @@ EpilogueParams mapPointwiseModeToHipblasLtEpilogue(
             withBias ? HIPBLASLT_EPILOGUE_BIAS : HIPBLASLT_EPILOGUE_DEFAULT, 0.0, 0.0};
     }
 
-    using PM = hipdnn_data_sdk::data_objects::PointwiseMode;
+    using PM = hipdnn_flatbuffers_sdk::data_objects::PointwiseMode;
     switch(attrs->operation())
     {
     case PM::RELU_FWD:
@@ -67,25 +67,26 @@ EpilogueParams mapPointwiseModeToHipblasLtEpilogue(
     }
 }
 
-hipDataType tensorDataTypeToHipDataType(const hipdnn_data_sdk::data_objects::DataType& dataType)
+hipDataType
+    tensorDataTypeToHipDataType(const hipdnn_flatbuffers_sdk::data_objects::DataType& dataType)
 {
     switch(dataType)
     {
-    case hipdnn_data_sdk::data_objects::DataType::FLOAT:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT:
         return HIP_R_32F;
-    case hipdnn_data_sdk::data_objects::DataType::INT32:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::INT32:
         return HIP_R_32I;
-    case hipdnn_data_sdk::data_objects::DataType::HALF:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::HALF:
         return HIP_R_16F;
-    case hipdnn_data_sdk::data_objects::DataType::BFLOAT16:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16:
         return HIP_R_16BF;
-    case hipdnn_data_sdk::data_objects::DataType::INT8:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::INT8:
         return HIP_R_8I;
     default:
         throw hipdnn_plugin_sdk::HipdnnPluginException(
             HIPDNN_PLUGIN_STATUS_BAD_PARAM,
             "Unsupported data type for hipBLASLt: "
-                + std::string(hipdnn_data_sdk::data_objects::toString(dataType)));
+                + std::string(hipdnn_flatbuffers_sdk::data_objects::toString(dataType)));
     }
 }
 
@@ -107,14 +108,16 @@ hipdnnPluginDeviceBuffer_t findDeviceBuffer(int64_t uid,
             + " not found in the provided device buffers.");
 }
 
-hipdnn_data_sdk::flatbuffer_utilities::TensorAttributesWrapper findTensorAttributes(
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+hipdnn_flatbuffers_sdk::flatbuffer_utilities::TensorAttributesWrapper findTensorAttributes(
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     int64_t uid)
 {
     if(auto tensorAttr = tensorMap.find(uid); tensorAttr != tensorMap.end())
     {
-        return hipdnn_data_sdk::flatbuffer_utilities::TensorAttributesWrapper(tensorAttr->second);
+        return hipdnn_flatbuffers_sdk::flatbuffer_utilities::TensorAttributesWrapper(
+            tensorAttr->second);
     }
 
     throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_INTERNAL_ERROR,

--- a/dnn-providers/hipblaslt-provider/HipblasltUtils.hpp
+++ b/dnn-providers/hipblaslt-provider/HipblasltUtils.hpp
@@ -4,11 +4,11 @@
 #pragma once
 
 #include <hipblaslt/hipblaslt.h>
-#include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
-#include <hipdnn_data_sdk/flatbuffer_utilities/TensorAttributesWrapper.hpp>
-#include <hipdnn_data_sdk/utilities/FlatbufferUtils.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/pointwise_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/TensorAttributesWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/utilities/FlatbufferUtils.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 #include <hipdnn_plugin_sdk/PluginLogging.hpp>
 #include <string>
@@ -87,16 +87,18 @@ struct EpilogueParams
 };
 
 EpilogueParams mapPointwiseModeToHipblasLtEpilogue(
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes* attrs, bool withBias);
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes* attrs, bool withBias);
 
-hipDataType tensorDataTypeToHipDataType(const hipdnn_data_sdk::data_objects::DataType& dataType);
+hipDataType
+    tensorDataTypeToHipDataType(const hipdnn_flatbuffers_sdk::data_objects::DataType& dataType);
 
 hipdnnPluginDeviceBuffer_t findDeviceBuffer(int64_t uid,
                                             const hipdnnPluginDeviceBuffer_t* deviceBuffers,
                                             uint32_t numDeviceBuffers);
 
-hipdnn_data_sdk::flatbuffer_utilities::TensorAttributesWrapper findTensorAttributes(
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+hipdnn_flatbuffers_sdk::flatbuffer_utilities::TensorAttributesWrapper findTensorAttributes(
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     int64_t uid);
 

--- a/dnn-providers/hipblaslt-provider/HipdnnEnginePluginExecutionContext.hpp
+++ b/dnn-providers/hipblaslt-provider/HipdnnEnginePluginExecutionContext.hpp
@@ -5,10 +5,10 @@
 
 #include <memory>
 
-#include <hipdnn_data_sdk/data_objects/engine_config_generated.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/engine_config_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 #include <hipdnn_plugin_sdk/PluginLogging.hpp>

--- a/dnn-providers/hipblaslt-provider/engines/EngineInterface.hpp
+++ b/dnn-providers/hipblaslt-provider/engines/EngineInterface.hpp
@@ -5,7 +5,7 @@
 
 #include <stdint.h>
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 
 #include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
 
@@ -19,8 +19,9 @@ public:
 
     virtual int64_t id() const = 0;
 
-    virtual bool isApplicable(HipdnnEnginePluginHandle& handle,
-                              const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+    virtual bool
+        isApplicable(HipdnnEnginePluginHandle& handle,
+                     const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
         = 0;
     virtual void getDetails(HipdnnEnginePluginHandle& handle,
                             hipdnnPluginConstData_t& detailsOut) const
@@ -28,13 +29,13 @@ public:
 
     virtual size_t
         getWorkspaceSize(const HipdnnEnginePluginHandle& handle,
-                         const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+                         const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
         = 0;
 
-    virtual void
-        initializeExecutionContext(const HipdnnEnginePluginHandle& handle,
-                                   const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-                                   HipdnnEnginePluginExecutionContext& executionContext) const
+    virtual void initializeExecutionContext(
+        const HipdnnEnginePluginHandle& handle,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+        HipdnnEnginePluginExecutionContext& executionContext) const
         = 0;
 };
 

--- a/dnn-providers/hipblaslt-provider/engines/HipblasltEngine.cpp
+++ b/dnn-providers/hipblaslt-provider/engines/HipblasltEngine.cpp
@@ -3,7 +3,7 @@
 
 #include "HipblasltEngine.hpp"
 
-#include <hipdnn_data_sdk/data_objects/engine_details_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/engine_details_generated.h>
 
 namespace hipblaslt_plugin
 {
@@ -20,7 +20,7 @@ int64_t HipblasltEngine::id() const
 
 bool HipblasltEngine::isApplicable(
     HipdnnEnginePluginHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
 {
     // This is wrong if we ever have more than 1 plan builder thats applicable.
     // If this is the case, we should split plan builders accross multiple engines.
@@ -38,7 +38,7 @@ void HipblasltEngine::getDetails(HipdnnEnginePluginHandle& handle,
                                  hipdnnPluginConstData_t& detailsOut) const
 {
     flatbuffers::FlatBufferBuilder builder;
-    auto engineDetails = hipdnn_data_sdk::data_objects::CreateEngineDetails(builder, _id);
+    auto engineDetails = hipdnn_flatbuffers_sdk::data_objects::CreateEngineDetails(builder, _id);
     builder.Finish(engineDetails);
     auto detachedBuffer = std::make_unique<flatbuffers::DetachedBuffer>(builder.Release());
     detailsOut.ptr = detachedBuffer->data();
@@ -49,7 +49,7 @@ void HipblasltEngine::getDetails(HipdnnEnginePluginHandle& handle,
 
 size_t HipblasltEngine::getWorkspaceSize(
     const HipdnnEnginePluginHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
 {
     size_t workspaceSize = 0;
     for(const auto& planBuilder : _planBuilders)
@@ -64,7 +64,7 @@ size_t HipblasltEngine::getWorkspaceSize(
 
 void HipblasltEngine::initializeExecutionContext(
     const HipdnnEnginePluginHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
     HipdnnEnginePluginExecutionContext& executionContext) const
 {
     for(const auto& planBuilder : _planBuilders)

--- a/dnn-providers/hipblaslt-provider/engines/HipblasltEngine.hpp
+++ b/dnn-providers/hipblaslt-provider/engines/HipblasltEngine.hpp
@@ -20,17 +20,18 @@ public:
 
     int64_t id() const override;
 
-    bool isApplicable(HipdnnEnginePluginHandle& handle,
-                      const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+    bool isApplicable(
+        HipdnnEnginePluginHandle& handle,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
     void getDetails(HipdnnEnginePluginHandle& handle,
                     hipdnnPluginConstData_t& detailsOut) const override;
     size_t getWorkspaceSize(
         const HipdnnEnginePluginHandle& handle,
-        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
 
     void initializeExecutionContext(
         const HipdnnEnginePluginHandle& handle,
-        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
         HipdnnEnginePluginExecutionContext& executionContext) const override;
 
     void addPlanBuilder(std::unique_ptr<IPlanBuilder> planBuilder);

--- a/dnn-providers/hipblaslt-provider/engines/plans/HipblasltMatmulPlan.cpp
+++ b/dnn-providers/hipblaslt-provider/engines/plans/HipblasltMatmulPlan.cpp
@@ -7,9 +7,9 @@
 #include <string>
 
 #include <hipblaslt/hipblaslt.h>
-#include <hipdnn_data_sdk/utilities/FlatbufferUtils.hpp>
 #include <hipdnn_data_sdk/utilities/ScopedResource.hpp>
 #include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_flatbuffers_sdk/utilities/FlatbufferUtils.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 
 #include "HipblasltMatmulPlan.hpp"
@@ -29,8 +29,8 @@ inline int64_t getBatchCount(const std::vector<int64_t>& dims)
 }
 } // namespace
 
-hipblasOperation_t
-    MatmulParams::getTrans(const hipdnn_data_sdk::flatbuffer_utilities::TensorAttributesWrapper& t)
+hipblasOperation_t MatmulParams::getTrans(
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::TensorAttributesWrapper& t)
 {
     const auto& strides = t.strides();
     PLUGIN_THROW_IF_FALSE(strides.size() > 1,
@@ -51,8 +51,8 @@ hipblasOperation_t
 }
 
 hipblasComputeType_t MatmulParams::getComputeDataType(
-    const hipdnn_data_sdk::flatbuffer_utilities::TensorAttributesWrapper& tA,
-    const hipdnn_data_sdk::flatbuffer_utilities::TensorAttributesWrapper& tB)
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::TensorAttributesWrapper& tA,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::TensorAttributesWrapper& tB)
 {
     auto hipDataTypeA = hipblaslt_utils::tensorDataTypeToHipDataType(tA.dataType());
     auto hipDataTypeB = hipblaslt_utils::tensorDataTypeToHipDataType(tB.dataType());
@@ -68,18 +68,20 @@ hipblasComputeType_t MatmulParams::getComputeDataType(
 }
 
 MatmulParams::MatmulParams(
-    const hipdnn_data_sdk::data_objects::MatmulAttributes& attributes,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::MatmulAttributes& attributes,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
     : MatmulParams(attributes, nullptr, nullptr, tensorMap)
 {
 }
 
 MatmulParams::MatmulParams(
-    const hipdnn_data_sdk::data_objects::MatmulAttributes& attributes,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes* biasAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes* activAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::MatmulAttributes& attributes,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes* biasAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes* activAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     const auto tA = hipblaslt_utils::findTensorAttributes(tensorMap, attributes.a_tensor_uid());
@@ -166,9 +168,9 @@ MatmulParams::MatmulParams(
 }
 
 void MatmulParams::setBatchInfo(
-    const hipdnn_data_sdk::flatbuffer_utilities::TensorAttributesWrapper& tA,
-    const hipdnn_data_sdk::flatbuffer_utilities::TensorAttributesWrapper& tB,
-    const hipdnn_data_sdk::flatbuffer_utilities::TensorAttributesWrapper& tC)
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::TensorAttributesWrapper& tA,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::TensorAttributesWrapper& tB,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::TensorAttributesWrapper& tC)
 {
     // Batch support: we flatten all batch dimensions (all except last two) into a single batch count.
     // hipBLASLt uses a single strided batch offset, so we can only support uniform batch strides.
@@ -213,8 +215,9 @@ void MatmulParams::setBatchInfo(
     }
 }
 
-void MatmulParams::setEpilogue(const hipdnn_data_sdk::data_objects::PointwiseAttributes* activAttr,
-                               hipDataType biasDataType)
+void MatmulParams::setEpilogue(
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes* activAttr,
+    hipDataType biasDataType)
 {
     auto epilogueParams
         = hipblaslt_utils::mapPointwiseModeToHipblasLtEpilogue(activAttr, _biasUid.has_value());

--- a/dnn-providers/hipblaslt-provider/engines/plans/HipblasltMatmulPlan.hpp
+++ b/dnn-providers/hipblaslt-provider/engines/plans/HipblasltMatmulPlan.hpp
@@ -6,9 +6,9 @@
 #include <memory>
 
 #include <hipblaslt/hipblaslt.h>
-#include <hipdnn_data_sdk/data_objects/matmul_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/matmul_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/pointwise_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/tensor_attributes_generated.h>
 
 #include "HipblasltMatmulDesc.hpp"
 #include "HipblasltMatrixLayout.hpp"
@@ -20,14 +20,16 @@ class MatmulParams
 {
 public:
     MatmulParams(
-        const hipdnn_data_sdk::data_objects::MatmulAttributes& attributes,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::MatmulAttributes& attributes,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap);
     MatmulParams(
-        const hipdnn_data_sdk::data_objects::MatmulAttributes& attributes,
-        const hipdnn_data_sdk::data_objects::PointwiseAttributes* biasAttr,
-        const hipdnn_data_sdk::data_objects::PointwiseAttributes* activAttr,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::MatmulAttributes& attributes,
+        const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes* biasAttr,
+        const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes* activAttr,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap);
 
     MatmulParams(const MatmulParams&) = delete;
@@ -45,16 +47,17 @@ public:
 
 private:
     static hipblasOperation_t
-        getTrans(const hipdnn_data_sdk::flatbuffer_utilities::TensorAttributesWrapper& t);
+        getTrans(const hipdnn_flatbuffers_sdk::flatbuffer_utilities::TensorAttributesWrapper& t);
     static hipblasComputeType_t getComputeDataType(
-        const hipdnn_data_sdk::flatbuffer_utilities::TensorAttributesWrapper& tA,
-        const hipdnn_data_sdk::flatbuffer_utilities::TensorAttributesWrapper& tB);
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::TensorAttributesWrapper& tA,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::TensorAttributesWrapper& tB);
 
-    void setBatchInfo(const hipdnn_data_sdk::flatbuffer_utilities::TensorAttributesWrapper& tA,
-                      const hipdnn_data_sdk::flatbuffer_utilities::TensorAttributesWrapper& tB,
-                      const hipdnn_data_sdk::flatbuffer_utilities::TensorAttributesWrapper& tC);
+    void setBatchInfo(
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::TensorAttributesWrapper& tA,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::TensorAttributesWrapper& tB,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::TensorAttributesWrapper& tC);
 
-    void setEpilogue(const hipdnn_data_sdk::data_objects::PointwiseAttributes* activAttr,
+    void setEpilogue(const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes* activAttr,
                      hipDataType biasDataType);
 
     HipblasltMatmulDesc _matmulDesc;

--- a/dnn-providers/hipblaslt-provider/engines/plans/HipblasltMatmulPlanBuilder.cpp
+++ b/dnn-providers/hipblaslt-provider/engines/plans/HipblasltMatmulPlanBuilder.cpp
@@ -17,14 +17,14 @@ namespace hipblaslt_plugin
 namespace
 {
 
-bool isBias(const hipdnn_data_sdk::data_objects::PointwiseAttributes& attr)
+bool isBias(const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& attr)
 {
-    return attr.operation() == hipdnn_data_sdk::data_objects::PointwiseMode::ADD;
+    return attr.operation() == hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::ADD;
 }
 
-bool isSupportedActivation(const hipdnn_data_sdk::data_objects::PointwiseAttributes& attr)
+bool isSupportedActivation(const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& attr)
 {
-    using PointwiseMode = hipdnn_data_sdk::data_objects::PointwiseMode;
+    using PointwiseMode = hipdnn_flatbuffers_sdk::data_objects::PointwiseMode;
     switch(attr.operation())
     {
     case PointwiseMode::RELU_FWD:
@@ -36,10 +36,10 @@ bool isSupportedActivation(const hipdnn_data_sdk::data_objects::PointwiseAttribu
     }
 }
 
-std::tuple<const hipdnn_data_sdk::data_objects::MatmulAttributes&,
-           const hipdnn_data_sdk::data_objects::PointwiseAttributes*,
-           const hipdnn_data_sdk::data_objects::PointwiseAttributes*>
-    getNodeAttrs(const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph)
+std::tuple<const hipdnn_flatbuffers_sdk::data_objects::MatmulAttributes&,
+           const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes*,
+           const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes*>
+    getNodeAttrs(const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph)
 {
     if(opGraph.nodeCount() < 1 || opGraph.nodeCount() > 3)
     {
@@ -54,17 +54,17 @@ std::tuple<const hipdnn_data_sdk::data_objects::MatmulAttributes&,
     const auto& matmulNodeWrapper = opGraph.getNodeWrapper(0);
     const auto matmulNodeName = matmulNodeWrapper.name();
     if(matmulNodeWrapper.attributesType()
-       != hipdnn_data_sdk::data_objects::NodeAttributes::MatmulAttributes)
+       != hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::MatmulAttributes)
     {
         throw hipdnn_plugin_sdk::HipdnnPluginException(
             HIPDNN_PLUGIN_STATUS_BAD_PARAM,
             "First node in the graph (" + matmulNodeName + ") must be matmul. Found node of type: "
-                + std::string(
-                    hipdnn_data_sdk::data_objects::toString(matmulNodeWrapper.attributesType())));
+                + std::string(hipdnn_flatbuffers_sdk::data_objects::toString(
+                    matmulNodeWrapper.attributesType())));
     }
 
     const auto& matmulAttr
-        = matmulNodeWrapper.attributesAs<hipdnn_data_sdk::data_objects::MatmulAttributes>();
+        = matmulNodeWrapper.attributesAs<hipdnn_flatbuffers_sdk::data_objects::MatmulAttributes>();
     if(opGraph.nodeCount() == 1)
     {
         return {matmulAttr, nullptr, nullptr};
@@ -74,18 +74,18 @@ std::tuple<const hipdnn_data_sdk::data_objects::MatmulAttributes&,
     const auto& secondNodeWrapper = opGraph.getNodeWrapper(1);
     const auto secondNodeName = secondNodeWrapper.name();
     if(secondNodeWrapper.attributesType()
-       != hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes)
+       != hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes)
     {
         throw hipdnn_plugin_sdk::HipdnnPluginException(
             HIPDNN_PLUGIN_STATUS_BAD_PARAM,
             "Second node in the graph (" + secondNodeName
                 + ") must be pointwise operation. Found node of type: "
-                + std::string(
-                    hipdnn_data_sdk::data_objects::toString(secondNodeWrapper.attributesType())));
+                + std::string(hipdnn_flatbuffers_sdk::data_objects::toString(
+                    secondNodeWrapper.attributesType())));
     }
     const auto& secondNodeAttr
         = opGraph.getNodeWrapper(1)
-              .attributesAs<hipdnn_data_sdk::data_objects::PointwiseAttributes>();
+              .attributesAs<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>();
 
     if(isSupportedActivation(secondNodeAttr))
     {
@@ -111,7 +111,8 @@ std::tuple<const hipdnn_data_sdk::data_objects::MatmulAttributes&,
             "Second node in the graph (" + secondNodeName
                 + ") must be either bias addition or supported activation. Found pointwise "
                   "operation: "
-                + std::string(hipdnn_data_sdk::data_objects::toString(secondNodeAttr.operation())));
+                + std::string(
+                    hipdnn_flatbuffers_sdk::data_objects::toString(secondNodeAttr.operation())));
     }
 
     // The second node is bias
@@ -125,18 +126,18 @@ std::tuple<const hipdnn_data_sdk::data_objects::MatmulAttributes&,
     const auto& thirdNodeWrapper = opGraph.getNodeWrapper(2);
     const auto thirdNodeName = thirdNodeWrapper.name();
     if(thirdNodeWrapper.attributesType()
-       != hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes)
+       != hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes)
     {
         throw hipdnn_plugin_sdk::HipdnnPluginException(
             HIPDNN_PLUGIN_STATUS_BAD_PARAM,
             "Third node in the graph (" + thirdNodeName
                 + ") must be pointwise operation. Found node of type: "
-                + std::string(
-                    hipdnn_data_sdk::data_objects::toString(thirdNodeWrapper.attributesType())));
+                + std::string(hipdnn_flatbuffers_sdk::data_objects::toString(
+                    thirdNodeWrapper.attributesType())));
     }
     const auto& thirdNodeAttr
         = opGraph.getNodeWrapper(2)
-              .attributesAs<hipdnn_data_sdk::data_objects::PointwiseAttributes>();
+              .attributesAs<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>();
 
     if(!isSupportedActivation(thirdNodeAttr))
     {
@@ -144,7 +145,8 @@ std::tuple<const hipdnn_data_sdk::data_objects::MatmulAttributes&,
             HIPDNN_PLUGIN_STATUS_BAD_PARAM,
             "Third node in the graph (" + thirdNodeName
                 + ") must be supported activation. Found pointwise operation: "
-                + std::string(hipdnn_data_sdk::data_objects::toString(thirdNodeAttr.operation())));
+                + std::string(
+                    hipdnn_flatbuffers_sdk::data_objects::toString(thirdNodeAttr.operation())));
     }
 
     const auto& activAttr = thirdNodeAttr;
@@ -152,10 +154,11 @@ std::tuple<const hipdnn_data_sdk::data_objects::MatmulAttributes&,
 }
 
 void checkNodeAttrsTensors(
-    const hipdnn_data_sdk::data_objects::MatmulAttributes& matmulAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes* biasAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes* activAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::MatmulAttributes& matmulAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes* biasAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes* activAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     const auto& aType
@@ -165,10 +168,10 @@ void checkNodeAttrsTensors(
     const auto& cType
         = hipblaslt_utils::findTensorAttributes(tensorMap, matmulAttr.c_tensor_uid()).dataType();
 
-    static constexpr std::array<hipdnn_data_sdk::data_objects::DataType, 3> validDataTypes
-        = {hipdnn_data_sdk::data_objects::DataType::FLOAT,
-           hipdnn_data_sdk::data_objects::DataType::HALF,
-           hipdnn_data_sdk::data_objects::DataType::BFLOAT16};
+    static constexpr std::array<hipdnn_flatbuffers_sdk::data_objects::DataType, 3> validDataTypes
+        = {hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+           hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+           hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16};
 
     if(std::find(validDataTypes.begin(), validDataTypes.end(), aType) == validDataTypes.end()
        || std::find(validDataTypes.begin(), validDataTypes.end(), bType) == validDataTypes.end()
@@ -238,16 +241,16 @@ void checkNodeAttrsTensors(
     }
 }
 
-void checkComputeTypes(const hipdnn_data_sdk::flatbuffer_utilities::IGraph& graph,
-                       const hipdnn_data_sdk::data_objects::PointwiseAttributes* biasAttr,
-                       const hipdnn_data_sdk::data_objects::PointwiseAttributes* activAttr)
+void checkComputeTypes(const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& graph,
+                       const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes* biasAttr,
+                       const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes* activAttr)
 {
     uint32_t matmulAttrIdx = 0;
     uint32_t biasAttrIdx = 1;
     uint32_t activAttrIdx = (biasAttr != nullptr) ? 2 : 1;
 
     if(graph.getNode(matmulAttrIdx).compute_data_type()
-       != hipdnn_data_sdk::data_objects::DataType::FLOAT)
+       != hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT)
     {
         throw hipdnn_plugin_sdk::HipdnnPluginException(
             HIPDNN_PLUGIN_STATUS_BAD_PARAM, "Matmul node compute data type must be float");
@@ -280,7 +283,7 @@ void checkComputeTypes(const hipdnn_data_sdk::flatbuffer_utilities::IGraph& grap
 
 bool HipblasltMatmulPlanBuilder::isApplicable(
     const HipdnnEnginePluginHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
 {
     try
     {
@@ -308,7 +311,7 @@ bool HipblasltMatmulPlanBuilder::isApplicable(
 
 size_t HipblasltMatmulPlanBuilder::getWorkspaceSize(
     const HipdnnEnginePluginHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
 {
     auto nodeAttrs = getNodeAttrs(opGraph);
     checkNodeAttrsTensors(std::get<0>(nodeAttrs),
@@ -326,7 +329,7 @@ size_t HipblasltMatmulPlanBuilder::getWorkspaceSize(
 
 void HipblasltMatmulPlanBuilder::buildPlan(
     const HipdnnEnginePluginHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
     HipdnnEnginePluginExecutionContext& executionContext) const
 {
     auto nodeAttrs = getNodeAttrs(opGraph);

--- a/dnn-providers/hipblaslt-provider/engines/plans/HipblasltMatmulPlanBuilder.hpp
+++ b/dnn-providers/hipblaslt-provider/engines/plans/HipblasltMatmulPlanBuilder.hpp
@@ -20,14 +20,15 @@ public:
     HipblasltMatmulPlanBuilder(const HipblasltMatmulPlanBuilder&) = delete;
     HipblasltMatmulPlanBuilder& operator=(const HipblasltMatmulPlanBuilder&) = delete;
 
-    bool isApplicable(const HipdnnEnginePluginHandle& handle,
-                      const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+    bool isApplicable(
+        const HipdnnEnginePluginHandle& handle,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
     size_t getWorkspaceSize(
         const HipdnnEnginePluginHandle& handle,
-        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
 
     void buildPlan(const HipdnnEnginePluginHandle& handle,
-                   const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                   const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                    HipdnnEnginePluginExecutionContext& executionContext) const override;
 };
 

--- a/dnn-providers/hipblaslt-provider/engines/plans/PlanBuilderInterface.hpp
+++ b/dnn-providers/hipblaslt-provider/engines/plans/PlanBuilderInterface.hpp
@@ -5,8 +5,8 @@
 
 #include <stdint.h>
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
 
 #include "HipdnnEnginePluginExecutionContext.hpp"
@@ -20,17 +20,18 @@ class IPlanBuilder
 public:
     virtual ~IPlanBuilder() = default;
 
-    virtual bool isApplicable(const HipdnnEnginePluginHandle& handle,
-                              const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+    virtual bool
+        isApplicable(const HipdnnEnginePluginHandle& handle,
+                     const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
         = 0;
 
     virtual size_t
         getWorkspaceSize(const HipdnnEnginePluginHandle& handle,
-                         const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+                         const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
         = 0;
 
     virtual void buildPlan(const HipdnnEnginePluginHandle& handle,
-                           const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                           const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                            HipdnnEnginePluginExecutionContext& executionContext) const
         = 0;
 };

--- a/dnn-providers/hipblaslt-provider/integration_tests/IntegrationGraphVerificationHarness.hpp
+++ b/dnn-providers/hipblaslt-provider/integration_tests/IntegrationGraphVerificationHarness.hpp
@@ -4,8 +4,8 @@
 #pragma once
 
 #include <gtest/gtest.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_data_sdk/utilities/Workspace.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_frontend/Graph.hpp>
 #include <hipdnn_frontend/Utilities.hpp>
 #include <hipdnn_frontend/attributes/TensorAttributes.hpp>

--- a/dnn-providers/hipblaslt-provider/tests/TestHipblasltEngineManager.cpp
+++ b/dnn-providers/hipblaslt-provider/tests/TestHipblasltEngineManager.cpp
@@ -19,6 +19,7 @@
 using namespace hipblaslt_plugin;
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_plugin_sdk;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 using ::testing::Return;
 
 TEST(TestHipblasltEngineManager, ReturnsApplicableEngineIds)

--- a/dnn-providers/hipblaslt-provider/tests/TestHipblasltEnginePluginApi.cpp
+++ b/dnn-providers/hipblaslt-provider/tests/TestHipblasltEnginePluginApi.cpp
@@ -4,8 +4,8 @@
 #include <gtest/gtest.h>
 
 #include <HipblasltPlugin.hpp>
-#include <hipdnn_data_sdk/flatbuffer_utilities/EngineDetailsWrapper.hpp>
 #include <hipdnn_data_sdk/utilities/EngineNames.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/EngineDetailsWrapper.hpp>
 #include <hipdnn_plugin_sdk/EnginePluginApi.h>
 #include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
 #include <hipdnn_plugin_sdk/PluginGraphTestUtils.hpp>
@@ -297,7 +297,7 @@ TEST(TestGpuHipblasltEnginePluginApi, GetEngineDetailsValid)
     auto status = hipdnnEnginePluginGetEngineDetailsImpl(
         handle, HIPBLASLT_ENGINE_ID, &opGraph, &engineDetailsOut);
 
-    hipdnn_data_sdk::flatbuffer_utilities::EngineDetailsWrapper engineDetails(
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::EngineDetailsWrapper engineDetails(
         engineDetailsOut.ptr, engineDetailsOut.size);
 
     EXPECT_EQ(status, HIPDNN_PLUGIN_STATUS_SUCCESS);

--- a/dnn-providers/hipblaslt-provider/tests/TestHipblasltMatrixLayout.cpp
+++ b/dnn-providers/hipblaslt-provider/tests/TestHipblasltMatrixLayout.cpp
@@ -3,8 +3,8 @@
 
 #include "HipblasltMatrixLayout.hpp"
 #include <gtest/gtest.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
-#include <hipdnn_data_sdk/flatbuffer_utilities/TensorAttributesWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/TensorAttributesWrapper.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 
@@ -13,8 +13,8 @@ using namespace hipblaslt_plugin;
 TEST(TestHipblasltMatrixLayout, CanCreateAndDestroy)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidMatmulGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& tensorMap = graph.getTensorMap();
     ASSERT_FALSE(tensorMap.empty());
@@ -22,7 +22,8 @@ TEST(TestHipblasltMatrixLayout, CanCreateAndDestroy)
     ASSERT_NE(tensorAttr, nullptr);
 
     EXPECT_NO_THROW({
-        hipdnn_data_sdk::flatbuffer_utilities::TensorAttributesWrapper tensorWrapper(tensorAttr);
+        hipdnn_flatbuffers_sdk::flatbuffer_utilities::TensorAttributesWrapper tensorWrapper(
+            tensorAttr);
         HipblasltMatrixLayout matLayout(tensorWrapper);
         EXPECT_EQ(matLayout.uid(), tensorWrapper.uid());
         EXPECT_NE(matLayout.matrixLayout(), nullptr);
@@ -32,12 +33,12 @@ TEST(TestHipblasltMatrixLayout, CanCreateAndDestroy)
 TEST(TestHipblasltMatrixLayout, TensorDescriptorIsValid)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidMatmulGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& tensorMap = graph.getTensorMap();
     ASSERT_FALSE(tensorMap.empty());
-    hipdnn_data_sdk::flatbuffer_utilities::TensorAttributesWrapper tensorWrapper(
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::TensorAttributesWrapper tensorWrapper(
         tensorMap.begin()->second);
     HipblasltMatrixLayout matLayout(tensorWrapper);
 
@@ -59,14 +60,14 @@ TEST(TestHipblasltMatrixLayout, TensorWithEmptyShape)
     std::vector<int64_t> strides = {1};
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 1, "", hipdnn_data_sdk::data_objects::DataType::UNSET, &strides, nullptr);
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "", hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET, &strides, nullptr);
     builder.Finish(attrOffset);
 
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::TensorAttributes>(
+    auto attrPtr = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>(
         builder.GetBufferPointer());
 
-    hipdnn_data_sdk::flatbuffer_utilities::TensorAttributesWrapper tensorWrapper(attrPtr);
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::TensorAttributesWrapper tensorWrapper(attrPtr);
     EXPECT_THROW(HipblasltMatrixLayout matLayout(tensorWrapper), std::invalid_argument);
 }
 
@@ -75,14 +76,14 @@ TEST(TestHipblasltMatrixLayout, TensorWithEmptyStride)
     std::vector<int64_t> dims = {10, 16};
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 1, "", hipdnn_data_sdk::data_objects::DataType::UNSET, nullptr, &dims);
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "", hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET, nullptr, &dims);
     builder.Finish(attrOffset);
 
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::TensorAttributes>(
+    auto attrPtr = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>(
         builder.GetBufferPointer());
 
-    hipdnn_data_sdk::flatbuffer_utilities::TensorAttributesWrapper tensorWrapper(attrPtr);
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::TensorAttributesWrapper tensorWrapper(attrPtr);
     EXPECT_THROW(HipblasltMatrixLayout matLayout(tensorWrapper), std::invalid_argument);
 }
 
@@ -92,14 +93,14 @@ TEST(TestHipblasltMatrixLayout, TensorWithInvalidShapeRank)
     std::vector<int64_t> strides = {1};
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 1, "", hipdnn_data_sdk::data_objects::DataType::UNSET, &strides, &dims);
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "", hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET, &strides, &dims);
     builder.Finish(attrOffset);
 
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::TensorAttributes>(
+    auto attrPtr = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>(
         builder.GetBufferPointer());
 
-    hipdnn_data_sdk::flatbuffer_utilities::TensorAttributesWrapper tensorWrapper(attrPtr);
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::TensorAttributesWrapper tensorWrapper(attrPtr);
     EXPECT_THROW(HipblasltMatrixLayout matLayout(tensorWrapper),
                  hipdnn_plugin_sdk::HipdnnPluginException);
 }
@@ -110,14 +111,14 @@ TEST(TestHipblasltMatrixLayout, TensorWithInvalidMatrixType)
     std::vector<int64_t> strides = {1, 8, 16};
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 1, "", hipdnn_data_sdk::data_objects::DataType::UNSET, &strides, &dims);
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "", hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET, &strides, &dims);
     builder.Finish(attrOffset);
 
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::TensorAttributes>(
+    auto attrPtr = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>(
         builder.GetBufferPointer());
 
-    hipdnn_data_sdk::flatbuffer_utilities::TensorAttributesWrapper tensorWrapper(attrPtr);
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::TensorAttributesWrapper tensorWrapper(attrPtr);
     EXPECT_THROW(HipblasltMatrixLayout matLayout(tensorWrapper),
                  hipdnn_plugin_sdk::HipdnnPluginException);
 }
@@ -125,15 +126,16 @@ TEST(TestHipblasltMatrixLayout, TensorWithInvalidMatrixType)
 TEST(TestHipblasltMatrixLayout, SetBatchCount)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidMatmulGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& tensorMap = graph.getTensorMap();
     ASSERT_FALSE(tensorMap.empty());
     const auto* tensorAttr = tensorMap.begin()->second;
 
     EXPECT_NO_THROW({
-        hipdnn_data_sdk::flatbuffer_utilities::TensorAttributesWrapper tensorWrapper(tensorAttr);
+        hipdnn_flatbuffers_sdk::flatbuffer_utilities::TensorAttributesWrapper tensorWrapper(
+            tensorAttr);
         HipblasltMatrixLayout matLayout(tensorWrapper);
         matLayout.setBatchCount(2);
     });
@@ -142,15 +144,16 @@ TEST(TestHipblasltMatrixLayout, SetBatchCount)
 TEST(TestHipblasltMatrixLayout, setStridedBatchOffset)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidMatmulGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& tensorMap = graph.getTensorMap();
     ASSERT_FALSE(tensorMap.empty());
     const auto* tensorAttr = tensorMap.begin()->second;
 
     EXPECT_NO_THROW({
-        hipdnn_data_sdk::flatbuffer_utilities::TensorAttributesWrapper tensorWrapper(tensorAttr);
+        hipdnn_flatbuffers_sdk::flatbuffer_utilities::TensorAttributesWrapper tensorWrapper(
+            tensorAttr);
         HipblasltMatrixLayout matLayout(tensorWrapper);
         matLayout.setStridedBatchOffset(2);
     });

--- a/dnn-providers/hipblaslt-provider/tests/TestHipblasltUtils.cpp
+++ b/dnn-providers/hipblaslt-provider/tests/TestHipblasltUtils.cpp
@@ -3,14 +3,14 @@
 
 #include "HipblasltUtils.hpp"
 #include <gtest/gtest.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/pointwise_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/tensor_attributes_generated.h>
 #include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
 
 using namespace hipblaslt_plugin;
 using namespace hipblaslt_utils;
-using PM = hipdnn_data_sdk::data_objects::PointwiseMode;
+using PM = hipdnn_flatbuffers_sdk::data_objects::PointwiseMode;
 
 namespace
 {
@@ -20,26 +20,27 @@ namespace
 struct PointwiseAttrsHolder
 {
     flatbuffers::FlatBufferBuilder builder;
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes* attrs = nullptr;
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes* attrs = nullptr;
 
     PointwiseAttrsHolder(PM operation,
                          flatbuffers::Optional<float> reluLowerClip = flatbuffers::nullopt,
                          flatbuffers::Optional<float> reluUpperClip = flatbuffers::nullopt,
                          flatbuffers::Optional<float> swishBeta = flatbuffers::nullopt)
     {
-        auto offset = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(builder,
-                                                                               operation,
-                                                                               reluLowerClip,
-                                                                               reluUpperClip,
-                                                                               flatbuffers::nullopt,
-                                                                               flatbuffers::nullopt,
-                                                                               0,
-                                                                               flatbuffers::nullopt,
-                                                                               flatbuffers::nullopt,
-                                                                               0,
-                                                                               swishBeta);
+        auto offset
+            = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(builder,
+                                                                              operation,
+                                                                              reluLowerClip,
+                                                                              reluUpperClip,
+                                                                              flatbuffers::nullopt,
+                                                                              flatbuffers::nullopt,
+                                                                              0,
+                                                                              flatbuffers::nullopt,
+                                                                              flatbuffers::nullopt,
+                                                                              0,
+                                                                              swishBeta);
         builder.Finish(offset);
-        attrs = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
+        attrs = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
             builder.GetBufferPointer());
     }
 };
@@ -160,7 +161,7 @@ TEST(TestHipblasltUtils, MapPointwiseModeToHipblasLtEpilogue)
 
 TEST(TestHipblasltUtils, TensorDataTypeToHipblasltDataType)
 {
-    using namespace hipdnn_data_sdk::data_objects;
+    using namespace hipdnn_flatbuffers_sdk::data_objects;
 
     EXPECT_EQ(hipblaslt_utils::tensorDataTypeToHipDataType(DataType::FLOAT), HIP_R_32F);
     EXPECT_EQ(hipblaslt_utils::tensorDataTypeToHipDataType(DataType::INT32), HIP_R_32I);
@@ -173,7 +174,7 @@ TEST(TestHipblasltUtils, TensorDataTypeToHipblasltDataTypeThrowsOnUnsupported)
 {
     // Use a value not in the enum
     EXPECT_THROW(hipblaslt_utils::tensorDataTypeToHipDataType(
-                     static_cast<hipdnn_data_sdk::data_objects::DataType>(-1)),
+                     static_cast<hipdnn_flatbuffers_sdk::data_objects::DataType>(-1)),
                  hipdnn_plugin_sdk::HipdnnPluginException);
 }
 
@@ -207,20 +208,23 @@ TEST(TestHipblasltUtils, FindDeviceBufferThrowsIfNotFound)
 TEST(TestHipblasltUtils, FindTensorAttributesReturnsCorrectValue)
 {
     flatbuffers::FlatBufferBuilder builder1;
-    auto attrOffset1 = hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(builder1, 1);
+    auto attrOffset1
+        = hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(builder1, 1);
     builder1.Finish(attrOffset1);
 
     flatbuffers::FlatBufferBuilder builder2;
-    auto attrOffset2 = hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(builder2, 2);
+    auto attrOffset2
+        = hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(builder2, 2);
     builder2.Finish(attrOffset2);
 
-    auto attrPtr1 = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::TensorAttributes>(
+    auto attrPtr1 = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>(
         builder1.GetBufferPointer());
-    auto attrPtr2 = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::TensorAttributes>(
+    auto attrPtr2 = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>(
         builder2.GetBufferPointer());
 
     auto attrMap
-        = std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>{
+        = std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>{
             {1, attrPtr1}, {2, attrPtr2}};
 
     EXPECT_EQ(hipblaslt_utils::findTensorAttributes(attrMap, 1).uid(), 1);
@@ -230,7 +234,8 @@ TEST(TestHipblasltUtils, FindTensorAttributesReturnsCorrectValue)
 TEST(TestHipblasltUtils, FindTensorAttributesThrowsIfNotFound)
 {
     auto attrMap
-        = std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>{};
+        = std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>{};
 
     EXPECT_THROW(hipblaslt_utils::findTensorAttributes(attrMap, 1),
                  hipdnn_plugin_sdk::HipdnnPluginException);

--- a/dnn-providers/hipblaslt-provider/tests/engines/TestHipblasltEngine.cpp
+++ b/dnn-providers/hipblaslt-provider/tests/engines/TestHipblasltEngine.cpp
@@ -5,9 +5,9 @@
 #include <memory>
 #include <set>
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/EngineDetailsWrapper.hpp>
 #include <hipdnn_data_sdk/utilities/EngineNames.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/EngineDetailsWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 #include <hipdnn_test_sdk/utilities/MockGraph.hpp>
 
@@ -18,6 +18,7 @@
 using namespace hipblaslt_plugin;
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_plugin_sdk;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 
 TEST(TestHipblasltEngine, ConstructorAndId)
 {
@@ -163,8 +164,8 @@ TEST(TestHipblasltEngine, GetDetailsReturnsSerializedEngineDetails)
     hipdnnPluginConstData_t result;
     engine.getDetails(dummyHandle, result);
 
-    hipdnn_data_sdk::flatbuffer_utilities::EngineDetailsWrapper engineDetails(result.ptr,
-                                                                              result.size);
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::EngineDetailsWrapper engineDetails(result.ptr,
+                                                                                     result.size);
     EXPECT_EQ(engineDetails.engineId(), hipdnn_data_sdk::utilities::HIPBLASLT_ENGINE_ID);
 }
 

--- a/dnn-providers/hipblaslt-provider/tests/engines/plans/TestHipblasltMatmulPlan.cpp
+++ b/dnn-providers/hipblaslt-provider/tests/engines/plans/TestHipblasltMatmulPlan.cpp
@@ -3,7 +3,7 @@
 
 #include <gtest/gtest.h>
 #include <hipblaslt/hipblaslt.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 #include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
@@ -13,6 +13,7 @@
 
 using namespace hipblaslt_plugin;
 using namespace hipdnn_plugin_sdk;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 using namespace hipdnn_test_sdk::utilities;
 
 class TestGpuMatmulPlan : public ::testing::Test
@@ -67,7 +68,7 @@ TEST(TestMatmulParams, InitializesWithBiasAndActivation)
         {4, 5},
         {5, 1},
         true,
-        hipdnn_data_sdk::data_objects::PointwiseMode::GELU_APPROX_TANH_FWD);
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::GELU_APPROX_TANH_FWD);
     GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
 
     auto* matmulAttrs = graph.getNode(0).attributes_as_MatmulAttributes();
@@ -88,16 +89,16 @@ TEST(TestMatmulParams, InitializesWithBiasAndActivation)
 
 TEST(TestMatmulParams, InitializesWithActivationOnly)
 {
-    auto builder
-        = createValidMatmulBiasActivGraph({4, 8},
-                                          {8, 1},
-                                          {8, 5},
-                                          {5, 1},
-                                          {4, 5},
-                                          {5, 1},
-                                          false,
-                                          hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
-                                          0.0f);
+    auto builder = createValidMatmulBiasActivGraph(
+        {4, 8},
+        {8, 1},
+        {8, 5},
+        {5, 1},
+        {4, 5},
+        {5, 1},
+        false,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
+        0.0f);
     GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
 
     auto* matmulAttrs = graph.getNode(0).attributes_as_MatmulAttributes();
@@ -115,15 +116,15 @@ TEST(TestMatmulParams, InitializesWithActivationOnly)
 
 TEST(TestMatmulParams, InitializesWithBiasOnly)
 {
-    auto builder
-        = createValidMatmulBiasActivGraph({4, 8},
-                                          {8, 1},
-                                          {8, 5},
-                                          {5, 1},
-                                          {4, 5},
-                                          {5, 1},
-                                          true,
-                                          hipdnn_data_sdk::data_objects::PointwiseMode::UNSET);
+    auto builder = createValidMatmulBiasActivGraph(
+        {4, 8},
+        {8, 1},
+        {8, 5},
+        {5, 1},
+        {4, 5},
+        {5, 1},
+        true,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::UNSET);
     GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
 
     auto* matmulAttrs = graph.getNode(0).attributes_as_MatmulAttributes();
@@ -142,15 +143,15 @@ TEST(TestMatmulParams, InitializesWithBiasOnly)
 
 TEST(TestMatmulParams, BiasUidMatchesBiasTensor)
 {
-    auto builder
-        = createValidMatmulBiasActivGraph({4, 8},
-                                          {8, 1},
-                                          {8, 5},
-                                          {5, 1},
-                                          {4, 5},
-                                          {5, 1},
-                                          true,
-                                          hipdnn_data_sdk::data_objects::PointwiseMode::UNSET);
+    auto builder = createValidMatmulBiasActivGraph(
+        {4, 8},
+        {8, 1},
+        {8, 5},
+        {5, 1},
+        {4, 5},
+        {5, 1},
+        true,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::UNSET);
     GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
 
     auto* matmulAttrs = graph.getNode(0).attributes_as_MatmulAttributes();
@@ -513,7 +514,7 @@ TEST_F(TestGpuMatmulPlan, CreatesPlanWithHalfPrecision)
                                           bStrides,
                                           cDims,
                                           cStrides,
-                                          hipdnn_data_sdk::data_objects::DataType::HALF);
+                                          hipdnn_flatbuffers_sdk::data_objects::DataType::HALF);
     GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
 
     const auto& node = graph.getNode(0);
@@ -542,7 +543,7 @@ TEST_F(TestGpuMatmulPlan, CreatesPlanWithBFloat16)
                                           bStrides,
                                           cDims,
                                           cStrides,
-                                          hipdnn_data_sdk::data_objects::DataType::BFLOAT16);
+                                          hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16);
     GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
 
     const auto& node = graph.getNode(0);
@@ -565,7 +566,7 @@ TEST_F(TestGpuMatmulPlan, CreatesPlanWithBiasAndGelu)
         {4, 5},
         {5, 1},
         true,
-        hipdnn_data_sdk::data_objects::PointwiseMode::GELU_APPROX_TANH_FWD);
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::GELU_APPROX_TANH_FWD);
     GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
 
     auto* matmulAttrs = graph.getNode(0).attributes_as_MatmulAttributes();
@@ -582,16 +583,16 @@ TEST_F(TestGpuMatmulPlan, CreatesPlanWithBiasAndGelu)
 
 TEST_F(TestGpuMatmulPlan, CreatesPlanWithBiasAndRelu)
 {
-    auto builder
-        = createValidMatmulBiasActivGraph({4, 8},
-                                          {8, 1},
-                                          {8, 5},
-                                          {5, 1},
-                                          {4, 5},
-                                          {5, 1},
-                                          true,
-                                          hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
-                                          0.0f);
+    auto builder = createValidMatmulBiasActivGraph(
+        {4, 8},
+        {8, 1},
+        {8, 5},
+        {5, 1},
+        {4, 5},
+        {5, 1},
+        true,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
+        0.0f);
     GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
 
     auto* matmulAttrs = graph.getNode(0).attributes_as_MatmulAttributes();
@@ -608,16 +609,16 @@ TEST_F(TestGpuMatmulPlan, CreatesPlanWithBiasAndRelu)
 
 TEST_F(TestGpuMatmulPlan, CreatesPlanWithActivationOnly)
 {
-    auto builder
-        = createValidMatmulBiasActivGraph({4, 8},
-                                          {8, 1},
-                                          {8, 5},
-                                          {5, 1},
-                                          {4, 5},
-                                          {5, 1},
-                                          false,
-                                          hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
-                                          0.0f);
+    auto builder = createValidMatmulBiasActivGraph(
+        {4, 8},
+        {8, 1},
+        {8, 5},
+        {5, 1},
+        {4, 5},
+        {5, 1},
+        false,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
+        0.0f);
     GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
 
     auto* matmulAttrs = graph.getNode(0).attributes_as_MatmulAttributes();
@@ -632,18 +633,18 @@ TEST_F(TestGpuMatmulPlan, CreatesPlanWithActivationOnly)
 
 TEST_F(TestGpuMatmulPlan, CreatesPlanWithBiasAndSwish)
 {
-    auto builder
-        = createValidMatmulBiasActivGraph({4, 8},
-                                          {8, 1},
-                                          {8, 5},
-                                          {5, 1},
-                                          {4, 5},
-                                          {5, 1},
-                                          true,
-                                          hipdnn_data_sdk::data_objects::PointwiseMode::SWISH_FWD,
-                                          std::nullopt,
-                                          std::nullopt,
-                                          1.0f);
+    auto builder = createValidMatmulBiasActivGraph(
+        {4, 8},
+        {8, 1},
+        {8, 5},
+        {5, 1},
+        {4, 5},
+        {5, 1},
+        true,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SWISH_FWD,
+        std::nullopt,
+        std::nullopt,
+        1.0f);
     GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
 
     auto* matmulAttrs = graph.getNode(0).attributes_as_MatmulAttributes();
@@ -660,15 +661,15 @@ TEST_F(TestGpuMatmulPlan, CreatesPlanWithBiasAndSwish)
 
 TEST_F(TestGpuMatmulPlan, CreatesPlanWithBiasOnly)
 {
-    auto builder
-        = createValidMatmulBiasActivGraph({4, 8},
-                                          {8, 1},
-                                          {8, 5},
-                                          {5, 1},
-                                          {4, 5},
-                                          {5, 1},
-                                          true,
-                                          hipdnn_data_sdk::data_objects::PointwiseMode::UNSET);
+    auto builder = createValidMatmulBiasActivGraph(
+        {4, 8},
+        {8, 1},
+        {8, 5},
+        {5, 1},
+        {4, 5},
+        {5, 1},
+        true,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::UNSET);
     GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
 
     auto* matmulAttrs = graph.getNode(0).attributes_as_MatmulAttributes();
@@ -683,15 +684,15 @@ TEST_F(TestGpuMatmulPlan, CreatesPlanWithBiasOnly)
 
 TEST_F(TestGpuMatmulPlan, PlanReturnValidWorkspaceSizeWithBiasOnly)
 {
-    auto builder
-        = createValidMatmulBiasActivGraph({4, 8},
-                                          {8, 1},
-                                          {8, 5},
-                                          {5, 1},
-                                          {4, 5},
-                                          {5, 1},
-                                          true,
-                                          hipdnn_data_sdk::data_objects::PointwiseMode::UNSET);
+    auto builder = createValidMatmulBiasActivGraph(
+        {4, 8},
+        {8, 1},
+        {8, 5},
+        {5, 1},
+        {4, 5},
+        {5, 1},
+        true,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::UNSET);
     GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
 
     auto* matmulAttrs = graph.getNode(0).attributes_as_MatmulAttributes();
@@ -715,7 +716,7 @@ TEST_F(TestGpuMatmulPlan, PlanReturnValidWorkspaceSizeWithBiasActivation)
         {4, 5},
         {5, 1},
         true,
-        hipdnn_data_sdk::data_objects::PointwiseMode::GELU_APPROX_TANH_FWD);
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::GELU_APPROX_TANH_FWD);
     GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
 
     auto* matmulAttrs = graph.getNode(0).attributes_as_MatmulAttributes();

--- a/dnn-providers/hipblaslt-provider/tests/engines/plans/TestHipblasltMatmulPlanBuilder.cpp
+++ b/dnn-providers/hipblaslt-provider/tests/engines/plans/TestHipblasltMatmulPlanBuilder.cpp
@@ -12,6 +12,7 @@
 
 using namespace hipblaslt_plugin;
 using namespace hipdnn_plugin_sdk;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 using namespace hipdnn_test_sdk::utilities;
 
 class TestHipblasltMatmulPlanBuilder : public ::testing::Test
@@ -106,13 +107,14 @@ TEST_F(TestHipblasltMatmulPlanBuilder, IsApplicable)
         std::vector<int64_t> cDims = {2, 4, 5};
         std::vector<int64_t> cStrides = {20, 5, 1};
 
-        auto builder = createValidMatmulGraph(aDims,
-                                              aStrides,
-                                              bDims,
-                                              bStrides,
-                                              cDims,
-                                              cStrides,
-                                              hipdnn_data_sdk::data_objects::DataType::INT32);
+        auto builder
+            = createValidMatmulGraph(aDims,
+                                     aStrides,
+                                     bDims,
+                                     bStrides,
+                                     cDims,
+                                     cStrides,
+                                     hipdnn_flatbuffers_sdk::data_objects::DataType::INT32);
 
         GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
 
@@ -124,9 +126,9 @@ TEST_F(TestHipblasltMatmulPlanBuilder, IsApplicable)
         flatbuffers::FlatBufferBuilder builder = createValidMatmulGraph();
 
         auto mutableGraph
-            = hipdnn_data_sdk::data_objects::GetMutableGraph(builder.GetBufferPointer());
+            = hipdnn_flatbuffers_sdk::data_objects::GetMutableGraph(builder.GetBufferPointer());
         mutableGraph->mutable_nodes()->GetMutableObject(0)->mutate_compute_data_type(
-            hipdnn_data_sdk::data_objects::DataType::HALF);
+            hipdnn_flatbuffers_sdk::data_objects::DataType::HALF);
 
         GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
         EXPECT_FALSE(_planBuilder.isApplicable(_handle, graph));
@@ -142,15 +144,15 @@ TEST_F(TestHipblasltMatmulPlanBuilder, IsApplicable)
 
     // Supported graph with matmul + bias only (no activation)
     {
-        auto builder
-            = createValidMatmulBiasActivGraph({4, 8},
-                                              {8, 1},
-                                              {8, 5},
-                                              {5, 1},
-                                              {4, 5},
-                                              {5, 1},
-                                              true,
-                                              hipdnn_data_sdk::data_objects::PointwiseMode::UNSET);
+        auto builder = createValidMatmulBiasActivGraph(
+            {4, 8},
+            {8, 1},
+            {8, 5},
+            {5, 1},
+            {4, 5},
+            {5, 1},
+            true,
+            hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::UNSET);
         GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
 
         EXPECT_TRUE(_planBuilder.isApplicable(_handle, graph));
@@ -166,7 +168,7 @@ TEST_F(TestHipblasltMatmulPlanBuilder, IsApplicable)
             {4, 5},
             {5, 1},
             true,
-            hipdnn_data_sdk::data_objects::PointwiseMode::GELU_APPROX_TANH_FWD);
+            hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::GELU_APPROX_TANH_FWD);
         GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
 
         EXPECT_TRUE(_planBuilder.isApplicable(_handle, graph));
@@ -182,7 +184,7 @@ TEST_F(TestHipblasltMatmulPlanBuilder, IsApplicable)
             {4, 5},
             {5, 1},
             false,
-            hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+            hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
             0.0f);
         GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
 
@@ -199,7 +201,7 @@ TEST_F(TestHipblasltMatmulPlanBuilder, IsApplicable)
             {4, 5},
             {5, 1},
             true,
-            hipdnn_data_sdk::data_objects::PointwiseMode::SWISH_FWD,
+            hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SWISH_FWD,
             std::nullopt,
             std::nullopt,
             1.0f);
@@ -218,7 +220,7 @@ TEST_F(TestHipblasltMatmulPlanBuilder, IsApplicable)
             {4, 5},
             {5, 1},
             true,
-            hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+            hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
             0.f,
             6.f);
         GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
@@ -236,12 +238,12 @@ TEST_F(TestHipblasltMatmulPlanBuilder, IsApplicable)
             {4, 5},
             {5, 1},
             true,
-            hipdnn_data_sdk::data_objects::PointwiseMode::GELU_APPROX_TANH_FWD);
+            hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::GELU_APPROX_TANH_FWD);
 
         auto mutableGraph
-            = hipdnn_data_sdk::data_objects::GetMutableGraph(builder.GetBufferPointer());
+            = hipdnn_flatbuffers_sdk::data_objects::GetMutableGraph(builder.GetBufferPointer());
         mutableGraph->mutable_nodes()->GetMutableObject(2)->mutate_compute_data_type(
-            hipdnn_data_sdk::data_objects::DataType::HALF);
+            hipdnn_flatbuffers_sdk::data_objects::DataType::HALF);
 
         GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
         EXPECT_FALSE(_planBuilder.isApplicable(_handle, graph));
@@ -276,15 +278,15 @@ TEST_F(TestHipblasltMatmulPlanBuilder, GetWorkspaceSize)
 
     // Supported Graph with matmul + bias only (no activation)
     {
-        auto builder
-            = createValidMatmulBiasActivGraph({4, 8},
-                                              {8, 1},
-                                              {8, 5},
-                                              {5, 1},
-                                              {4, 5},
-                                              {5, 1},
-                                              true,
-                                              hipdnn_data_sdk::data_objects::PointwiseMode::UNSET);
+        auto builder = createValidMatmulBiasActivGraph(
+            {4, 8},
+            {8, 1},
+            {8, 5},
+            {5, 1},
+            {4, 5},
+            {5, 1},
+            true,
+            hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::UNSET);
         GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
 
         EXPECT_NO_THROW(_planBuilder.getWorkspaceSize(_handle, graph));
@@ -300,7 +302,7 @@ TEST_F(TestHipblasltMatmulPlanBuilder, GetWorkspaceSize)
             {4, 5},
             {5, 1},
             true,
-            hipdnn_data_sdk::data_objects::PointwiseMode::GELU_APPROX_TANH_FWD);
+            hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::GELU_APPROX_TANH_FWD);
         GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
 
         EXPECT_NO_THROW(_planBuilder.getWorkspaceSize(_handle, graph));
@@ -316,7 +318,7 @@ TEST_F(TestHipblasltMatmulPlanBuilder, GetWorkspaceSize)
             {4, 5},
             {5, 1},
             false,
-            hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+            hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
             0.0f);
         GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
 
@@ -358,15 +360,15 @@ TEST_F(TestHipblasltMatmulPlanBuilder, BuildPlan)
 
     // Supported Graph with matmul + bias only (no activation)
     {
-        auto builder
-            = createValidMatmulBiasActivGraph({4, 8},
-                                              {8, 1},
-                                              {8, 5},
-                                              {5, 1},
-                                              {4, 5},
-                                              {5, 1},
-                                              true,
-                                              hipdnn_data_sdk::data_objects::PointwiseMode::UNSET);
+        auto builder = createValidMatmulBiasActivGraph(
+            {4, 8},
+            {8, 1},
+            {8, 5},
+            {5, 1},
+            {4, 5},
+            {5, 1},
+            true,
+            hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::UNSET);
         GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
         HipdnnEnginePluginExecutionContext ctx;
 
@@ -384,7 +386,7 @@ TEST_F(TestHipblasltMatmulPlanBuilder, BuildPlan)
             {4, 5},
             {5, 1},
             true,
-            hipdnn_data_sdk::data_objects::PointwiseMode::GELU_APPROX_TANH_FWD);
+            hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::GELU_APPROX_TANH_FWD);
         GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
         HipdnnEnginePluginExecutionContext ctx;
 
@@ -402,7 +404,7 @@ TEST_F(TestHipblasltMatmulPlanBuilder, BuildPlan)
             {4, 5},
             {5, 1},
             false,
-            hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+            hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
             0.0f);
         GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
         HipdnnEnginePluginExecutionContext ctx;

--- a/dnn-providers/hipblaslt-provider/tests/mocks/MockEngine.hpp
+++ b/dnn-providers/hipblaslt-provider/tests/mocks/MockEngine.hpp
@@ -21,7 +21,7 @@ public:
     MOCK_METHOD(bool,
                 isApplicable,
                 (HipdnnEnginePluginHandle & handle,
-                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph),
+                 const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph),
                 (const, override));
     MOCK_METHOD(void,
                 getDetails,
@@ -30,13 +30,13 @@ public:
     MOCK_METHOD(size_t,
                 getWorkspaceSize,
                 (const HipdnnEnginePluginHandle& handle,
-                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph),
+                 const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph),
                 (const, override));
 
     MOCK_METHOD(void,
                 initializeExecutionContext,
                 (const HipdnnEnginePluginHandle& handle,
-                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                 const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                  HipdnnEnginePluginExecutionContext& executionContext),
                 (const, override));
 };

--- a/dnn-providers/hipblaslt-provider/tests/mocks/MockPlanBuilder.hpp
+++ b/dnn-providers/hipblaslt-provider/tests/mocks/MockPlanBuilder.hpp
@@ -5,7 +5,7 @@
 
 #include <gmock/gmock.h>
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 
 #include "engines/plans/PlanBuilderInterface.hpp"
 
@@ -18,18 +18,18 @@ public:
     MOCK_METHOD(bool,
                 isApplicable,
                 (const HipdnnEnginePluginHandle& handle,
-                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph),
+                 const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph),
                 (const, override));
     MOCK_METHOD(size_t,
                 getWorkspaceSize,
                 (const HipdnnEnginePluginHandle& handle,
-                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph),
+                 const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph),
                 (const, override));
 
     MOCK_METHOD(void,
                 buildPlan,
                 (const HipdnnEnginePluginHandle& handle,
-                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                 const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                  HipdnnEnginePluginExecutionContext& executionContext),
                 (const, override));
 };

--- a/dnn-providers/integration-tests/src/common/ActivationCommon.hpp
+++ b/dnn-providers/integration-tests/src/common/ActivationCommon.hpp
@@ -3,10 +3,10 @@
 
 #pragma once
 
-#include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/pointwise_attributes_generated.h>
 
 #include <exception>
-#include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
 #include <optional>
 
 namespace test_activation_common
@@ -14,7 +14,7 @@ namespace test_activation_common
 
 struct ActivTestCase
 {
-    hipdnn_data_sdk::data_objects::PointwiseMode mode;
+    hipdnn_flatbuffers_sdk::data_objects::PointwiseMode mode;
     std::optional<float> reluLowerClip;
     std::optional<float> reluUpperClip;
     std::optional<float> reluLowerClipSlope;
@@ -22,7 +22,7 @@ struct ActivTestCase
     std::optional<float> eluAlpha;
     std::optional<float> softplusBeta;
 
-    ActivTestCase(hipdnn_data_sdk::data_objects::PointwiseMode modeLocal,
+    ActivTestCase(hipdnn_flatbuffers_sdk::data_objects::PointwiseMode modeLocal,
                   std::optional<float> reluLowerClipLocal = std::nullopt,
                   std::optional<float> reluUpperClipLocal = std::nullopt,
                   std::optional<float> reluLowerClipSlopeLocal = std::nullopt,
@@ -37,7 +37,7 @@ struct ActivTestCase
         , eluAlpha(eluAlphaLocal)
         , softplusBeta(softplusBetaLocal)
     {
-        using PointwiseMode = hipdnn_data_sdk::data_objects::PointwiseMode;
+        using PointwiseMode = hipdnn_flatbuffers_sdk::data_objects::PointwiseMode;
 
         switch(mode)
         {
@@ -94,7 +94,7 @@ struct ActivTestCase
 
 inline std::vector<ActivTestCase> createFwdActivationSmokeCases()
 {
-    using PM = hipdnn_data_sdk::data_objects::PointwiseMode;
+    using PM = hipdnn_flatbuffers_sdk::data_objects::PointwiseMode;
 
     std::vector<ActivTestCase> cases;
 
@@ -113,7 +113,7 @@ inline std::vector<ActivTestCase> createFwdActivationSmokeCases()
 
 inline std::vector<ActivTestCase> createFwdActivationFullCases()
 {
-    using PM = hipdnn_data_sdk::data_objects::PointwiseMode;
+    using PM = hipdnn_flatbuffers_sdk::data_objects::PointwiseMode;
 
     std::vector<ActivTestCase> cases;
 
@@ -163,7 +163,7 @@ inline std::vector<ActivTestCase> createFwdActivationFullCases()
 inline std::vector<ActivTestCase> createBatchnormBwdActivationTestCases()
 {
     return {// ReLU Backward: d/dx Max(0, x) = 1 * (x > 0)
-            ActivTestCase(hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+            ActivTestCase(hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD,
                           0.0f,
                           std::nullopt,
                           std::nullopt,
@@ -171,7 +171,7 @@ inline std::vector<ActivTestCase> createBatchnormBwdActivationTestCases()
                           std::nullopt,
                           std::nullopt),
             // Clipped ReLU Backward: d/dx Clamp(x, -inf, upper)
-            ActivTestCase(hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+            ActivTestCase(hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD,
                           std::nullopt,
                           0.5f,
                           std::nullopt,
@@ -179,7 +179,7 @@ inline std::vector<ActivTestCase> createBatchnormBwdActivationTestCases()
                           std::nullopt,
                           std::nullopt),
             // CLAMP Backward: d/dx Clamp(x, lower, upper)
-            ActivTestCase(hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+            ActivTestCase(hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD,
                           0.1f,
                           0.5f,
                           std::nullopt,

--- a/dnn-providers/integration-tests/src/harness/IntegrationGraphVerificationHarness.hpp
+++ b/dnn-providers/integration-tests/src/harness/IntegrationGraphVerificationHarness.hpp
@@ -6,8 +6,8 @@
 #include <gtest/gtest.h>
 
 #include <functional>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_data_sdk/utilities/Workspace.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_frontend/Graph.hpp>
 #include <hipdnn_frontend/Utilities.hpp>
 #include <hipdnn_frontend/attributes/TensorAttributes.hpp>

--- a/dnn-providers/integration-tests/src/harness/gpu_graph_executor/GpuReferenceGraphExecutor.hpp
+++ b/dnn-providers/integration-tests/src/harness/gpu_graph_executor/GpuReferenceGraphExecutor.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/detail/FlatbufferTensorAttributesUtils.hpp>
 
 #include "detail/GpuPlanBuilderRegistry.hpp"
@@ -20,7 +20,8 @@ public:
                  size_t size,
                  const std::unordered_map<int64_t, void*>& variantPack)
     {
-        auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(graphBuffer, size);
+        auto graphWrap
+            = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(graphBuffer, size);
 
         std::vector<std::unique_ptr<detail::IGpuGraphNodePlanExecutor>> planExecutors;
 
@@ -44,7 +45,8 @@ public:
 private:
     static std::unordered_map<int64_t, void*> populateVariantPackWithMissingVirtualTensors(
         const std::unordered_map<int64_t, void*>& variantPack,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap,
         std::vector<std::unique_ptr<hipdnn_data_sdk::utilities::ITensor>>& virtualTensors)
     {
@@ -65,8 +67,8 @@ private:
     }
 
     std::unique_ptr<detail::IGpuGraphNodePlanExecutor>
-        buildPlanForNode(const hipdnn_data_sdk::flatbuffer_utilities::IGraph& graph,
-                         const hipdnn_data_sdk::data_objects::Node& node)
+        buildPlanForNode(const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& graph,
+                         const hipdnn_flatbuffers_sdk::data_objects::Node& node)
     {
         auto key = buildSignatureKey(node, graph.getTensorMap());
 
@@ -83,11 +85,12 @@ private:
     }
 
     static detail::GpuPlanRegistrySignatureKey buildSignatureKey(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap)
     {
-        using NodeAttrs = hipdnn_data_sdk::data_objects::NodeAttributes;
+        using NodeAttrs = hipdnn_flatbuffers_sdk::data_objects::NodeAttributes;
 
         switch(node.attributes_type())
         {

--- a/dnn-providers/integration-tests/src/harness/gpu_graph_executor/detail/GpuPointwiseDummyAddOnePlan.hpp
+++ b/dnn-providers/integration-tests/src/harness/gpu_graph_executor/detail/GpuPointwiseDummyAddOnePlan.hpp
@@ -4,8 +4,8 @@
 #pragma once
 
 #include <cstddef>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <stdexcept>
 
 #include "IGpuGraphNodePlanBuilder.hpp"
@@ -47,19 +47,19 @@ private:
 class GpuDummyAddOnePlanBuilder : public IGpuGraphNodePlanBuilder
 {
 public:
-    bool isApplicable(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        [[maybe_unused]] const std::unordered_map<
-            int64_t,
-            const hipdnn_data_sdk::data_objects::TensorAttributes*>& tensorMap) const override
+    bool isApplicable(const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+                      [[maybe_unused]] const std::unordered_map<
+                          int64_t,
+                          const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>& tensorMap)
+        const override
     {
         return node.attributes_type()
-               == hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes;
+               == hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes;
     }
 
     std::unique_ptr<IGpuGraphNodePlanExecutor>
-        buildNodePlan(const hipdnn_data_sdk::flatbuffer_utilities::IGraph& graph,
-                      const hipdnn_data_sdk::data_objects::Node& node) const override
+        buildNodePlan(const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& graph,
+                      const hipdnn_flatbuffers_sdk::data_objects::Node& node) const override
     {
         const auto* attrs = node.attributes_as_PointwiseAttributes();
         if(attrs == nullptr)

--- a/dnn-providers/integration-tests/src/harness/gpu_graph_executor/detail/GpuPointwiseDummySignatureKey.hpp
+++ b/dnn-providers/integration-tests/src/harness/gpu_graph_executor/detail/GpuPointwiseDummySignatureKey.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <ostream>
 #include <unordered_map>
 
@@ -21,15 +21,15 @@ namespace hipdnn_integration_tests::gpu_graph_executor::detail
 struct GpuPointwiseDummySignatureKey
 {
     static constexpr auto NODE_TYPE
-        = hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes;
+        = hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes;
 
     GpuPointwiseDummySignatureKey() = default;
 
     GpuPointwiseDummySignatureKey(
-        [[maybe_unused]] const hipdnn_data_sdk::data_objects::Node& node,
+        [[maybe_unused]] const hipdnn_flatbuffers_sdk::data_objects::Node& node,
         [[maybe_unused]] const std::unordered_map<
             int64_t,
-            const hipdnn_data_sdk::data_objects::TensorAttributes*>& tensorMap)
+            const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>& tensorMap)
     {
         // Currently matches all pointwise nodes regardless of type/mode.
         // When real GPU plans are added, extract operation, data types, etc.

--- a/dnn-providers/integration-tests/src/harness/gpu_graph_executor/detail/IGpuGraphNodePlanBuilder.hpp
+++ b/dnn-providers/integration-tests/src/harness/gpu_graph_executor/detail/IGpuGraphNodePlanBuilder.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 
 #include "IGpuGraphNodePlanExecutor.hpp"
 
@@ -17,14 +17,15 @@ public:
     virtual ~IGpuGraphNodePlanBuilder() = default;
 
     virtual bool isApplicable(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap) const
         = 0;
 
     virtual std::unique_ptr<IGpuGraphNodePlanExecutor>
-        buildNodePlan(const hipdnn_data_sdk::flatbuffer_utilities::IGraph& graph,
-                      const hipdnn_data_sdk::data_objects::Node& node) const
+        buildNodePlan(const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& graph,
+                      const hipdnn_flatbuffers_sdk::data_objects::Node& node) const
         = 0;
 };
 

--- a/dnn-providers/integration-tests/tests/TestGpuReferenceGraphExecutor.cpp
+++ b/dnn-providers/integration-tests/tests/TestGpuReferenceGraphExecutor.cpp
@@ -6,7 +6,7 @@
 #include <array>
 #include <cstdint>
 #include <hip/hip_runtime.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
 #include <unordered_map>
 #include <vector>
@@ -16,7 +16,7 @@
 namespace
 {
 
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using hipdnn_integration_tests::gpu_graph_executor::GpuReferenceGraphExecutor;
 
 // Creates a minimal pointwise graph with two FLOAT tensors (input + output).

--- a/dnn-providers/miopen-provider/CMakeLists.txt
+++ b/dnn-providers/miopen-provider/CMakeLists.txt
@@ -105,8 +105,8 @@ list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/llvm ${ROCM_PATH} ${ROCM_PATH}/hip)
 
     # hipdnn SDK dependencies - use targets directly if available (superbuild),
     # otherwise find installed packages (true standalone)
-    if(NOT TARGET hipdnn_data_sdk)
-        find_package(hipdnn_data_sdk CONFIG REQUIRED)
+    if(NOT TARGET hipdnn_flatbuffers_sdk)
+        find_package(hipdnn_flatbuffers_sdk CONFIG REQUIRED)
     endif()
     if(NOT TARGET hipdnn_plugin_sdk)
         find_package(hipdnn_plugin_sdk CONFIG REQUIRED)
@@ -167,7 +167,7 @@ add_library(
     MiopenPluginPublic.cpp
 )
 target_include_directories(miopen_plugin_impl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(miopen_plugin_impl PUBLIC MIOpen hipdnn_data_sdk hipdnn_plugin_sdk)
+target_link_libraries(miopen_plugin_impl PUBLIC MIOpen hipdnn_flatbuffers_sdk hipdnn_plugin_sdk)
 
 target_compile_definitions(miopen_plugin_impl PUBLIC MIOPEN_BETA_API)
 target_compile_options(miopen_plugin_impl PRIVATE ${MIOPENPROVIDER_WARNING_COMPILE_OPTIONS})
@@ -182,10 +182,10 @@ clang_tidy_check(miopen_plugin_impl)
 add_library(miopen_plugin_private STATIC $<TARGET_OBJECTS:miopen_plugin_impl>)
 target_include_directories(miopen_plugin_private PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 # Link to miopen_plugin_impl to inherit its PUBLIC properties
-target_link_libraries(miopen_plugin_private PUBLIC MIOpen hipdnn_data_sdk hipdnn_plugin_sdk miopen_plugin_impl)
+target_link_libraries(miopen_plugin_private PUBLIC MIOpen hipdnn_flatbuffers_sdk hipdnn_plugin_sdk miopen_plugin_impl)
 
 add_library(miopen_plugin SHARED $<TARGET_OBJECTS:miopen_plugin_impl>)
-target_link_libraries(miopen_plugin PRIVATE MIOpen hipdnn_data_sdk hipdnn_plugin_sdk)
+target_link_libraries(miopen_plugin PRIVATE MIOpen hipdnn_flatbuffers_sdk hipdnn_plugin_sdk)
 
 if(NOT WIN32)
     target_link_libraries(miopen_plugin PRIVATE "-Xlinker --exclude-libs=ALL")

--- a/dnn-providers/miopen-provider/MiopenActivationDescriptor.cpp
+++ b/dnn-providers/miopen-provider/MiopenActivationDescriptor.cpp
@@ -10,7 +10,7 @@ namespace miopen_plugin
 {
 
 MiopenActivationDescriptor::MiopenActivationDescriptor(
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& pointwiseAttrs)
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& pointwiseAttrs)
 {
     using namespace miopen_utils;
 

--- a/dnn-providers/miopen-provider/MiopenActivationDescriptor.hpp
+++ b/dnn-providers/miopen-provider/MiopenActivationDescriptor.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/pointwise_attributes_generated.h>
 #include <miopen/miopen.h>
 
 namespace miopen_plugin
@@ -13,7 +13,7 @@ class MiopenActivationDescriptor
 {
 public:
     explicit MiopenActivationDescriptor(
-        const hipdnn_data_sdk::data_objects::PointwiseAttributes& pointwiseAttrs);
+        const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& pointwiseAttrs);
 
     MiopenActivationDescriptor(const MiopenActivationDescriptor&) = delete;
     MiopenActivationDescriptor& operator=(const MiopenActivationDescriptor&) = delete;

--- a/dnn-providers/miopen-provider/MiopenConvDescriptor.cpp
+++ b/dnn-providers/miopen-provider/MiopenConvDescriptor.cpp
@@ -44,7 +44,7 @@ void copyWithCheck(const flatbuffers::Vector<int64_t>* src,
 
 MiopenConvDescriptor::MiopenConvDescriptor(
     size_t spatialDimCount,
-    const hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes& attributes,
+    const hipdnn_flatbuffers_sdk::data_objects::ConvolutionFwdAttributes& attributes,
     int groupCount,
     bool deterministicEnabled)
 {
@@ -60,7 +60,7 @@ MiopenConvDescriptor::MiopenConvDescriptor(
 
 MiopenConvDescriptor::MiopenConvDescriptor(
     size_t spatialDimCount,
-    const hipdnn_data_sdk::data_objects::ConvolutionBwdAttributes& attributes,
+    const hipdnn_flatbuffers_sdk::data_objects::ConvolutionBwdAttributes& attributes,
     int groupCount,
     bool deterministicEnabled)
 {
@@ -76,7 +76,7 @@ MiopenConvDescriptor::MiopenConvDescriptor(
 
 MiopenConvDescriptor::MiopenConvDescriptor(
     size_t spatialDimCount,
-    const hipdnn_data_sdk::data_objects::ConvolutionWrwAttributes& attributes,
+    const hipdnn_flatbuffers_sdk::data_objects::ConvolutionWrwAttributes& attributes,
     int groupCount,
     bool deterministicEnabled)
 {
@@ -130,7 +130,7 @@ void MiopenConvDescriptor::createDescriptorInternal(
     const flatbuffers::Vector<int64_t>* attrPostPadding,
     const flatbuffers::Vector<int64_t>* attrStride,
     const flatbuffers::Vector<int64_t>* attrDilation,
-    hipdnn_data_sdk::data_objects::ConvMode convMode,
+    hipdnn_flatbuffers_sdk::data_objects::ConvMode convMode,
     int groupCount,
     bool deterministicEnabled)
 {
@@ -141,7 +141,7 @@ void MiopenConvDescriptor::createDescriptorInternal(
             "MiopenConvDescriptor: spatialDimCount must be not greater than INT_MAX");
     }
 
-    if(convMode != hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION)
+    if(convMode != hipdnn_flatbuffers_sdk::data_objects::ConvMode::CROSS_CORRELATION)
     {
         throw hipdnn_plugin_sdk::HipdnnPluginException(
             HIPDNN_PLUGIN_STATUS_BAD_PARAM,

--- a/dnn-providers/miopen-provider/MiopenConvDescriptor.hpp
+++ b/dnn-providers/miopen-provider/MiopenConvDescriptor.hpp
@@ -3,9 +3,9 @@
 
 #pragma once
 
-#include <hipdnn_data_sdk/data_objects/convolution_bwd_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/convolution_fwd_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/convolution_wrw_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/convolution_bwd_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/convolution_fwd_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/convolution_wrw_attributes_generated.h>
 #include <miopen/miopen.h>
 
 namespace miopen_plugin
@@ -15,18 +15,21 @@ class MiopenConvDescriptor
 {
 public:
     MiopenConvDescriptor() = default;
-    MiopenConvDescriptor(size_t spatialDimCount,
-                         const hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes& attributes,
-                         int groupCount,
-                         bool deterministicEnabled = false);
-    MiopenConvDescriptor(size_t spatialDimCount,
-                         const hipdnn_data_sdk::data_objects::ConvolutionBwdAttributes& attributes,
-                         int groupCount,
-                         bool deterministicEnabled = false);
-    MiopenConvDescriptor(size_t spatialDimCount,
-                         const hipdnn_data_sdk::data_objects::ConvolutionWrwAttributes& attributes,
-                         int groupCount,
-                         bool deterministicEnabled = false);
+    MiopenConvDescriptor(
+        size_t spatialDimCount,
+        const hipdnn_flatbuffers_sdk::data_objects::ConvolutionFwdAttributes& attributes,
+        int groupCount,
+        bool deterministicEnabled = false);
+    MiopenConvDescriptor(
+        size_t spatialDimCount,
+        const hipdnn_flatbuffers_sdk::data_objects::ConvolutionBwdAttributes& attributes,
+        int groupCount,
+        bool deterministicEnabled = false);
+    MiopenConvDescriptor(
+        size_t spatialDimCount,
+        const hipdnn_flatbuffers_sdk::data_objects::ConvolutionWrwAttributes& attributes,
+        int groupCount,
+        bool deterministicEnabled = false);
 
     MiopenConvDescriptor(const MiopenConvDescriptor&) = delete;
     MiopenConvDescriptor& operator=(const MiopenConvDescriptor&) = delete;
@@ -46,7 +49,7 @@ private:
                                   const flatbuffers::Vector<int64_t>* attrPostPadding,
                                   const flatbuffers::Vector<int64_t>* attrStride,
                                   const flatbuffers::Vector<int64_t>* attrDilation,
-                                  hipdnn_data_sdk::data_objects::ConvMode convMode,
+                                  hipdnn_flatbuffers_sdk::data_objects::ConvMode convMode,
                                   int groupCount,
                                   bool deterministicEnabled);
 };

--- a/dnn-providers/miopen-provider/MiopenTensor.cpp
+++ b/dnn-providers/miopen-provider/MiopenTensor.cpp
@@ -12,10 +12,11 @@ namespace miopen_plugin
 namespace
 {
 template <typename Container>
-miopenTensorDescriptor_t createTensorDescriptor(int64_t uid,
-                                                hipdnn_data_sdk::data_objects::DataType dataType,
-                                                const Container& inputDims,
-                                                const Container& inputStrides)
+miopenTensorDescriptor_t
+    createTensorDescriptor(int64_t uid,
+                           hipdnn_flatbuffers_sdk::data_objects::DataType dataType,
+                           const Container& inputDims,
+                           const Container& inputStrides)
 {
     // Validate dims and strides size match
     if(inputDims.size() != inputStrides.size())
@@ -87,7 +88,7 @@ miopenTensorDescriptor_t createTensorDescriptor(int64_t uid,
 }
 } // namespace
 
-MiopenTensor::MiopenTensor(const hipdnn_data_sdk::data_objects::TensorAttributes& tensor)
+MiopenTensor::MiopenTensor(const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& tensor)
     : _uid(tensor.uid())
 {
     PLUGIN_THROW_IF_NULL(tensor.dims(),
@@ -102,7 +103,7 @@ MiopenTensor::MiopenTensor(const hipdnn_data_sdk::data_objects::TensorAttributes
 }
 
 MiopenTensor::MiopenTensor(int64_t uid,
-                           hipdnn_data_sdk::data_objects::DataType dataType,
+                           hipdnn_flatbuffers_sdk::data_objects::DataType dataType,
                            const std::vector<int64_t>& inputDims,
                            const std::vector<int64_t>& inputStrides)
     : _uid(uid)

--- a/dnn-providers/miopen-provider/MiopenTensor.hpp
+++ b/dnn-providers/miopen-provider/MiopenTensor.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/tensor_attributes_generated.h>
 #include <miopen/miopen.h>
 
 namespace miopen_plugin
@@ -12,10 +12,10 @@ namespace miopen_plugin
 class MiopenTensor
 {
 public:
-    MiopenTensor(const hipdnn_data_sdk::data_objects::TensorAttributes& tensor);
+    MiopenTensor(const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& tensor);
 
     MiopenTensor(int64_t uid,
-                 hipdnn_data_sdk::data_objects::DataType dataType,
+                 hipdnn_flatbuffers_sdk::data_objects::DataType dataType,
                  const std::vector<int64_t>& inputDims,
                  const std::vector<int64_t>& inputStrides);
 

--- a/dnn-providers/miopen-provider/MiopenUtils.cpp
+++ b/dnn-providers/miopen-provider/MiopenUtils.cpp
@@ -25,26 +25,27 @@ hipdnnPluginDeviceBuffer_t findDeviceBuffer(int64_t uid,
 }
 
 miopenDataType_t
-    tensorDataTypeToMiopenDataType(const hipdnn_data_sdk::data_objects::DataType& dataType)
+    tensorDataTypeToMiopenDataType(const hipdnn_flatbuffers_sdk::data_objects::DataType& dataType)
 {
     switch(dataType)
     {
-    case hipdnn_data_sdk::data_objects::DataType::FLOAT:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT:
         return miopenFloat;
-    case hipdnn_data_sdk::data_objects::DataType::HALF:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::HALF:
         return miopenHalf;
-    case hipdnn_data_sdk::data_objects::DataType::BFLOAT16:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16:
         return miopenBFloat16;
     default:
         throw hipdnn_plugin_sdk::HipdnnPluginException(
             HIPDNN_PLUGIN_STATUS_BAD_PARAM,
             "Unsupported data type for MIOpen: "
-                + std::string(hipdnn_data_sdk::data_objects::toString(dataType)));
+                + std::string(hipdnn_flatbuffers_sdk::data_objects::toString(dataType)));
     }
 }
 
-const hipdnn_data_sdk::data_objects::TensorAttributes& findTensorAttributes(
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& findTensorAttributes(
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     int64_t uid)
 {
@@ -59,7 +60,8 @@ const hipdnn_data_sdk::data_objects::TensorAttributes& findTensorAttributes(
 }
 
 MiopenTensor createTensor(
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     int64_t uid)
 {
@@ -68,7 +70,8 @@ MiopenTensor createTensor(
 }
 
 MiopenTensor createBatchnormTensor(
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     int64_t uid)
 {
@@ -109,7 +112,7 @@ MiopenTensor createBatchnormTensor(
     return {uid, tensorAttr.data_type(), dims, strides};
 }
 
-size_t getSpatialDimCount(const hipdnn_data_sdk::data_objects::TensorAttributes& attr)
+size_t getSpatialDimCount(const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& attr)
 {
     if(attr.dims()->size() < 3)
     {
@@ -123,9 +126,9 @@ size_t getSpatialDimCount(const hipdnn_data_sdk::data_objects::TensorAttributes&
 }
 
 ActivationParams mapPointwiseModeToMiopenActivation(
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& attrs)
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& attrs)
 {
-    using PM = hipdnn_data_sdk::data_objects::PointwiseMode;
+    using PM = hipdnn_flatbuffers_sdk::data_objects::PointwiseMode;
 
     switch(attrs.operation())
     {

--- a/dnn-providers/miopen-provider/MiopenUtils.hpp
+++ b/dnn-providers/miopen-provider/MiopenUtils.hpp
@@ -8,10 +8,10 @@
 
 #include <hipdnn_plugin_sdk/PluginLogging.hpp>
 
-#include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
-#include <hipdnn_data_sdk/utilities/FlatbufferUtils.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/pointwise_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+#include <hipdnn_flatbuffers_sdk/utilities/FlatbufferUtils.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 #include <miopen/miopen.h>
 
@@ -142,22 +142,24 @@ struct ActivationParams
 };
 
 ActivationParams mapPointwiseModeToMiopenActivation(
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& attrs);
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& attrs);
 
 hipdnnPluginDeviceBuffer_t findDeviceBuffer(int64_t uid,
                                             const hipdnnPluginDeviceBuffer_t* deviceBuffers,
                                             uint32_t numDeviceBuffers);
 
 miopenDataType_t
-    tensorDataTypeToMiopenDataType(const hipdnn_data_sdk::data_objects::DataType& dataType);
+    tensorDataTypeToMiopenDataType(const hipdnn_flatbuffers_sdk::data_objects::DataType& dataType);
 
-const hipdnn_data_sdk::data_objects::TensorAttributes& findTensorAttributes(
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& findTensorAttributes(
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     int64_t uid);
 
 MiopenTensor createTensor(
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     int64_t uid);
 
@@ -170,13 +172,14 @@ MiopenTensor createTensor(
 /// @param uid The tensor UID to look up
 /// @return MiopenTensor with potentially padded descriptor
 MiopenTensor createBatchnormTensor(
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     int64_t uid);
 
-size_t getSpatialDimCount(const hipdnn_data_sdk::data_objects::TensorAttributes& attr);
+size_t getSpatialDimCount(const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& attr);
 
-using hipdnn_data_sdk::utilities::extractDoubleFromTensorValue;
-using hipdnn_data_sdk::utilities::extractValueFromTensorValue;
+using hipdnn_flatbuffers_sdk::utilities::extractDoubleFromTensorValue;
+using hipdnn_flatbuffers_sdk::utilities::extractValueFromTensorValue;
 
 } // namespace miopen_plugin::miopen_utils

--- a/dnn-providers/miopen-provider/engines/MiopenEngine.cpp
+++ b/dnn-providers/miopen-provider/engines/MiopenEngine.cpp
@@ -4,9 +4,9 @@
 #include "MiopenEngine.hpp"
 #include "plans/MiopenBatchnormPlanBuilder.hpp"
 
-#include <hipdnn_data_sdk/data_objects/engine_details_generated.h>
-#include <hipdnn_data_sdk/data_objects/knob_value_generated.h>
 #include <hipdnn_data_sdk/utilities/StringUtil.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/engine_details_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/knob_value_generated.h>
 #include <hipdnn_plugin_sdk/GlobalKnobDefines.hpp>
 #include <hipdnn_plugin_sdk/KnobFactory.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
@@ -24,8 +24,9 @@ auto createBenchmarkingKnob(flatbuffers::FlatBufferBuilder& builder)
         builder, hipdnn_plugin_sdk::BENCHMARKING_KNOB_NAME, "Enable benchmarking", 0, 0, 1, 1, {});
 }
 
-void handleBenchmarkingKnobSetting(const hipdnn_plugin_sdk::IEngineConfig& engineConfig,
-                                   HipdnnMiopenSettings& executionSettings)
+void handleBenchmarkingKnobSetting(
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+    HipdnnMiopenSettings& executionSettings)
 {
     if(!engineConfig.hasKnobSetting(hipdnn_plugin_sdk::BENCHMARKING_KNOB_NAME))
     {
@@ -35,21 +36,21 @@ void handleBenchmarkingKnobSetting(const hipdnn_plugin_sdk::IEngineConfig& engin
     const auto& knobSetting
         = engineConfig.getKnobSettingByName(hipdnn_plugin_sdk::BENCHMARKING_KNOB_NAME);
 
-    if(knobSetting.valueType() != hipdnn_data_sdk::data_objects::KnobValue::IntValue)
+    if(knobSetting.valueType() != hipdnn_flatbuffers_sdk::data_objects::KnobValue::IntValue)
     {
         throw hipdnn_plugin_sdk::HipdnnPluginException(
             HIPDNN_PLUGIN_STATUS_BAD_PARAM,
             "Benchmarking knob setting value is not an integer. Type: "
-                + std::string(
-                    hipdnn_data_sdk::data_objects::EnumNameKnobValue(knobSetting.valueType())));
+                + std::string(hipdnn_flatbuffers_sdk::data_objects::EnumNameKnobValue(
+                    knobSetting.valueType())));
     }
 
-    auto value = knobSetting.valueAs<hipdnn_data_sdk::data_objects::IntValue>().value();
+    auto value = knobSetting.valueAs<hipdnn_flatbuffers_sdk::data_objects::IntValue>().value();
     executionSettings.setBenchmarkingEnabled(value != 0);
 }
 
 void initializeMiopenSettings(
-    const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
     HipdnnMiopenSettings& executionSettings)
 {
     if(engineConfig.isValid())
@@ -74,8 +75,9 @@ int64_t MiopenEngine::id() const
     return _id;
 }
 
-bool MiopenEngine::isApplicable(HipdnnMiopenHandle& handle,
-                                const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+bool MiopenEngine::isApplicable(
+    HipdnnMiopenHandle& handle,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
 {
     // This is wrong if we ever have more than 1 plan builder thats applicable.
     // If this is the case, we should split plan builders accross multiple engines.
@@ -90,14 +92,14 @@ bool MiopenEngine::isApplicable(HipdnnMiopenHandle& handle,
 }
 
 void MiopenEngine::getDetails(HipdnnMiopenHandle& handle,
-                              const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                              const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                               hipdnnPluginConstData_t& detailsOut) const
 {
     flatbuffers::FlatBufferBuilder builder;
 
     auto benchmarkingKnob = createBenchmarkingKnob(builder);
 
-    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::Knob>> knobsVector;
+    std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Knob>> knobsVector;
     knobsVector.push_back(benchmarkingKnob);
 
     // Collect custom knobs from plan builders
@@ -112,7 +114,7 @@ void MiopenEngine::getDetails(HipdnnMiopenHandle& handle,
 
         for(const auto& knobT : customKnobs)
         {
-            auto knobOffset = hipdnn_data_sdk::data_objects::Knob::Pack(builder, &knobT);
+            auto knobOffset = hipdnn_flatbuffers_sdk::data_objects::Knob::Pack(builder, &knobT);
             knobsVector.push_back(knobOffset);
         }
 
@@ -123,7 +125,8 @@ void MiopenEngine::getDetails(HipdnnMiopenHandle& handle,
 
     auto knobs = builder.CreateVector(knobsVector);
 
-    auto engineDetails = hipdnn_data_sdk::data_objects::CreateEngineDetails(builder, _id, knobs);
+    auto engineDetails
+        = hipdnn_flatbuffers_sdk::data_objects::CreateEngineDetails(builder, _id, knobs);
     builder.Finish(engineDetails);
     auto detachedBuffer = std::make_unique<flatbuffers::DetachedBuffer>(builder.Release());
     detailsOut.ptr = detachedBuffer->data();
@@ -134,8 +137,8 @@ void MiopenEngine::getDetails(HipdnnMiopenHandle& handle,
 
 size_t MiopenEngine::getMaxWorkspaceSize(
     const HipdnnMiopenHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-    const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig) const
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig) const
 {
     HipdnnMiopenSettings baseExecutionSettings;
     initializeMiopenSettings(engineConfig, baseExecutionSettings);
@@ -160,8 +163,8 @@ size_t MiopenEngine::getMaxWorkspaceSize(
 
 void MiopenEngine::initializeExecutionContext(
     const HipdnnMiopenHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-    const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
     HipdnnMiopenContext& executionContext) const
 {
     HipdnnMiopenSettings executionSettings;

--- a/dnn-providers/miopen-provider/engines/MiopenEngine.hpp
+++ b/dnn-providers/miopen-provider/engines/MiopenEngine.hpp
@@ -27,22 +27,23 @@ public:
 
     int64_t id() const override;
 
-    bool isApplicable(HipdnnMiopenHandle& handle,
-                      const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+    bool isApplicable(
+        HipdnnMiopenHandle& handle,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
 
     void getDetails(HipdnnMiopenHandle& handle,
-                    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                     hipdnnPluginConstData_t& detailsOut) const override;
 
-    size_t getMaxWorkspaceSize(
-        const HipdnnMiopenHandle& handle,
-        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-        const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig) const override;
+    size_t getMaxWorkspaceSize(const HipdnnMiopenHandle& handle,
+                               const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+                               const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig&
+                                   engineConfig) const override;
 
     void initializeExecutionContext(
         const HipdnnMiopenHandle& handle,
-        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-        const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
         HipdnnMiopenContext& executionContext) const override;
 
     void addPlanBuilder(

--- a/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormApplicabilityChecks.cpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormApplicabilityChecks.cpp
@@ -16,9 +16,10 @@ namespace miopen_plugin
 
 // --- Type Configuration Helpers ---
 
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType> bn_type_configs::getAllowedIoTypes()
+std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType>
+    bn_type_configs::getAllowedIoTypes()
 {
-    std::unordered_set<hipdnn_data_sdk::data_objects::DataType> types;
+    std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> types;
     for(const auto& config : VALID)
     {
         types.insert(config.io);
@@ -26,9 +27,10 @@ std::unordered_set<hipdnn_data_sdk::data_objects::DataType> bn_type_configs::get
     return types;
 }
 
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType> bn_type_configs::getAllowedAffineTypes()
+std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType>
+    bn_type_configs::getAllowedAffineTypes()
 {
-    std::unordered_set<hipdnn_data_sdk::data_objects::DataType> types;
+    std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> types;
     for(const auto& config : VALID)
     {
         types.insert(config.affine);
@@ -36,9 +38,10 @@ std::unordered_set<hipdnn_data_sdk::data_objects::DataType> bn_type_configs::get
     return types;
 }
 
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType> bn_type_configs::getAllowedStatTypes()
+std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType>
+    bn_type_configs::getAllowedStatTypes()
 {
-    std::unordered_set<hipdnn_data_sdk::data_objects::DataType> types;
+    std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> types;
     for(const auto& config : VALID)
     {
         types.insert(config.stat);
@@ -46,10 +49,10 @@ std::unordered_set<hipdnn_data_sdk::data_objects::DataType> bn_type_configs::get
     return types;
 }
 
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType>
+std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType>
     bn_type_configs::getAllowedIntermediateTypes()
 {
-    std::unordered_set<hipdnn_data_sdk::data_objects::DataType> types;
+    std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> types;
     for(const auto& config : VALID)
     {
         types.insert(config.intermediate);
@@ -60,7 +63,7 @@ std::unordered_set<hipdnn_data_sdk::data_objects::DataType>
 // --- Tensor Descriptor Implementation ---
 
 BatchnormTensorDescriptor::BatchnormTensorDescriptor(
-    const hipdnn_data_sdk::data_objects::TensorAttributes* attr)
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* attr)
     : dims(attr->dims()->begin(), attr->dims()->end())
     , strides(attr->strides()->begin(), attr->strides()->end())
     , strideOrder(hipdnn_data_sdk::utilities::extractStrideOrder(strides))
@@ -199,8 +202,8 @@ void validateConsistentLayouts(const std::vector<BatchnormTensorDescriptor>& ten
 }
 
 void validateDataTypeIsSupported(
-    hipdnn_data_sdk::data_objects::DataType dataType,
-    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
+    hipdnn_flatbuffers_sdk::data_objects::DataType dataType,
+    const std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType>& allowedTypes,
     const std::string& errorMessage)
 {
     if(allowedTypes.count(dataType) > 0)
@@ -212,9 +215,10 @@ void validateDataTypeIsSupported(
 
 void validateConsistentDataTypes(
     const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
-    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
+    const std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType>& allowedTypes,
     const std::string& typeErrorMessage,
     const std::string& consistencyErrorMessage)
 {
@@ -241,9 +245,10 @@ void validateConsistentDataTypes(
 
 void validateFixedDataType(
     const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
-    hipdnn_data_sdk::data_objects::DataType expectedType,
+    hipdnn_flatbuffers_sdk::data_objects::DataType expectedType,
     const std::string& errorMessage)
 {
     for(const auto tensorId : tensorIds)
@@ -259,7 +264,8 @@ void validateFixedDataType(
 
 void validateConsistentShapes(
     const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     const std::vector<int64_t>& referenceShape,
     const std::string& errorMessage)
@@ -312,7 +318,8 @@ void validatePeerStatsNotPopulated(const flatbuffers::Vector<int64_t>* peerStats
 // --- Component Validators ---
 
 void checkTensorLayoutsAndDimsSupported(
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     // Skip scalars (epsilon, momentum) - their type is validated by MIOpen
@@ -321,7 +328,7 @@ void checkTensorLayoutsAndDimsSupported(
 
     for(const auto& [id, attr] : tensorMap)
     {
-        if(attr->value_type() != hipdnn_data_sdk::data_objects::TensorValue::NONE)
+        if(attr->value_type() != hipdnn_flatbuffers_sdk::data_objects::TensorValue::NONE)
         {
             continue;
         }
@@ -338,7 +345,8 @@ void checkTensorDataTypesSupported(
     const std::vector<int64_t>& affineTensorIds,
     const std::vector<int64_t>& statTensorIds,
     const std::vector<int64_t>& intermediateTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     validators::validateConsistentDataTypes(
@@ -411,7 +419,8 @@ void checkTensorShapesSupported(
     const std::vector<int64_t>& ioTensorIds,
     const std::vector<int64_t>& affineTensorIds,
     const std::vector<int64_t>& statTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     bool isTraining)
 {
@@ -456,7 +465,8 @@ void checkBatchnormTensorConfigSupported(
     const std::vector<int64_t>& affineTensorIds,
     const std::vector<int64_t>& statTensorIds,
     const std::vector<int64_t>& intermediateTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     bool isTraining)
 {
@@ -469,8 +479,9 @@ void checkBatchnormTensorConfigSupported(
 } // namespace
 
 void checkBatchnormInferenceTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     std::vector<int64_t> ioTensorIds = {bnInfAttr.x_tensor_uid(), bnInfAttr.y_tensor_uid()};
@@ -484,8 +495,9 @@ void checkBatchnormInferenceTensorConfigSupported(
 }
 
 void checkBatchnormInferenceVarianceExtTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     std::vector<int64_t> ioTensorIds = {bnInfAttr.x_tensor_uid(), bnInfAttr.y_tensor_uid()};
@@ -499,9 +511,10 @@ void checkBatchnormInferenceVarianceExtTensorConfigSupported(
 }
 
 void checkBatchnormInferenceVarianceExtActivationTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     checkBatchnormFwdActivationModeSupported(actAttr);
@@ -519,9 +532,10 @@ void checkBatchnormInferenceVarianceExtActivationTensorConfigSupported(
 }
 
 void checkBatchnormInferenceActivationTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     checkBatchnormFwdActivationModeSupported(actAttr);
@@ -539,8 +553,9 @@ void checkBatchnormInferenceActivationTensorConfigSupported(
 }
 
 void checkBatchnormFwdTrainingTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormAttributes& bnAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormAttributes& bnAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     validators::validatePeerStatsNotPopulated(
@@ -564,9 +579,10 @@ void checkBatchnormFwdTrainingTensorConfigSupported(
 }
 
 void checkBatchnormFwdTrainingActivationTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormAttributes& bnAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormAttributes& bnAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     validators::validatePeerStatsNotPopulated(
@@ -591,8 +607,9 @@ void checkBatchnormFwdTrainingActivationTensorConfigSupported(
 }
 
 void checkBatchnormBackwardTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormBackwardAttributes& bnBwdAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormBackwardAttributes& bnBwdAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     validators::validatePeerStatsNotPopulated(
@@ -617,10 +634,11 @@ void checkBatchnormBackwardTensorConfigSupported(
 }
 
 void checkBatchnormInferenceActivationBackwardTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
-    const hipdnn_data_sdk::data_objects::BatchnormBackwardAttributes& bnBwdAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& actAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormBackwardAttributes& bnBwdAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     checkBatchnormBwdActivationModeSupported(actAttr);
@@ -666,18 +684,18 @@ namespace
 {
 
 void checkBatchnormActivationModeSupported(
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& activAttr, bool isBwd)
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& activAttr, bool isBwd)
 {
     // MIOpen supports: PASSTHRU, RELU, CLIPPEDREU, CLAMP (no Leaky ReLU)
 
-    if(activAttr.operation() == hipdnn_data_sdk::data_objects::PointwiseMode::IDENTITY)
+    if(activAttr.operation() == hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::IDENTITY)
     {
         return;
     }
 
     if(activAttr.operation()
-       == (isBwd ? hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD
-                 : hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD))
+       == (isBwd ? hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD
+                 : hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD))
     {
         if(!activAttr.relu_lower_clip_slope())
         {
@@ -695,13 +713,13 @@ void checkBatchnormActivationModeSupported(
 } // namespace
 
 void checkBatchnormFwdActivationModeSupported(
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& activAttr)
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& activAttr)
 {
     checkBatchnormActivationModeSupported(activAttr, false);
 }
 
 void checkBatchnormBwdActivationModeSupported(
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& activAttr)
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& activAttr)
 {
     checkBatchnormActivationModeSupported(activAttr, true);
 }

--- a/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormApplicabilityChecks.hpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormApplicabilityChecks.hpp
@@ -8,12 +8,12 @@
 #include <unordered_set>
 #include <vector>
 
-#include <hipdnn_data_sdk/data_objects/batchnorm_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/batchnorm_backward_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/batchnorm_inference_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/batchnorm_inference_attributes_variance_ext_generated.h>
-#include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/batchnorm_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/batchnorm_backward_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/batchnorm_inference_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/batchnorm_inference_attributes_variance_ext_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/pointwise_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/tensor_attributes_generated.h>
 
 namespace miopen_plugin
 {
@@ -26,7 +26,8 @@ struct BatchnormTensorDescriptor
     std::vector<int64_t> strides;
     std::vector<int64_t> strideOrder;
 
-    explicit BatchnormTensorDescriptor(const hipdnn_data_sdk::data_objects::TensorAttributes* attr);
+    explicit BatchnormTensorDescriptor(
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* attr);
 
     size_t numDims() const
     {
@@ -50,28 +51,31 @@ void validateSupportedLayout(const std::vector<int64_t>& strideOrder, size_t num
 void validateConsistentLayouts(const std::vector<BatchnormTensorDescriptor>& tensors);
 
 void validateDataTypeIsSupported(
-    hipdnn_data_sdk::data_objects::DataType dataType,
-    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
+    hipdnn_flatbuffers_sdk::data_objects::DataType dataType,
+    const std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType>& allowedTypes,
     const std::string& errorMessage);
 
 void validateConsistentDataTypes(
     const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
-    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
+    const std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType>& allowedTypes,
     const std::string& typeErrorMessage,
     const std::string& consistencyErrorMessage);
 
 void validateFixedDataType(
     const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
-    hipdnn_data_sdk::data_objects::DataType expectedType,
+    hipdnn_flatbuffers_sdk::data_objects::DataType expectedType,
     const std::string& errorMessage);
 
 void validateConsistentShapes(
     const std::vector<int64_t>& tensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     const std::vector<int64_t>& referenceShape,
     const std::string& errorMessage);
@@ -83,7 +87,8 @@ void validateSpatialDimensions(const std::vector<int64_t>& ioDims);
 // --- Component Validators ---
 
 void checkTensorLayoutsAndDimsSupported(
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
 void checkTensorDataTypesSupported(
@@ -91,69 +96,79 @@ void checkTensorDataTypesSupported(
     const std::vector<int64_t>& affineTensorIds,
     const std::vector<int64_t>& statTensorIds,
     const std::vector<int64_t>& intermediateTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
 void checkTensorShapesSupported(
     const std::vector<int64_t>& ioTensorIds,
     const std::vector<int64_t>& affineTensorIds,
     const std::vector<int64_t>& statTensorIds,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     bool isTraining);
 
 // --- High-Level Configuration Validators ---
 
 void checkBatchnormInferenceTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
 void checkBatchnormInferenceVarianceExtTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
 void checkBatchnormInferenceVarianceExtActivationTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
 void checkBatchnormInferenceActivationTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
 void checkBatchnormFwdTrainingTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormAttributes& bnAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormAttributes& bnAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
 void checkBatchnormFwdTrainingActivationTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormAttributes& bnAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormAttributes& bnAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
 void checkBatchnormBackwardTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormBackwardAttributes& bnBwdAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormBackwardAttributes& bnBwdAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
 void checkBatchnormInferenceActivationBackwardTensorConfigSupported(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
-    const hipdnn_data_sdk::data_objects::BatchnormBackwardAttributes& bnBwdAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& actAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormBackwardAttributes& bnBwdAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap);
 
 void checkBatchnormFwdActivationModeSupported(
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& activAttr);
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& activAttr);
 
 void checkBatchnormBwdActivationModeSupported(
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& activAttr);
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& activAttr);
 
 // --- Batchnorm Type Configuration ---
 
@@ -162,15 +177,15 @@ void checkBatchnormBwdActivationModeSupported(
 // - Affine/Stat/Intermediate tensors: FLOAT only
 struct BnTensorTypes
 {
-    hipdnn_data_sdk::data_objects::DataType io;
-    hipdnn_data_sdk::data_objects::DataType affine;
-    hipdnn_data_sdk::data_objects::DataType stat;
-    hipdnn_data_sdk::data_objects::DataType intermediate;
+    hipdnn_flatbuffers_sdk::data_objects::DataType io;
+    hipdnn_flatbuffers_sdk::data_objects::DataType affine;
+    hipdnn_flatbuffers_sdk::data_objects::DataType stat;
+    hipdnn_flatbuffers_sdk::data_objects::DataType intermediate;
 };
 
 namespace bn_type_configs
 {
-using DT = hipdnn_data_sdk::data_objects::DataType;
+using DT = hipdnn_flatbuffers_sdk::data_objects::DataType;
 
 inline constexpr BnTensorTypes ALL_FLOAT = {DT::FLOAT, DT::FLOAT, DT::FLOAT, DT::FLOAT};
 inline constexpr BnTensorTypes HALF_IO = {DT::HALF, DT::FLOAT, DT::FLOAT, DT::FLOAT};
@@ -178,10 +193,10 @@ inline constexpr BnTensorTypes BFLOAT16_IO = {DT::BFLOAT16, DT::FLOAT, DT::FLOAT
 
 inline constexpr std::array<BnTensorTypes, 3> VALID = {ALL_FLOAT, HALF_IO, BFLOAT16_IO};
 
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType> getAllowedIoTypes();
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType> getAllowedAffineTypes();
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType> getAllowedStatTypes();
-std::unordered_set<hipdnn_data_sdk::data_objects::DataType> getAllowedIntermediateTypes();
+std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> getAllowedIoTypes();
+std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> getAllowedAffineTypes();
+std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> getAllowedStatTypes();
+std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> getAllowedIntermediateTypes();
 
 } // namespace bn_type_configs
 

--- a/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormBwdPlan.cpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormBwdPlan.cpp
@@ -30,8 +30,9 @@ int64_t getRequiredOptionalUid(const flatbuffers::Optional<int64_t>& opt,
 const miopenBatchNormMode_t MIOPEN_BATCHNORM_MODE = miopenBNSpatial;
 
 BatchnormBwdParams::BatchnormBwdParams(
-    const hipdnn_data_sdk::data_objects::BatchnormBackwardAttributes& attributes,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormBackwardAttributes& attributes,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
     : _x(miopen_utils::createBatchnormTensor(tensorMap, attributes.x_tensor_uid()))
     , _dy(miopen_utils::createBatchnormTensor(tensorMap, attributes.dy_tensor_uid()))
@@ -54,10 +55,13 @@ BatchnormBwdParams::BatchnormBwdParams(
 }
 
 BatchnormBwdParams::BatchnormBwdParams(
-    const hipdnn_data_sdk::data_objects::BatchnormBackwardAttributes& batchnormBackwardAttributes,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& pointwiseAttributes,
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& batchnormInferenceAttributes,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormBackwardAttributes&
+        batchnormBackwardAttributes,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& pointwiseAttributes,
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes&
+        batchnormInferenceAttributes,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
     : _x(miopen_utils::createBatchnormTensor(tensorMap, batchnormBackwardAttributes.x_tensor_uid()))
     , _dy(miopen_utils::createBatchnormTensor(

--- a/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormBwdPlan.hpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormBwdPlan.hpp
@@ -5,10 +5,10 @@
 
 #include <optional>
 
-#include <hipdnn_data_sdk/data_objects/batchnorm_backward_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/batchnorm_inference_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/batchnorm_backward_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/batchnorm_inference_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/pointwise_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/tensor_attributes_generated.h>
 
 #include <hipdnn_plugin_sdk/interfaces/IPlan.hpp>
 
@@ -24,17 +24,19 @@ class BatchnormBwdParams
 {
 public:
     BatchnormBwdParams(
-        const hipdnn_data_sdk::data_objects::BatchnormBackwardAttributes& attributes,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::BatchnormBackwardAttributes& attributes,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap);
 
     BatchnormBwdParams(
-        const hipdnn_data_sdk::data_objects::BatchnormBackwardAttributes&
+        const hipdnn_flatbuffers_sdk::data_objects::BatchnormBackwardAttributes&
             batchnormBackwardAttributes,
-        const hipdnn_data_sdk::data_objects::PointwiseAttributes& pointwiseAttributes,
-        const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes&
+        const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& pointwiseAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes&
             batchnormInferenceAttributes,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap);
 
     BatchnormBwdParams(const BatchnormBwdParams&) = delete;

--- a/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormFwdInferencePlan.cpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormFwdInferencePlan.cpp
@@ -14,8 +14,9 @@ namespace miopen_plugin
 const miopenBatchNormMode_t MIOPEN_BATCHNORM_MODE = miopenBNSpatial;
 
 BatchnormFwdInferenceParams::BatchnormFwdInferenceParams(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& attributes,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes& attributes,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
     : _x(miopen_utils::createBatchnormTensor(tensorMap, attributes.x_tensor_uid()))
     , _y(miopen_utils::createBatchnormTensor(tensorMap, attributes.y_tensor_uid()))
@@ -28,9 +29,10 @@ BatchnormFwdInferenceParams::BatchnormFwdInferenceParams(
 }
 
 BatchnormFwdInferenceParams::BatchnormFwdInferenceParams(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& inferenceAttributes,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& pointwiseAttributes,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes& inferenceAttributes,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& pointwiseAttributes,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
     : _x(miopen_utils::createBatchnormTensor(tensorMap, inferenceAttributes.x_tensor_uid()))
     , _y(miopen_utils::createBatchnormTensor(tensorMap, inferenceAttributes.y_tensor_uid()))

--- a/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormFwdInferencePlan.hpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormFwdInferencePlan.hpp
@@ -20,14 +20,17 @@ class BatchnormFwdInferenceParams
 {
 public:
     BatchnormFwdInferenceParams(
-        const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& attributes,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes& attributes,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap);
 
     BatchnormFwdInferenceParams(
-        const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& inferenceAttributes,
-        const hipdnn_data_sdk::data_objects::PointwiseAttributes& pointwiseAttributes,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes&
+            inferenceAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& pointwiseAttributes,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap);
 
     BatchnormFwdInferenceParams(const BatchnormFwdInferenceParams&) = delete;

--- a/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormFwdInferenceWithVariancePlan.cpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormFwdInferenceWithVariancePlan.cpp
@@ -14,8 +14,9 @@ namespace miopen_plugin
 const miopenBatchNormMode_t MIOPEN_BATCHNORM_MODE = miopenBNSpatial;
 
 BatchnormFwdInferenceWithVarianceParams::BatchnormFwdInferenceWithVarianceParams(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& attributes,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& attributes,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
     : _x(miopen_utils::createBatchnormTensor(tensorMap, attributes.x_tensor_uid()))
     , _y(miopen_utils::createBatchnormTensor(tensorMap, attributes.y_tensor_uid()))
@@ -30,10 +31,11 @@ BatchnormFwdInferenceWithVarianceParams::BatchnormFwdInferenceWithVarianceParams
 }
 
 BatchnormFwdInferenceWithVarianceParams::BatchnormFwdInferenceWithVarianceParams(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributesVarianceExt&
         inferenceAttributes,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& pointwiseAttributes,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& pointwiseAttributes,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
     : _x(miopen_utils::createBatchnormTensor(tensorMap, inferenceAttributes.x_tensor_uid()))
     , _y(miopen_utils::createBatchnormTensor(tensorMap, inferenceAttributes.y_tensor_uid()))

--- a/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormFwdInferenceWithVariancePlan.hpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormFwdInferenceWithVariancePlan.hpp
@@ -19,15 +19,18 @@ class BatchnormFwdInferenceWithVarianceParams
 {
 public:
     BatchnormFwdInferenceWithVarianceParams(
-        const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& attributes,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributesVarianceExt&
+            attributes,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap);
 
     BatchnormFwdInferenceWithVarianceParams(
-        const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt&
+        const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributesVarianceExt&
             inferenceAttributes,
-        const hipdnn_data_sdk::data_objects::PointwiseAttributes& pointwiseAttributes,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& pointwiseAttributes,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap);
 
     BatchnormFwdInferenceWithVarianceParams(const BatchnormFwdInferenceWithVarianceParams&)

--- a/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormFwdTrainingPlan.cpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormFwdTrainingPlan.cpp
@@ -13,8 +13,9 @@ namespace miopen_plugin
 const miopenBatchNormMode_t MIOPEN_BATCHNORM_MODE_TRAINING = miopenBNSpatial;
 
 BatchnormFwdTrainingParams::BatchnormFwdTrainingParams(
-    const hipdnn_data_sdk::data_objects::BatchnormAttributes& attributes,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormAttributes& attributes,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
     : _x(miopen_utils::createBatchnormTensor(tensorMap, attributes.x_tensor_uid()))
     , _y(miopen_utils::createBatchnormTensor(tensorMap, attributes.y_tensor_uid()))
@@ -60,9 +61,10 @@ BatchnormFwdTrainingParams::BatchnormFwdTrainingParams(
 }
 
 BatchnormFwdTrainingParams::BatchnormFwdTrainingParams(
-    const hipdnn_data_sdk::data_objects::BatchnormAttributes& attributes,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& pointwiseAttributes,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormAttributes& attributes,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& pointwiseAttributes,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
     : _x(miopen_utils::createBatchnormTensor(tensorMap, attributes.x_tensor_uid()))
     , _y(miopen_utils::createBatchnormTensor(tensorMap, attributes.y_tensor_uid()))

--- a/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormFwdTrainingPlan.hpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormFwdTrainingPlan.hpp
@@ -19,14 +19,16 @@ class BatchnormFwdTrainingParams
 {
 public:
     BatchnormFwdTrainingParams(
-        const hipdnn_data_sdk::data_objects::BatchnormAttributes& attributes,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::BatchnormAttributes& attributes,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap);
 
     BatchnormFwdTrainingParams(
-        const hipdnn_data_sdk::data_objects::BatchnormAttributes& attributes,
-        const hipdnn_data_sdk::data_objects::PointwiseAttributes& pointwiseAttributes,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::BatchnormAttributes& attributes,
+        const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& pointwiseAttributes,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap);
 
     BatchnormFwdTrainingParams(const BatchnormFwdTrainingParams&) = delete;

--- a/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormFwdTrainingPlanBuilder.cpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormFwdTrainingPlanBuilder.cpp
@@ -18,9 +18,9 @@ namespace miopen_plugin
 namespace
 {
 
-bool isNodeActivFwd(const hipdnn_data_sdk::data_objects::PointwiseAttributes& attr)
+bool isNodeActivFwd(const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& attr)
 {
-    using PointwiseMode = hipdnn_data_sdk::data_objects::PointwiseMode;
+    using PointwiseMode = hipdnn_flatbuffers_sdk::data_objects::PointwiseMode;
 
     // Check if operation is supported for batchnorm fusion
     switch(attr.operation())
@@ -39,31 +39,35 @@ bool isNodeActivFwd(const hipdnn_data_sdk::data_objects::PointwiseAttributes& at
     return !attr.relu_lower_clip_slope();
 }
 
-const hipdnn_data_sdk::data_objects::BatchnormAttributes&
-    checkBatchnormNode(const hipdnn_data_sdk::flatbuffer_utilities::INodeWrapper& node)
+const hipdnn_flatbuffers_sdk::data_objects::BatchnormAttributes&
+    checkBatchnormNode(const hipdnn_flatbuffers_sdk::flatbuffer_utilities::INodeWrapper& node)
 {
-    if(node.attributesType() != hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes)
+    if(node.attributesType()
+       != hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes)
     {
         throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM,
                                                        "First node must be batchnorm");
     }
 
-    const auto& bnAttr = node.attributesAs<hipdnn_data_sdk::data_objects::BatchnormAttributes>();
+    const auto& bnAttr
+        = node.attributesAs<hipdnn_flatbuffers_sdk::data_objects::BatchnormAttributes>();
 
     return bnAttr;
 }
 
-const hipdnn_data_sdk::data_objects::PointwiseAttributes&
-    checkActivationNode(const hipdnn_data_sdk::flatbuffer_utilities::INodeWrapper& node,
-                        const hipdnn_data_sdk::data_objects::BatchnormAttributes& bnAttr)
+const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes&
+    checkActivationNode(const hipdnn_flatbuffers_sdk::flatbuffer_utilities::INodeWrapper& node,
+                        const hipdnn_flatbuffers_sdk::data_objects::BatchnormAttributes& bnAttr)
 {
-    if(node.attributesType() != hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes)
+    if(node.attributesType()
+       != hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes)
     {
         throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM,
                                                        "Second node must be pointwise");
     }
 
-    const auto& activAttr = node.attributesAs<hipdnn_data_sdk::data_objects::PointwiseAttributes>();
+    const auto& activAttr
+        = node.attributesAs<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>();
 
     if(!isNodeActivFwd(activAttr))
     {
@@ -81,8 +85,9 @@ const hipdnn_data_sdk::data_objects::PointwiseAttributes&
 }
 
 void checkRunningStatisticsTensorVirtuality(
-    const hipdnn_data_sdk::data_objects::BatchnormAttributes& bnAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormAttributes& bnAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     // Optional running statistics tensors must be non-virtual if present
@@ -136,8 +141,9 @@ void checkRunningStatisticsTensorVirtuality(
 }
 
 void checkTensorVirtuality1Node(
-    const hipdnn_data_sdk::data_objects::BatchnormAttributes& bnAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormAttributes& bnAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     // Check for virtual tensors - 1-node case (solo batchnorm training)
@@ -184,9 +190,10 @@ void checkTensorVirtuality1Node(
 }
 
 void checkTensorVirtuality2Node(
-    const hipdnn_data_sdk::data_objects::BatchnormAttributes& bnAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormAttributes& bnAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     // Check for virtual tensors - 2-node case (batchnorm training + activation)
@@ -248,7 +255,7 @@ void checkTensorVirtuality2Node(
 
 bool MiopenBatchnormFwdTrainingPlanBuilder::isApplicable(
     [[maybe_unused]] const HipdnnMiopenHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
 {
     if(opGraph.nodeCount() != 1 && opGraph.nodeCount() != 2)
     {
@@ -261,7 +268,7 @@ bool MiopenBatchnormFwdTrainingPlanBuilder::isApplicable(
         const auto& bnAttr = checkBatchnormNode(opGraph.getNodeWrapper(0));
 
         auto hasFloatComputeDataType = [](const auto& node) {
-            return node->computeDataType() == hipdnn_data_sdk::data_objects::DataType::FLOAT;
+            return node->computeDataType() == hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT;
         };
 
         if(!std::all_of(opGraph.nodeWrappers().begin(),
@@ -309,7 +316,7 @@ bool MiopenBatchnormFwdTrainingPlanBuilder::isApplicable(
 
 size_t MiopenBatchnormFwdTrainingPlanBuilder::getMaxWorkspaceSize(
     [[maybe_unused]] const HipdnnMiopenHandle& handle,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
     [[maybe_unused]] const HipdnnMiopenSettings& executionSettings) const
 {
     // No workspace needed for batchnorm forward training
@@ -318,16 +325,18 @@ size_t MiopenBatchnormFwdTrainingPlanBuilder::getMaxWorkspaceSize(
 
 void MiopenBatchnormFwdTrainingPlanBuilder::initializeExecutionSettings(
     [[maybe_unused]] const HipdnnMiopenHandle& handle,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig&
+        engineConfig,
     [[maybe_unused]] HipdnnMiopenSettings& executionSettings) const
 {
 }
 
 void MiopenBatchnormFwdTrainingPlanBuilder::buildPlan(
     [[maybe_unused]] const HipdnnMiopenHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig&
+        engineConfig,
     HipdnnMiopenContext& executionContext) const
 {
     if(opGraph.nodeCount() == 1)
@@ -335,7 +344,7 @@ void MiopenBatchnormFwdTrainingPlanBuilder::buildPlan(
         // Solo batchnorm training
         const auto& bnAttr
             = opGraph.getNodeWrapper(0)
-                  .attributesAs<hipdnn_data_sdk::data_objects::BatchnormAttributes>();
+                  .attributesAs<hipdnn_flatbuffers_sdk::data_objects::BatchnormAttributes>();
 
         BatchnormFwdTrainingParams params(bnAttr, opGraph.getTensorMap());
         auto plan = std::make_unique<BatchnormFwdTrainingPlan>(
@@ -347,10 +356,10 @@ void MiopenBatchnormFwdTrainingPlanBuilder::buildPlan(
         // Batchnorm training + activation fusion
         const auto& bnAttr
             = opGraph.getNodeWrapper(0)
-                  .attributesAs<hipdnn_data_sdk::data_objects::BatchnormAttributes>();
+                  .attributesAs<hipdnn_flatbuffers_sdk::data_objects::BatchnormAttributes>();
         const auto& activAttr
             = opGraph.getNodeWrapper(1)
-                  .attributesAs<hipdnn_data_sdk::data_objects::PointwiseAttributes>();
+                  .attributesAs<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>();
 
         BatchnormFwdTrainingParams params(bnAttr, activAttr, opGraph.getTensorMap());
         auto plan = std::make_unique<BatchnormFwdTrainingPlan>(
@@ -365,10 +374,10 @@ void MiopenBatchnormFwdTrainingPlanBuilder::buildPlan(
     }
 }
 
-std::vector<hipdnn_data_sdk::data_objects::KnobT>
+std::vector<hipdnn_flatbuffers_sdk::data_objects::KnobT>
     MiopenBatchnormFwdTrainingPlanBuilder::getCustomKnobs(
         [[maybe_unused]] const HipdnnMiopenHandle& handle,
-        [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+        [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
 {
     return {};
 }

--- a/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormFwdTrainingPlanBuilder.hpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormFwdTrainingPlanBuilder.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <hipdnn_data_sdk/data_objects/knob_value_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/knob_value_generated.h>
 #include <hipdnn_plugin_sdk/interfaces/IPlanBuilder.hpp>
 
 #include "HipdnnMiopenContext.hpp"
@@ -26,28 +26,30 @@ public:
     MiopenBatchnormFwdTrainingPlanBuilder& operator=(const MiopenBatchnormFwdTrainingPlanBuilder&)
         = delete;
 
-    bool isApplicable(const HipdnnMiopenHandle& handle,
-                      const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+    bool isApplicable(
+        const HipdnnMiopenHandle& handle,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
 
     size_t getMaxWorkspaceSize(const HipdnnMiopenHandle& handle,
-                               const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                               const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                                const HipdnnMiopenSettings& executionSettings) const override;
 
     void initializeExecutionSettings(
         const HipdnnMiopenHandle& handle,
-        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-        const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
         HipdnnMiopenSettings& executionSettings) const override;
 
     void buildPlan(
         const HipdnnMiopenHandle& handle,
-        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-        [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+        [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig&
+            engineConfig,
         HipdnnMiopenContext& executionContext) const override;
 
-    std::vector<hipdnn_data_sdk::data_objects::KnobT>
-        getCustomKnobs(const HipdnnMiopenHandle& handle,
-                       const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+    std::vector<hipdnn_flatbuffers_sdk::data_objects::KnobT> getCustomKnobs(
+        const HipdnnMiopenHandle& handle,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
 };
 
 }

--- a/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormPlanBuilder.cpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormPlanBuilder.cpp
@@ -1,7 +1,7 @@
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier:  MIT
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 #include <hipdnn_plugin_sdk/PluginLogging.hpp>
 #include <miopen/miopen.h>
@@ -22,11 +22,11 @@ namespace miopen_plugin
 namespace
 {
 
-std::tuple<const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes&,
-           const hipdnn_data_sdk::data_objects::PointwiseAttributes&,
-           const hipdnn_data_sdk::data_objects::BatchnormBackwardAttributes&>
+std::tuple<const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes&,
+           const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes&,
+           const hipdnn_flatbuffers_sdk::data_objects::BatchnormBackwardAttributes&>
     getBatchnormBackwardFusionNodeAttrs(
-        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph)
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph)
 {
     if(opGraph.nodeCount() != 3)
     {
@@ -38,20 +38,21 @@ std::tuple<const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes&,
 
     const auto& bnInfAttr
         = opGraph.getNodeWrapper(0)
-              .attributesAs<hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes>();
+              .attributesAs<hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes>();
 
-    const auto& actAttr = opGraph.getNodeWrapper(1)
-                              .attributesAs<hipdnn_data_sdk::data_objects::PointwiseAttributes>();
+    const auto& actAttr
+        = opGraph.getNodeWrapper(1)
+              .attributesAs<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>();
 
     const auto& bnBwdAttr
         = opGraph.getNodeWrapper(2)
-              .attributesAs<hipdnn_data_sdk::data_objects::BatchnormBackwardAttributes>();
+              .attributesAs<hipdnn_flatbuffers_sdk::data_objects::BatchnormBackwardAttributes>();
 
     return {bnInfAttr, actAttr, bnBwdAttr};
 }
 
 auto getBatchnormBackwardFusionNodeAttrsLogErrors(
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph)
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph)
     -> std::optional<decltype(getBatchnormBackwardFusionNodeAttrs(opGraph))>
 {
     try
@@ -66,13 +67,14 @@ auto getBatchnormBackwardFusionNodeAttrsLogErrors(
 }
 
 void batchnormBwdFusionCheckTensors(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
-    const hipdnn_data_sdk::data_objects::BatchnormBackwardAttributes& bnBwdAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& actAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormBackwardAttributes& bnBwdAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
-    using PM = hipdnn_data_sdk::data_objects::PointwiseMode;
+    using PM = hipdnn_flatbuffers_sdk::data_objects::PointwiseMode;
     static const std::unordered_set<PM> s_supportedActivations = {PM::RELU_BWD};
 
     if(s_supportedActivations.count(actAttr.operation()) == 0)
@@ -199,12 +201,13 @@ void batchnormBwdFusionCheckTensors(
 }
 
 void batchnormFwdFusionCheckTensors(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
-    using PM = hipdnn_data_sdk::data_objects::PointwiseMode;
+    using PM = hipdnn_flatbuffers_sdk::data_objects::PointwiseMode;
     static const std::unordered_set<PM> s_supportedActivations = {PM::RELU_FWD};
 
     if(s_supportedActivations.count(actAttr.operation()) == 0)
@@ -258,10 +261,11 @@ void batchnormFwdFusionCheckTensors(
 }
 
 bool batchnormBwdFusionCheckTensorsLogErrors(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
-    const hipdnn_data_sdk::data_objects::BatchnormBackwardAttributes& bnBwdAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& actAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormBackwardAttributes& bnBwdAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     try
@@ -277,9 +281,10 @@ bool batchnormBwdFusionCheckTensorsLogErrors(
 }
 
 bool batchnormFwdFusionCheckTensorsLogErrors(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     try
@@ -295,12 +300,13 @@ bool batchnormFwdFusionCheckTensorsLogErrors(
 }
 
 void batchnormFwdFusionCheckTensors(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
-    using PM = hipdnn_data_sdk::data_objects::PointwiseMode;
+    using PM = hipdnn_flatbuffers_sdk::data_objects::PointwiseMode;
     static const std::unordered_set<PM> s_supportedActivations = {PM::RELU_FWD};
 
     if(s_supportedActivations.count(actAttr.operation()) == 0)
@@ -354,9 +360,10 @@ void batchnormFwdFusionCheckTensors(
 }
 
 bool batchnormFwdFusionCheckTensorsLogErrors(
-    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     try
@@ -375,12 +382,13 @@ bool batchnormFwdFusionCheckTensorsLogErrors(
 
 bool MiopenBatchnormPlanBuilder::isApplicable(
     [[maybe_unused]] const HipdnnMiopenHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
 {
     auto anyNodeIsNotF32Compute = [&]() {
         return !std::all_of(
             opGraph.nodeWrappers().begin(), opGraph.nodeWrappers().end(), [](const auto& node) {
-                return node->computeDataType() == hipdnn_data_sdk::data_objects::DataType::FLOAT;
+                return node->computeDataType()
+                       == hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT;
             });
     };
 
@@ -395,13 +403,13 @@ bool MiopenBatchnormPlanBuilder::isApplicable(
             return false;
         }
 
-        if(!opGraph.hasOnlySupportedAttributes(
-               std::set<hipdnn_data_sdk::data_objects::NodeAttributes>{
-                   hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes,
-                   hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
-                   hipdnn_data_sdk::data_objects::NodeAttributes::
-                       BatchnormInferenceAttributesVarianceExt,
-                   hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes}))
+        if(!opGraph.hasOnlySupportedAttributes(std::set<hipdnn_flatbuffers_sdk::data_objects::
+                                                            NodeAttributes>{
+               hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes,
+               hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+               hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::
+                   BatchnormInferenceAttributesVarianceExt,
+               hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes}))
         {
             HIPDNN_PLUGIN_LOG_INFO("Batchnorm plan builder is not applicable for this graph");
             return false;
@@ -411,7 +419,7 @@ bool MiopenBatchnormPlanBuilder::isApplicable(
 
         // Only batchnorm training (BatchnormAttributes) has running statistics
         if(node.attributes_type()
-           == hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes)
+           == hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes)
         {
             const auto* attr = node.attributes_as_BatchnormAttributes();
             if(attr != nullptr && attr->prev_running_mean_tensor_uid().has_value()
@@ -430,21 +438,21 @@ bool MiopenBatchnormPlanBuilder::isApplicable(
         {
             switch(node.attributes_type())
             {
-            case hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes:
+            case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes:
                 checkBatchnormFwdTrainingTensorConfigSupported(
                     *node.attributes_as_BatchnormAttributes(), opGraph.getTensorMap());
                 break;
-            case hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes:
+            case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes:
                 checkBatchnormInferenceTensorConfigSupported(
                     *node.attributes_as_BatchnormInferenceAttributes(), opGraph.getTensorMap());
                 break;
-            case hipdnn_data_sdk::data_objects::NodeAttributes::
+            case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::
                 BatchnormInferenceAttributesVarianceExt:
                 checkBatchnormInferenceVarianceExtTensorConfigSupported(
                     *node.attributes_as_BatchnormInferenceAttributesVarianceExt(),
                     opGraph.getTensorMap());
                 break;
-            case hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes:
+            case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes:
                 checkBatchnormBackwardTensorConfigSupported(
                     *node.attributes_as_BatchnormBackwardAttributes(), opGraph.getTensorMap());
                 break;
@@ -475,13 +483,14 @@ bool MiopenBatchnormPlanBuilder::isApplicable(
 
         bool isFwdInferenceFirst
             = node0.attributesType()
-              == hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes;
-        bool isFwdInferenceWithVarianceFirst = node0.attributesType()
-                                               == hipdnn_data_sdk::data_objects::NodeAttributes::
-                                                   BatchnormInferenceAttributesVarianceExt;
+              == hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes;
+        bool isFwdInferenceWithVarianceFirst
+            = node0.attributesType()
+              == hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::
+                  BatchnormInferenceAttributesVarianceExt;
         bool isPointwiseSecond
             = node1.attributesType()
-              == hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes;
+              == hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes;
 
         if(!((isFwdInferenceFirst || isFwdInferenceWithVarianceFirst) && isPointwiseSecond))
         {
@@ -492,10 +501,10 @@ bool MiopenBatchnormPlanBuilder::isApplicable(
 
         if(isFwdInferenceFirst)
         {
-            const auto& bnInfAttr
-                = node0.attributesAs<hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes>();
+            const auto& bnInfAttr = node0.attributesAs<
+                hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes>();
             const auto& actAttr
-                = node1.attributesAs<hipdnn_data_sdk::data_objects::PointwiseAttributes>();
+                = node1.attributesAs<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>();
             if(!batchnormFwdFusionCheckTensorsLogErrors(bnInfAttr, actAttr, opGraph.getTensorMap()))
             {
                 return false;
@@ -517,9 +526,9 @@ bool MiopenBatchnormPlanBuilder::isApplicable(
         else
         {
             const auto& bnInfAttr = node0.attributesAs<
-                hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt>();
+                hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributesVarianceExt>();
             const auto& actAttr
-                = node1.attributesAs<hipdnn_data_sdk::data_objects::PointwiseAttributes>();
+                = node1.attributesAs<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>();
 
             if(!batchnormFwdFusionCheckTensorsLogErrors(bnInfAttr, actAttr, opGraph.getTensorMap()))
             {
@@ -599,7 +608,7 @@ bool MiopenBatchnormPlanBuilder::isApplicable(
 
 size_t MiopenBatchnormPlanBuilder::getMaxWorkspaceSize(
     [[maybe_unused]] const HipdnnMiopenHandle& handle,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
     [[maybe_unused]] const HipdnnMiopenSettings& executionSettings) const
 {
     // batchnorm plan builder does not require workspace size
@@ -608,8 +617,9 @@ size_t MiopenBatchnormPlanBuilder::getMaxWorkspaceSize(
 
 void MiopenBatchnormPlanBuilder::initializeExecutionSettings(
     [[maybe_unused]] const HipdnnMiopenHandle& handle,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig&
+        engineConfig,
     [[maybe_unused]] HipdnnMiopenSettings& executionSettings) const
 {
 }
@@ -619,12 +629,13 @@ namespace
 
 void buildPlanInferenceSingleNode(
     [[maybe_unused]] const HipdnnMiopenHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-    const hipdnn_data_sdk::flatbuffer_utilities::INodeWrapper& nodeWrapper,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::INodeWrapper& nodeWrapper,
     HipdnnMiopenContext& executionContext)
 {
     const auto& attr
-        = nodeWrapper.attributesAs<hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes>();
+        = nodeWrapper
+              .attributesAs<hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes>();
 
     BatchnormFwdInferenceParams params(attr, opGraph.getTensorMap());
     auto plan = std::make_unique<BatchnormFwdInferencePlan>(std::move(params),
@@ -634,12 +645,12 @@ void buildPlanInferenceSingleNode(
 
 void buildPlanInferenceWithVarianceSingleNode(
     [[maybe_unused]] const HipdnnMiopenHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-    const hipdnn_data_sdk::flatbuffer_utilities::INodeWrapper& nodeWrapper,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::INodeWrapper& nodeWrapper,
     HipdnnMiopenContext& executionContext)
 {
     const auto& attr = nodeWrapper.attributesAs<
-        hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt>();
+        hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributesVarianceExt>();
 
     BatchnormFwdInferenceWithVarianceParams params(attr, opGraph.getTensorMap());
     auto plan = std::make_unique<BatchnormFwdInferenceWithVariancePlan>(
@@ -649,12 +660,12 @@ void buildPlanInferenceWithVarianceSingleNode(
 
 void buildPlanFwdTrainingSingleNode(
     [[maybe_unused]] const HipdnnMiopenHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-    const hipdnn_data_sdk::flatbuffer_utilities::INodeWrapper& nodeWrapper,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::INodeWrapper& nodeWrapper,
     HipdnnMiopenContext& executionContext)
 {
     const auto& attr
-        = nodeWrapper.attributesAs<hipdnn_data_sdk::data_objects::BatchnormAttributes>();
+        = nodeWrapper.attributesAs<hipdnn_flatbuffers_sdk::data_objects::BatchnormAttributes>();
 
     BatchnormFwdTrainingParams params(attr, opGraph.getTensorMap());
     auto plan = std::make_unique<BatchnormFwdTrainingPlan>(std::move(params),
@@ -662,13 +673,15 @@ void buildPlanFwdTrainingSingleNode(
     executionContext.setPlan(std::move(plan));
 }
 
-void buildPlanBwdSingleNode([[maybe_unused]] const HipdnnMiopenHandle& handle,
-                            const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-                            const hipdnn_data_sdk::flatbuffer_utilities::INodeWrapper& nodeWrapper,
-                            HipdnnMiopenContext& executionContext)
+void buildPlanBwdSingleNode(
+    [[maybe_unused]] const HipdnnMiopenHandle& handle,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::INodeWrapper& nodeWrapper,
+    HipdnnMiopenContext& executionContext)
 {
     const auto& attr
-        = nodeWrapper.attributesAs<hipdnn_data_sdk::data_objects::BatchnormBackwardAttributes>();
+        = nodeWrapper
+              .attributesAs<hipdnn_flatbuffers_sdk::data_objects::BatchnormBackwardAttributes>();
 
     BatchnormBwdParams params(attr, opGraph.getTensorMap());
     auto plan = std::make_unique<BatchnormBwdPlan>(std::move(params),
@@ -676,9 +689,10 @@ void buildPlanBwdSingleNode([[maybe_unused]] const HipdnnMiopenHandle& handle,
     executionContext.setPlan(std::move(plan));
 }
 
-void buildPlanFusedBackwardsActivation([[maybe_unused]] const HipdnnMiopenHandle& handle,
-                                       const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-                                       HipdnnMiopenContext& executionContext)
+void buildPlanFusedBackwardsActivation(
+    [[maybe_unused]] const HipdnnMiopenHandle& handle,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    HipdnnMiopenContext& executionContext)
 {
     const auto [bnInfAttr, actAttr, bnBwdAttr] = getBatchnormBackwardFusionNodeAttrs(opGraph);
     batchnormBwdFusionCheckTensors(bnInfAttr, actAttr, bnBwdAttr, opGraph.getTensorMap());
@@ -691,16 +705,16 @@ void buildPlanFusedBackwardsActivation([[maybe_unused]] const HipdnnMiopenHandle
 
 void buildPlanFusedFwdInferenceActivation(
     [[maybe_unused]] const HipdnnMiopenHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
     HipdnnMiopenContext& executionContext)
 {
     const auto& node0 = opGraph.getNodeWrapper(0);
     const auto& node1 = opGraph.getNodeWrapper(1);
 
     const auto& fwdInference
-        = node0.attributesAs<hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes>();
+        = node0.attributesAs<hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes>();
     const auto& activation
-        = node1.attributesAs<hipdnn_data_sdk::data_objects::PointwiseAttributes>();
+        = node1.attributesAs<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>();
 
     BatchnormFwdInferenceParams params(fwdInference, activation, opGraph.getTensorMap());
     auto plan = std::make_unique<BatchnormFwdInferencePlan>(std::move(params),
@@ -710,16 +724,16 @@ void buildPlanFusedFwdInferenceActivation(
 
 void buildPlanFusedFwdInferenceWithVarianceActivation(
     [[maybe_unused]] const HipdnnMiopenHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
     HipdnnMiopenContext& executionContext)
 {
     const auto& node0 = opGraph.getNodeWrapper(0);
     const auto& node1 = opGraph.getNodeWrapper(1);
 
     const auto& fwdInference = node0.attributesAs<
-        hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt>();
+        hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributesVarianceExt>();
     const auto& activation
-        = node1.attributesAs<hipdnn_data_sdk::data_objects::PointwiseAttributes>();
+        = node1.attributesAs<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>();
 
     BatchnormFwdInferenceWithVarianceParams params(
         fwdInference, activation, opGraph.getTensorMap());
@@ -732,21 +746,22 @@ void buildPlanFusedFwdInferenceWithVarianceActivation(
 
 void MiopenBatchnormPlanBuilder::buildPlan(
     const HipdnnMiopenHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig&
+        engineConfig,
     HipdnnMiopenContext& executionContext) const
 {
     if(opGraph.nodeCount() == 2)
     {
         const auto& node0 = opGraph.getNodeWrapper(0);
         if(node0.attributesType()
-           == hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes)
+           == hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes)
         {
             HIPDNN_PLUGIN_LOG_INFO("Building batchnorm inference + activation fusion plan");
             buildPlanFusedFwdInferenceActivation(handle, opGraph, executionContext);
         }
         else if(node0.attributesType()
-                == hipdnn_data_sdk::data_objects::NodeAttributes::
+                == hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::
                     BatchnormInferenceAttributesVarianceExt)
         {
             HIPDNN_PLUGIN_LOG_INFO(
@@ -768,20 +783,21 @@ void MiopenBatchnormPlanBuilder::buildPlan(
 
     switch(nodeWrapper.attributesType())
     {
-    case hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes:
+    case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes:
         HIPDNN_PLUGIN_LOG_INFO("Building batchnorm fwd inference plan for node: " << nodeName);
         buildPlanInferenceSingleNode(handle, opGraph, nodeWrapper, executionContext);
         break;
-    case hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributesVarianceExt:
+    case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::
+        BatchnormInferenceAttributesVarianceExt:
         HIPDNN_PLUGIN_LOG_INFO(
             "Building batchnorm fwd inference with variance plan for node: " << nodeName);
         buildPlanInferenceWithVarianceSingleNode(handle, opGraph, nodeWrapper, executionContext);
         break;
-    case hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes:
+    case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes:
         HIPDNN_PLUGIN_LOG_INFO("Building batchnorm fwd training plan for node: " << nodeName);
         buildPlanFwdTrainingSingleNode(handle, opGraph, nodeWrapper, executionContext);
         break;
-    case hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes:
+    case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes:
         HIPDNN_PLUGIN_LOG_INFO("Building batchnorm backward plan for node: " << nodeName);
         buildPlanBwdSingleNode(handle, opGraph, nodeWrapper, executionContext);
         break;
@@ -790,13 +806,13 @@ void MiopenBatchnormPlanBuilder::buildPlan(
             HIPDNN_PLUGIN_STATUS_BAD_PARAM,
             "Unsupported node type for batchnorm plan builder: "
                 + std::string(
-                    hipdnn_data_sdk::data_objects::toString(nodeWrapper.attributesType())));
+                    hipdnn_flatbuffers_sdk::data_objects::toString(nodeWrapper.attributesType())));
     }
 }
 
-std::vector<hipdnn_data_sdk::data_objects::KnobT> MiopenBatchnormPlanBuilder::getCustomKnobs(
+std::vector<hipdnn_flatbuffers_sdk::data_objects::KnobT> MiopenBatchnormPlanBuilder::getCustomKnobs(
     [[maybe_unused]] const HipdnnMiopenHandle& handle,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
 {
     return {};
 }

--- a/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormPlanBuilder.hpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormPlanBuilder.hpp
@@ -6,7 +6,7 @@
 #include <memory>
 #include <vector>
 
-#include <hipdnn_data_sdk/data_objects/knob_value_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/knob_value_generated.h>
 #include <hipdnn_plugin_sdk/interfaces/IPlanBuilder.hpp>
 
 #include "HipdnnMiopenContext.hpp"
@@ -28,27 +28,29 @@ public:
     MiopenBatchnormPlanBuilder(const MiopenBatchnormPlanBuilder&) = delete;
     MiopenBatchnormPlanBuilder& operator=(const MiopenBatchnormPlanBuilder&) = delete;
 
-    bool isApplicable(const HipdnnMiopenHandle& handle,
-                      const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+    bool isApplicable(
+        const HipdnnMiopenHandle& handle,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
     size_t getMaxWorkspaceSize(const HipdnnMiopenHandle& handle,
-                               const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                               const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                                const HipdnnMiopenSettings& executionSettings) const override;
 
     void initializeExecutionSettings(
         const HipdnnMiopenHandle& handle,
-        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-        const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
         HipdnnMiopenSettings& executionSettings) const override;
 
     void buildPlan(
         const HipdnnMiopenHandle& handle,
-        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-        [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+        [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig&
+            engineConfig,
         HipdnnMiopenContext& executionContext) const override;
 
-    std::vector<hipdnn_data_sdk::data_objects::KnobT>
-        getCustomKnobs(const HipdnnMiopenHandle& handle,
-                       const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+    std::vector<hipdnn_flatbuffers_sdk::data_objects::KnobT> getCustomKnobs(
+        const HipdnnMiopenHandle& handle,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
 };
 
 }

--- a/dnn-providers/miopen-provider/engines/plans/MiopenConvBwdPlan.cpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenConvBwdPlan.cpp
@@ -1,8 +1,8 @@
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier:  MIT
 
-#include <hipdnn_data_sdk/utilities/FlatbufferUtils.hpp>
 #include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_flatbuffers_sdk/utilities/FlatbufferUtils.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 #include <hipdnn_plugin_sdk/PluginLogging.hpp>
 
@@ -13,8 +13,9 @@ namespace miopen_plugin
 {
 
 ConvBwdParams::ConvBwdParams(
-    const hipdnn_data_sdk::data_objects::ConvolutionBwdAttributes& attributes,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::ConvolutionBwdAttributes& attributes,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     bool deterministicEnabled)
     : _spatialDimCount(miopen_utils::getSpatialDimCount(
@@ -28,9 +29,9 @@ ConvBwdParams::ConvBwdParams(
     const auto& attrDY = miopen_utils::findTensorAttributes(tensorMap, _dy.uid());
 
     const auto inputDims
-        = hipdnn_data_sdk::utilities::convertFlatBufferVectorToStdVector(attrDX.dims());
+        = hipdnn_flatbuffers_sdk::utilities::convertFlatBufferVectorToStdVector(attrDX.dims());
     const auto weightDims
-        = hipdnn_data_sdk::utilities::convertFlatBufferVectorToStdVector(attrW.dims());
+        = hipdnn_flatbuffers_sdk::utilities::convertFlatBufferVectorToStdVector(attrW.dims());
     const auto groupCount = hipdnn_data_sdk::utilities::calculateGroupCount(inputDims, weightDims);
 
     _conv = MiopenConvDescriptor(

--- a/dnn-providers/miopen-provider/engines/plans/MiopenConvBwdPlan.hpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenConvBwdPlan.hpp
@@ -6,8 +6,8 @@
 #include <memory>
 #include <mutex>
 
-#include <hipdnn_data_sdk/data_objects/convolution_bwd_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/convolution_bwd_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/tensor_attributes_generated.h>
 #include <miopen/miopen.h>
 
 #include <hipdnn_plugin_sdk/interfaces/IPlan.hpp>
@@ -24,8 +24,9 @@ class ConvBwdParams
 {
 public:
     ConvBwdParams(
-        const hipdnn_data_sdk::data_objects::ConvolutionBwdAttributes& attributes,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::ConvolutionBwdAttributes& attributes,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap,
         bool deterministicEnabled = false);
 

--- a/dnn-providers/miopen-provider/engines/plans/MiopenConvFwdBiasActivPlan.cpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenConvFwdBiasActivPlan.cpp
@@ -1,8 +1,8 @@
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier:  MIT
 
-#include <hipdnn_data_sdk/utilities/FlatbufferUtils.hpp>
 #include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_flatbuffers_sdk/utilities/FlatbufferUtils.hpp>
 
 #include "MiopenConvFwdBiasActivPlan.hpp"
 
@@ -10,10 +10,11 @@ namespace miopen_plugin
 {
 
 ConvFwdBiasActivParams::ConvFwdBiasActivParams(
-    const hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes& convAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes* biasAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& activAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::ConvolutionFwdAttributes& convAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes* biasAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& activAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     bool deterministicEnabled)
     : _spatialDimCount(miopen_utils::getSpatialDimCount(
@@ -27,8 +28,10 @@ ConvFwdBiasActivParams::ConvFwdBiasActivParams(
     const auto& attrX = findTensorAttributes(tensorMap, _x.uid());
     const auto& attrW = findTensorAttributes(tensorMap, _w.uid());
 
-    const auto xDims = hipdnn_data_sdk::utilities::convertFlatBufferVectorToStdVector(attrX.dims());
-    const auto wDims = hipdnn_data_sdk::utilities::convertFlatBufferVectorToStdVector(attrW.dims());
+    const auto xDims
+        = hipdnn_flatbuffers_sdk::utilities::convertFlatBufferVectorToStdVector(attrX.dims());
+    const auto wDims
+        = hipdnn_flatbuffers_sdk::utilities::convertFlatBufferVectorToStdVector(attrW.dims());
     const auto groupCount = hipdnn_data_sdk::utilities::calculateGroupCount(xDims, wDims);
 
     _conv = MiopenConvDescriptor(

--- a/dnn-providers/miopen-provider/engines/plans/MiopenConvFwdBiasActivPlan.hpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenConvFwdBiasActivPlan.hpp
@@ -6,10 +6,10 @@
 #include <memory>
 #include <optional>
 
-#include <hipdnn_data_sdk/data_objects/convolution_fwd_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
 #include <hipdnn_data_sdk/utilities/ScopedResource.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/convolution_fwd_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/pointwise_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/tensor_attributes_generated.h>
 #include <miopen/miopen.h>
 
 #include <hipdnn_plugin_sdk/interfaces/IPlan.hpp>
@@ -27,10 +27,11 @@ class ConvFwdBiasActivParams
 {
 public:
     ConvFwdBiasActivParams(
-        const hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes& convAttr,
-        const hipdnn_data_sdk::data_objects::PointwiseAttributes* biasAttr,
-        const hipdnn_data_sdk::data_objects::PointwiseAttributes& activAttr,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::ConvolutionFwdAttributes& convAttr,
+        const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes* biasAttr,
+        const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& activAttr,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap,
         bool deterministicEnabled = false);
     ConvFwdBiasActivParams(const ConvFwdBiasActivParams&) = delete;

--- a/dnn-providers/miopen-provider/engines/plans/MiopenConvFwdBiasActivPlanBuilder.cpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenConvFwdBiasActivPlanBuilder.cpp
@@ -21,14 +21,14 @@ MiopenConvFwdBiasActivPlanBuilder::MiopenConvFwdBiasActivPlanBuilder(bool determ
 namespace
 {
 
-bool isNodeBias(const hipdnn_data_sdk::data_objects::PointwiseAttributes& attr)
+bool isNodeBias(const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& attr)
 {
-    return attr.operation() == hipdnn_data_sdk::data_objects::PointwiseMode::ADD;
+    return attr.operation() == hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::ADD;
 }
 
-bool isNodeActivFwd(const hipdnn_data_sdk::data_objects::PointwiseAttributes& attr)
+bool isNodeActivFwd(const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& attr)
 {
-    using PointwiseMode = hipdnn_data_sdk::data_objects::PointwiseMode;
+    using PointwiseMode = hipdnn_flatbuffers_sdk::data_objects::PointwiseMode;
     switch(attr.operation())
     {
     case PointwiseMode::ABS:
@@ -46,10 +46,10 @@ bool isNodeActivFwd(const hipdnn_data_sdk::data_objects::PointwiseAttributes& at
     }
 }
 
-std::tuple<const hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes&,
-           const hipdnn_data_sdk::data_objects::PointwiseAttributes*,
-           const hipdnn_data_sdk::data_objects::PointwiseAttributes&>
-    getNodeAttrs(const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph)
+std::tuple<const hipdnn_flatbuffers_sdk::data_objects::ConvolutionFwdAttributes&,
+           const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes*,
+           const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes&>
+    getNodeAttrs(const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph)
 {
     if(opGraph.nodeCount() < 2 || opGraph.nodeCount() > 3)
     {
@@ -64,34 +64,35 @@ std::tuple<const hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes&,
     const auto& convNodeWrapper = opGraph.getNodeWrapper(0);
     const auto convNodeName = convNodeWrapper.name();
     if(convNodeWrapper.attributesType()
-       != hipdnn_data_sdk::data_objects::NodeAttributes::ConvolutionFwdAttributes)
+       != hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::ConvolutionFwdAttributes)
     {
         throw hipdnn_plugin_sdk::HipdnnPluginException(
             HIPDNN_PLUGIN_STATUS_BAD_PARAM,
             "First node in the graph (" + convNodeName
                 + ") must be convolution forward. Found node of type: "
-                + std::string(
-                    hipdnn_data_sdk::data_objects::toString(convNodeWrapper.attributesType())));
+                + std::string(hipdnn_flatbuffers_sdk::data_objects::toString(
+                    convNodeWrapper.attributesType())));
     }
     const auto& convAttr
-        = convNodeWrapper.attributesAs<hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes>();
+        = convNodeWrapper
+              .attributesAs<hipdnn_flatbuffers_sdk::data_objects::ConvolutionFwdAttributes>();
 
     // Expect the second node to be either bias or activation forward
     const auto& secondNodeWrapper = opGraph.getNodeWrapper(1);
     const auto secondNodeName = secondNodeWrapper.name();
     if(secondNodeWrapper.attributesType()
-       != hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes)
+       != hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes)
     {
         throw hipdnn_plugin_sdk::HipdnnPluginException(
             HIPDNN_PLUGIN_STATUS_BAD_PARAM,
             "Second node in the graph (" + secondNodeName
                 + ") must be pointwise operation. Found node of type: "
-                + std::string(
-                    hipdnn_data_sdk::data_objects::toString(secondNodeWrapper.attributesType())));
+                + std::string(hipdnn_flatbuffers_sdk::data_objects::toString(
+                    secondNodeWrapper.attributesType())));
     }
     const auto& secondNodeAttr
         = opGraph.getNodeWrapper(1)
-              .attributesAs<hipdnn_data_sdk::data_objects::PointwiseAttributes>();
+              .attributesAs<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>();
 
     if(isNodeActivFwd(secondNodeAttr))
     {
@@ -116,7 +117,8 @@ std::tuple<const hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes&,
             "Second node in the graph (" + secondNodeName
                 + ") must be either bias addition or activation forward. Found pointwise "
                   "operation: "
-                + std::string(hipdnn_data_sdk::data_objects::toString(secondNodeAttr.operation())));
+                + std::string(
+                    hipdnn_flatbuffers_sdk::data_objects::toString(secondNodeAttr.operation())));
     }
 
     // The second node is bias
@@ -133,18 +135,18 @@ std::tuple<const hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes&,
     const auto& thirdNodeWrapper = opGraph.getNodeWrapper(2);
     const auto thirdNodeName = thirdNodeWrapper.name();
     if(thirdNodeWrapper.attributesType()
-       != hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes)
+       != hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes)
     {
         throw hipdnn_plugin_sdk::HipdnnPluginException(
             HIPDNN_PLUGIN_STATUS_BAD_PARAM,
             "Third node in the graph (" + thirdNodeName
                 + ") must be pointwise operation. Found node of type: "
-                + std::string(
-                    hipdnn_data_sdk::data_objects::toString(thirdNodeWrapper.attributesType())));
+                + std::string(hipdnn_flatbuffers_sdk::data_objects::toString(
+                    thirdNodeWrapper.attributesType())));
     }
     const auto& thirdNodeAttr
         = opGraph.getNodeWrapper(2)
-              .attributesAs<hipdnn_data_sdk::data_objects::PointwiseAttributes>();
+              .attributesAs<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>();
 
     if(!isNodeActivFwd(thirdNodeAttr))
     {
@@ -152,14 +154,15 @@ std::tuple<const hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes&,
             HIPDNN_PLUGIN_STATUS_BAD_PARAM,
             "Third node in the graph (" + thirdNodeName
                 + ") must be activation forward. Found pointwise operation: "
-                + std::string(hipdnn_data_sdk::data_objects::toString(thirdNodeAttr.operation())));
+                + std::string(
+                    hipdnn_flatbuffers_sdk::data_objects::toString(thirdNodeAttr.operation())));
     }
 
     const auto& activAttr = thirdNodeAttr;
     return {convAttr, &biasAttr, activAttr};
 }
 
-auto getNodeAttrsLogErrors(const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph)
+auto getNodeAttrsLogErrors(const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph)
     -> std::optional<decltype(getNodeAttrs(opGraph))>
 {
     try
@@ -174,13 +177,14 @@ auto getNodeAttrsLogErrors(const hipdnn_data_sdk::flatbuffer_utilities::IGraph& 
 }
 
 void nodeAttrsCheckTensors(
-    const hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes& convAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes* biasAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& activAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::ConvolutionFwdAttributes& convAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes* biasAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& activAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
-    using DataType = hipdnn_data_sdk::data_objects::DataType;
+    using DataType = hipdnn_flatbuffers_sdk::data_objects::DataType;
 
     // Check the connections between the convolution and bias/activation nodes
     if(biasAttr != nullptr)
@@ -321,10 +325,11 @@ void nodeAttrsCheckTensors(
 }
 
 bool nodeAttrsCheckTensorsLogErrors(
-    const hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes& convAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes* biasAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes& activAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::ConvolutionFwdAttributes& convAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes* biasAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes& activAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     try
@@ -340,10 +345,11 @@ bool nodeAttrsCheckTensorsLogErrors(
 }
 
 void checkComputeTypes(
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& graph,
-    const hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes& convAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes* biasAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& graph,
+    const hipdnn_flatbuffers_sdk::data_objects::ConvolutionFwdAttributes& convAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes* biasAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     uint32_t convAttrIdx = 0;
@@ -351,7 +357,7 @@ void checkComputeTypes(
     uint32_t activAttrIdx = (biasAttr != nullptr) ? 2 : 1;
 
     if(graph.getNode(convAttrIdx).compute_data_type()
-       != hipdnn_data_sdk::data_objects::DataType::FLOAT)
+       != hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT)
     {
         throw hipdnn_plugin_sdk::HipdnnPluginException(
             HIPDNN_PLUGIN_STATUS_BAD_PARAM, "Convolution node compute data type must be float");
@@ -378,7 +384,7 @@ void checkComputeTypes(
     }
 
     if(graph.getNode(activAttrIdx).compute_data_type()
-       != hipdnn_data_sdk::data_objects::DataType::FLOAT)
+       != hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT)
     {
         throw hipdnn_plugin_sdk::HipdnnPluginException(
             HIPDNN_PLUGIN_STATUS_BAD_PARAM, "Activation node compute data type must be float");
@@ -386,10 +392,11 @@ void checkComputeTypes(
 }
 
 bool checkComputeTypesLogErrors(
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& graph,
-    const hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes& convAttr,
-    const hipdnn_data_sdk::data_objects::PointwiseAttributes* biasAttr,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& graph,
+    const hipdnn_flatbuffers_sdk::data_objects::ConvolutionFwdAttributes& convAttr,
+    const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes* biasAttr,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
     try
@@ -408,7 +415,7 @@ bool checkComputeTypesLogErrors(
 
 bool MiopenConvFwdBiasActivPlanBuilder::isApplicable(
     const HipdnnMiopenHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
 {
     auto nodeAttrs = getNodeAttrsLogErrors(opGraph);
     if(!nodeAttrs.has_value())
@@ -452,7 +459,7 @@ bool MiopenConvFwdBiasActivPlanBuilder::isApplicable(
 
 size_t MiopenConvFwdBiasActivPlanBuilder::getMaxWorkspaceSize(
     const HipdnnMiopenHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
     const HipdnnMiopenSettings& executionSettings) const
 {
     const auto [convAttr, biasAttr, activAttr] = getNodeAttrs(opGraph);
@@ -466,16 +473,18 @@ size_t MiopenConvFwdBiasActivPlanBuilder::getMaxWorkspaceSize(
 
 void MiopenConvFwdBiasActivPlanBuilder::initializeExecutionSettings(
     [[maybe_unused]] const HipdnnMiopenHandle& handle,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig&
+        engineConfig,
     [[maybe_unused]] HipdnnMiopenSettings& executionSettings) const
 {
 }
 
 void MiopenConvFwdBiasActivPlanBuilder::buildPlan(
     const HipdnnMiopenHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig&
+        engineConfig,
     HipdnnMiopenContext& executionContext) const
 {
     const auto [convAttr, biasAttr, activAttr] = getNodeAttrs(opGraph);
@@ -488,9 +497,10 @@ void MiopenConvFwdBiasActivPlanBuilder::buildPlan(
     executionContext.setPlan(std::move(plan));
 }
 
-std::vector<hipdnn_data_sdk::data_objects::KnobT> MiopenConvFwdBiasActivPlanBuilder::getCustomKnobs(
-    [[maybe_unused]] const HipdnnMiopenHandle& handle,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+std::vector<hipdnn_flatbuffers_sdk::data_objects::KnobT>
+    MiopenConvFwdBiasActivPlanBuilder::getCustomKnobs(
+        [[maybe_unused]] const HipdnnMiopenHandle& handle,
+        [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
 {
     return {};
 }

--- a/dnn-providers/miopen-provider/engines/plans/MiopenConvFwdBiasActivPlanBuilder.hpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenConvFwdBiasActivPlanBuilder.hpp
@@ -6,7 +6,7 @@
 #include <memory>
 #include <vector>
 
-#include <hipdnn_data_sdk/data_objects/knob_value_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/knob_value_generated.h>
 #include <hipdnn_plugin_sdk/interfaces/IPlanBuilder.hpp>
 
 #include "HipdnnMiopenContext.hpp"
@@ -28,28 +28,30 @@ public:
     MiopenConvFwdBiasActivPlanBuilder(const MiopenConvFwdBiasActivPlanBuilder&) = delete;
     MiopenConvFwdBiasActivPlanBuilder& operator=(const MiopenConvFwdBiasActivPlanBuilder&) = delete;
 
-    bool isApplicable(const HipdnnMiopenHandle& handle,
-                      const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+    bool isApplicable(
+        const HipdnnMiopenHandle& handle,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
 
     size_t getMaxWorkspaceSize(const HipdnnMiopenHandle& handle,
-                               const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                               const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                                const HipdnnMiopenSettings& executionSettings) const override;
 
     void initializeExecutionSettings(
         const HipdnnMiopenHandle& handle,
-        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-        const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
         HipdnnMiopenSettings& executionSettings) const override;
 
     void buildPlan(
         const HipdnnMiopenHandle& handle,
-        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-        [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+        [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig&
+            engineConfig,
         HipdnnMiopenContext& executionContext) const override;
 
-    std::vector<hipdnn_data_sdk::data_objects::KnobT>
-        getCustomKnobs(const HipdnnMiopenHandle& handle,
-                       const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+    std::vector<hipdnn_flatbuffers_sdk::data_objects::KnobT> getCustomKnobs(
+        const HipdnnMiopenHandle& handle,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
 
 private:
     bool _deterministic;

--- a/dnn-providers/miopen-provider/engines/plans/MiopenConvFwdPlan.cpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenConvFwdPlan.cpp
@@ -1,8 +1,8 @@
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier:  MIT
 
-#include <hipdnn_data_sdk/utilities/FlatbufferUtils.hpp>
 #include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_flatbuffers_sdk/utilities/FlatbufferUtils.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 #include <hipdnn_plugin_sdk/PluginLogging.hpp>
 
@@ -13,8 +13,9 @@ namespace miopen_plugin
 {
 
 ConvFwdParams::ConvFwdParams(
-    const hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes& attributes,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::ConvolutionFwdAttributes& attributes,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     bool deterministicEnabled)
     : _spatialDimCount(miopen_utils::getSpatialDimCount(
@@ -28,9 +29,9 @@ ConvFwdParams::ConvFwdParams(
     const auto& attrY = miopen_utils::findTensorAttributes(tensorMap, _y.uid());
 
     const auto inputDims
-        = hipdnn_data_sdk::utilities::convertFlatBufferVectorToStdVector(attrX.dims());
+        = hipdnn_flatbuffers_sdk::utilities::convertFlatBufferVectorToStdVector(attrX.dims());
     const auto weightDims
-        = hipdnn_data_sdk::utilities::convertFlatBufferVectorToStdVector(attrW.dims());
+        = hipdnn_flatbuffers_sdk::utilities::convertFlatBufferVectorToStdVector(attrW.dims());
     const auto groupCount = hipdnn_data_sdk::utilities::calculateGroupCount(inputDims, weightDims);
 
     _conv = MiopenConvDescriptor(

--- a/dnn-providers/miopen-provider/engines/plans/MiopenConvFwdPlan.hpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenConvFwdPlan.hpp
@@ -6,8 +6,8 @@
 #include <memory>
 #include <mutex>
 
-#include <hipdnn_data_sdk/data_objects/convolution_fwd_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/convolution_fwd_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/tensor_attributes_generated.h>
 #include <miopen/miopen.h>
 
 #include <hipdnn_plugin_sdk/interfaces/IPlan.hpp>
@@ -24,8 +24,9 @@ class ConvFwdParams
 {
 public:
     ConvFwdParams(
-        const hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes& attributes,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::ConvolutionFwdAttributes& attributes,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap,
         bool deterministicEnabled = false);
 

--- a/dnn-providers/miopen-provider/engines/plans/MiopenConvPlanBuilder.cpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenConvPlanBuilder.cpp
@@ -29,11 +29,12 @@ namespace
 {
 
 bool isApplicableFwd(const HipdnnMiopenHandle& handle,
-                     const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                     const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                      bool deterministicEnabled)
 {
-    const auto& attr = opGraph.getNodeWrapper(0)
-                           .attributesAs<hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes>();
+    const auto& attr
+        = opGraph.getNodeWrapper(0)
+              .attributesAs<hipdnn_flatbuffers_sdk::data_objects::ConvolutionFwdAttributes>();
 
     size_t solutionCount = 0;
     try
@@ -66,11 +67,12 @@ bool isApplicableFwd(const HipdnnMiopenHandle& handle,
 }
 
 bool isApplicableBwd(const HipdnnMiopenHandle& handle,
-                     const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                     const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                      bool deterministicEnabled)
 {
-    const auto& attr = opGraph.getNodeWrapper(0)
-                           .attributesAs<hipdnn_data_sdk::data_objects::ConvolutionBwdAttributes>();
+    const auto& attr
+        = opGraph.getNodeWrapper(0)
+              .attributesAs<hipdnn_flatbuffers_sdk::data_objects::ConvolutionBwdAttributes>();
 
     size_t solutionCount = 0;
     try
@@ -103,11 +105,12 @@ bool isApplicableBwd(const HipdnnMiopenHandle& handle,
 }
 
 bool isApplicableWrw(const HipdnnMiopenHandle& handle,
-                     const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                     const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                      bool deterministicEnabled)
 {
-    const auto& attr = opGraph.getNodeWrapper(0)
-                           .attributesAs<hipdnn_data_sdk::data_objects::ConvolutionWrwAttributes>();
+    const auto& attr
+        = opGraph.getNodeWrapper(0)
+              .attributesAs<hipdnn_flatbuffers_sdk::data_objects::ConvolutionWrwAttributes>();
 
     size_t solutionCount = 0;
     try
@@ -142,11 +145,12 @@ bool isApplicableWrw(const HipdnnMiopenHandle& handle,
 
 MiopenConvPlanBuilder::WorkspaceSizeRange
     getWorkspaceSizeRangeFwd(const HipdnnMiopenHandle& handle,
-                             const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                             const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                              bool deterministicEnabled)
 {
-    const auto& attr = opGraph.getNodeWrapper(0)
-                           .attributesAs<hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes>();
+    const auto& attr
+        = opGraph.getNodeWrapper(0)
+              .attributesAs<hipdnn_flatbuffers_sdk::data_objects::ConvolutionFwdAttributes>();
     ConvFwdParams params(attr, opGraph.getTensorMap(), deterministicEnabled);
 
     size_t solutionCount = 0;
@@ -197,11 +201,12 @@ MiopenConvPlanBuilder::WorkspaceSizeRange
 
 MiopenConvPlanBuilder::WorkspaceSizeRange
     getWorkspaceSizeRangeBwd(const HipdnnMiopenHandle& handle,
-                             const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                             const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                              bool deterministicEnabled)
 {
-    const auto& attr = opGraph.getNodeWrapper(0)
-                           .attributesAs<hipdnn_data_sdk::data_objects::ConvolutionBwdAttributes>();
+    const auto& attr
+        = opGraph.getNodeWrapper(0)
+              .attributesAs<hipdnn_flatbuffers_sdk::data_objects::ConvolutionBwdAttributes>();
     ConvBwdParams params(attr, opGraph.getTensorMap(), deterministicEnabled);
 
     size_t solutionCount = 0;
@@ -253,11 +258,12 @@ MiopenConvPlanBuilder::WorkspaceSizeRange
 
 MiopenConvPlanBuilder::WorkspaceSizeRange
     getWorkspaceSizeRangeWrw(const HipdnnMiopenHandle& handle,
-                             const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                             const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                              bool deterministicEnabled)
 {
-    const auto& attr = opGraph.getNodeWrapper(0)
-                           .attributesAs<hipdnn_data_sdk::data_objects::ConvolutionWrwAttributes>();
+    const auto& attr
+        = opGraph.getNodeWrapper(0)
+              .attributesAs<hipdnn_flatbuffers_sdk::data_objects::ConvolutionWrwAttributes>();
     ConvWrwParams params(attr, opGraph.getTensorMap(), deterministicEnabled);
 
     size_t solutionCount = 0;
@@ -309,7 +315,7 @@ MiopenConvPlanBuilder::WorkspaceSizeRange
 }
 
 size_t getMaxWorkspaceSizeFwd(const HipdnnMiopenHandle& handle,
-                              const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                              const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                               const HipdnnMiopenSettings& executionSettings,
                               bool deterministicEnabled)
 {
@@ -319,7 +325,7 @@ size_t getMaxWorkspaceSizeFwd(const HipdnnMiopenHandle& handle,
     {
         const auto& attr
             = opGraph.getNodeWrapper(0)
-                  .attributesAs<hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes>();
+                  .attributesAs<hipdnn_flatbuffers_sdk::data_objects::ConvolutionFwdAttributes>();
         ConvFwdParams params(attr, opGraph.getTensorMap(), deterministicEnabled);
         THROW_ON_MIOPEN_FAILURE(
             miopenConvolutionForwardGetWorkSpaceSize(handle.miopenHandle,
@@ -334,7 +340,7 @@ size_t getMaxWorkspaceSizeFwd(const HipdnnMiopenHandle& handle,
 }
 
 size_t getMaxWorkspaceSizeBwd(const HipdnnMiopenHandle& handle,
-                              const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                              const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                               const HipdnnMiopenSettings& executionSettings,
                               bool deterministicEnabled)
 {
@@ -344,7 +350,7 @@ size_t getMaxWorkspaceSizeBwd(const HipdnnMiopenHandle& handle,
     {
         const auto& attr
             = opGraph.getNodeWrapper(0)
-                  .attributesAs<hipdnn_data_sdk::data_objects::ConvolutionBwdAttributes>();
+                  .attributesAs<hipdnn_flatbuffers_sdk::data_objects::ConvolutionBwdAttributes>();
         ConvBwdParams params(attr, opGraph.getTensorMap(), deterministicEnabled);
 
         THROW_ON_MIOPEN_FAILURE(
@@ -360,7 +366,7 @@ size_t getMaxWorkspaceSizeBwd(const HipdnnMiopenHandle& handle,
 }
 
 size_t getMaxWorkspaceSizeWrw(const HipdnnMiopenHandle& handle,
-                              const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                              const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                               const HipdnnMiopenSettings& executionSettings,
                               bool deterministicEnabled)
 {
@@ -370,7 +376,7 @@ size_t getMaxWorkspaceSizeWrw(const HipdnnMiopenHandle& handle,
     {
         const auto& attr
             = opGraph.getNodeWrapper(0)
-                  .attributesAs<hipdnn_data_sdk::data_objects::ConvolutionWrwAttributes>();
+                  .attributesAs<hipdnn_flatbuffers_sdk::data_objects::ConvolutionWrwAttributes>();
         ConvWrwParams params(attr, opGraph.getTensorMap(), deterministicEnabled);
 
         THROW_ON_MIOPEN_FAILURE(
@@ -386,12 +392,13 @@ size_t getMaxWorkspaceSizeWrw(const HipdnnMiopenHandle& handle,
 }
 
 void buildPlanFwd(const HipdnnMiopenHandle& handle,
-                  const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                  const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                   HipdnnMiopenContext& executionContext,
                   bool deterministicEnabled)
 {
-    const auto& attr = opGraph.getNodeWrapper(0)
-                           .attributesAs<hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes>();
+    const auto& attr
+        = opGraph.getNodeWrapper(0)
+              .attributesAs<hipdnn_flatbuffers_sdk::data_objects::ConvolutionFwdAttributes>();
     ConvFwdParams params(attr, opGraph.getTensorMap(), deterministicEnabled);
     auto plan = std::make_unique<ConvFwdPlan>(
         handle, std::move(params), executionContext.executionSettings());
@@ -399,12 +406,13 @@ void buildPlanFwd(const HipdnnMiopenHandle& handle,
 }
 
 void buildPlanBwd(const HipdnnMiopenHandle& handle,
-                  const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                  const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                   HipdnnMiopenContext& executionContext,
                   bool deterministicEnabled)
 {
-    const auto& attr = opGraph.getNodeWrapper(0)
-                           .attributesAs<hipdnn_data_sdk::data_objects::ConvolutionBwdAttributes>();
+    const auto& attr
+        = opGraph.getNodeWrapper(0)
+              .attributesAs<hipdnn_flatbuffers_sdk::data_objects::ConvolutionBwdAttributes>();
     ConvBwdParams params(attr, opGraph.getTensorMap(), deterministicEnabled);
     auto plan = std::make_unique<ConvBwdPlan>(
         handle, std::move(params), executionContext.executionSettings());
@@ -412,12 +420,13 @@ void buildPlanBwd(const HipdnnMiopenHandle& handle,
 }
 
 void buildPlanWrw(const HipdnnMiopenHandle& handle,
-                  const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                  const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                   HipdnnMiopenContext& executionContext,
                   bool deterministicEnabled)
 {
-    const auto& attr = opGraph.getNodeWrapper(0)
-                           .attributesAs<hipdnn_data_sdk::data_objects::ConvolutionWrwAttributes>();
+    const auto& attr
+        = opGraph.getNodeWrapper(0)
+              .attributesAs<hipdnn_flatbuffers_sdk::data_objects::ConvolutionWrwAttributes>();
     ConvWrwParams params(attr, opGraph.getTensorMap(), deterministicEnabled);
     auto plan = std::make_unique<ConvWrwPlan>(
         handle, std::move(params), executionContext.executionSettings());
@@ -428,7 +437,7 @@ void buildPlanWrw(const HipdnnMiopenHandle& handle,
 
 bool MiopenConvPlanBuilder::isApplicable(
     const HipdnnMiopenHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
 {
     if(opGraph.nodeCount() != 1)
     {
@@ -439,7 +448,8 @@ bool MiopenConvPlanBuilder::isApplicable(
         return false;
     }
 
-    if(opGraph.getNode(0).compute_data_type() != hipdnn_data_sdk::data_objects::DataType::FLOAT)
+    if(opGraph.getNode(0).compute_data_type()
+       != hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT)
     {
         HIPDNN_PLUGIN_LOG_ERROR("Convolution plan builder only supports nodes with an fp32 "
                                 "compute_data_type");
@@ -451,13 +461,13 @@ bool MiopenConvPlanBuilder::isApplicable(
 
     switch(node.attributes_type())
     {
-    case hipdnn_data_sdk::data_objects::NodeAttributes::ConvolutionFwdAttributes:
+    case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::ConvolutionFwdAttributes:
         ret = isApplicableFwd(handle, opGraph, _deterministic);
         break;
-    case hipdnn_data_sdk::data_objects::NodeAttributes::ConvolutionBwdAttributes:
+    case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::ConvolutionBwdAttributes:
         ret = isApplicableBwd(handle, opGraph, _deterministic);
         break;
-    case hipdnn_data_sdk::data_objects::NodeAttributes::ConvolutionWrwAttributes:
+    case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::ConvolutionWrwAttributes:
         ret = isApplicableWrw(handle, opGraph, _deterministic);
         break;
     default:
@@ -473,7 +483,7 @@ bool MiopenConvPlanBuilder::isApplicable(
 
 MiopenConvPlanBuilder::WorkspaceSizeRange MiopenConvPlanBuilder::getWorkspaceSizeRange(
     const HipdnnMiopenHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
 {
     if(opGraph.nodeCount() != 1)
     {
@@ -487,23 +497,24 @@ MiopenConvPlanBuilder::WorkspaceSizeRange MiopenConvPlanBuilder::getWorkspaceSiz
 
     switch(node.attributes_type())
     {
-    case hipdnn_data_sdk::data_objects::NodeAttributes::ConvolutionFwdAttributes:
+    case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::ConvolutionFwdAttributes:
         return getWorkspaceSizeRangeFwd(handle, opGraph, _deterministic);
-    case hipdnn_data_sdk::data_objects::NodeAttributes::ConvolutionBwdAttributes:
+    case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::ConvolutionBwdAttributes:
         return getWorkspaceSizeRangeBwd(handle, opGraph, _deterministic);
-    case hipdnn_data_sdk::data_objects::NodeAttributes::ConvolutionWrwAttributes:
+    case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::ConvolutionWrwAttributes:
         return getWorkspaceSizeRangeWrw(handle, opGraph, _deterministic);
     default:
         throw hipdnn_plugin_sdk::HipdnnPluginException(
             HIPDNN_PLUGIN_STATUS_BAD_PARAM,
             "Unsupported node type for convolution plan builder: "
-                + std::string(hipdnn_data_sdk::data_objects::toString(node.attributes_type())));
+                + std::string(
+                    hipdnn_flatbuffers_sdk::data_objects::toString(node.attributes_type())));
     }
 }
 
 size_t MiopenConvPlanBuilder::getMaxWorkspaceSize(
     const HipdnnMiopenHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
     const HipdnnMiopenSettings& executionSettings) const
 {
     if(opGraph.nodeCount() != 1)
@@ -518,24 +529,25 @@ size_t MiopenConvPlanBuilder::getMaxWorkspaceSize(
 
     switch(node.attributes_type())
     {
-    case hipdnn_data_sdk::data_objects::NodeAttributes::ConvolutionFwdAttributes:
+    case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::ConvolutionFwdAttributes:
         return getMaxWorkspaceSizeFwd(handle, opGraph, executionSettings, _deterministic);
-    case hipdnn_data_sdk::data_objects::NodeAttributes::ConvolutionBwdAttributes:
+    case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::ConvolutionBwdAttributes:
         return getMaxWorkspaceSizeBwd(handle, opGraph, executionSettings, _deterministic);
-    case hipdnn_data_sdk::data_objects::NodeAttributes::ConvolutionWrwAttributes:
+    case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::ConvolutionWrwAttributes:
         return getMaxWorkspaceSizeWrw(handle, opGraph, executionSettings, _deterministic);
     default:
         throw hipdnn_plugin_sdk::HipdnnPluginException(
             HIPDNN_PLUGIN_STATUS_BAD_PARAM,
             "Unsupported node type for convolution plan builder: "
-                + std::string(hipdnn_data_sdk::data_objects::toString(node.attributes_type())));
+                + std::string(
+                    hipdnn_flatbuffers_sdk::data_objects::toString(node.attributes_type())));
     }
 }
 
 void MiopenConvPlanBuilder::initializeExecutionSettings(
     const HipdnnMiopenHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-    const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
     HipdnnMiopenSettings& executionSettings) const
 {
     // Read workspace size limit knob setting
@@ -545,16 +557,16 @@ void MiopenConvPlanBuilder::initializeExecutionSettings(
         const auto& knobSetting
             = engineConfig.getKnobSettingByName(hipdnn_plugin_sdk::WORKSPACE_SIZE_LIMIT_KNOB_NAME);
 
-        if(knobSetting.valueType() != hipdnn_data_sdk::data_objects::KnobValue::IntValue)
+        if(knobSetting.valueType() != hipdnn_flatbuffers_sdk::data_objects::KnobValue::IntValue)
         {
             throw hipdnn_plugin_sdk::HipdnnPluginException(
                 HIPDNN_PLUGIN_STATUS_BAD_PARAM,
                 "Workspace size limit knob setting value is not an integer. Type: "
-                    + std::string(
-                        hipdnn_data_sdk::data_objects::EnumNameKnobValue(knobSetting.valueType())));
+                    + std::string(hipdnn_flatbuffers_sdk::data_objects::EnumNameKnobValue(
+                        knobSetting.valueType())));
         }
 
-        auto value = knobSetting.valueAs<hipdnn_data_sdk::data_objects::IntValue>().value();
+        auto value = knobSetting.valueAs<hipdnn_flatbuffers_sdk::data_objects::IntValue>().value();
 
         if(value < 0)
         {
@@ -587,8 +599,9 @@ void MiopenConvPlanBuilder::initializeExecutionSettings(
 
 void MiopenConvPlanBuilder::buildPlan(
     const HipdnnMiopenHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+    [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig&
+        engineConfig,
     HipdnnMiopenContext& executionContext) const
 {
     if(opGraph.nodeCount() != 1)
@@ -604,15 +617,15 @@ void MiopenConvPlanBuilder::buildPlan(
 
     switch(nodeWrapper.attributesType())
     {
-    case hipdnn_data_sdk::data_objects::NodeAttributes::ConvolutionFwdAttributes:
+    case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::ConvolutionFwdAttributes:
         HIPDNN_PLUGIN_LOG_INFO("Building convolution fwd plan for node: " << nodeName);
         buildPlanFwd(handle, opGraph, executionContext, _deterministic);
         break;
-    case hipdnn_data_sdk::data_objects::NodeAttributes::ConvolutionBwdAttributes:
+    case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::ConvolutionBwdAttributes:
         HIPDNN_PLUGIN_LOG_INFO("Building convolution bwd plan for node: " << nodeName);
         buildPlanBwd(handle, opGraph, executionContext, _deterministic);
         break;
-    case hipdnn_data_sdk::data_objects::NodeAttributes::ConvolutionWrwAttributes:
+    case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::ConvolutionWrwAttributes:
         HIPDNN_PLUGIN_LOG_INFO("Building convolution wrw plan for node: " << nodeName);
         buildPlanWrw(handle, opGraph, executionContext, _deterministic);
         break;
@@ -621,15 +634,15 @@ void MiopenConvPlanBuilder::buildPlan(
             HIPDNN_PLUGIN_STATUS_BAD_PARAM,
             "Unsupported node type for convolution plan builder: "
                 + std::string(
-                    hipdnn_data_sdk::data_objects::toString(nodeWrapper.attributesType())));
+                    hipdnn_flatbuffers_sdk::data_objects::toString(nodeWrapper.attributesType())));
     }
 }
 
-std::vector<hipdnn_data_sdk::data_objects::KnobT> MiopenConvPlanBuilder::getCustomKnobs(
+std::vector<hipdnn_flatbuffers_sdk::data_objects::KnobT> MiopenConvPlanBuilder::getCustomKnobs(
     const HipdnnMiopenHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
 {
-    std::vector<hipdnn_data_sdk::data_objects::KnobT> knobs;
+    std::vector<hipdnn_flatbuffers_sdk::data_objects::KnobT> knobs;
 
     if(!isApplicable(handle, opGraph))
     {
@@ -658,15 +671,15 @@ std::vector<hipdnn_data_sdk::data_objects::KnobT> MiopenConvPlanBuilder::getCust
     const auto minWorkspace = static_cast<int64_t>(range.min);
     const auto maxWorkspace = static_cast<int64_t>(range.max);
 
-    hipdnn_data_sdk::data_objects::KnobT workspaceKnob;
+    hipdnn_flatbuffers_sdk::data_objects::KnobT workspaceKnob;
     workspaceKnob.knob_id = hipdnn_plugin_sdk::WORKSPACE_SIZE_LIMIT_KNOB_NAME;
     workspaceKnob.description = "Workspace size limit in bytes";
 
-    hipdnn_data_sdk::data_objects::IntValueT workspaceDefaultValue;
+    hipdnn_flatbuffers_sdk::data_objects::IntValueT workspaceDefaultValue;
     workspaceDefaultValue.value = maxWorkspace;
     workspaceKnob.default_value.Set(workspaceDefaultValue);
 
-    hipdnn_data_sdk::data_objects::IntConstraintT workspaceConstraint;
+    hipdnn_flatbuffers_sdk::data_objects::IntConstraintT workspaceConstraint;
     workspaceConstraint.min_value = minWorkspace;
     workspaceConstraint.max_value = maxWorkspace;
     workspaceConstraint.step = 1;

--- a/dnn-providers/miopen-provider/engines/plans/MiopenConvPlanBuilder.hpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenConvPlanBuilder.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <hipdnn_data_sdk/data_objects/knob_value_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/knob_value_generated.h>
 #include <hipdnn_plugin_sdk/interfaces/IPlanBuilder.hpp>
 
 #include "HipdnnMiopenContext.hpp"
@@ -31,31 +31,33 @@ public:
     MiopenConvPlanBuilder(const MiopenConvPlanBuilder&) = delete;
     MiopenConvPlanBuilder& operator=(const MiopenConvPlanBuilder&) = delete;
 
-    bool isApplicable(const HipdnnMiopenHandle& handle,
-                      const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+    bool isApplicable(
+        const HipdnnMiopenHandle& handle,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
 
-    WorkspaceSizeRange
-        getWorkspaceSizeRange(const HipdnnMiopenHandle& handle,
-                              const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const;
+    WorkspaceSizeRange getWorkspaceSizeRange(
+        const HipdnnMiopenHandle& handle,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const;
     size_t getMaxWorkspaceSize(const HipdnnMiopenHandle& handle,
-                               const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                               const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                                const HipdnnMiopenSettings& executionSettings) const override;
 
     void initializeExecutionSettings(
         const HipdnnMiopenHandle& handle,
-        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-        const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
         HipdnnMiopenSettings& executionSettings) const override;
 
     void buildPlan(
         const HipdnnMiopenHandle& handle,
-        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-        [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+        [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig&
+            engineConfig,
         HipdnnMiopenContext& executionContext) const override;
 
-    std::vector<hipdnn_data_sdk::data_objects::KnobT>
-        getCustomKnobs(const HipdnnMiopenHandle& handle,
-                       const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+    std::vector<hipdnn_flatbuffers_sdk::data_objects::KnobT> getCustomKnobs(
+        const HipdnnMiopenHandle& handle,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
 
 private:
     bool _deterministic;

--- a/dnn-providers/miopen-provider/engines/plans/MiopenConvWrwPlan.cpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenConvWrwPlan.cpp
@@ -1,8 +1,8 @@
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier:  MIT
 
-#include <hipdnn_data_sdk/utilities/FlatbufferUtils.hpp>
 #include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_flatbuffers_sdk/utilities/FlatbufferUtils.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 #include <hipdnn_plugin_sdk/PluginLogging.hpp>
 
@@ -13,8 +13,9 @@ namespace miopen_plugin
 {
 
 ConvWrwParams::ConvWrwParams(
-    const hipdnn_data_sdk::data_objects::ConvolutionWrwAttributes& attributes,
-    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+    const hipdnn_flatbuffers_sdk::data_objects::ConvolutionWrwAttributes& attributes,
+    const std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
         tensorMap,
     bool deterministicEnabled)
     : _spatialDimCount(miopen_utils::getSpatialDimCount(
@@ -28,9 +29,9 @@ ConvWrwParams::ConvWrwParams(
     const auto& attrDY = miopen_utils::findTensorAttributes(tensorMap, _dy.uid());
 
     const auto inputDims
-        = hipdnn_data_sdk::utilities::convertFlatBufferVectorToStdVector(attrX.dims());
+        = hipdnn_flatbuffers_sdk::utilities::convertFlatBufferVectorToStdVector(attrX.dims());
     const auto weightDims
-        = hipdnn_data_sdk::utilities::convertFlatBufferVectorToStdVector(attrDW.dims());
+        = hipdnn_flatbuffers_sdk::utilities::convertFlatBufferVectorToStdVector(attrDW.dims());
     const auto groupCount = hipdnn_data_sdk::utilities::calculateGroupCount(inputDims, weightDims);
 
     _conv = MiopenConvDescriptor(

--- a/dnn-providers/miopen-provider/engines/plans/MiopenConvWrwPlan.hpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenConvWrwPlan.hpp
@@ -6,8 +6,8 @@
 #include <memory>
 #include <mutex>
 
-#include <hipdnn_data_sdk/data_objects/convolution_wrw_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/convolution_wrw_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/tensor_attributes_generated.h>
 #include <miopen/miopen.h>
 
 #include <hipdnn_plugin_sdk/interfaces/IPlan.hpp>
@@ -24,8 +24,9 @@ class ConvWrwParams
 {
 public:
     ConvWrwParams(
-        const hipdnn_data_sdk::data_objects::ConvolutionWrwAttributes& attributes,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::ConvolutionWrwAttributes& attributes,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap,
         bool deterministicEnabled = false);
 

--- a/dnn-providers/miopen-provider/integration_tests/IntegrationGraphVerificationHarness.hpp
+++ b/dnn-providers/miopen-provider/integration_tests/IntegrationGraphVerificationHarness.hpp
@@ -4,8 +4,8 @@
 #pragma once
 
 #include <gtest/gtest.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_data_sdk/utilities/Workspace.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_frontend/Graph.hpp>
 #include <hipdnn_frontend/Utilities.hpp>
 #include <hipdnn_frontend/attributes/TensorAttributes.hpp>

--- a/dnn-providers/miopen-provider/tests/TestMiopenActivationDescriptor.cpp
+++ b/dnn-providers/miopen-provider/tests/TestMiopenActivationDescriptor.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier:  MIT
 
 #include <gtest/gtest.h>
-#include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/pointwise_attributes_generated.h>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 #include <miopen/miopen.h>
 
@@ -15,7 +15,7 @@ namespace
 
 // Helper function to create PointwiseAttributes flatbuffer
 flatbuffers::FlatBufferBuilder createPointwiseAttributesBuilder(
-    hipdnn_data_sdk::data_objects::PointwiseMode mode,
+    hipdnn_flatbuffers_sdk::data_objects::PointwiseMode mode,
     flatbuffers::Optional<float> reluLowerClip = flatbuffers::nullopt,
     flatbuffers::Optional<float> reluUpperClip = flatbuffers::nullopt,
     flatbuffers::Optional<float> reluLowerClipSlope = flatbuffers::nullopt,
@@ -23,7 +23,7 @@ flatbuffers::FlatBufferBuilder createPointwiseAttributesBuilder(
     flatbuffers::Optional<float> softplusBeta = flatbuffers::nullopt)
 {
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
         mode,
         reluLowerClip,
@@ -45,10 +45,11 @@ flatbuffers::FlatBufferBuilder createPointwiseAttributesBuilder(
 
 TEST(TestMiopenActivationDescriptor, CreatesStandardRelu)
 {
-    auto builder
-        = createPointwiseAttributesBuilder(hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+    auto builder = createPointwiseAttributesBuilder(
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD);
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     MiopenActivationDescriptor activDesc(*attr);
 
@@ -67,10 +68,11 @@ TEST(TestMiopenActivationDescriptor, CreatesStandardRelu)
 
 TEST(TestMiopenActivationDescriptor, CreatesStandardReluBwd)
 {
-    auto builder
-        = createPointwiseAttributesBuilder(hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+    auto builder = createPointwiseAttributesBuilder(
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD);
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     MiopenActivationDescriptor activDesc(*attr);
 
@@ -88,9 +90,12 @@ TEST(TestMiopenActivationDescriptor, CreatesClippedRelu)
 {
     const float upperClip = 6.0f;
     auto builder = createPointwiseAttributesBuilder(
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD, flatbuffers::nullopt, upperClip);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
+        flatbuffers::nullopt,
+        upperClip);
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     MiopenActivationDescriptor activDesc(*attr);
 
@@ -108,13 +113,14 @@ TEST(TestMiopenActivationDescriptor, CreatesClippedRelu)
 TEST(TestMiopenActivationDescriptor, CreatesLeakyRelu)
 {
     const float slope = 0.01f;
-    auto builder
-        = createPointwiseAttributesBuilder(hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
-                                           flatbuffers::nullopt,
-                                           flatbuffers::nullopt,
-                                           slope);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+    auto builder = createPointwiseAttributesBuilder(
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        slope);
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     MiopenActivationDescriptor activDesc(*attr);
 
@@ -134,9 +140,10 @@ TEST(TestMiopenActivationDescriptor, CreatesClamp)
     const float lowerClip = 1.0f;
     const float upperClip = 6.0f;
     auto builder = createPointwiseAttributesBuilder(
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD, lowerClip, upperClip);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD, lowerClip, upperClip);
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     MiopenActivationDescriptor activDesc(*attr);
 
@@ -155,9 +162,10 @@ TEST(TestMiopenActivationDescriptor, CreatesClamp)
 TEST(TestMiopenActivationDescriptor, CreatesSigmoidFwd)
 {
     auto builder = createPointwiseAttributesBuilder(
-        hipdnn_data_sdk::data_objects::PointwiseMode::SIGMOID_FWD);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SIGMOID_FWD);
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     MiopenActivationDescriptor activDesc(*attr);
 
@@ -174,9 +182,10 @@ TEST(TestMiopenActivationDescriptor, CreatesSigmoidFwd)
 TEST(TestMiopenActivationDescriptor, CreatesSigmoidBwd)
 {
     auto builder = createPointwiseAttributesBuilder(
-        hipdnn_data_sdk::data_objects::PointwiseMode::SIGMOID_BWD);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SIGMOID_BWD);
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     MiopenActivationDescriptor activDesc(*attr);
 
@@ -192,10 +201,11 @@ TEST(TestMiopenActivationDescriptor, CreatesSigmoidBwd)
 
 TEST(TestMiopenActivationDescriptor, CreatesTanhFwd)
 {
-    auto builder
-        = createPointwiseAttributesBuilder(hipdnn_data_sdk::data_objects::PointwiseMode::TANH_FWD);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+    auto builder = createPointwiseAttributesBuilder(
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::TANH_FWD);
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     MiopenActivationDescriptor activDesc(*attr);
 
@@ -213,10 +223,11 @@ TEST(TestMiopenActivationDescriptor, CreatesTanhFwd)
 
 TEST(TestMiopenActivationDescriptor, CreatesTanhBwd)
 {
-    auto builder
-        = createPointwiseAttributesBuilder(hipdnn_data_sdk::data_objects::PointwiseMode::TANH_BWD);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+    auto builder = createPointwiseAttributesBuilder(
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::TANH_BWD);
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     MiopenActivationDescriptor activDesc(*attr);
 
@@ -233,14 +244,15 @@ TEST(TestMiopenActivationDescriptor, CreatesTanhBwd)
 TEST(TestMiopenActivationDescriptor, CreatesEluWithCustomAlpha)
 {
     const float eluAlpha = 2.0f;
-    auto builder
-        = createPointwiseAttributesBuilder(hipdnn_data_sdk::data_objects::PointwiseMode::ELU_FWD,
-                                           flatbuffers::nullopt,
-                                           flatbuffers::nullopt,
-                                           flatbuffers::nullopt,
-                                           eluAlpha);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+    auto builder = createPointwiseAttributesBuilder(
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::ELU_FWD,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        eluAlpha);
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     MiopenActivationDescriptor activDesc(*attr);
 
@@ -257,10 +269,11 @@ TEST(TestMiopenActivationDescriptor, CreatesEluWithCustomAlpha)
 
 TEST(TestMiopenActivationDescriptor, CreatesEluWithDefaultAlpha)
 {
-    auto builder
-        = createPointwiseAttributesBuilder(hipdnn_data_sdk::data_objects::PointwiseMode::ELU_BWD);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+    auto builder = createPointwiseAttributesBuilder(
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::ELU_BWD);
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     MiopenActivationDescriptor activDesc(*attr);
 
@@ -278,9 +291,10 @@ TEST(TestMiopenActivationDescriptor, CreatesEluWithDefaultAlpha)
 TEST(TestMiopenActivationDescriptor, CreatesSoftplusFwdWithoutBeta)
 {
     auto builder = createPointwiseAttributesBuilder(
-        hipdnn_data_sdk::data_objects::PointwiseMode::SOFTPLUS_FWD);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SOFTPLUS_FWD);
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     MiopenActivationDescriptor activDesc(*attr);
 
@@ -297,9 +311,10 @@ TEST(TestMiopenActivationDescriptor, CreatesSoftplusFwdWithoutBeta)
 TEST(TestMiopenActivationDescriptor, CreatesSoftplusBwdWithoutBeta)
 {
     auto builder = createPointwiseAttributesBuilder(
-        hipdnn_data_sdk::data_objects::PointwiseMode::SOFTPLUS_BWD);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SOFTPLUS_BWD);
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     MiopenActivationDescriptor activDesc(*attr);
 
@@ -317,14 +332,15 @@ TEST(TestMiopenActivationDescriptor, CreatesSoftplusWithBetaOne)
 {
     const float softplusBeta = 1.0f;
     auto builder = createPointwiseAttributesBuilder(
-        hipdnn_data_sdk::data_objects::PointwiseMode::SOFTPLUS_FWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SOFTPLUS_FWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         softplusBeta);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     MiopenActivationDescriptor activDesc(*attr);
 
@@ -342,14 +358,15 @@ TEST(TestMiopenActivationDescriptor, ThrowsOnSoftplusWithInvalidBeta)
 {
     const float softplusBeta = 2.0f;
     auto builder = createPointwiseAttributesBuilder(
-        hipdnn_data_sdk::data_objects::PointwiseMode::SOFTPLUS_BWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SOFTPLUS_BWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         softplusBeta);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     EXPECT_THROW(MiopenActivationDescriptor activDesc(*attr),
                  hipdnn_plugin_sdk::HipdnnPluginException);
@@ -357,10 +374,11 @@ TEST(TestMiopenActivationDescriptor, ThrowsOnSoftplusWithInvalidBeta)
 
 TEST(TestMiopenActivationDescriptor, CreatesAbs)
 {
-    auto builder
-        = createPointwiseAttributesBuilder(hipdnn_data_sdk::data_objects::PointwiseMode::ABS);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+    auto builder = createPointwiseAttributesBuilder(
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::ABS);
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     MiopenActivationDescriptor activDesc(*attr);
 
@@ -376,10 +394,11 @@ TEST(TestMiopenActivationDescriptor, CreatesAbs)
 
 TEST(TestMiopenActivationDescriptor, CreatesIdentity)
 {
-    auto builder
-        = createPointwiseAttributesBuilder(hipdnn_data_sdk::data_objects::PointwiseMode::IDENTITY);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+    auto builder = createPointwiseAttributesBuilder(
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::IDENTITY);
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     MiopenActivationDescriptor activDesc(*attr);
 
@@ -395,10 +414,11 @@ TEST(TestMiopenActivationDescriptor, CreatesIdentity)
 
 TEST(TestMiopenActivationDescriptor, ThrowsOnUnsupportedMode)
 {
-    auto builder
-        = createPointwiseAttributesBuilder(hipdnn_data_sdk::data_objects::PointwiseMode::ADD);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+    auto builder = createPointwiseAttributesBuilder(
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::ADD);
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     EXPECT_THROW(MiopenActivationDescriptor activDesc(*attr),
                  hipdnn_plugin_sdk::HipdnnPluginException);
@@ -410,9 +430,10 @@ TEST(TestMiopenActivationDescriptor, ClampTakesPrecedenceOverClippedRelu)
     const float lowerClip = -1.0f;
     const float upperClip = 6.0f;
     auto builder = createPointwiseAttributesBuilder(
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD, lowerClip, upperClip);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD, lowerClip, upperClip);
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     MiopenActivationDescriptor activDesc(*attr);
 
@@ -433,9 +454,12 @@ TEST(TestMiopenActivationDescriptor, UpperClipWithoutLowerUsesClippedRelu)
     // Only upper clip present should use CLIPPED_RELU, not CLAMP
     const float upperClip = 6.0f;
     auto builder = createPointwiseAttributesBuilder(
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD, flatbuffers::nullopt, upperClip);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
+        flatbuffers::nullopt,
+        upperClip);
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     MiopenActivationDescriptor activDesc(*attr);
 

--- a/dnn-providers/miopen-provider/tests/TestMiopenConvDescriptor.cpp
+++ b/dnn-providers/miopen-provider/tests/TestMiopenConvDescriptor.cpp
@@ -4,7 +4,7 @@
 #include <limits>
 
 #include <gtest/gtest.h>
-#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/tensor_attributes_generated.h>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 #include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
 #include <miopen/miopen.h>
@@ -19,15 +19,16 @@ TEST(TestMiopenConvDescriptor, CreateValidDescriptorFwd)
     const std::vector<int64_t> postPadding{0, 0, 0};
     const std::vector<int64_t> stride{1, 1, 1};
     const std::vector<int64_t> dilation{1, 1, 1};
-    const auto convMode = hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION;
+    const auto convMode = hipdnn_flatbuffers_sdk::data_objects::ConvMode::CROSS_CORRELATION;
     size_t spatialDimCount = 3;
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateConvolutionFwdAttributesDirect(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionFwdAttributesDirect(
         builder, 0, 0, 0, &prePadding, &postPadding, &stride, &dilation, convMode);
     builder.Finish(attrOffset);
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes>(
-        builder.GetBufferPointer());
+    auto attrPtr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::ConvolutionFwdAttributes>(
+            builder.GetBufferPointer());
 
     MiopenConvDescriptor convDesc(spatialDimCount, *attrPtr, 1);
 
@@ -62,14 +63,15 @@ TEST(TestMiopenConvDescriptor, ThrowsOnWrongSpatialDimCountFwd)
     const std::vector<int64_t> postPadding{0, 0, 0};
     const std::vector<int64_t> stride{1, 1, 1};
     const std::vector<int64_t> dilation{1, 1, 1};
-    const auto convMode = hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION;
+    const auto convMode = hipdnn_flatbuffers_sdk::data_objects::ConvMode::CROSS_CORRELATION;
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateConvolutionFwdAttributesDirect(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionFwdAttributesDirect(
         builder, 0, 0, 0, &prePadding, &postPadding, &stride, &dilation, convMode);
     builder.Finish(attrOffset);
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes>(
-        builder.GetBufferPointer());
+    auto attrPtr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::ConvolutionFwdAttributes>(
+            builder.GetBufferPointer());
 
     EXPECT_THROW(MiopenConvDescriptor convDesc(
                      static_cast<size_t>(std::numeric_limits<int>::max()) + 1, *attrPtr, 1),
@@ -90,15 +92,16 @@ TEST(TestMiopenConvDescriptor, ThrowsOnWrongConvModeFwd)
     const std::vector<int64_t> postPadding{0, 0, 0};
     const std::vector<int64_t> stride{1, 1, 1};
     const std::vector<int64_t> dilation{1, 1, 1};
-    const auto convMode = hipdnn_data_sdk::data_objects::ConvMode::CONVOLUTION;
+    const auto convMode = hipdnn_flatbuffers_sdk::data_objects::ConvMode::CONVOLUTION;
     size_t spatialDimCount = 3;
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateConvolutionFwdAttributesDirect(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionFwdAttributesDirect(
         builder, 0, 0, 0, &prePadding, &postPadding, &stride, &dilation, convMode);
     builder.Finish(attrOffset);
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes>(
-        builder.GetBufferPointer());
+    auto attrPtr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::ConvolutionFwdAttributes>(
+            builder.GetBufferPointer());
 
     EXPECT_THROW(MiopenConvDescriptor convDesc(spatialDimCount, *attrPtr, 1),
                  hipdnn_plugin_sdk::HipdnnPluginException);
@@ -113,15 +116,16 @@ TEST(TestMiopenConvDescriptor, ThrowsOnAsymmetricPaddingFwd)
     const std::vector<int64_t> postPadding{0, 1, 0};
     const std::vector<int64_t> stride{1, 1, 1};
     const std::vector<int64_t> dilation{1, 1, 1};
-    const auto convMode = hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION;
+    const auto convMode = hipdnn_flatbuffers_sdk::data_objects::ConvMode::CROSS_CORRELATION;
     size_t spatialDimCount = 3;
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateConvolutionFwdAttributesDirect(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionFwdAttributesDirect(
         builder, 0, 0, 0, &prePadding, &postPadding, &stride, &dilation, convMode);
     builder.Finish(attrOffset);
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes>(
-        builder.GetBufferPointer());
+    auto attrPtr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::ConvolutionFwdAttributes>(
+            builder.GetBufferPointer());
 
     EXPECT_THROW(MiopenConvDescriptor convDesc(spatialDimCount, *attrPtr, 1),
                  hipdnn_plugin_sdk::HipdnnPluginException);
@@ -136,15 +140,16 @@ TEST(TestMiopenConvDescriptor, ThrowsOnWrongPaddingFwd)
     const std::vector<int64_t> postPadding{0, -1, 0};
     const std::vector<int64_t> stride{1, 1, 1};
     const std::vector<int64_t> dilation{1, 1, 1};
-    const auto convMode = hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION;
+    const auto convMode = hipdnn_flatbuffers_sdk::data_objects::ConvMode::CROSS_CORRELATION;
     size_t spatialDimCount = 3;
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateConvolutionFwdAttributesDirect(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionFwdAttributesDirect(
         builder, 0, 0, 0, &prePadding, &postPadding, &stride, &dilation, convMode);
     builder.Finish(attrOffset);
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes>(
-        builder.GetBufferPointer());
+    auto attrPtr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::ConvolutionFwdAttributes>(
+            builder.GetBufferPointer());
 
     EXPECT_THROW(MiopenConvDescriptor convDesc(spatialDimCount, *attrPtr, 1),
                  hipdnn_plugin_sdk::HipdnnPluginException);
@@ -159,15 +164,16 @@ TEST(TestMiopenConvDescriptor, ThrowsOnWrongStrideFwd)
     const std::vector<int64_t> postPadding{0, 0, 0};
     const std::vector<int64_t> stride{1, 0, 1};
     const std::vector<int64_t> dilation{1, 1, 1};
-    const auto convMode = hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION;
+    const auto convMode = hipdnn_flatbuffers_sdk::data_objects::ConvMode::CROSS_CORRELATION;
     size_t spatialDimCount = 3;
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateConvolutionFwdAttributesDirect(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionFwdAttributesDirect(
         builder, 0, 0, 0, &prePadding, &postPadding, &stride, &dilation, convMode);
     builder.Finish(attrOffset);
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes>(
-        builder.GetBufferPointer());
+    auto attrPtr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::ConvolutionFwdAttributes>(
+            builder.GetBufferPointer());
 
     EXPECT_THROW(MiopenConvDescriptor convDesc(spatialDimCount, *attrPtr, 1),
                  hipdnn_plugin_sdk::HipdnnPluginException);
@@ -182,15 +188,16 @@ TEST(TestMiopenConvDescriptor, ThrowsOnWrongDilationFwd)
     const std::vector<int64_t> postPadding{0, 0, 0};
     const std::vector<int64_t> stride{1, 1, 1};
     const std::vector<int64_t> dilation{1, 0, 1};
-    const auto convMode = hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION;
+    const auto convMode = hipdnn_flatbuffers_sdk::data_objects::ConvMode::CROSS_CORRELATION;
     size_t spatialDimCount = 3;
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateConvolutionFwdAttributesDirect(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionFwdAttributesDirect(
         builder, 0, 0, 0, &prePadding, &postPadding, &stride, &dilation, convMode);
     builder.Finish(attrOffset);
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes>(
-        builder.GetBufferPointer());
+    auto attrPtr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::ConvolutionFwdAttributes>(
+            builder.GetBufferPointer());
 
     EXPECT_THROW(MiopenConvDescriptor convDesc(spatialDimCount, *attrPtr, 1),
                  hipdnn_plugin_sdk::HipdnnPluginException);
@@ -202,15 +209,16 @@ TEST(TestMiopenConvDescriptor, CreateValidDescriptorBwd)
     const std::vector<int64_t> postPadding{0, 0, 0};
     const std::vector<int64_t> stride{1, 1, 1};
     const std::vector<int64_t> dilation{1, 1, 1};
-    const auto convMode = hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION;
+    const auto convMode = hipdnn_flatbuffers_sdk::data_objects::ConvMode::CROSS_CORRELATION;
     size_t spatialDimCount = 3;
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateConvolutionBwdAttributesDirect(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionBwdAttributesDirect(
         builder, 0, 0, 0, &prePadding, &postPadding, &stride, &dilation, convMode);
     builder.Finish(attrOffset);
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::ConvolutionBwdAttributes>(
-        builder.GetBufferPointer());
+    auto attrPtr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::ConvolutionBwdAttributes>(
+            builder.GetBufferPointer());
 
     MiopenConvDescriptor convDesc(spatialDimCount, *attrPtr, 1);
 
@@ -245,14 +253,15 @@ TEST(TestMiopenConvDescriptor, ThrowsOnWrongSpatialDimCountBwd)
     const std::vector<int64_t> postPadding{0, 0, 0};
     const std::vector<int64_t> stride{1, 1, 1};
     const std::vector<int64_t> dilation{1, 1, 1};
-    const auto convMode = hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION;
+    const auto convMode = hipdnn_flatbuffers_sdk::data_objects::ConvMode::CROSS_CORRELATION;
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateConvolutionBwdAttributesDirect(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionBwdAttributesDirect(
         builder, 0, 0, 0, &prePadding, &postPadding, &stride, &dilation, convMode);
     builder.Finish(attrOffset);
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::ConvolutionBwdAttributes>(
-        builder.GetBufferPointer());
+    auto attrPtr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::ConvolutionBwdAttributes>(
+            builder.GetBufferPointer());
 
     EXPECT_THROW(MiopenConvDescriptor convDesc(
                      static_cast<size_t>(std::numeric_limits<int>::max()) + 1, *attrPtr, 1),
@@ -273,15 +282,16 @@ TEST(TestMiopenConvDescriptor, ThrowsOnWrongConvModeBwd)
     const std::vector<int64_t> postPadding{0, 0, 0};
     const std::vector<int64_t> stride{1, 1, 1};
     const std::vector<int64_t> dilation{1, 1, 1};
-    const auto convMode = hipdnn_data_sdk::data_objects::ConvMode::CONVOLUTION;
+    const auto convMode = hipdnn_flatbuffers_sdk::data_objects::ConvMode::CONVOLUTION;
     size_t spatialDimCount = 3;
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateConvolutionBwdAttributesDirect(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionBwdAttributesDirect(
         builder, 0, 0, 0, &prePadding, &postPadding, &stride, &dilation, convMode);
     builder.Finish(attrOffset);
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::ConvolutionBwdAttributes>(
-        builder.GetBufferPointer());
+    auto attrPtr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::ConvolutionBwdAttributes>(
+            builder.GetBufferPointer());
 
     EXPECT_THROW(MiopenConvDescriptor convDesc(spatialDimCount, *attrPtr, 1),
                  hipdnn_plugin_sdk::HipdnnPluginException);
@@ -296,15 +306,16 @@ TEST(TestMiopenConvDescriptor, ThrowsOnAsymmetricPaddingBwd)
     const std::vector<int64_t> postPadding{0, 1, 0};
     const std::vector<int64_t> stride{1, 1, 1};
     const std::vector<int64_t> dilation{1, 1, 1};
-    const auto convMode = hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION;
+    const auto convMode = hipdnn_flatbuffers_sdk::data_objects::ConvMode::CROSS_CORRELATION;
     size_t spatialDimCount = 3;
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateConvolutionBwdAttributesDirect(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionBwdAttributesDirect(
         builder, 0, 0, 0, &prePadding, &postPadding, &stride, &dilation, convMode);
     builder.Finish(attrOffset);
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::ConvolutionBwdAttributes>(
-        builder.GetBufferPointer());
+    auto attrPtr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::ConvolutionBwdAttributes>(
+            builder.GetBufferPointer());
 
     EXPECT_THROW(MiopenConvDescriptor convDesc(spatialDimCount, *attrPtr, 1),
                  hipdnn_plugin_sdk::HipdnnPluginException);
@@ -319,15 +330,16 @@ TEST(TestMiopenConvDescriptor, ThrowsOnWrongPaddingBwd)
     const std::vector<int64_t> postPadding{0, -1, 0};
     const std::vector<int64_t> stride{1, 1, 1};
     const std::vector<int64_t> dilation{1, 1, 1};
-    const auto convMode = hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION;
+    const auto convMode = hipdnn_flatbuffers_sdk::data_objects::ConvMode::CROSS_CORRELATION;
     size_t spatialDimCount = 3;
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateConvolutionBwdAttributesDirect(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionBwdAttributesDirect(
         builder, 0, 0, 0, &prePadding, &postPadding, &stride, &dilation, convMode);
     builder.Finish(attrOffset);
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::ConvolutionBwdAttributes>(
-        builder.GetBufferPointer());
+    auto attrPtr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::ConvolutionBwdAttributes>(
+            builder.GetBufferPointer());
 
     EXPECT_THROW(MiopenConvDescriptor convDesc(spatialDimCount, *attrPtr, 1),
                  hipdnn_plugin_sdk::HipdnnPluginException);
@@ -342,15 +354,16 @@ TEST(TestMiopenConvDescriptor, ThrowsOnWrongStrideBwd)
     const std::vector<int64_t> postPadding{0, 0, 0};
     const std::vector<int64_t> stride{1, 0, 1};
     const std::vector<int64_t> dilation{1, 1, 1};
-    const auto convMode = hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION;
+    const auto convMode = hipdnn_flatbuffers_sdk::data_objects::ConvMode::CROSS_CORRELATION;
     size_t spatialDimCount = 3;
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateConvolutionBwdAttributesDirect(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionBwdAttributesDirect(
         builder, 0, 0, 0, &prePadding, &postPadding, &stride, &dilation, convMode);
     builder.Finish(attrOffset);
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::ConvolutionBwdAttributes>(
-        builder.GetBufferPointer());
+    auto attrPtr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::ConvolutionBwdAttributes>(
+            builder.GetBufferPointer());
 
     EXPECT_THROW(MiopenConvDescriptor convDesc(spatialDimCount, *attrPtr, 1),
                  hipdnn_plugin_sdk::HipdnnPluginException);
@@ -365,15 +378,16 @@ TEST(TestMiopenConvDescriptor, ThrowsOnWrongDilationBwd)
     const std::vector<int64_t> postPadding{0, 0, 0};
     const std::vector<int64_t> stride{1, 1, 1};
     const std::vector<int64_t> dilation{1, 0, 1};
-    const auto convMode = hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION;
+    const auto convMode = hipdnn_flatbuffers_sdk::data_objects::ConvMode::CROSS_CORRELATION;
     size_t spatialDimCount = 3;
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateConvolutionBwdAttributesDirect(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionBwdAttributesDirect(
         builder, 0, 0, 0, &prePadding, &postPadding, &stride, &dilation, convMode);
     builder.Finish(attrOffset);
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::ConvolutionBwdAttributes>(
-        builder.GetBufferPointer());
+    auto attrPtr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::ConvolutionBwdAttributes>(
+            builder.GetBufferPointer());
 
     EXPECT_THROW(MiopenConvDescriptor convDesc(spatialDimCount, *attrPtr, 1),
                  hipdnn_plugin_sdk::HipdnnPluginException);
@@ -385,15 +399,16 @@ TEST(TestMiopenConvDescriptor, CreateValidDescriptorWrw)
     const std::vector<int64_t> postPadding{0, 0, 0};
     const std::vector<int64_t> stride{1, 1, 1};
     const std::vector<int64_t> dilation{1, 1, 1};
-    const auto convMode = hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION;
+    const auto convMode = hipdnn_flatbuffers_sdk::data_objects::ConvMode::CROSS_CORRELATION;
     size_t spatialDimCount = 3;
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateConvolutionWrwAttributesDirect(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionWrwAttributesDirect(
         builder, 0, 0, 0, &prePadding, &postPadding, &stride, &dilation, convMode);
     builder.Finish(attrOffset);
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::ConvolutionWrwAttributes>(
-        builder.GetBufferPointer());
+    auto attrPtr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::ConvolutionWrwAttributes>(
+            builder.GetBufferPointer());
 
     MiopenConvDescriptor convDesc(spatialDimCount, *attrPtr, 1);
 
@@ -428,14 +443,15 @@ TEST(TestMiopenConvDescriptor, ThrowsOnWrongSpatialDimCountWrw)
     const std::vector<int64_t> postPadding{0, 0, 0};
     const std::vector<int64_t> stride{1, 1, 1};
     const std::vector<int64_t> dilation{1, 1, 1};
-    const auto convMode = hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION;
+    const auto convMode = hipdnn_flatbuffers_sdk::data_objects::ConvMode::CROSS_CORRELATION;
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateConvolutionWrwAttributesDirect(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionWrwAttributesDirect(
         builder, 0, 0, 0, &prePadding, &postPadding, &stride, &dilation, convMode);
     builder.Finish(attrOffset);
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::ConvolutionWrwAttributes>(
-        builder.GetBufferPointer());
+    auto attrPtr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::ConvolutionWrwAttributes>(
+            builder.GetBufferPointer());
 
     EXPECT_THROW(MiopenConvDescriptor convDesc(
                      static_cast<size_t>(std::numeric_limits<int>::max()) + 1, *attrPtr, 1),
@@ -456,15 +472,16 @@ TEST(TestMiopenConvDescriptor, ThrowsOnWrongConvModeWrw)
     const std::vector<int64_t> postPadding{0, 0, 0};
     const std::vector<int64_t> stride{1, 1, 1};
     const std::vector<int64_t> dilation{1, 1, 1};
-    const auto convMode = hipdnn_data_sdk::data_objects::ConvMode::CONVOLUTION;
+    const auto convMode = hipdnn_flatbuffers_sdk::data_objects::ConvMode::CONVOLUTION;
     size_t spatialDimCount = 3;
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateConvolutionWrwAttributesDirect(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionWrwAttributesDirect(
         builder, 0, 0, 0, &prePadding, &postPadding, &stride, &dilation, convMode);
     builder.Finish(attrOffset);
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::ConvolutionWrwAttributes>(
-        builder.GetBufferPointer());
+    auto attrPtr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::ConvolutionWrwAttributes>(
+            builder.GetBufferPointer());
 
     EXPECT_THROW(MiopenConvDescriptor convDesc(spatialDimCount, *attrPtr, 1),
                  hipdnn_plugin_sdk::HipdnnPluginException);
@@ -479,15 +496,16 @@ TEST(TestMiopenConvDescriptor, ThrowsOnAsymmetricPaddingWrw)
     const std::vector<int64_t> postPadding{0, 1, 0};
     const std::vector<int64_t> stride{1, 1, 1};
     const std::vector<int64_t> dilation{1, 1, 1};
-    const auto convMode = hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION;
+    const auto convMode = hipdnn_flatbuffers_sdk::data_objects::ConvMode::CROSS_CORRELATION;
     size_t spatialDimCount = 3;
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateConvolutionWrwAttributesDirect(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionWrwAttributesDirect(
         builder, 0, 0, 0, &prePadding, &postPadding, &stride, &dilation, convMode);
     builder.Finish(attrOffset);
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::ConvolutionWrwAttributes>(
-        builder.GetBufferPointer());
+    auto attrPtr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::ConvolutionWrwAttributes>(
+            builder.GetBufferPointer());
 
     EXPECT_THROW(MiopenConvDescriptor convDesc(spatialDimCount, *attrPtr, 1),
                  hipdnn_plugin_sdk::HipdnnPluginException);
@@ -502,15 +520,16 @@ TEST(TestMiopenConvDescriptor, ThrowsOnWrongPaddingWrw)
     const std::vector<int64_t> postPadding{0, -1, 0};
     const std::vector<int64_t> stride{1, 1, 1};
     const std::vector<int64_t> dilation{1, 1, 1};
-    const auto convMode = hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION;
+    const auto convMode = hipdnn_flatbuffers_sdk::data_objects::ConvMode::CROSS_CORRELATION;
     size_t spatialDimCount = 3;
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateConvolutionWrwAttributesDirect(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionWrwAttributesDirect(
         builder, 0, 0, 0, &prePadding, &postPadding, &stride, &dilation, convMode);
     builder.Finish(attrOffset);
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::ConvolutionWrwAttributes>(
-        builder.GetBufferPointer());
+    auto attrPtr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::ConvolutionWrwAttributes>(
+            builder.GetBufferPointer());
 
     EXPECT_THROW(MiopenConvDescriptor convDesc(spatialDimCount, *attrPtr, 1),
                  hipdnn_plugin_sdk::HipdnnPluginException);
@@ -525,15 +544,16 @@ TEST(TestMiopenConvDescriptor, ThrowsOnWrongStrideWrw)
     const std::vector<int64_t> postPadding{0, 0, 0};
     const std::vector<int64_t> stride{1, 0, 1};
     const std::vector<int64_t> dilation{1, 1, 1};
-    const auto convMode = hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION;
+    const auto convMode = hipdnn_flatbuffers_sdk::data_objects::ConvMode::CROSS_CORRELATION;
     size_t spatialDimCount = 3;
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateConvolutionWrwAttributesDirect(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionWrwAttributesDirect(
         builder, 0, 0, 0, &prePadding, &postPadding, &stride, &dilation, convMode);
     builder.Finish(attrOffset);
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::ConvolutionWrwAttributes>(
-        builder.GetBufferPointer());
+    auto attrPtr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::ConvolutionWrwAttributes>(
+            builder.GetBufferPointer());
 
     EXPECT_THROW(MiopenConvDescriptor convDesc(spatialDimCount, *attrPtr, 1),
                  hipdnn_plugin_sdk::HipdnnPluginException);
@@ -548,15 +568,16 @@ TEST(TestMiopenConvDescriptor, ThrowsOnWrongDilationWrw)
     const std::vector<int64_t> postPadding{0, 0, 0};
     const std::vector<int64_t> stride{1, 1, 1};
     const std::vector<int64_t> dilation{1, 0, 1};
-    const auto convMode = hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION;
+    const auto convMode = hipdnn_flatbuffers_sdk::data_objects::ConvMode::CROSS_CORRELATION;
     size_t spatialDimCount = 3;
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateConvolutionWrwAttributesDirect(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionWrwAttributesDirect(
         builder, 0, 0, 0, &prePadding, &postPadding, &stride, &dilation, convMode);
     builder.Finish(attrOffset);
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::ConvolutionWrwAttributes>(
-        builder.GetBufferPointer());
+    auto attrPtr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::ConvolutionWrwAttributes>(
+            builder.GetBufferPointer());
 
     EXPECT_THROW(MiopenConvDescriptor convDesc(spatialDimCount, *attrPtr, 1),
                  hipdnn_plugin_sdk::HipdnnPluginException);
@@ -568,15 +589,16 @@ TEST(TestMiopenConvDescriptor, AcceptsValidGroupCount)
     const std::vector<int64_t> postPadding{0, 0, 0};
     const std::vector<int64_t> stride{1, 1, 1};
     const std::vector<int64_t> dilation{1, 1, 1};
-    const auto convMode = hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION;
+    const auto convMode = hipdnn_flatbuffers_sdk::data_objects::ConvMode::CROSS_CORRELATION;
     size_t spatialDimCount = 3;
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateConvolutionFwdAttributesDirect(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionFwdAttributesDirect(
         builder, 0, 0, 0, &prePadding, &postPadding, &stride, &dilation, convMode);
     builder.Finish(attrOffset);
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes>(
-        builder.GetBufferPointer());
+    auto attrPtr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::ConvolutionFwdAttributes>(
+            builder.GetBufferPointer());
 
     EXPECT_NO_THROW(MiopenConvDescriptor convDesc(spatialDimCount, *attrPtr, 1));
     EXPECT_NO_THROW(MiopenConvDescriptor convDesc(spatialDimCount, *attrPtr, 2));
@@ -589,16 +611,17 @@ TEST(TestMiopenConvDescriptor, VerifiesGroupCountSetCorrectly)
     const std::vector<int64_t> postPadding{0, 0, 0};
     const std::vector<int64_t> stride{1, 1, 1};
     const std::vector<int64_t> dilation{1, 1, 1};
-    const auto convMode = hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION;
+    const auto convMode = hipdnn_flatbuffers_sdk::data_objects::ConvMode::CROSS_CORRELATION;
     size_t spatialDimCount = 3;
     int groupCount = 4;
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateConvolutionFwdAttributesDirect(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionFwdAttributesDirect(
         builder, 0, 0, 0, &prePadding, &postPadding, &stride, &dilation, convMode);
     builder.Finish(attrOffset);
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes>(
-        builder.GetBufferPointer());
+    auto attrPtr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::ConvolutionFwdAttributes>(
+            builder.GetBufferPointer());
 
     MiopenConvDescriptor convDesc(spatialDimCount, *attrPtr, groupCount);
 
@@ -615,15 +638,16 @@ TEST(TestMiopenConvDescriptor, ThrowsOnInvalidGroupCount)
     const std::vector<int64_t> postPadding{0, 0, 0};
     const std::vector<int64_t> stride{1, 1, 1};
     const std::vector<int64_t> dilation{1, 1, 1};
-    const auto convMode = hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION;
+    const auto convMode = hipdnn_flatbuffers_sdk::data_objects::ConvMode::CROSS_CORRELATION;
     size_t spatialDimCount = 3;
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateConvolutionFwdAttributesDirect(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionFwdAttributesDirect(
         builder, 0, 0, 0, &prePadding, &postPadding, &stride, &dilation, convMode);
     builder.Finish(attrOffset);
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes>(
-        builder.GetBufferPointer());
+    auto attrPtr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::ConvolutionFwdAttributes>(
+            builder.GetBufferPointer());
 
     EXPECT_THROW(MiopenConvDescriptor convDesc(spatialDimCount, *attrPtr, 0),
                  hipdnn_plugin_sdk::HipdnnPluginException);
@@ -637,15 +661,16 @@ TEST(TestMiopenConvDescriptor, SetsDeterministicAttributeWhenEnabled)
     const std::vector<int64_t> postPadding{0, 0};
     const std::vector<int64_t> stride{1, 1};
     const std::vector<int64_t> dilation{1, 1};
-    const auto convMode = hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION;
+    const auto convMode = hipdnn_flatbuffers_sdk::data_objects::ConvMode::CROSS_CORRELATION;
     size_t spatialDimCount = 2;
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateConvolutionFwdAttributesDirect(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionFwdAttributesDirect(
         builder, 0, 0, 0, &prePadding, &postPadding, &stride, &dilation, convMode);
     builder.Finish(attrOffset);
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes>(
-        builder.GetBufferPointer());
+    auto attrPtr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::ConvolutionFwdAttributes>(
+            builder.GetBufferPointer());
 
     // Create descriptor with deterministic enabled
     MiopenConvDescriptor convDesc(spatialDimCount, *attrPtr, 1, true);
@@ -664,15 +689,16 @@ TEST(TestMiopenConvDescriptor, DeterministicAttributeDefaultsToDisabled)
     const std::vector<int64_t> postPadding{0, 0};
     const std::vector<int64_t> stride{1, 1};
     const std::vector<int64_t> dilation{1, 1};
-    const auto convMode = hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION;
+    const auto convMode = hipdnn_flatbuffers_sdk::data_objects::ConvMode::CROSS_CORRELATION;
     size_t spatialDimCount = 2;
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateConvolutionFwdAttributesDirect(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionFwdAttributesDirect(
         builder, 0, 0, 0, &prePadding, &postPadding, &stride, &dilation, convMode);
     builder.Finish(attrOffset);
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::ConvolutionFwdAttributes>(
-        builder.GetBufferPointer());
+    auto attrPtr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::ConvolutionFwdAttributes>(
+            builder.GetBufferPointer());
 
     // Create descriptor with default (deterministic disabled)
     MiopenConvDescriptor convDesc(spatialDimCount, *attrPtr, 1);
@@ -691,15 +717,16 @@ TEST(TestMiopenConvDescriptor, SetsDeterministicAttributeForBwdDescriptor)
     const std::vector<int64_t> postPadding{0, 0};
     const std::vector<int64_t> stride{1, 1};
     const std::vector<int64_t> dilation{1, 1};
-    const auto convMode = hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION;
+    const auto convMode = hipdnn_flatbuffers_sdk::data_objects::ConvMode::CROSS_CORRELATION;
     size_t spatialDimCount = 2;
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateConvolutionBwdAttributesDirect(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionBwdAttributesDirect(
         builder, 0, 0, 0, &prePadding, &postPadding, &stride, &dilation, convMode);
     builder.Finish(attrOffset);
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::ConvolutionBwdAttributes>(
-        builder.GetBufferPointer());
+    auto attrPtr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::ConvolutionBwdAttributes>(
+            builder.GetBufferPointer());
 
     // Create descriptor with deterministic enabled
     MiopenConvDescriptor convDesc(spatialDimCount, *attrPtr, 1, true);
@@ -718,15 +745,16 @@ TEST(TestMiopenConvDescriptor, SetsDeterministicAttributeForWrwDescriptor)
     const std::vector<int64_t> postPadding{0, 0};
     const std::vector<int64_t> stride{1, 1};
     const std::vector<int64_t> dilation{1, 1};
-    const auto convMode = hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION;
+    const auto convMode = hipdnn_flatbuffers_sdk::data_objects::ConvMode::CROSS_CORRELATION;
     size_t spatialDimCount = 2;
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateConvolutionWrwAttributesDirect(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionWrwAttributesDirect(
         builder, 0, 0, 0, &prePadding, &postPadding, &stride, &dilation, convMode);
     builder.Finish(attrOffset);
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::ConvolutionWrwAttributes>(
-        builder.GetBufferPointer());
+    auto attrPtr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::ConvolutionWrwAttributes>(
+            builder.GetBufferPointer());
 
     // Create descriptor with deterministic enabled
     MiopenConvDescriptor convDesc(spatialDimCount, *attrPtr, 1, true);

--- a/dnn-providers/miopen-provider/tests/TestMiopenEngineManager.cpp
+++ b/dnn-providers/miopen-provider/tests/TestMiopenEngineManager.cpp
@@ -119,14 +119,15 @@ TEST(TestMiopenEngineManager, ReturnsEngineDetails)
     auto mockEngine = std::make_unique<MockEngine>();
     EXPECT_CALL(*mockEngine, id()).WillRepeatedly(Return(1));
     EXPECT_CALL(*mockEngine, getDetails(::testing::_, ::testing::_, ::testing::_))
-        .WillOnce([&engineDetails](HipdnnMiopenHandle& handle,
-                                   const hipdnn_data_sdk::flatbuffer_utilities::IGraph& graph,
-                                   hipdnnPluginConstData_t& out) {
-            (void)handle;
-            (void)graph;
-            out.ptr = engineDetails.ptr;
-            out.size = engineDetails.size;
-        });
+        .WillOnce(
+            [&engineDetails](HipdnnMiopenHandle& handle,
+                             const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& graph,
+                             hipdnnPluginConstData_t& out) {
+                (void)handle;
+                (void)graph;
+                out.ptr = engineDetails.ptr;
+                out.size = engineDetails.size;
+            });
 
     manager.addEngine(std::move(mockEngine));
 

--- a/dnn-providers/miopen-provider/tests/TestMiopenTensor.cpp
+++ b/dnn-providers/miopen-provider/tests/TestMiopenTensor.cpp
@@ -3,7 +3,7 @@
 
 #include "MiopenTensor.hpp"
 #include <gtest/gtest.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 
@@ -13,8 +13,8 @@ TEST(TestMiopenTensor, CanCreateAndDestroy)
 {
     // Use a real tensor attributes from a valid batchnorm graph
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the first tensor attributes from the tensor map
     const auto& tensorMap = graph.getTensorMap();
@@ -33,8 +33,8 @@ TEST(TestMiopenTensor, CanCreateAndDestroy)
 TEST(TestMiopenTensor, TensorDescriptorIsValid)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& tensorMap = graph.getTensorMap();
     ASSERT_FALSE(tensorMap.empty());
@@ -52,7 +52,8 @@ TEST(TestMiopenTensor, ConstructorWithDimsAndStridesSucceeds)
     const std::vector<int64_t> strides = {static_cast<int64_t>(16) * 224, 224, 1};
 
     EXPECT_NO_THROW({
-        MiopenTensor tensor(UID, hipdnn_data_sdk::data_objects::DataType::FLOAT, dims, strides);
+        MiopenTensor tensor(
+            UID, hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT, dims, strides);
         EXPECT_NE(tensor.tensorDescriptor(), nullptr);
     });
 }
@@ -63,8 +64,9 @@ TEST(TestMiopenTensor, ConstructorThrowsOnDimsStridesSizeMismatch)
     const std::vector<int64_t> dims = {2, 16, 224};
     const std::vector<int64_t> strides = {224, 1}; // Wrong size
 
-    EXPECT_THROW(MiopenTensor(UID, hipdnn_data_sdk::data_objects::DataType::FLOAT, dims, strides),
-                 hipdnn_plugin_sdk::HipdnnPluginException);
+    EXPECT_THROW(
+        MiopenTensor(UID, hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT, dims, strides),
+        hipdnn_plugin_sdk::HipdnnPluginException);
 }
 
 TEST(TestMiopenTensor, ConstructorThrowsOnNegativeDimension)
@@ -73,8 +75,9 @@ TEST(TestMiopenTensor, ConstructorThrowsOnNegativeDimension)
     const std::vector<int64_t> dims = {2, -16, 224}; // Negative dimension
     const std::vector<int64_t> strides = {static_cast<int64_t>(16) * 224, 224, 1};
 
-    EXPECT_THROW(MiopenTensor(UID, hipdnn_data_sdk::data_objects::DataType::FLOAT, dims, strides),
-                 hipdnn_plugin_sdk::HipdnnPluginException);
+    EXPECT_THROW(
+        MiopenTensor(UID, hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT, dims, strides),
+        hipdnn_plugin_sdk::HipdnnPluginException);
 }
 
 TEST(TestMiopenTensor, ConstructorThrowsOnNegativeStride)
@@ -84,8 +87,9 @@ TEST(TestMiopenTensor, ConstructorThrowsOnNegativeStride)
     const std::vector<int64_t> strides
         = {static_cast<int64_t>(16) * 224, -224, 1}; // Negative stride
 
-    EXPECT_THROW(MiopenTensor(UID, hipdnn_data_sdk::data_objects::DataType::FLOAT, dims, strides),
-                 hipdnn_plugin_sdk::HipdnnPluginException);
+    EXPECT_THROW(
+        MiopenTensor(UID, hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT, dims, strides),
+        hipdnn_plugin_sdk::HipdnnPluginException);
 }
 
 TEST(TestMiopenTensor, ConstructorSetsCorrectUid)
@@ -95,7 +99,7 @@ TEST(TestMiopenTensor, ConstructorSetsCorrectUid)
     const std::vector<int64_t> strides = {16, 1};
 
     MiopenTensor tensor(
-        EXPECTED_UID, hipdnn_data_sdk::data_objects::DataType::FLOAT, dims, strides);
+        EXPECTED_UID, hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT, dims, strides);
 
     EXPECT_EQ(tensor.uid(), EXPECTED_UID);
 }

--- a/dnn-providers/miopen-provider/tests/TestMiopenUtils.cpp
+++ b/dnn-providers/miopen-provider/tests/TestMiopenUtils.cpp
@@ -5,8 +5,8 @@
 #include "common/MiopenHandleFixture.hpp"
 
 #include <gtest/gtest.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/tensor_attributes_generated.h>
 #include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
 
 using namespace miopen_plugin;
@@ -33,7 +33,7 @@ TEST(TestMiopenUtils, FindDeviceBufferThrowsIfNotFound)
 
 TEST(TestMiopenUtils, TensorDataTypeToMiopenDataType)
 {
-    using namespace hipdnn_data_sdk::data_objects;
+    using namespace hipdnn_flatbuffers_sdk::data_objects;
 
     EXPECT_EQ(miopen_utils::tensorDataTypeToMiopenDataType(DataType::FLOAT), miopenFloat);
     EXPECT_EQ(miopen_utils::tensorDataTypeToMiopenDataType(DataType::HALF), miopenHalf);
@@ -44,27 +44,30 @@ TEST(TestMiopenUtils, TensorDataTypeToMiopenDataTypeThrowsOnUnsupported)
 {
     // Use a value not in the enum
     EXPECT_THROW(miopen_utils::tensorDataTypeToMiopenDataType(
-                     static_cast<hipdnn_data_sdk::data_objects::DataType>(-1)),
+                     static_cast<hipdnn_flatbuffers_sdk::data_objects::DataType>(-1)),
                  hipdnn_plugin_sdk::HipdnnPluginException);
 }
 
 TEST(TestMiopenUtils, FindTensorAttributesReturnsCorrectValue)
 {
     flatbuffers::FlatBufferBuilder builder1;
-    auto attrOffset1 = hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(builder1, 1);
+    auto attrOffset1
+        = hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(builder1, 1);
     builder1.Finish(attrOffset1);
 
     flatbuffers::FlatBufferBuilder builder2;
-    auto attrOffset2 = hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(builder2, 2);
+    auto attrOffset2
+        = hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(builder2, 2);
     builder2.Finish(attrOffset2);
 
-    auto attrPtr1 = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::TensorAttributes>(
+    auto attrPtr1 = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>(
         builder1.GetBufferPointer());
-    auto attrPtr2 = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::TensorAttributes>(
+    auto attrPtr2 = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>(
         builder2.GetBufferPointer());
 
     auto attrMap
-        = std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>{
+        = std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>{
             {1, attrPtr1}, {2, attrPtr2}};
 
     EXPECT_EQ(miopen_utils::findTensorAttributes(attrMap, 1).uid(), 1);
@@ -74,7 +77,8 @@ TEST(TestMiopenUtils, FindTensorAttributesReturnsCorrectValue)
 TEST(TestMiopenUtils, FindTensorAttributesThrowsIfNotFound)
 {
     auto attrMap
-        = std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>{};
+        = std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>{};
 
     EXPECT_THROW(miopen_utils::findTensorAttributes(attrMap, 1),
                  hipdnn_plugin_sdk::HipdnnPluginException);
@@ -85,11 +89,11 @@ TEST(TestMiopenUtils, GetSpatialDimCountReturnsCorrectValue)
     std::vector<int64_t> dims = {1, 1, 1, 1, 1};
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 1, "", hipdnn_data_sdk::data_objects::DataType::UNSET, nullptr, &dims);
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "", hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET, nullptr, &dims);
     builder.Finish(attrOffset);
 
-    auto attrPtr1 = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::TensorAttributes>(
+    auto attrPtr1 = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>(
         builder.GetBufferPointer());
 
     EXPECT_EQ(miopen_utils::getSpatialDimCount(*attrPtr1), 3);
@@ -100,11 +104,11 @@ TEST(TestMiopenUtils, GetSpatialDimCountThrowsOnInvalidDims)
     std::vector<int64_t> dims = {1, 1};
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 1, "", hipdnn_data_sdk::data_objects::DataType::UNSET, nullptr, &dims);
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "", hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET, nullptr, &dims);
     builder.Finish(attrOffset);
 
-    auto attrPtr1 = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::TensorAttributes>(
+    auto attrPtr1 = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>(
         builder.GetBufferPointer());
 
     EXPECT_THROW(miopen_utils::getSpatialDimCount(*attrPtr1),
@@ -118,15 +122,16 @@ TEST(TestMiopenUtils, CreateBatchnormTensor4dPassthrough)
     std::vector<int64_t> strides = {588, 196, 14, 1};
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 42, "", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims);
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 42, "", hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT, &strides, &dims);
     builder.Finish(attrOffset);
 
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::TensorAttributes>(
+    auto attrPtr = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>(
         builder.GetBufferPointer());
 
     auto tensorMap
-        = std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>{
+        = std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>{
             {42, attrPtr}};
 
     auto result = miopen_utils::createBatchnormTensor(tensorMap, 42);
@@ -162,15 +167,16 @@ TEST(TestMiopenUtils, CreateBatchnormTensor5dPassthrough)
     std::vector<int64_t> strides = {2352, 784, 196, 14, 1};
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 42, "", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims);
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 42, "", hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT, &strides, &dims);
     builder.Finish(attrOffset);
 
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::TensorAttributes>(
+    auto attrPtr = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>(
         builder.GetBufferPointer());
 
     auto tensorMap
-        = std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>{
+        = std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>{
             {42, attrPtr}};
 
     auto result = miopen_utils::createBatchnormTensor(tensorMap, 42);
@@ -209,15 +215,16 @@ TEST(TestMiopenUtils, CreateBatchnormTensor3dNclPadsToNchw)
     std::vector<int64_t> strides = {42, 14, 1};
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 42, "", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims);
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 42, "", hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT, &strides, &dims);
     builder.Finish(attrOffset);
 
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::TensorAttributes>(
+    auto attrPtr = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>(
         builder.GetBufferPointer());
 
     auto tensorMap
-        = std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>{
+        = std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>{
             {42, attrPtr}};
 
     auto result = miopen_utils::createBatchnormTensor(tensorMap, 42);
@@ -249,15 +256,16 @@ TEST(TestMiopenUtils, CreateBatchnormTensor3dNlcPadsToNhwc)
     std::vector<int64_t> strides = {42, 1, 3};
 
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 42, "", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims);
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 42, "", hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT, &strides, &dims);
     builder.Finish(attrOffset);
 
-    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::TensorAttributes>(
+    auto attrPtr = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>(
         builder.GetBufferPointer());
 
     auto tensorMap
-        = std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>{
+        = std::unordered_map<int64_t,
+                             const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>{
             {42, attrPtr}};
 
     auto result = miopen_utils::createBatchnormTensor(tensorMap, 42);
@@ -284,11 +292,12 @@ TEST(TestMiopenUtils, CreateBatchnormTensor3dNlcPadsToNhwc)
 TEST(TestMiopenUtils, MapPointwiseModeStandardRelu)
 {
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
-        builder, hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD);
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
+        builder, hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD);
     builder.Finish(attrOffset);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     ActivationParams result;
     ASSERT_NO_THROW(result = mapPointwiseModeToMiopenActivation(*attr));
@@ -300,11 +309,12 @@ TEST(TestMiopenUtils, MapPointwiseModeReluNonZeroLowerClipOnly)
 {
     const float lowerClip = 0.1f;
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
-        builder, hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD, lowerClip);
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
+        builder, hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD, lowerClip);
     builder.Finish(attrOffset);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     ASSERT_THROW(mapPointwiseModeToMiopenActivation(*attr),
                  hipdnn_plugin_sdk::HipdnnPluginException);
@@ -314,11 +324,12 @@ TEST(TestMiopenUtils, MapPointwiseModeReluZeroLowerClipOnly)
 {
     const float lowerClip = 0.0f;
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
-        builder, hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD, lowerClip);
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
+        builder, hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD, lowerClip);
     builder.Finish(attrOffset);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     ActivationParams result;
     ASSERT_NO_THROW(result = mapPointwiseModeToMiopenActivation(*attr));
@@ -330,14 +341,15 @@ TEST(TestMiopenUtils, MapPointwiseModeClippedRelu)
 {
     const float upperClip = 6.0f;
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD,
         flatbuffers::nullopt,
         upperClip);
     builder.Finish(attrOffset);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     ActivationParams result;
     ASSERT_NO_THROW(result = miopen_utils::mapPointwiseModeToMiopenActivation(*attr));
@@ -349,15 +361,16 @@ TEST(TestMiopenUtils, MapPointwiseModeLeakyRelu)
 {
     const float slope = 0.01f;
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         slope);
     builder.Finish(attrOffset);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     ActivationParams result;
     ASSERT_NO_THROW(result = miopen_utils::mapPointwiseModeToMiopenActivation(*attr));
@@ -370,11 +383,15 @@ TEST(TestMiopenUtils, MapPointwiseModeClamp)
     const float lowerClip = -1.0f;
     const float upperClip = 6.0f;
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
-        builder, hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD, lowerClip, upperClip);
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD,
+        lowerClip,
+        upperClip);
     builder.Finish(attrOffset);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     ActivationParams result;
     ASSERT_NO_THROW(result = miopen_utils::mapPointwiseModeToMiopenActivation(*attr));
@@ -386,11 +403,12 @@ TEST(TestMiopenUtils, MapPointwiseModeClamp)
 TEST(TestMiopenUtils, MapPointwiseModeSigmoid)
 {
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
-        builder, hipdnn_data_sdk::data_objects::PointwiseMode::SIGMOID_FWD);
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
+        builder, hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SIGMOID_FWD);
     builder.Finish(attrOffset);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     ActivationParams result;
     ASSERT_NO_THROW(result = miopen_utils::mapPointwiseModeToMiopenActivation(*attr));
@@ -400,11 +418,12 @@ TEST(TestMiopenUtils, MapPointwiseModeSigmoid)
 TEST(TestMiopenUtils, MapPointwiseModeTanh)
 {
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
-        builder, hipdnn_data_sdk::data_objects::PointwiseMode::TANH_BWD);
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
+        builder, hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::TANH_BWD);
     builder.Finish(attrOffset);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     ActivationParams result;
     ASSERT_NO_THROW(result = miopen_utils::mapPointwiseModeToMiopenActivation(*attr));
@@ -417,9 +436,9 @@ TEST(TestMiopenUtils, MapPointwiseModeEluWithCustomAlpha)
 {
     const float eluAlpha = 2.0f;
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::ELU_FWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::ELU_FWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -431,8 +450,9 @@ TEST(TestMiopenUtils, MapPointwiseModeEluWithCustomAlpha)
         flatbuffers::nullopt,
         eluAlpha);
     builder.Finish(attrOffset);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     ActivationParams result;
     ASSERT_NO_THROW(result = miopen_utils::mapPointwiseModeToMiopenActivation(*attr));
@@ -443,11 +463,12 @@ TEST(TestMiopenUtils, MapPointwiseModeEluWithCustomAlpha)
 TEST(TestMiopenUtils, MapPointwiseModeEluWithDefaultAlpha)
 {
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
-        builder, hipdnn_data_sdk::data_objects::PointwiseMode::ELU_BWD);
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
+        builder, hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::ELU_BWD);
     builder.Finish(attrOffset);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     ActivationParams result;
     ASSERT_NO_THROW(result = miopen_utils::mapPointwiseModeToMiopenActivation(*attr));
@@ -458,11 +479,12 @@ TEST(TestMiopenUtils, MapPointwiseModeEluWithDefaultAlpha)
 TEST(TestMiopenUtils, MapPointwiseModeSoftplusWithoutBeta)
 {
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
-        builder, hipdnn_data_sdk::data_objects::PointwiseMode::SOFTPLUS_FWD);
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
+        builder, hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SOFTPLUS_FWD);
     builder.Finish(attrOffset);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     ActivationParams result;
     ASSERT_NO_THROW(result = miopen_utils::mapPointwiseModeToMiopenActivation(*attr));
@@ -473,9 +495,9 @@ TEST(TestMiopenUtils, MapPointwiseModeSoftplusWithBetaOne)
 {
     const float beta = 1.0f;
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::SOFTPLUS_BWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SOFTPLUS_BWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -488,8 +510,9 @@ TEST(TestMiopenUtils, MapPointwiseModeSoftplusWithBetaOne)
         flatbuffers::nullopt,
         beta);
     builder.Finish(attrOffset);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     ActivationParams result;
     ASSERT_NO_THROW(result = miopen_utils::mapPointwiseModeToMiopenActivation(*attr));
@@ -500,9 +523,9 @@ TEST(TestMiopenUtils, MapPointwiseModeSoftplusWithInvalidBeta)
 {
     const float beta = 2.0f;
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::SOFTPLUS_FWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SOFTPLUS_FWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -515,8 +538,9 @@ TEST(TestMiopenUtils, MapPointwiseModeSoftplusWithInvalidBeta)
         flatbuffers::nullopt,
         beta);
     builder.Finish(attrOffset);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     ASSERT_THROW(miopen_utils::mapPointwiseModeToMiopenActivation(*attr),
                  hipdnn_plugin_sdk::HipdnnPluginException);
@@ -525,11 +549,12 @@ TEST(TestMiopenUtils, MapPointwiseModeSoftplusWithInvalidBeta)
 TEST(TestMiopenUtils, MapPointwiseModeAbs)
 {
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
-        builder, hipdnn_data_sdk::data_objects::PointwiseMode::ABS);
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
+        builder, hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::ABS);
     builder.Finish(attrOffset);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     ActivationParams result;
     ASSERT_NO_THROW(result = miopen_utils::mapPointwiseModeToMiopenActivation(*attr));
@@ -539,11 +564,12 @@ TEST(TestMiopenUtils, MapPointwiseModeAbs)
 TEST(TestMiopenUtils, MapPointwiseModeIdentity)
 {
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
-        builder, hipdnn_data_sdk::data_objects::PointwiseMode::IDENTITY);
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
+        builder, hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::IDENTITY);
     builder.Finish(attrOffset);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     ActivationParams result;
     ASSERT_NO_THROW(result = miopen_utils::mapPointwiseModeToMiopenActivation(*attr));
@@ -553,11 +579,12 @@ TEST(TestMiopenUtils, MapPointwiseModeIdentity)
 TEST(TestMiopenUtils, MapPointwiseModeUnsupported)
 {
     flatbuffers::FlatBufferBuilder builder;
-    auto attrOffset = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
-        builder, hipdnn_data_sdk::data_objects::PointwiseMode::ADD);
+    auto attrOffset = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
+        builder, hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::ADD);
     builder.Finish(attrOffset);
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     ASSERT_THROW(miopen_utils::mapPointwiseModeToMiopenActivation(*attr),
                  hipdnn_plugin_sdk::HipdnnPluginException);

--- a/dnn-providers/miopen-provider/tests/common/ActivationCommon.hpp
+++ b/dnn-providers/miopen-provider/tests/common/ActivationCommon.hpp
@@ -6,15 +6,15 @@
 #include <exception>
 #include <optional>
 
-#include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/pointwise_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
 
 namespace test_activation_common
 {
 
 struct ActivTestCase
 {
-    hipdnn_data_sdk::data_objects::PointwiseMode mode;
+    hipdnn_flatbuffers_sdk::data_objects::PointwiseMode mode;
     std::optional<float> reluLowerClip;
     std::optional<float> reluUpperClip;
     std::optional<float> reluLowerClipSlope;
@@ -22,7 +22,7 @@ struct ActivTestCase
     std::optional<float> eluAlpha;
     std::optional<float> softplusBeta;
 
-    ActivTestCase(hipdnn_data_sdk::data_objects::PointwiseMode modeLocal,
+    ActivTestCase(hipdnn_flatbuffers_sdk::data_objects::PointwiseMode modeLocal,
                   std::optional<float> reluLowerClipLocal = std::nullopt,
                   std::optional<float> reluUpperClipLocal = std::nullopt,
                   std::optional<float> reluLowerClipSlopeLocal = std::nullopt,
@@ -37,7 +37,7 @@ struct ActivTestCase
         , eluAlpha(eluAlphaLocal)
         , softplusBeta(softplusBetaLocal)
     {
-        using PointwiseMode = hipdnn_data_sdk::data_objects::PointwiseMode;
+        using PointwiseMode = hipdnn_flatbuffers_sdk::data_objects::PointwiseMode;
 
         switch(mode)
         {
@@ -94,7 +94,7 @@ struct ActivTestCase
 
 inline std::vector<ActivTestCase> createFwdActivationSmokeCases()
 {
-    using PM = hipdnn_data_sdk::data_objects::PointwiseMode;
+    using PM = hipdnn_flatbuffers_sdk::data_objects::PointwiseMode;
 
     std::vector<ActivTestCase> cases;
 
@@ -113,7 +113,7 @@ inline std::vector<ActivTestCase> createFwdActivationSmokeCases()
 
 inline std::vector<ActivTestCase> createFwdActivationFullCases()
 {
-    using PM = hipdnn_data_sdk::data_objects::PointwiseMode;
+    using PM = hipdnn_flatbuffers_sdk::data_objects::PointwiseMode;
 
     std::vector<ActivTestCase> cases;
 
@@ -172,7 +172,7 @@ inline std::vector<ActivTestCase> createFwdActivationFullCases()
 inline std::vector<ActivTestCase> createBatchnormBwdActivationTestCases()
 {
     return {// ReLU Backward: d/dx Max(0, x) = 1 * (x > 0)
-            ActivTestCase(hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+            ActivTestCase(hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD,
                           0.0f,
                           std::nullopt,
                           std::nullopt,
@@ -180,7 +180,7 @@ inline std::vector<ActivTestCase> createBatchnormBwdActivationTestCases()
                           std::nullopt,
                           std::nullopt),
             // Clipped ReLU Backward: d/dx Clamp(x, -inf, upper)
-            ActivTestCase(hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+            ActivTestCase(hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD,
                           std::nullopt,
                           0.5f,
                           std::nullopt,
@@ -188,7 +188,7 @@ inline std::vector<ActivTestCase> createBatchnormBwdActivationTestCases()
                           std::nullopt,
                           std::nullopt),
             // CLAMP Backward: d/dx Clamp(x, lower, upper)
-            ActivTestCase(hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+            ActivTestCase(hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD,
                           0.1f,
                           0.5f,
                           std::nullopt,

--- a/dnn-providers/miopen-provider/tests/engines/TestMiopenEngine.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/TestMiopenEngine.cpp
@@ -5,10 +5,10 @@
 #include <memory>
 #include <set>
 
-#include <hipdnn_data_sdk/data_objects/engine_config_generated.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/EngineDetailsWrapper.hpp>
 #include <hipdnn_data_sdk/utilities/StringUtil.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/engine_config_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/EngineDetailsWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 #include <hipdnn_test_sdk/utilities/MockGraph.hpp>
 
@@ -19,7 +19,7 @@
 
 using namespace miopen_plugin;
 using namespace hipdnn_test_sdk::utilities;
-using namespace hipdnn_data_sdk::flatbuffer_utilities;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 
 TEST(TestMiopenEngine, ConstructorAndId)
 {
@@ -184,8 +184,8 @@ TEST(TestMiopenEngine, GetDetailsReturnsSerializedEngineDetails)
     hipdnnPluginConstData_t result;
     engine.getDetails(dummyHandle, mockGraph, result);
 
-    hipdnn_data_sdk::flatbuffer_utilities::EngineDetailsWrapper engineDetails(result.ptr,
-                                                                              result.size);
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::EngineDetailsWrapper engineDetails(result.ptr,
+                                                                                     result.size);
     EXPECT_EQ(engineDetails.engineId(), 1);
 }
 
@@ -198,8 +198,8 @@ TEST(TestMiopenEngine, GetDetailsContainsBenchmarkingKnob)
     hipdnnPluginConstData_t result;
     engine.getDetails(dummyHandle, mockGraph, result);
 
-    hipdnn_data_sdk::flatbuffer_utilities::EngineDetailsWrapper engineDetails(result.ptr,
-                                                                              result.size);
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::EngineDetailsWrapper engineDetails(result.ptr,
+                                                                                     result.size);
     ASSERT_EQ(engineDetails.knobCount(), 1u);
 
     const auto& knob = engineDetails.getKnobByName("global.benchmarking");
@@ -207,13 +207,16 @@ TEST(TestMiopenEngine, GetDetailsContainsBenchmarkingKnob)
     EXPECT_EQ(knob.description(), "Enable benchmarking");
 
     ASSERT_TRUE(knob.hasDefaultValue());
-    EXPECT_EQ(knob.defaultValueType(), hipdnn_data_sdk::data_objects::KnobValue::IntValue);
-    const auto& defaultValue = knob.defaultValueAs<hipdnn_data_sdk::data_objects::IntValue>();
+    EXPECT_EQ(knob.defaultValueType(), hipdnn_flatbuffers_sdk::data_objects::KnobValue::IntValue);
+    const auto& defaultValue
+        = knob.defaultValueAs<hipdnn_flatbuffers_sdk::data_objects::IntValue>();
     EXPECT_EQ(defaultValue.value(), 0);
 
     ASSERT_TRUE(knob.hasConstraint());
-    EXPECT_EQ(knob.constraintType(), hipdnn_data_sdk::data_objects::KnobConstraint::IntConstraint);
-    const auto& constraint = knob.constraintAs<hipdnn_data_sdk::data_objects::IntConstraint>();
+    EXPECT_EQ(knob.constraintType(),
+              hipdnn_flatbuffers_sdk::data_objects::KnobConstraint::IntConstraint);
+    const auto& constraint
+        = knob.constraintAs<hipdnn_flatbuffers_sdk::data_objects::IntConstraint>();
     EXPECT_EQ(constraint.min_value(), 0);
     EXPECT_EQ(constraint.max_value(), 1);
     EXPECT_EQ(constraint.step(), 1);
@@ -225,28 +228,28 @@ TEST(TestMiopenEngine, GetDetailsOnlyUsesFirstPlanBuilderCustomKnobs)
     auto mockPlanBuilder2 = std::make_unique<MockPlanBuilder>();
 
     // Set up first plan builder to return a custom knob
-    hipdnn_data_sdk::data_objects::KnobT knob1;
+    hipdnn_flatbuffers_sdk::data_objects::KnobT knob1;
     knob1.knob_id = "custom.knob1";
     knob1.description = "First custom knob";
-    hipdnn_data_sdk::data_objects::IntValueT defaultValue1;
+    hipdnn_flatbuffers_sdk::data_objects::IntValueT defaultValue1;
     defaultValue1.value = 1;
     knob1.default_value.Set(defaultValue1);
 
-    std::vector<hipdnn_data_sdk::data_objects::KnobT> customKnobs1;
+    std::vector<hipdnn_flatbuffers_sdk::data_objects::KnobT> customKnobs1;
     customKnobs1.push_back(knob1);
 
     EXPECT_CALL(*mockPlanBuilder1, getCustomKnobs(::testing::_, ::testing::_))
         .WillOnce(::testing::Return(customKnobs1));
 
     // Set up second plan builder to also return a custom knob (this should be ignored)
-    hipdnn_data_sdk::data_objects::KnobT knob2;
+    hipdnn_flatbuffers_sdk::data_objects::KnobT knob2;
     knob2.knob_id = "custom.knob2";
     knob2.description = "Second custom knob";
-    hipdnn_data_sdk::data_objects::IntValueT defaultValue2;
+    hipdnn_flatbuffers_sdk::data_objects::IntValueT defaultValue2;
     defaultValue2.value = 2;
     knob2.default_value.Set(defaultValue2);
 
-    std::vector<hipdnn_data_sdk::data_objects::KnobT> customKnobs2;
+    std::vector<hipdnn_flatbuffers_sdk::data_objects::KnobT> customKnobs2;
     customKnobs2.push_back(knob2);
 
     // This should NOT be called because we break after first non-empty custom knobs
@@ -262,7 +265,8 @@ TEST(TestMiopenEngine, GetDetailsOnlyUsesFirstPlanBuilderCustomKnobs)
     hipdnnPluginConstData_t result;
     engine.getDetails(dummyHandle, mockGraph, result);
 
-    hipdnn_plugin_sdk::EngineDetailsWrapper engineDetails(result.ptr, result.size);
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::EngineDetailsWrapper engineDetails(result.ptr,
+                                                                                     result.size);
 
     // Should have 2 knobs: benchmarking (always present) + custom.knob1 (from first builder)
     ASSERT_EQ(engineDetails.knobCount(), 2u);
@@ -323,23 +327,24 @@ TEST(TestMiopenEngine, InitializeExecutionContextThrowsOnInvalidBenchmarkingKnob
     flatbuffers::FlatBufferBuilder builder;
     auto knobIdOffset = builder.CreateString("global.benchmarking");
     auto stringValueOffset = builder.CreateString("invalid_value");
-    auto knobValue = hipdnn_data_sdk::data_objects::CreateStringValue(builder, stringValueOffset);
-    hipdnn_data_sdk::data_objects::KnobSettingBuilder knobSettingBuilder(builder);
+    auto knobValue
+        = hipdnn_flatbuffers_sdk::data_objects::CreateStringValue(builder, stringValueOffset);
+    hipdnn_flatbuffers_sdk::data_objects::KnobSettingBuilder knobSettingBuilder(builder);
     knobSettingBuilder.add_knob_id(knobIdOffset);
-    knobSettingBuilder.add_value_type(hipdnn_data_sdk::data_objects::KnobValue::StringValue);
+    knobSettingBuilder.add_value_type(hipdnn_flatbuffers_sdk::data_objects::KnobValue::StringValue);
     knobSettingBuilder.add_value(knobValue.Union());
     auto knobSetting = knobSettingBuilder.Finish();
 
-    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::KnobSetting>> knobsVector;
+    std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::KnobSetting>> knobsVector;
     knobsVector.push_back(knobSetting);
     auto knobs = builder.CreateVector(knobsVector);
 
-    auto engineConfig = hipdnn_data_sdk::data_objects::CreateEngineConfig(builder, 1, knobs);
+    auto engineConfig = hipdnn_flatbuffers_sdk::data_objects::CreateEngineConfig(builder, 1, knobs);
     builder.Finish(engineConfig);
 
     auto buffer = builder.Release();
-    hipdnn_data_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
-                                                                             buffer.size());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
+                                                                                    buffer.size());
 
     EXPECT_THROW(engine.initializeExecutionContext(dummyHandle, mockGraph, configWrapper, ctx),
                  hipdnn_plugin_sdk::HipdnnPluginException);
@@ -354,23 +359,23 @@ TEST(TestMiopenEngine, InitializeExecutionContextSetsBenchmarkingEnabled)
 
     flatbuffers::FlatBufferBuilder builder;
     auto knobIdOffset = builder.CreateString("global.benchmarking");
-    auto knobValue = hipdnn_data_sdk::data_objects::CreateIntValue(builder, 1);
-    hipdnn_data_sdk::data_objects::KnobSettingBuilder knobSettingBuilder(builder);
+    auto knobValue = hipdnn_flatbuffers_sdk::data_objects::CreateIntValue(builder, 1);
+    hipdnn_flatbuffers_sdk::data_objects::KnobSettingBuilder knobSettingBuilder(builder);
     knobSettingBuilder.add_knob_id(knobIdOffset);
-    knobSettingBuilder.add_value_type(hipdnn_data_sdk::data_objects::KnobValue::IntValue);
+    knobSettingBuilder.add_value_type(hipdnn_flatbuffers_sdk::data_objects::KnobValue::IntValue);
     knobSettingBuilder.add_value(knobValue.Union());
     auto knobSetting = knobSettingBuilder.Finish();
 
-    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::KnobSetting>> knobsVector;
+    std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::KnobSetting>> knobsVector;
     knobsVector.push_back(knobSetting);
     auto knobs = builder.CreateVector(knobsVector);
 
-    auto engineConfig = hipdnn_data_sdk::data_objects::CreateEngineConfig(builder, 1, knobs);
+    auto engineConfig = hipdnn_flatbuffers_sdk::data_objects::CreateEngineConfig(builder, 1, knobs);
     builder.Finish(engineConfig);
 
     auto buffer = builder.Release();
-    hipdnn_data_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
-                                                                             buffer.size());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
+                                                                                    buffer.size());
 
     engine.initializeExecutionContext(dummyHandle, mockGraph, configWrapper, ctx);
 
@@ -387,23 +392,23 @@ TEST(TestMiopenEngine, InitializeExecutionContextSetsBenchmarkingDisabled)
     flatbuffers::FlatBufferBuilder builder;
     auto knobIdOffset = builder.CreateString("global.benchmarking");
     auto knobValue
-        = hipdnn_data_sdk::data_objects::CreateIntValue(builder, static_cast<int64_t>(0));
-    hipdnn_data_sdk::data_objects::KnobSettingBuilder knobSettingBuilder(builder);
+        = hipdnn_flatbuffers_sdk::data_objects::CreateIntValue(builder, static_cast<int64_t>(0));
+    hipdnn_flatbuffers_sdk::data_objects::KnobSettingBuilder knobSettingBuilder(builder);
     knobSettingBuilder.add_knob_id(knobIdOffset);
-    knobSettingBuilder.add_value_type(hipdnn_data_sdk::data_objects::KnobValue::IntValue);
+    knobSettingBuilder.add_value_type(hipdnn_flatbuffers_sdk::data_objects::KnobValue::IntValue);
     knobSettingBuilder.add_value(knobValue.Union());
     auto knobSetting = knobSettingBuilder.Finish();
 
-    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::KnobSetting>> knobsVector;
+    std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::KnobSetting>> knobsVector;
     knobsVector.push_back(knobSetting);
     auto knobs = builder.CreateVector(knobsVector);
 
-    auto engineConfig = hipdnn_data_sdk::data_objects::CreateEngineConfig(builder, 1, knobs);
+    auto engineConfig = hipdnn_flatbuffers_sdk::data_objects::CreateEngineConfig(builder, 1, knobs);
     builder.Finish(engineConfig);
 
     auto buffer = builder.Release();
-    hipdnn_data_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
-                                                                             buffer.size());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
+                                                                                    buffer.size());
 
     engine.initializeExecutionContext(dummyHandle, mockGraph, configWrapper, ctx);
 
@@ -433,12 +438,12 @@ TEST(TestMiopenEngine, InitializeExecutionContextDefaultsBenchmarkingDisabledWhe
     MockHipdnnMiopenContext ctx;
 
     flatbuffers::FlatBufferBuilder builder;
-    auto engineConfig = hipdnn_data_sdk::data_objects::CreateEngineConfig(builder, 1, 0);
+    auto engineConfig = hipdnn_flatbuffers_sdk::data_objects::CreateEngineConfig(builder, 1, 0);
     builder.Finish(engineConfig);
 
     auto buffer = builder.Release();
-    hipdnn_data_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
-                                                                             buffer.size());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
+                                                                                    buffer.size());
 
     engine.initializeExecutionContext(dummyHandle, mockGraph, configWrapper, ctx);
 

--- a/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormApplicabilityChecks.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormApplicabilityChecks.cpp
@@ -3,9 +3,9 @@
 
 #include <gtest/gtest.h>
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 
@@ -22,7 +22,7 @@ struct TensorConfig
 {
     int64_t uid;
     std::string name;
-    hipdnn_data_sdk::data_objects::DataType dataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType dataType;
     std::vector<int64_t> dims;
     std::vector<int64_t> strides;
     std::string description;
@@ -175,7 +175,7 @@ inline const std::vector<const TensorLayout*> LAYOUTS_5D
 
 namespace type_configs
 {
-using DT = hipdnn_data_sdk::data_objects::DataType;
+using DT = hipdnn_flatbuffers_sdk::data_objects::DataType;
 
 // All invalid type configurations that should be REJECTED
 // Documents what type combinations are NOT supported by MIOpen
@@ -218,7 +218,7 @@ public:
     TensorConfigBuilder(int64_t uid, const std::string& name, TensorRole role)
         : _config{uid,
                   name,
-                  hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                  hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
                   {},
                   {},
                   "",
@@ -229,7 +229,7 @@ public:
     {
     }
 
-    TensorConfigBuilder& withDataType(hipdnn_data_sdk::data_objects::DataType dt)
+    TensorConfigBuilder& withDataType(hipdnn_flatbuffers_sdk::data_objects::DataType dt)
     {
         _config.dataType = dt;
         return *this;
@@ -282,7 +282,7 @@ private:
 
 inline TensorConfig createIoTensor(int64_t uid,
                                    const std::string& name,
-                                   hipdnn_data_sdk::data_objects::DataType dt,
+                                   hipdnn_flatbuffers_sdk::data_objects::DataType dt,
                                    const std::vector<int64_t>& dims,
                                    const std::vector<int64_t>& strides,
                                    bool isVirtual = false)
@@ -299,11 +299,12 @@ inline TensorConfig createIoTensor(int64_t uid,
     return builder.build();
 }
 
-[[maybe_unused]] inline TensorConfig createAffineTensor(int64_t uid,
-                                                        const std::string& name,
-                                                        hipdnn_data_sdk::data_objects::DataType dt,
-                                                        const std::vector<int64_t>& derivedDims,
-                                                        const std::vector<int64_t>& derivedStrides)
+[[maybe_unused]] inline TensorConfig
+    createAffineTensor(int64_t uid,
+                       const std::string& name,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType dt,
+                       const std::vector<int64_t>& derivedDims,
+                       const std::vector<int64_t>& derivedStrides)
 {
     return TensorConfigBuilder(uid, name, TensorRole::AFFINE)
         .withDataType(dt)
@@ -312,11 +313,12 @@ inline TensorConfig createIoTensor(int64_t uid,
         .build();
 }
 
-[[maybe_unused]] inline TensorConfig createStatTensor(int64_t uid,
-                                                      const std::string& name,
-                                                      hipdnn_data_sdk::data_objects::DataType dt,
-                                                      const std::vector<int64_t>& derivedDims,
-                                                      const std::vector<int64_t>& derivedStrides)
+[[maybe_unused]] inline TensorConfig
+    createStatTensor(int64_t uid,
+                     const std::string& name,
+                     hipdnn_flatbuffers_sdk::data_objects::DataType dt,
+                     const std::vector<int64_t>& derivedDims,
+                     const std::vector<int64_t>& derivedStrides)
 {
     return TensorConfigBuilder(uid, name, TensorRole::STAT)
         .withDataType(dt)
@@ -511,9 +513,9 @@ inline std::vector<TensorConfig> createBatchnormFusedBackwardTensors(
 
 // --- BnTensorTypes Helpers ---
 
-inline std::string dataTypeToString(hipdnn_data_sdk::data_objects::DataType dt)
+inline std::string dataTypeToString(hipdnn_flatbuffers_sdk::data_objects::DataType dt)
 {
-    using DT = hipdnn_data_sdk::data_objects::DataType;
+    using DT = hipdnn_flatbuffers_sdk::data_objects::DataType;
     switch(dt)
     {
     case DT::FLOAT:
@@ -533,9 +535,9 @@ inline std::string toString(const BnTensorTypes& types)
            + "_Stat_" + dataTypeToString(types.stat);
 }
 
-inline std::string activationModeToString(hipdnn_data_sdk::data_objects::PointwiseMode mode)
+inline std::string activationModeToString(hipdnn_flatbuffers_sdk::data_objects::PointwiseMode mode)
 {
-    using PM = hipdnn_data_sdk::data_objects::PointwiseMode;
+    using PM = hipdnn_flatbuffers_sdk::data_objects::PointwiseMode;
     switch(mode)
     {
     case PM::IDENTITY:
@@ -597,8 +599,8 @@ struct DataTypeIsSupportedTestCase
 {
     std::string name;
     bool shouldPass;
-    hipdnn_data_sdk::data_objects::DataType dataType;
-    std::unordered_set<hipdnn_data_sdk::data_objects::DataType> allowedTypes;
+    hipdnn_flatbuffers_sdk::data_objects::DataType dataType;
+    std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> allowedTypes;
 
     friend std::ostream& operator<<(std::ostream& os, const DataTypeIsSupportedTestCase& tc)
     {
@@ -612,7 +614,7 @@ struct ConsistentDataTypesTestCase
     bool shouldPass;
     std::vector<TensorConfig> tensorConfigs;
     std::vector<int64_t> tensorIds;
-    std::unordered_set<hipdnn_data_sdk::data_objects::DataType> allowedTypes;
+    std::unordered_set<hipdnn_flatbuffers_sdk::data_objects::DataType> allowedTypes;
 
     friend std::ostream& operator<<(std::ostream& os, const ConsistentDataTypesTestCase& tc)
     {
@@ -626,7 +628,7 @@ struct FixedDataTypeTestCase
     bool shouldPass;
     std::vector<TensorConfig> tensorConfigs;
     std::vector<int64_t> tensorIds;
-    hipdnn_data_sdk::data_objects::DataType expectedType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType expectedType;
 
     friend std::ostream& operator<<(std::ostream& os, const FixedDataTypeTestCase& tc)
     {
@@ -781,7 +783,7 @@ struct BatchnormFusedBackwardConfigTestCase
     int64_t dbiasUid;
     int64_t bnYVirtualUid;
     int64_t dxDreluVirtualUid;
-    hipdnn_data_sdk::data_objects::PointwiseMode activationMode;
+    hipdnn_flatbuffers_sdk::data_objects::PointwiseMode activationMode;
 
     friend std::ostream& operator<<(std::ostream& os,
                                     const BatchnormFusedBackwardConfigTestCase& tc)
@@ -802,7 +804,7 @@ struct BatchnormInferenceVarianceExtFusedConfigTestCase
     int64_t epsilonUid;
     int64_t meanUid;
     int64_t varianceUid;
-    hipdnn_data_sdk::data_objects::PointwiseMode activationMode;
+    hipdnn_flatbuffers_sdk::data_objects::PointwiseMode activationMode;
 
     friend std::ostream& operator<<(std::ostream& os,
                                     const BatchnormInferenceVarianceExtFusedConfigTestCase& tc)
@@ -815,7 +817,7 @@ struct ActivationModeTestCase
 {
     std::string name;
     bool shouldPass;
-    hipdnn_data_sdk::data_objects::PointwiseMode mode;
+    hipdnn_flatbuffers_sdk::data_objects::PointwiseMode mode;
     flatbuffers::Optional<double> reluLowerClip;
     flatbuffers::Optional<double> reluUpperClip;
     flatbuffers::Optional<double> reluLowerClipSlope;
@@ -828,24 +830,26 @@ struct ActivationModeTestCase
 
 // --- Helper Functions ---
 
-std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*> buildTensorMap(
-    flatbuffers::FlatBufferBuilder& builder,
-    const std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>&
-        tensorOffsets)
+std::unordered_map<int64_t, const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>
+    buildTensorMap(flatbuffers::FlatBufferBuilder& builder,
+                   const std::vector<
+                       flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>&
+                       tensorOffsets)
 {
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test_graph",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorOffsets,
         nullptr);
 
     builder.Finish(graphOffset);
 
-    const auto* graph = hipdnn_data_sdk::data_objects::GetGraph(builder.GetBufferPointer());
-    std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*> tensorMap;
+    const auto* graph = hipdnn_flatbuffers_sdk::data_objects::GetGraph(builder.GetBufferPointer());
+    std::unordered_map<int64_t, const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>
+        tensorMap;
 
     if(graph->tensors() != nullptr)
     {
@@ -861,7 +865,8 @@ std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttribute
 auto buildTensorMapFromConfigs(const std::vector<TensorConfig>& configs)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>> tensorOffsets;
+    std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
+        tensorOffsets;
     tensorOffsets.reserve(configs.size());
 
     for(const auto& config : configs)
@@ -869,29 +874,31 @@ auto buildTensorMapFromConfigs(const std::vector<TensorConfig>& configs)
         if(config.isPassByValue)
         {
             // Create a pass-by-value tensor with embedded scalar value
-            hipdnn_data_sdk::data_objects::Float64Value floatValue(config.passedValue);
+            hipdnn_flatbuffers_sdk::data_objects::Float64Value floatValue(config.passedValue);
             auto valueOffset = builder.CreateStruct(floatValue).Union();
-            tensorOffsets.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-                builder,
-                config.uid,
-                config.name.c_str(),
-                config.dataType,
-                &config.strides,
-                &config.dims,
-                config.isVirtual,
-                hipdnn_data_sdk::data_objects::TensorValue::Float64Value,
-                valueOffset));
+            tensorOffsets.push_back(
+                hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+                    builder,
+                    config.uid,
+                    config.name.c_str(),
+                    config.dataType,
+                    &config.strides,
+                    &config.dims,
+                    config.isVirtual,
+                    hipdnn_flatbuffers_sdk::data_objects::TensorValue::Float64Value,
+                    valueOffset));
         }
         else
         {
             tensorOffsets.push_back(
-                hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(builder,
-                                                                            config.uid,
-                                                                            config.name.c_str(),
-                                                                            config.dataType,
-                                                                            &config.strides,
-                                                                            &config.dims,
-                                                                            config.isVirtual));
+                hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+                    builder,
+                    config.uid,
+                    config.name.c_str(),
+                    config.dataType,
+                    &config.strides,
+                    &config.dims,
+                    config.isVirtual));
         }
     }
 
@@ -913,40 +920,41 @@ inline flatbuffers::FlatBufferBuilder
     flatbuffers::FlatBufferBuilder builder;
 
     // Build tensor attribute offsets from configs
-    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>> tensorOffsets;
+    std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
+        tensorOffsets;
     tensorOffsets.reserve(configs.size());
     for(const auto& cfg : configs)
     {
         tensorOffsets.push_back(
-            hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(builder,
-                                                                        cfg.uid,
-                                                                        cfg.name.c_str(),
-                                                                        cfg.dataType,
-                                                                        &cfg.strides,
-                                                                        &cfg.dims,
-                                                                        cfg.isVirtual));
+            hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(builder,
+                                                                               cfg.uid,
+                                                                               cfg.name.c_str(),
+                                                                               cfg.dataType,
+                                                                               &cfg.strides,
+                                                                               &cfg.dims,
+                                                                               cfg.isVirtual));
     }
 
     // Create BatchnormInferenceAttributes with specified UIDs
-    auto bnInfAttrs = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+    auto bnInfAttrs = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormInferenceAttributes(
         builder, xUid, meanUid, invVarianceUid, scaleUid, biasUid, yUid);
 
     // Create node
-    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "batchnorm_inference",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
         bnInfAttrs.Union()));
 
     // Build graph
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test_graph",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorOffsets,
         &nodes);
 
@@ -968,41 +976,43 @@ inline flatbuffers::FlatBufferBuilder
     flatbuffers::FlatBufferBuilder builder;
 
     // Build tensor attribute offsets
-    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>> tensorOffsets;
+    std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
+        tensorOffsets;
     tensorOffsets.reserve(configs.size());
     for(const auto& cfg : configs)
     {
         if(cfg.isPassByValue)
         {
             // Create a pass-by-value tensor with embedded scalar value
-            hipdnn_data_sdk::data_objects::Float64Value floatValue(cfg.passedValue);
+            hipdnn_flatbuffers_sdk::data_objects::Float64Value floatValue(cfg.passedValue);
             auto valueOffset = builder.CreateStruct(floatValue).Union();
-            tensorOffsets.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-                builder,
-                cfg.uid,
-                cfg.name.c_str(),
-                cfg.dataType,
-                &cfg.strides,
-                &cfg.dims,
-                cfg.isVirtual,
-                hipdnn_data_sdk::data_objects::TensorValue::Float64Value,
-                valueOffset));
+            tensorOffsets.push_back(
+                hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+                    builder,
+                    cfg.uid,
+                    cfg.name.c_str(),
+                    cfg.dataType,
+                    &cfg.strides,
+                    &cfg.dims,
+                    cfg.isVirtual,
+                    hipdnn_flatbuffers_sdk::data_objects::TensorValue::Float64Value,
+                    valueOffset));
         }
         else
         {
             tensorOffsets.push_back(
-                hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(builder,
-                                                                            cfg.uid,
-                                                                            cfg.name.c_str(),
-                                                                            cfg.dataType,
-                                                                            &cfg.strides,
-                                                                            &cfg.dims,
-                                                                            cfg.isVirtual));
+                hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(builder,
+                                                                                   cfg.uid,
+                                                                                   cfg.name.c_str(),
+                                                                                   cfg.dataType,
+                                                                                   &cfg.strides,
+                                                                                   &cfg.dims,
+                                                                                   cfg.isVirtual));
         }
     }
 
     // Create BatchnormAttributes (training mode) with specified UIDs
-    auto bnAttrs = hipdnn_data_sdk::data_objects::CreateBatchnormAttributes(
+    auto bnAttrs = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormAttributes(
         builder,
         xUid,
         scaleUid,
@@ -1020,21 +1030,21 @@ inline flatbuffers::FlatBufferBuilder
     );
 
     // Create node
-    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "batchnorm_training",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes,
         bnAttrs.Union()));
 
     // Build graph
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test_graph",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorOffsets,
         &nodes);
 
@@ -1057,22 +1067,23 @@ inline flatbuffers::FlatBufferBuilder
     flatbuffers::FlatBufferBuilder builder;
 
     // Build tensor attribute offsets
-    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>> tensorOffsets;
+    std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
+        tensorOffsets;
     tensorOffsets.reserve(configs.size());
     for(const auto& cfg : configs)
     {
         tensorOffsets.push_back(
-            hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(builder,
-                                                                        cfg.uid,
-                                                                        cfg.name.c_str(),
-                                                                        cfg.dataType,
-                                                                        &cfg.strides,
-                                                                        &cfg.dims,
-                                                                        cfg.isVirtual));
+            hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(builder,
+                                                                               cfg.uid,
+                                                                               cfg.name.c_str(),
+                                                                               cfg.dataType,
+                                                                               &cfg.strides,
+                                                                               &cfg.dims,
+                                                                               cfg.isVirtual));
     }
 
     // Create BatchnormBackwardAttributes with specified UIDs
-    auto bnBwdAttrs = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+    auto bnBwdAttrs = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormBackwardAttributes(
         builder,
         dyUid,
         xUid,
@@ -1085,21 +1096,21 @@ inline flatbuffers::FlatBufferBuilder
         dbiasUid);
 
     // Create node
-    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "batchnorm_backward",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
         bnBwdAttrs.Union()));
 
     // Build graph
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test_graph",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorOffsets,
         &nodes);
 
@@ -1107,54 +1118,55 @@ inline flatbuffers::FlatBufferBuilder
     return builder;
 }
 
-inline flatbuffers::FlatBufferBuilder
-    buildBatchnormFusedBackwardGraph(const std::vector<TensorConfig>& configs,
-                                     int64_t xUid,
-                                     int64_t scaleUid,
-                                     int64_t biasUid,
-                                     int64_t meanUid,
-                                     int64_t invVarianceUid,
-                                     int64_t dyUid,
-                                     int64_t dxUid,
-                                     int64_t dscaleUid,
-                                     int64_t dbiasUid,
-                                     int64_t bnYVirtualUid,
-                                     int64_t dxDreluVirtualUid,
-                                     hipdnn_data_sdk::data_objects::PointwiseMode activationMode
-                                     = hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD)
+inline flatbuffers::FlatBufferBuilder buildBatchnormFusedBackwardGraph(
+    const std::vector<TensorConfig>& configs,
+    int64_t xUid,
+    int64_t scaleUid,
+    int64_t biasUid,
+    int64_t meanUid,
+    int64_t invVarianceUid,
+    int64_t dyUid,
+    int64_t dxUid,
+    int64_t dscaleUid,
+    int64_t dbiasUid,
+    int64_t bnYVirtualUid,
+    int64_t dxDreluVirtualUid,
+    hipdnn_flatbuffers_sdk::data_objects::PointwiseMode activationMode
+    = hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD)
 {
     flatbuffers::FlatBufferBuilder builder;
 
     // Build tensor attribute offsets
-    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>> tensorOffsets;
+    std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
+        tensorOffsets;
     tensorOffsets.reserve(configs.size());
     for(const auto& cfg : configs)
     {
         tensorOffsets.push_back(
-            hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(builder,
-                                                                        cfg.uid,
-                                                                        cfg.name.c_str(),
-                                                                        cfg.dataType,
-                                                                        &cfg.strides,
-                                                                        &cfg.dims,
-                                                                        cfg.isVirtual));
+            hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(builder,
+                                                                               cfg.uid,
+                                                                               cfg.name.c_str(),
+                                                                               cfg.dataType,
+                                                                               &cfg.strides,
+                                                                               &cfg.dims,
+                                                                               cfg.isVirtual));
     }
 
     // Create 3 nodes for the fusion
-    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // Node 0: Batchnorm Inference
-    auto bnInfAttrs = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+    auto bnInfAttrs = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormInferenceAttributes(
         builder, xUid, meanUid, invVarianceUid, scaleUid, biasUid, bnYVirtualUid);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "batchnorm_inference",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
         bnInfAttrs.Union()));
 
     // Node 1: Activation (Backward mode, e.g., RELU_BWD)
-    auto actAttrs = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto actAttrs = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
         activationMode,
         flatbuffers::nullopt, // relu_lower_clip
@@ -1165,15 +1177,15 @@ inline flatbuffers::FlatBufferBuilder
         flatbuffers::Optional<int64_t>(dyUid),
         flatbuffers::nullopt, // in_2_tensor_uid
         dxDreluVirtualUid);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "activation_bwd",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttrs.Union()));
 
     // Node 2: Batchnorm Backward
-    auto bnBwdAttrs = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+    auto bnBwdAttrs = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormBackwardAttributes(
         builder,
         dxDreluVirtualUid,
         xUid,
@@ -1184,20 +1196,20 @@ inline flatbuffers::FlatBufferBuilder
         dxUid,
         dscaleUid,
         dbiasUid);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "batchnorm_backward",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
         bnBwdAttrs.Union()));
 
     // Build graph
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test_graph",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorOffsets,
         &nodes);
 
@@ -1215,58 +1227,62 @@ inline flatbuffers::FlatBufferBuilder buildBatchnormInferenceWithVarianceFusedGr
     int64_t meanUid,
     int64_t varianceUid,
     int64_t bnYVirtualUid,
-    hipdnn_data_sdk::data_objects::PointwiseMode activationMode
-    = hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD)
+    hipdnn_flatbuffers_sdk::data_objects::PointwiseMode activationMode
+    = hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD)
 {
     flatbuffers::FlatBufferBuilder builder;
 
-    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>> tensorOffsets;
+    std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
+        tensorOffsets;
     tensorOffsets.reserve(configs.size());
     for(const auto& cfg : configs)
     {
         if(cfg.isPassByValue)
         {
-            hipdnn_data_sdk::data_objects::Float64Value floatValue(cfg.passedValue);
+            hipdnn_flatbuffers_sdk::data_objects::Float64Value floatValue(cfg.passedValue);
             auto valueOffset = builder.CreateStruct(floatValue).Union();
-            tensorOffsets.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-                builder,
-                cfg.uid,
-                cfg.name.c_str(),
-                cfg.dataType,
-                &cfg.strides,
-                &cfg.dims,
-                cfg.isVirtual,
-                hipdnn_data_sdk::data_objects::TensorValue::Float64Value,
-                valueOffset));
+            tensorOffsets.push_back(
+                hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+                    builder,
+                    cfg.uid,
+                    cfg.name.c_str(),
+                    cfg.dataType,
+                    &cfg.strides,
+                    &cfg.dims,
+                    cfg.isVirtual,
+                    hipdnn_flatbuffers_sdk::data_objects::TensorValue::Float64Value,
+                    valueOffset));
         }
         else
         {
             tensorOffsets.push_back(
-                hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(builder,
-                                                                            cfg.uid,
-                                                                            cfg.name.c_str(),
-                                                                            cfg.dataType,
-                                                                            &cfg.strides,
-                                                                            &cfg.dims,
-                                                                            cfg.isVirtual));
+                hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(builder,
+                                                                                   cfg.uid,
+                                                                                   cfg.name.c_str(),
+                                                                                   cfg.dataType,
+                                                                                   &cfg.strides,
+                                                                                   &cfg.dims,
+                                                                                   cfg.isVirtual));
         }
     }
 
-    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // Node 0: Batchnorm Inference with Variance
-    auto bnAttrs = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributesVarianceExt(
-        builder, xUid, meanUid, varianceUid, scaleUid, biasUid, bnYVirtualUid, epsilonUid);
+    auto bnAttrs
+        = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormInferenceAttributesVarianceExt(
+            builder, xUid, meanUid, varianceUid, scaleUid, biasUid, bnYVirtualUid, epsilonUid);
 
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "batchnorm_inference_variance_ext",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributesVarianceExt,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::
+            BatchnormInferenceAttributesVarianceExt,
         bnAttrs.Union()));
 
     // Node 1: Activation
-    auto actAttrs = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto actAttrs = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
         activationMode,
         flatbuffers::nullopt, // relu_lower_clip
@@ -1278,20 +1294,20 @@ inline flatbuffers::FlatBufferBuilder buildBatchnormInferenceWithVarianceFusedGr
         flatbuffers::nullopt, // in_2_tensor_uid
         yUid); // out_0_tensor_uid
 
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "activation",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttrs.Union()));
 
     // Build graph
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test_graph",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorOffsets,
         &nodes);
 
@@ -1460,7 +1476,7 @@ inline std::vector<TensorDescriptorListTestCase> getValidateConsistentLayoutsTes
 
 inline std::vector<DataTypeIsSupportedTestCase> getValidateDataTypeIsSupportedTestCases()
 {
-    using DT = hipdnn_data_sdk::data_objects::DataType;
+    using DT = hipdnn_flatbuffers_sdk::data_objects::DataType;
     std::unordered_set<DT> ioTypes = {DT::FLOAT, DT::HALF, DT::BFLOAT16};
 
     return {
@@ -1518,7 +1534,7 @@ inline std::vector<SpatialDimensionsTestCase> getValidateSpatialDimensionsTestCa
 inline std::vector<ConsistentDataTypesTestCase> getValidateConsistentDataTypesTestCases()
 {
     using namespace canonical_layouts;
-    using DT = hipdnn_data_sdk::data_objects::DataType;
+    using DT = hipdnn_flatbuffers_sdk::data_objects::DataType;
 
     const auto& testDims = shapes::INFERENCE_4D[2]; // {1, 3, 224, 224}
     auto testStrides
@@ -1564,7 +1580,7 @@ inline std::vector<ConsistentDataTypesTestCase> getValidateConsistentDataTypesTe
 inline std::vector<FixedDataTypeTestCase> getValidateFixedDataTypeTestCases()
 {
     using namespace canonical_layouts;
-    using DT = hipdnn_data_sdk::data_objects::DataType;
+    using DT = hipdnn_flatbuffers_sdk::data_objects::DataType;
 
     auto derivedDims
         = hipdnn_data_sdk::utilities::getDerivedShape(shapes::INFERENCE_4D[2]); // {1, 3, 1, 1}
@@ -1614,7 +1630,7 @@ inline std::vector<FixedDataTypeTestCase> getValidateFixedDataTypeTestCases()
 inline std::vector<ConsistentShapesTestCase> getValidateConsistentShapesTestCases()
 {
     using namespace canonical_layouts;
-    using DT = hipdnn_data_sdk::data_objects::DataType;
+    using DT = hipdnn_flatbuffers_sdk::data_objects::DataType;
 
     auto canonicalDims = shapes::INFERENCE_4D[2]; // {1, 3, 224, 224}
     auto canonicalStrides = hipdnn_data_sdk::utilities::generateStrides(
@@ -1673,7 +1689,7 @@ inline std::vector<ConsistentShapesTestCase> getValidateConsistentShapesTestCase
 inline std::vector<TensorLayoutsAndDimsTestCase> getCheckTensorLayoutsAndDimsSupportedTestCases()
 {
     using namespace canonical_layouts;
-    using DT = hipdnn_data_sdk::data_objects::DataType;
+    using DT = hipdnn_flatbuffers_sdk::data_objects::DataType;
 
     auto dims3D = shapes::INFERENCE_3D[0]; // {1, 3, 224}
     auto dims4D = shapes::INFERENCE_4D[2]; // {1, 3, 224, 224}
@@ -1730,7 +1746,7 @@ inline std::vector<TensorLayoutsAndDimsTestCase> getCheckTensorLayoutsAndDimsSup
 inline std::vector<TensorDataTypesComponentTestCase> getCheckTensorDataTypesSupportedTestCases()
 {
     using namespace canonical_layouts;
-    using DT = hipdnn_data_sdk::data_objects::DataType;
+    using DT = hipdnn_flatbuffers_sdk::data_objects::DataType;
 
     auto ioDims = shapes::INFERENCE_4D[2]; // {1, 3, 224, 224}
     auto ioStrides
@@ -1817,7 +1833,7 @@ inline std::vector<TensorDataTypesComponentTestCase> getCheckTensorDataTypesSupp
 inline std::vector<TensorShapesComponentTestCase> getCheckTensorShapesSupportedTestCases()
 {
     using namespace canonical_layouts;
-    using DT = hipdnn_data_sdk::data_objects::DataType;
+    using DT = hipdnn_flatbuffers_sdk::data_objects::DataType;
 
     auto inferenceDims = shapes::INFERENCE_4D[2]; // {1, 3, 224, 224}
     auto inferenceStrides = hipdnn_data_sdk::utilities::generateStrides(
@@ -1909,7 +1925,7 @@ inline std::vector<BatchnormInferenceConfigTestCase>
     getCheckBatchnormInferenceConfigSupportedTestCases()
 {
     using namespace canonical_layouts;
-    using DT = hipdnn_data_sdk::data_objects::DataType;
+    using DT = hipdnn_flatbuffers_sdk::data_objects::DataType;
     using UIDs = BnCommonTensorIds;
 
     std::vector<BatchnormInferenceConfigTestCase> cases;
@@ -2031,7 +2047,7 @@ inline std::vector<BatchnormTrainingConfigTestCase>
     getCheckBatchnormTrainingConfigSupportedTestCases()
 {
     using namespace canonical_layouts;
-    using DT = hipdnn_data_sdk::data_objects::DataType;
+    using DT = hipdnn_flatbuffers_sdk::data_objects::DataType;
     using UIDs = BnTrainingTensorIds;
 
     std::vector<BatchnormTrainingConfigTestCase> cases;
@@ -2299,7 +2315,7 @@ inline std::vector<BatchnormBackwardConfigTestCase>
     getCheckBatchnormBackwardConfigSupportedTestCases()
 {
     using namespace canonical_layouts;
-    using DT = hipdnn_data_sdk::data_objects::DataType;
+    using DT = hipdnn_flatbuffers_sdk::data_objects::DataType;
     using UIDs = BnBackwardTensorIds;
 
     std::vector<BatchnormBackwardConfigTestCase> cases;
@@ -2521,13 +2537,13 @@ inline std::vector<BatchnormFusedBackwardConfigTestCase>
     getCheckBatchnormFusedBackwardConfigSupportedTestCases()
 {
     using namespace canonical_layouts;
-    using DT = hipdnn_data_sdk::data_objects::DataType;
+    using DT = hipdnn_flatbuffers_sdk::data_objects::DataType;
     using UIDs = BnFusedTensorIds;
 
     std::vector<BatchnormFusedBackwardConfigTestCase> cases;
 
     // Supported backward activation modes (from atomic validation tests)
-    using PM = hipdnn_data_sdk::data_objects::PointwiseMode;
+    using PM = hipdnn_flatbuffers_sdk::data_objects::PointwiseMode;
     const std::vector<PM> supportedBwdActivations = {PM::IDENTITY, PM::RELU_BWD};
 
     // Happy paths - all inference shapes × all 4D layouts × all valid type configs × all supported activations
@@ -2719,25 +2735,25 @@ inline std::vector<ActivationModeTestCase> getCheckBatchnormFwdActivationModeSup
         // Happy paths - supported activation modes
         {"AcceptsIdentity",
          true,
-         hipdnn_data_sdk::data_objects::PointwiseMode::IDENTITY,
+         hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::IDENTITY,
          flatbuffers::nullopt,
          flatbuffers::nullopt,
          flatbuffers::nullopt},
         {"AcceptsRelu",
          true,
-         hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+         hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
          flatbuffers::nullopt,
          flatbuffers::nullopt,
          flatbuffers::nullopt},
         {"AcceptsClippedRelu",
          true,
-         hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+         hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
          flatbuffers::nullopt,
          flatbuffers::Optional<double>(6.0),
          flatbuffers::nullopt},
         {"AcceptsClamp",
          true,
-         hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+         hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
          flatbuffers::Optional<double>(0.0),
          flatbuffers::Optional<double>(6.0),
          flatbuffers::nullopt},
@@ -2745,25 +2761,25 @@ inline std::vector<ActivationModeTestCase> getCheckBatchnormFwdActivationModeSup
         // Unhappy paths - unsupported activation modes
         {"RejectsLeakyRelu",
          false,
-         hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+         hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
          flatbuffers::nullopt,
          flatbuffers::nullopt,
          flatbuffers::Optional<double>(0.01)},
         {"RejectsSigmoid",
          false,
-         hipdnn_data_sdk::data_objects::PointwiseMode::SIGMOID_FWD,
+         hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SIGMOID_FWD,
          flatbuffers::nullopt,
          flatbuffers::nullopt,
          flatbuffers::nullopt},
         {"RejectsTanh",
          false,
-         hipdnn_data_sdk::data_objects::PointwiseMode::TANH_FWD,
+         hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::TANH_FWD,
          flatbuffers::nullopt,
          flatbuffers::nullopt,
          flatbuffers::nullopt},
         {"RejectsReluBwdInFwdContext",
          false,
-         hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+         hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD,
          flatbuffers::nullopt,
          flatbuffers::nullopt,
          flatbuffers::nullopt},
@@ -2776,25 +2792,25 @@ inline std::vector<ActivationModeTestCase> getCheckBatchnormBwdActivationModeSup
         // Happy paths - supported activation modes
         {"AcceptsIdentityBwd",
          true,
-         hipdnn_data_sdk::data_objects::PointwiseMode::IDENTITY,
+         hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::IDENTITY,
          flatbuffers::nullopt,
          flatbuffers::nullopt,
          flatbuffers::nullopt},
         {"AcceptsReluBwd",
          true,
-         hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+         hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD,
          flatbuffers::nullopt,
          flatbuffers::nullopt,
          flatbuffers::nullopt},
         {"AcceptsClippedReluBwd",
          true,
-         hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+         hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD,
          flatbuffers::nullopt,
          flatbuffers::Optional<double>(6.0),
          flatbuffers::nullopt},
         {"AcceptsClampBwd",
          true,
-         hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+         hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD,
          flatbuffers::Optional<double>(0.0),
          flatbuffers::Optional<double>(6.0),
          flatbuffers::nullopt},
@@ -2802,25 +2818,25 @@ inline std::vector<ActivationModeTestCase> getCheckBatchnormBwdActivationModeSup
         // Unhappy paths - unsupported activation modes
         {"RejectsLeakyReluBwd",
          false,
-         hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+         hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD,
          flatbuffers::nullopt,
          flatbuffers::nullopt,
          flatbuffers::Optional<double>(0.01)},
         {"RejectsSigmoidBwd",
          false,
-         hipdnn_data_sdk::data_objects::PointwiseMode::SIGMOID_BWD,
+         hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SIGMOID_BWD,
          flatbuffers::nullopt,
          flatbuffers::nullopt,
          flatbuffers::nullopt},
         {"RejectsTanhBwd",
          false,
-         hipdnn_data_sdk::data_objects::PointwiseMode::TANH_BWD,
+         hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::TANH_BWD,
          flatbuffers::nullopt,
          flatbuffers::nullopt,
          flatbuffers::nullopt},
         {"RejectsReluFwdInBwdContext",
          false,
-         hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+         hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
          flatbuffers::nullopt,
          flatbuffers::nullopt,
          flatbuffers::nullopt},
@@ -2869,17 +2885,18 @@ TEST_P(TestValidateConsistentDimensions, ValidatesCorrectly)
     for(size_t i = 0; i < tc.tensorDims.size(); ++i)
     {
         flatbuffers::FlatBufferBuilder builder;
-        auto tensorOffset = hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        auto tensorOffset = hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
             builder,
             static_cast<int64_t>(i + 1),
             ("tensor_" + std::to_string(i + 1)).c_str(),
-            hipdnn_data_sdk::data_objects::DataType::FLOAT,
+            hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
             &tc.tensorStrides[i],
             &tc.tensorDims[i]);
         builder.Finish(tensorOffset);
 
-        const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::TensorAttributes>(
-            builder.GetBufferPointer());
+        const auto* attr
+            = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>(
+                builder.GetBufferPointer());
         tensors.emplace_back(attr);
     }
 
@@ -2912,17 +2929,18 @@ TEST_P(TestValidatePackedTensors, ValidatesCorrectly)
     for(size_t i = 0; i < tc.tensorDims.size(); ++i)
     {
         flatbuffers::FlatBufferBuilder builder;
-        auto tensorOffset = hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        auto tensorOffset = hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
             builder,
             static_cast<int64_t>(i + 1),
             ("tensor_" + std::to_string(i + 1)).c_str(),
-            hipdnn_data_sdk::data_objects::DataType::FLOAT,
+            hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
             &tc.tensorStrides[i],
             &tc.tensorDims[i]);
         builder.Finish(tensorOffset);
 
-        const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::TensorAttributes>(
-            builder.GetBufferPointer());
+        const auto* attr
+            = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>(
+                builder.GetBufferPointer());
         tensors.emplace_back(attr);
     }
 
@@ -2978,17 +2996,18 @@ TEST_P(TestValidateConsistentLayouts, ValidatesCorrectly)
     for(size_t i = 0; i < tc.tensorDims.size(); ++i)
     {
         flatbuffers::FlatBufferBuilder builder;
-        auto tensorOffset = hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        auto tensorOffset = hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
             builder,
             static_cast<int64_t>(i + 1),
             ("tensor_" + std::to_string(i + 1)).c_str(),
-            hipdnn_data_sdk::data_objects::DataType::FLOAT,
+            hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
             &tc.tensorStrides[i],
             &tc.tensorDims[i]);
         builder.Finish(tensorOffset);
 
-        const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::TensorAttributes>(
-            builder.GetBufferPointer());
+        const auto* attr
+            = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>(
+                builder.GetBufferPointer());
         tensors.emplace_back(attr);
     }
 
@@ -3269,8 +3288,8 @@ TEST_P(TestCheckBatchnormInferenceConfigSupported, ValidatesCorrectly)
 
     auto builder = buildBatchnormInferenceGraph(
         tc.tensorConfigs, tc.xUid, tc.yUid, tc.scaleUid, tc.biasUid, tc.meanUid, tc.invVarianceUid);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     auto* attrs = node.attributes_as_BatchnormInferenceAttributes();
@@ -3310,8 +3329,8 @@ TEST_P(TestCheckBatchnormTrainingConfigSupported, ValidatesCorrectly)
                                                tc.epsilonUid,
                                                tc.meanUid,
                                                tc.invVarianceUid);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     auto* attrs = node.attributes_as_BatchnormAttributes();
@@ -3352,8 +3371,8 @@ TEST_P(TestCheckBatchnormBackwardConfigSupported, ValidatesCorrectly)
                                                tc.dbiasUid,
                                                tc.meanUid,
                                                tc.invVarianceUid);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     auto* attrs = node.attributes_as_BatchnormBackwardAttributes();
@@ -3398,8 +3417,8 @@ TEST_P(TestCheckBatchnormFusedBackwardConfigSupported, ValidatesCorrectly)
                                                     tc.bnYVirtualUid,
                                                     tc.dxDreluVirtualUid,
                                                     tc.activationMode);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& bnInfNode = graph.getNode(0);
     const auto& actNode = graph.getNode(1);
@@ -3446,20 +3465,22 @@ TEST_P(TestCheckBatchnormFwdActivationModeSupported, ValidatesCorrectly)
     const auto& tc = GetParam();
 
     flatbuffers::FlatBufferBuilder builder;
-    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(builder,
-                                                                            tc.mode,
-                                                                            tc.reluLowerClip,
-                                                                            tc.reluUpperClip,
-                                                                            tc.reluLowerClipSlope,
-                                                                            flatbuffers::nullopt,
-                                                                            1,
-                                                                            flatbuffers::nullopt,
-                                                                            flatbuffers::nullopt,
-                                                                            2);
+    auto actAttr
+        = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(builder,
+                                                                          tc.mode,
+                                                                          tc.reluLowerClip,
+                                                                          tc.reluUpperClip,
+                                                                          tc.reluLowerClipSlope,
+                                                                          flatbuffers::nullopt,
+                                                                          1,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          2);
     builder.Finish(actAttr);
 
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     if(tc.shouldPass)
     {
@@ -3487,20 +3508,22 @@ TEST_P(TestCheckBatchnormBwdActivationModeSupported, ValidatesCorrectly)
     const auto& tc = GetParam();
 
     flatbuffers::FlatBufferBuilder builder;
-    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(builder,
-                                                                            tc.mode,
-                                                                            tc.reluLowerClip,
-                                                                            tc.reluUpperClip,
-                                                                            tc.reluLowerClipSlope,
-                                                                            flatbuffers::nullopt,
-                                                                            1,
-                                                                            flatbuffers::nullopt,
-                                                                            flatbuffers::nullopt,
-                                                                            2);
+    auto actAttr
+        = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(builder,
+                                                                          tc.mode,
+                                                                          tc.reluLowerClip,
+                                                                          tc.reluUpperClip,
+                                                                          tc.reluLowerClipSlope,
+                                                                          flatbuffers::nullopt,
+                                                                          1,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          2);
     builder.Finish(actAttr);
 
-    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
-        builder.GetBufferPointer());
+    const auto* attr
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>(
+            builder.GetBufferPointer());
 
     if(tc.shouldPass)
     {
@@ -3523,7 +3546,7 @@ INSTANTIATE_TEST_SUITE_P(AllCases,
 TEST(TestBatchnormApplicabilityChecks, RejectsBatchnormFwdTrainingWithPeerStats)
 {
     using namespace canonical_layouts;
-    using DT = hipdnn_data_sdk::data_objects::DataType;
+    using DT = hipdnn_flatbuffers_sdk::data_objects::DataType;
     using UIDs = BnTrainingTensorIds;
 
     // Create valid tensor configs
@@ -3534,34 +3557,36 @@ TEST(TestBatchnormApplicabilityChecks, RejectsBatchnormFwdTrainingWithPeerStats)
     flatbuffers::FlatBufferBuilder builder;
 
     // Build tensor attributes
-    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>> tensorOffsets;
+    std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
+        tensorOffsets;
     for(const auto& cfg : configs)
     {
         if(cfg.isPassByValue)
         {
-            hipdnn_data_sdk::data_objects::Float64Value floatValue(cfg.passedValue);
+            hipdnn_flatbuffers_sdk::data_objects::Float64Value floatValue(cfg.passedValue);
             auto valueOffset = builder.CreateStruct(floatValue).Union();
-            tensorOffsets.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-                builder,
-                cfg.uid,
-                cfg.name.c_str(),
-                cfg.dataType,
-                &cfg.strides,
-                &cfg.dims,
-                cfg.isVirtual,
-                hipdnn_data_sdk::data_objects::TensorValue::Float64Value,
-                valueOffset));
+            tensorOffsets.push_back(
+                hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+                    builder,
+                    cfg.uid,
+                    cfg.name.c_str(),
+                    cfg.dataType,
+                    &cfg.strides,
+                    &cfg.dims,
+                    cfg.isVirtual,
+                    hipdnn_flatbuffers_sdk::data_objects::TensorValue::Float64Value,
+                    valueOffset));
         }
         else
         {
             tensorOffsets.push_back(
-                hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(builder,
-                                                                            cfg.uid,
-                                                                            cfg.name.c_str(),
-                                                                            cfg.dataType,
-                                                                            &cfg.strides,
-                                                                            &cfg.dims,
-                                                                            cfg.isVirtual));
+                hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(builder,
+                                                                                   cfg.uid,
+                                                                                   cfg.name.c_str(),
+                                                                                   cfg.dataType,
+                                                                                   &cfg.strides,
+                                                                                   &cfg.dims,
+                                                                                   cfg.isVirtual));
         }
     }
 
@@ -3570,7 +3595,7 @@ TEST(TestBatchnormApplicabilityChecks, RejectsBatchnormFwdTrainingWithPeerStats)
     auto peerStatsOffset = builder.CreateVector(peerStatsUids);
 
     // Create BatchnormAttributes WITH peer_stats populated
-    auto bnAttrs = hipdnn_data_sdk::data_objects::CreateBatchnormAttributes(
+    auto bnAttrs = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormAttributes(
         builder,
         UIDs::X,
         UIDs::SCALE,
@@ -3586,21 +3611,21 @@ TEST(TestBatchnormApplicabilityChecks, RejectsBatchnormFwdTrainingWithPeerStats)
         flatbuffers::nullopt,
         flatbuffers::nullopt);
 
-    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "batchnorm_training",
         DT::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes,
         bnAttrs.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder, "test_graph", DT::FLOAT, DT::HALF, DT::BFLOAT16, &tensorOffsets, &nodes);
 
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     const auto& node = graph.getNode(0);
     auto* attrs = node.attributes_as_BatchnormAttributes();
     ASSERT_NE(attrs, nullptr);
@@ -3654,55 +3679,59 @@ inline flatbuffers::FlatBufferBuilder
 {
     flatbuffers::FlatBufferBuilder builder;
 
-    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>> tensorOffsets;
+    std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
+        tensorOffsets;
     tensorOffsets.reserve(configs.size());
     for(const auto& cfg : configs)
     {
         if(cfg.isPassByValue)
         {
-            hipdnn_data_sdk::data_objects::Float64Value floatValue(cfg.passedValue);
+            hipdnn_flatbuffers_sdk::data_objects::Float64Value floatValue(cfg.passedValue);
             auto valueOffset = builder.CreateStruct(floatValue).Union();
-            tensorOffsets.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-                builder,
-                cfg.uid,
-                cfg.name.c_str(),
-                cfg.dataType,
-                &cfg.strides,
-                &cfg.dims,
-                cfg.isVirtual,
-                hipdnn_data_sdk::data_objects::TensorValue::Float64Value,
-                valueOffset));
+            tensorOffsets.push_back(
+                hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+                    builder,
+                    cfg.uid,
+                    cfg.name.c_str(),
+                    cfg.dataType,
+                    &cfg.strides,
+                    &cfg.dims,
+                    cfg.isVirtual,
+                    hipdnn_flatbuffers_sdk::data_objects::TensorValue::Float64Value,
+                    valueOffset));
         }
         else
         {
             tensorOffsets.push_back(
-                hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(builder,
-                                                                            cfg.uid,
-                                                                            cfg.name.c_str(),
-                                                                            cfg.dataType,
-                                                                            &cfg.strides,
-                                                                            &cfg.dims,
-                                                                            cfg.isVirtual));
+                hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(builder,
+                                                                                   cfg.uid,
+                                                                                   cfg.name.c_str(),
+                                                                                   cfg.dataType,
+                                                                                   &cfg.strides,
+                                                                                   &cfg.dims,
+                                                                                   cfg.isVirtual));
         }
     }
 
-    auto bnAttrs = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributesVarianceExt(
-        builder, xUid, meanUid, varianceUid, scaleUid, biasUid, yUid, epsilonUid);
+    auto bnAttrs
+        = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormInferenceAttributesVarianceExt(
+            builder, xUid, meanUid, varianceUid, scaleUid, biasUid, yUid, epsilonUid);
 
-    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "batchnorm_inference_variance_ext",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributesVarianceExt,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::
+            BatchnormInferenceAttributesVarianceExt,
         bnAttrs.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test_graph",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorOffsets,
         &nodes);
 
@@ -3804,9 +3833,9 @@ inline std::vector<BatchnormInferenceVarianceExtFusedConfigTestCase>
     getCheckBatchnormInferenceWithVarianceFusedConfigSupportedTestCases()
 {
     using namespace canonical_layouts;
-    using DT = hipdnn_data_sdk::data_objects::DataType;
+    using DT = hipdnn_flatbuffers_sdk::data_objects::DataType;
     using UIDs = BnInferenceVarianceExtTensorIds;
-    using PM = hipdnn_data_sdk::data_objects::PointwiseMode;
+    using PM = hipdnn_flatbuffers_sdk::data_objects::PointwiseMode;
 
     std::vector<BatchnormInferenceVarianceExtFusedConfigTestCase> cases;
     const int64_t bnYVirtualUid = 100;
@@ -3911,8 +3940,8 @@ TEST_P(TestCheckBatchnormInferenceWithVarianceConfigSupported, ValidatesCorrectl
                                                             tc.epsilonUid,
                                                             tc.meanUid,
                                                             tc.varianceUid);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     auto* attrs = node.attributes_as_BatchnormInferenceAttributesVarianceExt();
@@ -3960,8 +3989,8 @@ TEST_P(TestCheckBatchnormInferenceWithVarianceFusedConfigSupported, ValidatesCor
                                                                  tc.varianceUid,
                                                                  bnYVirtualUid,
                                                                  tc.activationMode);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& bnNode = graph.getNode(0);
     const auto& actNode = graph.getNode(1);
@@ -4003,7 +4032,7 @@ namespace
 TEST(TestBatchnormApplicabilityChecks, RejectsBatchnormBackwardWithPeerStats)
 {
     using namespace canonical_layouts;
-    using DT = hipdnn_data_sdk::data_objects::DataType;
+    using DT = hipdnn_flatbuffers_sdk::data_objects::DataType;
     using UIDs = BnBackwardTensorIds;
 
     // Create valid tensor configs
@@ -4014,18 +4043,19 @@ TEST(TestBatchnormApplicabilityChecks, RejectsBatchnormBackwardWithPeerStats)
     flatbuffers::FlatBufferBuilder builder;
 
     // Build tensor attributes
-    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>> tensorOffsets;
+    std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
+        tensorOffsets;
     tensorOffsets.reserve(configs.size());
     for(const auto& cfg : configs)
     {
         tensorOffsets.push_back(
-            hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(builder,
-                                                                        cfg.uid,
-                                                                        cfg.name.c_str(),
-                                                                        cfg.dataType,
-                                                                        &cfg.strides,
-                                                                        &cfg.dims,
-                                                                        cfg.isVirtual));
+            hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(builder,
+                                                                               cfg.uid,
+                                                                               cfg.name.c_str(),
+                                                                               cfg.dataType,
+                                                                               &cfg.strides,
+                                                                               &cfg.dims,
+                                                                               cfg.isVirtual));
     }
 
     // Create peer_stats_tensor_uid with populated values (should be rejected)
@@ -4033,7 +4063,7 @@ TEST(TestBatchnormApplicabilityChecks, RejectsBatchnormBackwardWithPeerStats)
     auto peerStatsOffset = builder.CreateVector(peerStatsUids);
 
     // Create BatchnormBackwardAttributes WITH peer_stats populated
-    auto bnBwdAttrs = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+    auto bnBwdAttrs = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormBackwardAttributes(
         builder,
         UIDs::DY,
         UIDs::X,
@@ -4045,21 +4075,21 @@ TEST(TestBatchnormApplicabilityChecks, RejectsBatchnormBackwardWithPeerStats)
         UIDs::DSCALE,
         UIDs::DBIAS);
 
-    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "batchnorm_backward",
         DT::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
         bnBwdAttrs.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder, "test_graph", DT::FLOAT, DT::HALF, DT::BFLOAT16, &tensorOffsets, &nodes);
 
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     const auto& node = graph.getNode(0);
     auto* attrs = node.attributes_as_BatchnormBackwardAttributes();
     ASSERT_NE(attrs, nullptr);

--- a/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormBwdPlan.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormBwdPlan.cpp
@@ -5,7 +5,7 @@
 #include "HipdnnMiopenSettings.hpp"
 #include "engines/plans/MiopenBatchnormBwdPlan.hpp"
 #include <gtest/gtest.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 
 using namespace miopen_plugin;
@@ -14,8 +14,8 @@ TEST(TestBatchnormBwdParams, InitializesAllTensorsFromValidGraph)
 {
     // Create a valid batchnorm graph
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormBwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the batchnorm node and attributes
     const auto& node = graph.getNode(0);
@@ -46,8 +46,8 @@ TEST(TestBatchnormBwdParams, HandlesMissingOptionalTensors)
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormBwdGraph(
         {1, 1, 1, 1}, {1, 1, 1, 1}, false // Set has_optional_attributes to false
     );
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the batchnorm node and attributes
     const auto& node = graph.getNode(0);
@@ -66,8 +66,8 @@ TEST(TestBatchnormBwdParams, InitializesFusedActivationBiasWithAllTensors)
 {
     // Create a fused batchnorm backward + activation + bias graph
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferActBwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the three required nodes
     const auto& batchnormInfNode = graph.getNode(0);
@@ -108,8 +108,8 @@ TEST(TestBatchnormBwdParams, FusedParamsHandlesMissingOptionalMeanVariance)
     // Create a fused graph without optional mean/variance
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferActBwdGraph(
         {1, 1, 1, 1}, {1, 1, 1, 1}, false);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& batchnormInfNode = graph.getNode(0);
     const auto& pointwiseNode = graph.getNode(1);
@@ -139,8 +139,8 @@ TEST(TestBatchnormBwdPlan, FusedModeHasActivationAndBias)
 {
     // Create a fused batchnorm backward + activation + bias graph
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferActBwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& batchnormInfNode = graph.getNode(0);
     const auto& pointwiseNode = graph.getNode(1);
@@ -165,8 +165,8 @@ TEST(TestBatchnormBwdPlan, FusedModeHasActivationAndBias)
 TEST(TestBatchnormBwdPlan, GetWorkspaceSizeReturnsZeroForFusedMode)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferActBwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& batchnormInfNode = graph.getNode(0);
     const auto& pointwiseNode = graph.getNode(1);
@@ -192,8 +192,8 @@ TEST(TestBatchnormBwdPlan, GetWorkspaceSizeReturnsZeroForFusedMode)
 TEST(TestBatchnormBwdPlan, GetWorkspaceSizeReturnsZero)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormBwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     auto* attrs = node.attributes_as_BatchnormBackwardAttributes();
@@ -210,8 +210,8 @@ TEST(TestBatchnormBwdPlan, GetWorkspaceSizeReturnsZero)
 TEST(TestBatchnormBwdPlan, OptionalTensorsAreNotPresentInBasicMode)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormBwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     auto* attrs = node.attributes_as_BatchnormBackwardAttributes();

--- a/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormFwdInferencePlan.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormFwdInferencePlan.cpp
@@ -3,7 +3,7 @@
 
 #include "engines/plans/MiopenBatchnormFwdInferencePlan.hpp"
 #include <gtest/gtest.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 
 using namespace miopen_plugin;
@@ -12,8 +12,8 @@ TEST(TestMiopenBatchnormFwdInferenceParams, InitializesAllTensorsFromValidGraph)
 {
     // Create a valid batchnorm graph
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the batchnorm node and attributes
     const auto& node = graph.getNode(0);
@@ -33,8 +33,8 @@ TEST(TestMiopenBatchnormFwdInferenceParams, InitializesFusedActivationBiasWithAl
 {
     // Create a fused batchnorm fwd + activation graph
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdInferActGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the two required nodes
     const auto& batchnormInfNode = graph.getNode(0);

--- a/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormFwdInferenceWithVariancePlan.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormFwdInferenceWithVariancePlan.cpp
@@ -3,7 +3,7 @@
 
 #include "engines/plans/MiopenBatchnormFwdInferenceWithVariancePlan.hpp"
 #include <gtest/gtest.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 
 using namespace miopen_plugin;
@@ -12,8 +12,8 @@ TEST(TestMiopenBatchnormFwdInferenceWithVarianceParams, InitializesAllTensorsFro
 {
     // Create a valid batchnorm graph with variance
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormWithVarianceInferenceGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the batchnorm node and attributes
     const auto& node = graph.getNode(0);
@@ -45,8 +45,8 @@ TEST(TestMiopenBatchnormFwdInferenceWithVarianceParams,
     // Create a valid batchnorm graph with variance and activation
     auto builder
         = hipdnn_test_sdk::utilities::createValidBatchnormWithVarianceInferenceActivGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the batchnorm node and attributes
     const auto& node = graph.getNode(0);

--- a/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormFwdTrainingActivPlan.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormFwdTrainingActivPlan.cpp
@@ -3,7 +3,7 @@
 
 #include "engines/plans/MiopenBatchnormFwdTrainingPlan.hpp"
 #include <gtest/gtest.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 
 using namespace miopen_plugin;
@@ -15,8 +15,8 @@ using namespace miopen_plugin;
 TEST(TestBatchnormFwdTrainingActivParams, InitializesRequiredTensorsFromValidGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingActivGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& bnNode = graph.getNode(0);
     auto* bnAttrs = bnNode.attributes_as_BatchnormAttributes();
@@ -39,8 +39,8 @@ TEST(TestBatchnormFwdTrainingActivParams, InitializesRequiredTensorsFromValidGra
 TEST(TestBatchnormFwdTrainingActivParams, ExtractsEpsilonValueCorrectly)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingActivGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& bnNode = graph.getNode(0);
     auto* bnAttrs = bnNode.attributes_as_BatchnormAttributes();
@@ -63,8 +63,8 @@ TEST(TestBatchnormFwdTrainingActivParams, ExtractsEpsilonValueCorrectly)
 TEST(TestBatchnormFwdTrainingActivParams, HandlesMeanVariancePresent)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingActivGraph(true);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& bnNode = graph.getNode(0);
     auto* bnAttrs = bnNode.attributes_as_BatchnormAttributes();
@@ -84,8 +84,8 @@ TEST(TestBatchnormFwdTrainingActivParams, HandlesMeanVariancePresent)
 TEST(TestBatchnormFwdTrainingActivParams, HandlesMeanVarianceMissing)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingActivGraph(false);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& bnNode = graph.getNode(0);
     auto* bnAttrs = bnNode.attributes_as_BatchnormAttributes();
@@ -103,8 +103,8 @@ TEST(TestBatchnormFwdTrainingActivParams, HandlesMeanVarianceMissing)
 TEST(TestBatchnormFwdTrainingActivParams, HasRunningStatsReturnsFalseWhenNotProvided)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingActivGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& bnNode = graph.getNode(0);
     auto* bnAttrs = bnNode.attributes_as_BatchnormAttributes();
@@ -126,7 +126,7 @@ TEST(TestBatchnormFwdTrainingActivParams, HasRunningStatsReturnsFalseWhenNotProv
 TEST(TestBatchnormFwdTrainingActivParams, ThrowsStdOutOfRangeForMissingEpsilonTensor)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     std::vector<int64_t> strides = {1, 3, 14, 14};
@@ -134,31 +134,37 @@ TEST(TestBatchnormFwdTrainingActivParams, ThrowsStdOutOfRangeForMissingEpsilonTe
     std::vector<int64_t> derivedStrides = {1, 3, 1, 1};
     std::vector<int64_t> derivedDims = {1, 3, 1, 1};
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 1, "x", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 2, "y", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims, true));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "x", hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT, &strides, &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        2,
+        "y",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &strides,
+        &dims,
+        true));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         3,
         "scale",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         4,
         "bias",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
     // Missing epsilon tensor (ID 5)
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // BN node referencing non-existent epsilon tensor
-    auto bnormAttributes = hipdnn_data_sdk::data_objects::CreateBatchnormAttributes(
+    auto bnormAttributes = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormAttributes(
         builder,
         1,
         3,
@@ -173,16 +179,16 @@ TEST(TestBatchnormFwdTrainingActivParams, ThrowsStdOutOfRangeForMissingEpsilonTe
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes,
         bnormAttributes.Union()));
 
-    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto actAttr = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -191,25 +197,25 @@ TEST(TestBatchnormFwdTrainingActivParams, ThrowsStdOutOfRangeForMissingEpsilonTe
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         3);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "act",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttr.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& bnNode = graph.getNode(0);
     auto* bnAttrs = bnNode.attributes_as_BatchnormAttributes();
@@ -231,7 +237,7 @@ TEST(TestBatchnormFwdTrainingActivParams, ThrowsStdOutOfRangeForMissingEpsilonTe
 TEST(TestBatchnormFwdTrainingActivParams, ThrowsWhenBnOutputDoesNotMatchActivationInput)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     std::vector<int64_t> strides = {1, 3, 14, 14};
@@ -239,77 +245,88 @@ TEST(TestBatchnormFwdTrainingActivParams, ThrowsWhenBnOutputDoesNotMatchActivati
     std::vector<int64_t> derivedStrides = {1, 3, 1, 1};
     std::vector<int64_t> derivedDims = {1, 3, 1, 1};
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 1, "x", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 2, "y_bn", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims, true));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "x", hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT, &strides, &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
-        6,
-        "y_wrong",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        2,
+        "y_bn",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &strides,
         &dims,
         true));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        6,
+        "y_wrong",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &strides,
+        &dims,
+        true));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         3,
         "scale",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         4,
         "bias",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
-    hipdnn_data_sdk::data_objects::Float32Value epsilonVal(1e-5f);
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributes(
+    hipdnn_flatbuffers_sdk::data_objects::Float32Value epsilonVal(1e-5f);
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributes(
         builder,
         5,
         builder.CreateString("epsilon"),
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         0,
         0,
         false,
-        hipdnn_data_sdk::data_objects::TensorValue::Float32Value,
+        hipdnn_flatbuffers_sdk::data_objects::TensorValue::Float32Value,
         builder.CreateStruct(epsilonVal).Union()));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 7, "final_out", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        7,
+        "final_out",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &strides,
+        &dims));
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // BN node with output tensor 2
     auto bnormAttributes
-        = hipdnn_data_sdk::data_objects::CreateBatchnormAttributes(builder,
-                                                                   1,
-                                                                   3,
-                                                                   4,
-                                                                   5,
-                                                                   0,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   2, // BN output
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormAttributes(builder,
+                                                                          1,
+                                                                          3,
+                                                                          4,
+                                                                          5,
+                                                                          0,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          2, // BN output
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt);
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes,
         bnormAttributes.Union()));
 
     // Activation with input tensor 6 (wrong - should be 2)
-    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto actAttr = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -318,25 +335,25 @@ TEST(TestBatchnormFwdTrainingActivParams, ThrowsWhenBnOutputDoesNotMatchActivati
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         7);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "act",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttr.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& bnNode = graph.getNode(0);
     auto* bnAttrs = bnNode.attributes_as_BatchnormAttributes();
@@ -353,7 +370,7 @@ TEST(TestBatchnormFwdTrainingActivParams, ThrowsWhenBnOutputDoesNotMatchActivati
 TEST(TestBatchnormFwdTrainingActivParams, ThrowsForMissingRequiredXTensor)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     std::vector<int64_t> strides = {1, 3, 14, 14};
@@ -362,66 +379,77 @@ TEST(TestBatchnormFwdTrainingActivParams, ThrowsForMissingRequiredXTensor)
     std::vector<int64_t> derivedDims = {1, 3, 1, 1};
 
     // Missing x tensor (ID 1)
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 2, "y", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims, true));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        2,
+        "y",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &strides,
+        &dims,
+        true));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         3,
         "scale",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         4,
         "bias",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
-    hipdnn_data_sdk::data_objects::Float32Value epsilonVal(1e-5f);
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributes(
+    hipdnn_flatbuffers_sdk::data_objects::Float32Value epsilonVal(1e-5f);
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributes(
         builder,
         5,
         builder.CreateString("epsilon"),
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         0,
         0,
         false,
-        hipdnn_data_sdk::data_objects::TensorValue::Float32Value,
+        hipdnn_flatbuffers_sdk::data_objects::TensorValue::Float32Value,
         builder.CreateStruct(epsilonVal).Union()));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 7, "final_out", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        7,
+        "final_out",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &strides,
+        &dims));
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // BN node referencing missing x tensor
     auto bnormAttributes
-        = hipdnn_data_sdk::data_objects::CreateBatchnormAttributes(builder,
-                                                                   1, // Missing x tensor
-                                                                   3,
-                                                                   4,
-                                                                   5,
-                                                                   0,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   2,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormAttributes(builder,
+                                                                          1, // Missing x tensor
+                                                                          3,
+                                                                          4,
+                                                                          5,
+                                                                          0,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          2,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt);
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes,
         bnormAttributes.Union()));
 
-    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto actAttr = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -430,25 +458,25 @@ TEST(TestBatchnormFwdTrainingActivParams, ThrowsForMissingRequiredXTensor)
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         7);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "act",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttr.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& bnNode = graph.getNode(0);
     auto* bnAttrs = bnNode.attributes_as_BatchnormAttributes();
@@ -465,7 +493,7 @@ TEST(TestBatchnormFwdTrainingActivParams, ThrowsForMissingRequiredXTensor)
 TEST(TestBatchnormFwdTrainingActivParams, ThrowsForMissingRequiredScaleTensor)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     std::vector<int64_t> strides = {1, 3, 14, 14};
@@ -473,62 +501,73 @@ TEST(TestBatchnormFwdTrainingActivParams, ThrowsForMissingRequiredScaleTensor)
     std::vector<int64_t> derivedStrides = {1, 3, 1, 1};
     std::vector<int64_t> derivedDims = {1, 3, 1, 1};
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 1, "x", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 2, "y", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims, true));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "x", hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT, &strides, &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        2,
+        "y",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &strides,
+        &dims,
+        true));
     // Missing scale tensor (ID 3)
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         4,
         "bias",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
-    hipdnn_data_sdk::data_objects::Float32Value epsilonVal(1e-5f);
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributes(
+    hipdnn_flatbuffers_sdk::data_objects::Float32Value epsilonVal(1e-5f);
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributes(
         builder,
         5,
         builder.CreateString("epsilon"),
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         0,
         0,
         false,
-        hipdnn_data_sdk::data_objects::TensorValue::Float32Value,
+        hipdnn_flatbuffers_sdk::data_objects::TensorValue::Float32Value,
         builder.CreateStruct(epsilonVal).Union()));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 7, "final_out", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        7,
+        "final_out",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &strides,
+        &dims));
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // BN node referencing missing scale tensor
     auto bnormAttributes
-        = hipdnn_data_sdk::data_objects::CreateBatchnormAttributes(builder,
-                                                                   1,
-                                                                   3, // Missing scale tensor
-                                                                   4,
-                                                                   5,
-                                                                   0,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   2,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormAttributes(builder,
+                                                                          1,
+                                                                          3, // Missing scale tensor
+                                                                          4,
+                                                                          5,
+                                                                          0,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          2,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt);
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes,
         bnormAttributes.Union()));
 
-    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto actAttr = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -537,25 +576,25 @@ TEST(TestBatchnormFwdTrainingActivParams, ThrowsForMissingRequiredScaleTensor)
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         7);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "act",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttr.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& bnNode = graph.getNode(0);
     auto* bnAttrs = bnNode.attributes_as_BatchnormAttributes();
@@ -572,7 +611,7 @@ TEST(TestBatchnormFwdTrainingActivParams, ThrowsForMissingRequiredScaleTensor)
 TEST(TestBatchnormFwdTrainingActivParams, ThrowsForMissingRequiredBiasTensor)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     std::vector<int64_t> strides = {1, 3, 14, 14};
@@ -580,62 +619,73 @@ TEST(TestBatchnormFwdTrainingActivParams, ThrowsForMissingRequiredBiasTensor)
     std::vector<int64_t> derivedStrides = {1, 3, 1, 1};
     std::vector<int64_t> derivedDims = {1, 3, 1, 1};
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 1, "x", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 2, "y", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims, true));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "x", hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT, &strides, &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        2,
+        "y",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &strides,
+        &dims,
+        true));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         3,
         "scale",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
     // Missing bias tensor (ID 4)
 
-    hipdnn_data_sdk::data_objects::Float32Value epsilonVal(1e-5f);
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributes(
+    hipdnn_flatbuffers_sdk::data_objects::Float32Value epsilonVal(1e-5f);
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributes(
         builder,
         5,
         builder.CreateString("epsilon"),
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         0,
         0,
         false,
-        hipdnn_data_sdk::data_objects::TensorValue::Float32Value,
+        hipdnn_flatbuffers_sdk::data_objects::TensorValue::Float32Value,
         builder.CreateStruct(epsilonVal).Union()));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 7, "final_out", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        7,
+        "final_out",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &strides,
+        &dims));
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // BN node referencing missing bias tensor
     auto bnormAttributes
-        = hipdnn_data_sdk::data_objects::CreateBatchnormAttributes(builder,
-                                                                   1,
-                                                                   3,
-                                                                   4, // Missing bias tensor
-                                                                   5,
-                                                                   0,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   2,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormAttributes(builder,
+                                                                          1,
+                                                                          3,
+                                                                          4, // Missing bias tensor
+                                                                          5,
+                                                                          0,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          2,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt);
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes,
         bnormAttributes.Union()));
 
-    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto actAttr = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -644,25 +694,25 @@ TEST(TestBatchnormFwdTrainingActivParams, ThrowsForMissingRequiredBiasTensor)
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         7);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "act",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttr.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& bnNode = graph.getNode(0);
     auto* bnAttrs = bnNode.attributes_as_BatchnormAttributes();
@@ -679,9 +729,9 @@ TEST(TestBatchnormFwdTrainingActivParams, ThrowsForMissingRequiredBiasTensor)
 TEST(TestBatchnormFwdTrainingActivParams, AcceptsReluFwdActivation)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingActivGraph(
-        false, false, hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+        false, false, hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD);
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& bnNode = graph.getNode(0);
     auto* bnAttrs = bnNode.attributes_as_BatchnormAttributes();

--- a/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormFwdTrainingActivPlanBuilder.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormFwdTrainingActivPlanBuilder.cpp
@@ -3,7 +3,7 @@
 
 #include <gtest/gtest.h>
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_plugin_sdk/EnginePluginApi.h>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 #include <hipdnn_test_sdk/utilities/MockEngineConfig.hpp>
@@ -16,7 +16,7 @@
 
 using namespace miopen_plugin;
 using namespace hipdnn_test_sdk::utilities;
-using namespace hipdnn_data_sdk::flatbuffer_utilities;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 
 class TestMiopenBatchnormFwdTrainingActivPlanBuilder : public ::testing::Test
 {
@@ -29,8 +29,8 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder,
        IsApplicableReturnsTrueForValidSingleNodeGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
 
@@ -50,8 +50,8 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder, IsApplicableReturnsFalseF
 TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder, IsApplicableReturnsTrueForValidTwoNodeGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingActivGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
 
@@ -63,8 +63,8 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder,
 {
     // Create a fused batchnorm training + activation graph WITHOUT running statistics
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingActivGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
 
@@ -75,9 +75,9 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder, IsApplicableReturnsFalseF
 {
     // Graph with SIGMOID_FWD instead of RELU_FWD
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingActivGraph(
-        false, false, hipdnn_data_sdk::data_objects::PointwiseMode::SIGMOID_FWD);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+        false, false, hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SIGMOID_FWD);
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
 
@@ -87,8 +87,8 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder, IsApplicableReturnsFalseF
 TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder, GetWorkspaceSizeReturnsZero)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingActivGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     HipdnnMiopenSettings settings;
     size_t workspaceSize = _planBuilder.getMaxWorkspaceSize(_dummyHandle, graph, settings);
@@ -99,8 +99,8 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder, GetWorkspaceSizeReturnsZe
 TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder, BuildPlanSetsPlanForValidGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingActivGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     MockEngineConfig mockEngineConfig;
     HipdnnMiopenContext ctx;
 
@@ -113,22 +113,22 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder,
 {
     // Create graph with batchnorm training node but null attributes
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // Node with BatchnormAttributes type but null attributes pointer
-    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "malformed_bn_training",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes,
         0);
     nodes.push_back(node);
 
-    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto actAttr = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -137,25 +137,25 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         3);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "act",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttr.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     MockEngineConfig mockEngineConfig;
     HipdnnMiopenContext ctx;
 
@@ -169,7 +169,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder,
 {
     // Create graph with valid batchnorm but malformed activation
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     std::vector<int64_t> strides = {1, 3, 14, 14};
@@ -177,88 +177,88 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder,
     std::vector<int64_t> derivedStrides = {1, 3, 1, 1};
     std::vector<int64_t> derivedDims = {1, 3, 1, 1};
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 1, "x", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "x", hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT, &strides, &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         2,
         "y_virtual",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &strides,
         &dims,
         true));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         3,
         "scale",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         4,
         "bias",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
-    hipdnn_data_sdk::data_objects::Float32Value epsilonVal(1e-5f);
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributes(
+    hipdnn_flatbuffers_sdk::data_objects::Float32Value epsilonVal(1e-5f);
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributes(
         builder,
         5,
         builder.CreateString("epsilon"),
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         0,
         0,
         false,
-        hipdnn_data_sdk::data_objects::TensorValue::Float32Value,
+        hipdnn_flatbuffers_sdk::data_objects::TensorValue::Float32Value,
         builder.CreateStruct(epsilonVal).Union()));
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // Valid batchnorm training node
     auto bnormAttributes
-        = hipdnn_data_sdk::data_objects::CreateBatchnormAttributes(builder,
-                                                                   1,
-                                                                   3,
-                                                                   4,
-                                                                   5,
-                                                                   0,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   2,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormAttributes(builder,
+                                                                          1,
+                                                                          3,
+                                                                          4,
+                                                                          5,
+                                                                          0,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          2,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt);
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_training",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes,
         bnormAttributes.Union()));
 
     // Malformed activation (null attributes)
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "malformed_act",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         0));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     MockEngineConfig mockEngineConfig;
     HipdnnMiopenContext ctx;
 
@@ -271,14 +271,14 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder, IsApplicableReturnsFalseF
 {
     // Create graph with nodes in wrong order (activation → batchnorm instead of batchnorm → activation)
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // Wrong order: activation first
-    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto actAttr = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -287,60 +287,60 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder, IsApplicableReturnsFalseF
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         2);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "act",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttr.Union()));
 
     // Then batchnorm (wrong order!)
-    hipdnn_data_sdk::data_objects::Float32Value epsilonVal(1e-5f);
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributes(
+    hipdnn_flatbuffers_sdk::data_objects::Float32Value epsilonVal(1e-5f);
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributes(
         builder,
         5,
         builder.CreateString("epsilon"),
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         0,
         0,
         false,
-        hipdnn_data_sdk::data_objects::TensorValue::Float32Value,
+        hipdnn_flatbuffers_sdk::data_objects::TensorValue::Float32Value,
         builder.CreateStruct(epsilonVal).Union()));
 
     auto bnormAttributes
-        = hipdnn_data_sdk::data_objects::CreateBatchnormAttributes(builder,
-                                                                   1,
-                                                                   3,
-                                                                   4,
-                                                                   5,
-                                                                   0,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   2,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormAttributes(builder,
+                                                                          1,
+                                                                          3,
+                                                                          4,
+                                                                          5,
+                                                                          0,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          2,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt);
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes,
         bnormAttributes.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
 
@@ -352,7 +352,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder,
 {
     // Create fusion graph where BN output tensor is non-virtual (should be virtual)
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     std::vector<int64_t> strides = {1, 3, 14, 14};
@@ -360,74 +360,79 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder,
     std::vector<int64_t> derivedStrides = {1, 3, 1, 1};
     std::vector<int64_t> derivedDims = {1, 3, 1, 1};
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 1, "x", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "x", hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT, &strides, &dims));
     // BN output NOT virtual (should be virtual for fusion)
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         2,
         "y_bn",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &strides,
         &dims,
         false));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         3,
         "scale",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         4,
         "bias",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
-    hipdnn_data_sdk::data_objects::Float32Value epsilonVal(1e-5f);
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributes(
+    hipdnn_flatbuffers_sdk::data_objects::Float32Value epsilonVal(1e-5f);
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributes(
         builder,
         5,
         builder.CreateString("epsilon"),
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         0,
         0,
         false,
-        hipdnn_data_sdk::data_objects::TensorValue::Float32Value,
+        hipdnn_flatbuffers_sdk::data_objects::TensorValue::Float32Value,
         builder.CreateStruct(epsilonVal).Union()));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 7, "final_out", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        7,
+        "final_out",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &strides,
+        &dims));
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     auto bnormAttributes
-        = hipdnn_data_sdk::data_objects::CreateBatchnormAttributes(builder,
-                                                                   1,
-                                                                   3,
-                                                                   4,
-                                                                   5,
-                                                                   0,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   2,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormAttributes(builder,
+                                                                          1,
+                                                                          3,
+                                                                          4,
+                                                                          5,
+                                                                          0,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          2,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt);
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes,
         bnormAttributes.Union()));
 
-    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto actAttr = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -436,25 +441,25 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         7);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "act",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttr.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
 
@@ -472,8 +477,8 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder, IsApplicableReturnsTrueFo
 
     auto builder
         = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph(strides3D, dims3D);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_TRUE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -485,9 +490,13 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder,
     std::vector<int64_t> strides3D = {42, 1, 3};
 
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingActivGraph(
-        true, false, hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD, strides3D, dims3D);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+        true,
+        false,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
+        strides3D,
+        dims3D);
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_TRUE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -499,8 +508,8 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder, BuildPlanSetsPlanFor3dNcl
 
     auto builder
         = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph(strides3D, dims3D);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     MockEngineConfig mockEngineConfig;
     HipdnnMiopenContext ctx;
 
@@ -514,9 +523,13 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder, BuildPlanSetsPlanFor3dNlc
     std::vector<int64_t> strides3D = {42, 1, 3};
 
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingActivGraph(
-        true, false, hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD, strides3D, dims3D);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+        true,
+        false,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
+        strides3D,
+        dims3D);
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     MockEngineConfig mockEngineConfig;
     HipdnnMiopenContext ctx;
 

--- a/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormFwdTrainingPlan.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormFwdTrainingPlan.cpp
@@ -3,7 +3,7 @@
 
 #include "engines/plans/MiopenBatchnormFwdTrainingPlan.hpp"
 #include <gtest/gtest.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 
 using namespace miopen_plugin;
@@ -11,8 +11,8 @@ using namespace miopen_plugin;
 TEST(TestBatchnormFwdTrainingParams, InitializesRequiredTensorsFromValidGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     auto* attrs = node.attributes_as_BatchnormAttributes();
@@ -30,8 +30,8 @@ TEST(TestBatchnormFwdTrainingParams, InitializesRequiredTensorsFromValidGraph)
 TEST(TestBatchnormFwdTrainingParams, ExtractsEpsilonValueCorrectly)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     auto* attrs = node.attributes_as_BatchnormAttributes();
@@ -47,8 +47,8 @@ TEST(TestBatchnormFwdTrainingParams, HandlesMeanVariancePresent)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph(
         {1, 3, 14, 14}, {1, 3, 14, 14}, true);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     auto* attrs = node.attributes_as_BatchnormAttributes();
@@ -65,8 +65,8 @@ TEST(TestBatchnormFwdTrainingParams, HandlesMeanVarianceMissing)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph(
         {1, 3, 14, 14}, {1, 3, 14, 14}, false);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     auto* attrs = node.attributes_as_BatchnormAttributes();
@@ -80,8 +80,8 @@ TEST(TestBatchnormFwdTrainingParams, HandlesMeanVarianceMissing)
 TEST(TestBatchnormFwdTrainingParams, HasRunningStatsReturnsFalseWhenNotProvided)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     auto* attrs = node.attributes_as_BatchnormAttributes();

--- a/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormFwdTrainingPlanBuilder.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormFwdTrainingPlanBuilder.cpp
@@ -3,7 +3,7 @@
 
 #include <gtest/gtest.h>
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_plugin_sdk/EnginePluginApi.h>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 #include <hipdnn_test_sdk/utilities/MockEngineConfig.hpp>
@@ -14,7 +14,7 @@
 
 using namespace miopen_plugin;
 using namespace hipdnn_test_sdk::utilities;
-using namespace hipdnn_data_sdk::flatbuffer_utilities;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 
 class TestMiopenBatchnormFwdTrainingPlanBuilder : public ::testing::Test
 {
@@ -30,8 +30,8 @@ protected:
 TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, IsApplicableReturnsTrueForValidSingleNodeGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
 
@@ -41,8 +41,8 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, IsApplicableReturnsTrueForVali
 TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, IsApplicableReturnsTrueForValidTwoNodeGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingActivGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
 
@@ -63,31 +63,31 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, IsApplicableReturnsFalseForWro
 {
     // Create a graph with wrong node type
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // Node with wrong type (Convolution instead of Batchnorm)
-    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "conv",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::ConvolutionFwdAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::ConvolutionFwdAttributes,
         0);
     nodes.push_back(node);
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
 
@@ -99,12 +99,13 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, IsApplicableReturnsFalseForUns
     flatbuffers::FlatBufferBuilder builder
         = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingActivGraph();
 
-    auto mutableGraph = hipdnn_data_sdk::data_objects::GetMutableGraph(builder.GetBufferPointer());
+    auto mutableGraph
+        = hipdnn_flatbuffers_sdk::data_objects::GetMutableGraph(builder.GetBufferPointer());
     mutableGraph->mutable_nodes()->GetMutableObject(1)->mutate_compute_data_type(
-        hipdnn_data_sdk::data_objects::DataType::HALF);
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
 
@@ -116,9 +117,9 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, IsApplicableReturnsFalseForNon
 {
     // Create a graph with unsupported activation (e.g., SIGMOID_FWD)
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingActivGraph(
-        false, false, hipdnn_data_sdk::data_objects::PointwiseMode::SIGMOID_FWD);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+        false, false, hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SIGMOID_FWD);
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
 
@@ -129,39 +130,39 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, IsApplicableReturnsFalseForWro
 {
     // Create a graph with 2 nodes but in wrong order (activation -> batchnorm)
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // Wrong order: activation first, then batchnorm
-    auto node0 = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    auto node0 = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "pointwise",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         0);
     nodes.push_back(node0);
 
-    auto node1 = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    auto node1 = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_training",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes,
         0);
     nodes.push_back(node1);
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
 
@@ -172,7 +173,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder,
        IsApplicableReturnsFalseWhenBnOutputDoesNotMatchActivationInput)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     std::vector<int64_t> strides = {1, 3, 14, 14};
@@ -180,77 +181,88 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder,
     std::vector<int64_t> derivedStrides = {1, 3, 1, 1};
     std::vector<int64_t> derivedDims = {1, 3, 1, 1};
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 1, "x", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 2, "y_bn", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims, true));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "x", hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT, &strides, &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
-        6,
-        "y_wrong",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        2,
+        "y_bn",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &strides,
         &dims,
         true));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        6,
+        "y_wrong",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &strides,
+        &dims,
+        true));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         3,
         "scale",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         4,
         "bias",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
-    hipdnn_data_sdk::data_objects::Float32Value epsilonVal(1e-5f);
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributes(
+    hipdnn_flatbuffers_sdk::data_objects::Float32Value epsilonVal(1e-5f);
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributes(
         builder,
         5,
         builder.CreateString("epsilon"),
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         0,
         0,
         false,
-        hipdnn_data_sdk::data_objects::TensorValue::Float32Value,
+        hipdnn_flatbuffers_sdk::data_objects::TensorValue::Float32Value,
         builder.CreateStruct(epsilonVal).Union()));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 7, "final_out", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        7,
+        "final_out",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &strides,
+        &dims));
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // BN node with output tensor 2
     auto bnormAttributes
-        = hipdnn_data_sdk::data_objects::CreateBatchnormAttributes(builder,
-                                                                   1,
-                                                                   3,
-                                                                   4,
-                                                                   5,
-                                                                   0,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   2, // BN output
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormAttributes(builder,
+                                                                          1,
+                                                                          3,
+                                                                          4,
+                                                                          5,
+                                                                          0,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          2, // BN output
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt);
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes,
         bnormAttributes.Union()));
 
     // Activation with input tensor 6 (wrong - should be 2)
-    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto actAttr = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -259,25 +271,25 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         7);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "act",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttr.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
 
@@ -288,7 +300,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder,
        IsApplicableReturnsFalseWhenBnOutputIsNotVirtualInFusion)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     std::vector<int64_t> strides = {1, 3, 14, 14};
@@ -296,73 +308,78 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder,
     std::vector<int64_t> derivedStrides = {1, 3, 1, 1};
     std::vector<int64_t> derivedDims = {1, 3, 1, 1};
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 1, "x", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "x", hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT, &strides, &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         2,
         "y_bn",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &strides,
         &dims,
         false)); // Non-virtual - wrong!
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         3,
         "scale",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         4,
         "bias",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
-    hipdnn_data_sdk::data_objects::Float32Value epsilonVal(1e-5f);
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributes(
+    hipdnn_flatbuffers_sdk::data_objects::Float32Value epsilonVal(1e-5f);
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributes(
         builder,
         5,
         builder.CreateString("epsilon"),
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         0,
         0,
         false,
-        hipdnn_data_sdk::data_objects::TensorValue::Float32Value,
+        hipdnn_flatbuffers_sdk::data_objects::TensorValue::Float32Value,
         builder.CreateStruct(epsilonVal).Union()));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 7, "final_out", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        7,
+        "final_out",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &strides,
+        &dims));
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     auto bnormAttributes
-        = hipdnn_data_sdk::data_objects::CreateBatchnormAttributes(builder,
-                                                                   1,
-                                                                   3,
-                                                                   4,
-                                                                   5,
-                                                                   0,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   2,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormAttributes(builder,
+                                                                          1,
+                                                                          3,
+                                                                          4,
+                                                                          5,
+                                                                          0,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          2,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt);
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes,
         bnormAttributes.Union()));
 
-    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto actAttr = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -371,25 +388,25 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         7);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "act",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttr.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
 
@@ -413,8 +430,8 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, GetWorkspaceSizeReturnsZero)
 TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, BuildPlanSetsPlanForValidSingleNodeGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     HipdnnMiopenContext ctx;
     MockEngineConfig mockEngineConfig;
 
@@ -425,8 +442,8 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, BuildPlanSetsPlanForValidSingl
 TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, BuildPlanSetsPlanForValidTwoNodeGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingActivGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     HipdnnMiopenContext ctx;
     MockEngineConfig mockEngineConfig;
 
@@ -438,33 +455,33 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, BuildPlanThrowsForUnsupportedN
 {
     // Create a graph with 3 nodes (unsupported)
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     for(int i = 0; i < 3; i++)
     {
-        auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
             builder,
             "node",
-            hipdnn_data_sdk::data_objects::DataType::FLOAT,
-            hipdnn_data_sdk::data_objects::NodeAttributes::NONE,
+            hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+            hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::NONE,
             0);
         nodes.push_back(node);
     }
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     HipdnnMiopenContext ctx;
     MockEngineConfig mockEngineConfig;
 
@@ -481,7 +498,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, IsApplicableReturnsFalseForInv
 {
     // Create a graph with 3D tensors (invalid layout)
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     std::vector<int64_t> strides3D = {1, 3, 14}; // 3D instead of 4D/5D
@@ -489,74 +506,84 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, IsApplicableReturnsFalseForInv
     std::vector<int64_t> derivedStrides = {1, 3, 1};
     std::vector<int64_t> derivedDims = {1, 3, 1};
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 1, "x", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides3D, &dims3D));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 2, "y", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides3D, &dims3D));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        1,
+        "x",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &strides3D,
+        &dims3D));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        2,
+        "y",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &strides3D,
+        &dims3D));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         3,
         "scale",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         4,
         "bias",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
-    hipdnn_data_sdk::data_objects::Float32Value epsilonVal(1e-5f);
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributes(
+    hipdnn_flatbuffers_sdk::data_objects::Float32Value epsilonVal(1e-5f);
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributes(
         builder,
         5,
         builder.CreateString("epsilon"),
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         0,
         0,
         false,
-        hipdnn_data_sdk::data_objects::TensorValue::Float32Value,
+        hipdnn_flatbuffers_sdk::data_objects::TensorValue::Float32Value,
         builder.CreateStruct(epsilonVal).Union()));
 
     auto bnormAttributes
-        = hipdnn_data_sdk::data_objects::CreateBatchnormAttributes(builder,
-                                                                   1,
-                                                                   3,
-                                                                   4,
-                                                                   5,
-                                                                   0,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   2,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt);
+        = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormAttributes(builder,
+                                                                          1,
+                                                                          3,
+                                                                          4,
+                                                                          5,
+                                                                          0,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          2,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt);
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes,
         bnormAttributes.Union());
     nodes.push_back(node);
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
 
@@ -567,7 +594,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, IsApplicableReturnsFalseForInv
 {
     // Create a graph with INT32 data type (unsupported)
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     std::vector<int64_t> strides = {588, 196, 14, 1};
@@ -575,74 +602,74 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, IsApplicableReturnsFalseForInv
     std::vector<int64_t> derivedStrides = {3, 1, 1, 1};
     std::vector<int64_t> derivedDims = {1, 3, 1, 1};
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 1, "x", hipdnn_data_sdk::data_objects::DataType::INT32, &strides, &dims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 2, "y", hipdnn_data_sdk::data_objects::DataType::INT32, &strides, &dims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "x", hipdnn_flatbuffers_sdk::data_objects::DataType::INT32, &strides, &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 2, "y", hipdnn_flatbuffers_sdk::data_objects::DataType::INT32, &strides, &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         3,
         "scale",
-        hipdnn_data_sdk::data_objects::DataType::INT32,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::INT32,
         &derivedStrides,
         &derivedDims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         4,
         "bias",
-        hipdnn_data_sdk::data_objects::DataType::INT32,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::INT32,
         &derivedStrides,
         &derivedDims));
 
-    hipdnn_data_sdk::data_objects::Int32Value epsilonVal(1);
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributes(
+    hipdnn_flatbuffers_sdk::data_objects::Int32Value epsilonVal(1);
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributes(
         builder,
         5,
         builder.CreateString("epsilon"),
-        hipdnn_data_sdk::data_objects::DataType::INT32,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::INT32,
         0,
         0,
         false,
-        hipdnn_data_sdk::data_objects::TensorValue::Int32Value,
+        hipdnn_flatbuffers_sdk::data_objects::TensorValue::Int32Value,
         builder.CreateStruct(epsilonVal).Union()));
 
     auto bnormAttributes
-        = hipdnn_data_sdk::data_objects::CreateBatchnormAttributes(builder,
-                                                                   1,
-                                                                   3,
-                                                                   4,
-                                                                   5,
-                                                                   0,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   2,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt);
+        = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormAttributes(builder,
+                                                                          1,
+                                                                          3,
+                                                                          4,
+                                                                          5,
+                                                                          0,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          2,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt);
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes,
         bnormAttributes.Union());
     nodes.push_back(node);
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
 
@@ -653,7 +680,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, IsApplicableReturnsFalseForInv
 {
     // Create a graph with wrong affine parameter shape
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     std::vector<int64_t> strides = {588, 196, 14, 1};
@@ -661,74 +688,74 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, IsApplicableReturnsFalseForInv
     std::vector<int64_t> wrongStrides = {5, 1, 1, 1}; // Wrong channel count
     std::vector<int64_t> wrongDims = {1, 5, 1, 1};
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 1, "x", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 2, "y", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "x", hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT, &strides, &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 2, "y", hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT, &strides, &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         3,
         "scale",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &wrongStrides,
         &wrongDims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         4,
         "bias",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &wrongStrides,
         &wrongDims));
 
-    hipdnn_data_sdk::data_objects::Float32Value epsilonVal(1e-5f);
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributes(
+    hipdnn_flatbuffers_sdk::data_objects::Float32Value epsilonVal(1e-5f);
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributes(
         builder,
         5,
         builder.CreateString("epsilon"),
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         0,
         0,
         false,
-        hipdnn_data_sdk::data_objects::TensorValue::Float32Value,
+        hipdnn_flatbuffers_sdk::data_objects::TensorValue::Float32Value,
         builder.CreateStruct(epsilonVal).Union()));
 
     auto bnormAttributes
-        = hipdnn_data_sdk::data_objects::CreateBatchnormAttributes(builder,
-                                                                   1,
-                                                                   3,
-                                                                   4,
-                                                                   5,
-                                                                   0,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   2,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt);
+        = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormAttributes(builder,
+                                                                          1,
+                                                                          3,
+                                                                          4,
+                                                                          5,
+                                                                          0,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          2,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt);
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes,
         bnormAttributes.Union());
     nodes.push_back(node);
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
 
@@ -739,7 +766,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, IsApplicableReturnsFalseForNon
 {
     // Create a graph with non-packed tensor (strides don't match packed layout)
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     std::vector<int64_t> nonPackedStrides = {1000, 3, 14, 14}; // Non-packed strides
@@ -747,74 +774,84 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, IsApplicableReturnsFalseForNon
     std::vector<int64_t> derivedStrides = {1, 3, 1, 1};
     std::vector<int64_t> derivedDims = {1, 3, 1, 1};
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 1, "x", hipdnn_data_sdk::data_objects::DataType::FLOAT, &nonPackedStrides, &dims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 2, "y", hipdnn_data_sdk::data_objects::DataType::FLOAT, &nonPackedStrides, &dims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        1,
+        "x",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &nonPackedStrides,
+        &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        2,
+        "y",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &nonPackedStrides,
+        &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         3,
         "scale",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         4,
         "bias",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
-    hipdnn_data_sdk::data_objects::Float32Value epsilonVal(1e-5f);
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributes(
+    hipdnn_flatbuffers_sdk::data_objects::Float32Value epsilonVal(1e-5f);
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributes(
         builder,
         5,
         builder.CreateString("epsilon"),
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         0,
         0,
         false,
-        hipdnn_data_sdk::data_objects::TensorValue::Float32Value,
+        hipdnn_flatbuffers_sdk::data_objects::TensorValue::Float32Value,
         builder.CreateStruct(epsilonVal).Union()));
 
     auto bnormAttributes
-        = hipdnn_data_sdk::data_objects::CreateBatchnormAttributes(builder,
-                                                                   1,
-                                                                   3,
-                                                                   4,
-                                                                   5,
-                                                                   0,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   2,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt);
+        = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormAttributes(builder,
+                                                                          1,
+                                                                          3,
+                                                                          4,
+                                                                          5,
+                                                                          0,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          2,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt);
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes,
         bnormAttributes.Union());
     nodes.push_back(node);
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
 
@@ -826,7 +863,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder,
 {
     // Create a graph with only 1 spatial dimension (NC layout, need at least 2)
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     std::vector<int64_t> strides = {3, 1}; // Only N and C dimensions
@@ -834,74 +871,74 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder,
     std::vector<int64_t> derivedStrides = {3, 1};
     std::vector<int64_t> derivedDims = {1, 3};
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 1, "x", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 2, "y", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "x", hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT, &strides, &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 2, "y", hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT, &strides, &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         3,
         "scale",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         4,
         "bias",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
-    hipdnn_data_sdk::data_objects::Float32Value epsilonVal(1e-5f);
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributes(
+    hipdnn_flatbuffers_sdk::data_objects::Float32Value epsilonVal(1e-5f);
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributes(
         builder,
         5,
         builder.CreateString("epsilon"),
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         0,
         0,
         false,
-        hipdnn_data_sdk::data_objects::TensorValue::Float32Value,
+        hipdnn_flatbuffers_sdk::data_objects::TensorValue::Float32Value,
         builder.CreateStruct(epsilonVal).Union()));
 
     auto bnormAttributes
-        = hipdnn_data_sdk::data_objects::CreateBatchnormAttributes(builder,
-                                                                   1,
-                                                                   3,
-                                                                   4,
-                                                                   5,
-                                                                   0,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   2,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt);
+        = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormAttributes(builder,
+                                                                          1,
+                                                                          3,
+                                                                          4,
+                                                                          5,
+                                                                          0,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          2,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt);
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes,
         bnormAttributes.Union());
     nodes.push_back(node);
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
 
@@ -912,7 +949,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, IsApplicableReturnsFalseForMix
 {
     // Create a graph with mixed NCHW and NHWC layouts
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     std::vector<int64_t> stridesNCHW = {588, 196, 14, 1}; // NCHW
@@ -923,75 +960,85 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, IsApplicableReturnsFalseForMix
     std::vector<int64_t> derivedDims = {1, 3, 1, 1};
 
     // Input in NCHW
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 1, "x", hipdnn_data_sdk::data_objects::DataType::FLOAT, &stridesNCHW, &dimsNCHW));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        1,
+        "x",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &stridesNCHW,
+        &dimsNCHW));
     // Output in NHWC (mixed layouts)
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 2, "y", hipdnn_data_sdk::data_objects::DataType::FLOAT, &stridesNHWC, &dimsNHWC));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        2,
+        "y",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &stridesNHWC,
+        &dimsNHWC));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         3,
         "scale",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         4,
         "bias",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
-    hipdnn_data_sdk::data_objects::Float32Value epsilonVal(1e-5f);
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributes(
+    hipdnn_flatbuffers_sdk::data_objects::Float32Value epsilonVal(1e-5f);
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributes(
         builder,
         5,
         builder.CreateString("epsilon"),
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         0,
         0,
         false,
-        hipdnn_data_sdk::data_objects::TensorValue::Float32Value,
+        hipdnn_flatbuffers_sdk::data_objects::TensorValue::Float32Value,
         builder.CreateStruct(epsilonVal).Union()));
 
     auto bnormAttributes
-        = hipdnn_data_sdk::data_objects::CreateBatchnormAttributes(builder,
-                                                                   1,
-                                                                   3,
-                                                                   4,
-                                                                   5,
-                                                                   0,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   2,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt,
-                                                                   flatbuffers::nullopt);
+        = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormAttributes(builder,
+                                                                          1,
+                                                                          3,
+                                                                          4,
+                                                                          5,
+                                                                          0,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          2,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt,
+                                                                          flatbuffers::nullopt);
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes,
         bnormAttributes.Union());
     nodes.push_back(node);
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
 

--- a/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormPlanBuilder.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormPlanBuilder.cpp
@@ -5,7 +5,7 @@
 #include <numeric>
 #include <unordered_set>
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_plugin_sdk/EnginePluginApi.h>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 #include <hipdnn_test_sdk/utilities/MockEngineConfig.hpp>
@@ -19,7 +19,7 @@
 
 using namespace miopen_plugin;
 using namespace hipdnn_test_sdk::utilities;
-using namespace hipdnn_data_sdk::flatbuffer_utilities;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 
 //tests in here
 namespace
@@ -27,7 +27,7 @@ namespace
 
 void createBatchnormFusionTensorAttributes(
     flatbuffers::FlatBufferBuilder& builder,
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>&
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>&
         tensorAttributes,
     int64_t numTensors,
     const std::unordered_set<int64_t>& virtualTensorIds)
@@ -46,14 +46,15 @@ void createBatchnormFusionTensorAttributes(
         const auto& tensorStrides = isDerived ? derivedStrides : strides;
         const auto isVirtual = virtualTensorIds.count(i) > 0;
 
-        tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-            builder,
-            i,
-            ("tensor_" + std::to_string(i)).c_str(),
-            hipdnn_data_sdk::data_objects::DataType::FLOAT,
-            &tensorStrides,
-            &tensorDims,
-            isVirtual));
+        tensorAttributes.push_back(
+            hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+                builder,
+                i,
+                ("tensor_" + std::to_string(i)).c_str(),
+                hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                &tensorStrides,
+                &tensorDims,
+                isVirtual));
     }
 }
 
@@ -99,8 +100,8 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsTrueForFusedTwoNodeGra
 {
     // Use a real flatbuffer graph with valid fusion pattern
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdInferActGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
 
@@ -111,8 +112,8 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsTrueForFusedThreeNodeG
 {
     // Use a real flatbuffer graph with valid fusion pattern
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferActBwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
 
@@ -123,39 +124,39 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseForIncorrectTwoNo
 {
     // Create a graph with 2 nodes but in wrong order
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // Wrong order: activation -> batchnorm inference
-    auto node0 = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    auto node0 = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "pointwise",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         0);
     nodes.push_back(node0);
 
-    auto node1 = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    auto node1 = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_inference",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
         0);
     nodes.push_back(node1);
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
 
@@ -166,47 +167,47 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseForIncorrectThree
 {
     // Create a graph with 3 nodes but in wrong order
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // Wrong order: activation -> batchnorm inference -> batchnorm backward
-    auto node0 = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    auto node0 = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "pointwise",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         0);
     nodes.push_back(node0);
 
-    auto node1 = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    auto node1 = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_inference",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
         0);
     nodes.push_back(node1);
 
-    auto node2 = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    auto node2 = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_backward",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
         0);
     nodes.push_back(node2);
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
 
@@ -217,27 +218,27 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseForTwoNodeFusionU
 {
     // Fusion graph with unsupported activation (e.g., MUL instead of RELU_FWD)
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     createBatchnormFusionTensorAttributes(builder, tensorAttributes, 7, {6});
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // BN inference
-    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+    auto bnInfAttr = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormInferenceAttributes(
         builder, 1, 4, 5, 2, 3, 6);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_inf",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
         bnInfAttr.Union()));
 
     // Activation with unsupported MUL
-    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto actAttr = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::MUL, // Unsupported!
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::MUL, // Unsupported!
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -246,25 +247,25 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseForTwoNodeFusionU
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         7);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "act",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttr.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -276,8 +277,8 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseForTwoNodeFusionU
 TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsTrueForValidSingleNodeBackward)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormBwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
 
@@ -290,9 +291,9 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BackwardIsApplicableReturnsFalseForInvali
         {150528, 50176, 224, 1},
         {1, 3, 224, 224},
         true,
-        hipdnn_data_sdk::data_objects::DataType::UINT8); // Invalid IO data type
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UINT8); // Invalid IO data type
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -303,10 +304,10 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BackwardIsApplicableReturnsFalseForInvali
         {150528, 50176, 224, 1},
         {1, 3, 224, 224},
         true,
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF); // Invalid scale/bias type
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF); // Invalid scale/bias type
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -317,11 +318,11 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BackwardIsApplicableReturnsFalseForInvali
         {150528, 50176, 224, 1},
         {1, 3, 224, 224},
         true,
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF); // Invalid mean/variance type
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF); // Invalid mean/variance type
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -330,7 +331,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BackwardIsApplicableReturnsFalseForInvali
 {
     // Create backward graph with 3D tensors in unsupported stride order (not NCL or NLC)
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     // Invalid stride order: {0, 1, 2} which is neither NCL {2, 1, 0} nor NLC {2, 0, 1}
@@ -339,35 +340,50 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BackwardIsApplicableReturnsFalseForInvali
     std::vector<int64_t> derivedStrides = {3, 1, 1};
     std::vector<int64_t> derivedDims = {1, 3, 1};
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 1, "x", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides3D, &dims3D));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 2, "dy", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides3D, &dims3D));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 3, "dx", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides3D, &dims3D));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        1,
+        "x",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &strides3D,
+        &dims3D));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        2,
+        "dy",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &strides3D,
+        &dims3D));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        3,
+        "dx",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &strides3D,
+        &dims3D));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         4,
         "scale",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         5,
         "dscale",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         6,
         "dbias",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
-    auto bnBwdAttr = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+    auto bnBwdAttr = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormBackwardAttributes(
         builder,
         2,
         1,
@@ -379,27 +395,27 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BackwardIsApplicableReturnsFalseForInvali
         5,
         6);
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_bwd",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
         bnBwdAttr.Union());
     nodes.push_back(node);
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -408,8 +424,8 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BackwardIsApplicableReturnsFalseForInsuff
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormBwdGraph(
         {3, 1, 1, 1}, {1, 3, 1, 1}); // Batch * spatial = 1 (invalid for training)
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -422,7 +438,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseForInvalidLayoutI
 {
     // Create an inference graph with 3D tensors (invalid layout)
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     std::vector<int64_t> strides3D = {42, 14, 1}; // 3D instead of 4D/5D
@@ -430,63 +446,73 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseForInvalidLayoutI
     std::vector<int64_t> derivedStrides = {3, 1, 1, 1};
     std::vector<int64_t> derivedDims = {1, 3, 1, 1};
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 1, "x", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides3D, &dims3D));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 2, "y", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides3D, &dims3D));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        1,
+        "x",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &strides3D,
+        &dims3D));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        2,
+        "y",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &strides3D,
+        &dims3D));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         3,
         "scale",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         4,
         "bias",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         5,
         "mean",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         6,
         "inv_variance",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
-    auto bnormAttributes = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+    auto bnormAttributes = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormInferenceAttributes(
         builder, 1, 5, 6, 3, 4, 2);
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
         bnormAttributes.Union());
     nodes.push_back(node);
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -499,7 +525,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseForNonPackedTenso
 {
     // Create a backward graph with non-packed tensors
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     std::vector<int64_t> nonPackedStrides = {1000, 300, 14, 1}; // Non-packed
@@ -507,45 +533,50 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseForNonPackedTenso
     std::vector<int64_t> derivedStrides = {3, 1, 1, 1};
     std::vector<int64_t> derivedDims = {1, 3, 1, 1};
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 1, "x", hipdnn_data_sdk::data_objects::DataType::FLOAT, &nonPackedStrides, &dims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        1,
+        "x",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &nonPackedStrides,
+        &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         2,
         "dy",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &nonPackedStrides,
         &dims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         3,
         "dx",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &nonPackedStrides,
         &dims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         4,
         "scale",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         5,
         "dscale",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         6,
         "dbias",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
-    auto bnBwdAttr = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+    auto bnBwdAttr = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormBackwardAttributes(
         builder,
         2,
         1,
@@ -557,27 +588,27 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseForNonPackedTenso
         5,
         6);
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_bwd",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
         bnBwdAttr.Union());
     nodes.push_back(node);
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -586,27 +617,27 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseForThreeNodeUnsup
 {
     // Fusion graph with unsupported activation (e.g., SIGMOID_BWD instead of RELU_BWD)
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     createBatchnormFusionTensorAttributes(builder, tensorAttributes, 12, {10, 11});
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // BN inference
-    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+    auto bnInfAttr = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormInferenceAttributes(
         builder, 1, 4, 5, 2, 3, 10);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_inf",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
         bnInfAttr.Union()));
 
     // Activation with unsupported SIGMOID_BWD
-    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto actAttr = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::SIGMOID_BWD, // Unsupported!
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SIGMOID_BWD, // Unsupported!
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -615,15 +646,15 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseForThreeNodeUnsup
         flatbuffers::Optional<int64_t>(6),
         flatbuffers::nullopt,
         11);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "act",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttr.Union()));
 
     // BN backward
-    auto bnBwdAttr = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+    auto bnBwdAttr = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormBackwardAttributes(
         builder,
         11,
         1,
@@ -634,25 +665,25 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseForThreeNodeUnsup
         7,
         8,
         9);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_bwd",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
         bnBwdAttr.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -661,27 +692,27 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseWhenActivationMis
 {
     // Fusion graph where activation doesn't have in_1 tensor (required for backward)
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     createBatchnormFusionTensorAttributes(builder, tensorAttributes, 12, {10, 11});
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // BN inference
-    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+    auto bnInfAttr = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormInferenceAttributes(
         builder, 1, 4, 5, 2, 3, 10);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_inf",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
         bnInfAttr.Union()));
 
     // Activation without in_1 (missing dy gradient!)
-    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto actAttr = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -690,15 +721,15 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseWhenActivationMis
         flatbuffers::nullopt, // Missing in_1!
         flatbuffers::nullopt,
         11);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "act",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttr.Union()));
 
     // BN backward
-    auto bnBwdAttr = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+    auto bnBwdAttr = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormBackwardAttributes(
         builder,
         11,
         1,
@@ -709,25 +740,25 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseWhenActivationMis
         7,
         8,
         9);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_bwd",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
         bnBwdAttr.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -752,9 +783,9 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseForUnsupportedCom
     auto nodeA = std::make_unique<MockNode>();
     auto nodeB = std::make_unique<MockNode>();
     EXPECT_CALL(*nodeA, computeDataType())
-        .WillOnce(::testing::Return(hipdnn_data_sdk::data_objects::DataType::FLOAT));
+        .WillOnce(::testing::Return(hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT));
     EXPECT_CALL(*nodeB, computeDataType())
-        .WillOnce(::testing::Return(hipdnn_data_sdk::data_objects::DataType::BFLOAT16));
+        .WillOnce(::testing::Return(hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16));
 
     std::vector<std::unique_ptr<INodeWrapper>> nodeWrappers;
     nodeWrappers.emplace_back(std::move(nodeA));
@@ -780,8 +811,8 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanSetsPlanForSupportedInferenceNod
 {
     // Use a real flatbuffer graph with a valid batchnorm node
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     HipdnnMiopenContext ctx;
 
     EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx));
@@ -792,8 +823,8 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanSetsPlanForSupportedInferenceWit
 {
     // Use a real flatbuffer graph with a valid batchnorm variance node
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormWithVarianceInferenceGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     HipdnnMiopenContext ctx;
 
     EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx));
@@ -804,8 +835,8 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanSetsPlanForSupportedBackwardNode
 {
     // Use a real flatbuffer graph with a valid batchnorm backward node
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormBwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     HipdnnMiopenContext ctx;
 
     EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx));
@@ -816,8 +847,8 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanSetsPlanForFusedTwoNodeGraph)
 {
     // Use a real flatbuffer graph with valid fusion pattern
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdInferActGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     HipdnnMiopenContext ctx;
 
     EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx));
@@ -828,8 +859,8 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanSetsPlanForFusedThreeNodeGraph)
 {
     // Use a real flatbuffer graph with valid fusion pattern
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferActBwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     HipdnnMiopenContext ctx;
 
     EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx));
@@ -840,31 +871,31 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanThrowsForUnsupportedNodeType)
 {
     // Create a graph with a node of unsupported type
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // Node with NONE attributes type
-    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "unsupported",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::NONE,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::NONE,
         0);
     nodes.push_back(node);
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     HipdnnMiopenContext ctx;
 
@@ -877,31 +908,31 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanThrowsForMalformedInferenceAttri
 {
     // Create a graph with batchnorm inference node but malformed attributes
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // Node with BatchnormInferenceAttributes type but null attributes pointer
-    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "malformed_bn_inference",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
         0);
     nodes.push_back(node);
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     HipdnnMiopenContext ctx;
 
     EXPECT_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx),
@@ -913,31 +944,31 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanThrowsForMalformedBackwardAttrib
 {
     // Create a graph with batchnorm backward node but malformed attributes
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // Node with BatchnormBackwardAttributes type but null attributes pointer
-    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "malformed_bn_backward",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
         0);
     nodes.push_back(node);
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     HipdnnMiopenContext ctx;
 
     EXPECT_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx),
@@ -948,23 +979,23 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanThrowsForMalformedBackwardAttrib
 TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanThrowsForMalformedTwoNodeFusedGraphFirstNode)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     createBatchnormFusionTensorAttributes(builder, tensorAttributes, 7, {6});
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_inf",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
         0)); // Malformed!
 
-    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto actAttr = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -973,25 +1004,25 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanThrowsForMalformedTwoNodeFusedGr
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         7);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "act",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttr.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     HipdnnMiopenContext ctx;
 
@@ -1003,42 +1034,42 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanThrowsForMalformedTwoNodeFusedGr
 TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanThrowsForMalformedTwoNodeFusedGraphSecondNode)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     createBatchnormFusionTensorAttributes(builder, tensorAttributes, 7, {6});
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // BN inference
-    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+    auto bnInfAttr = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormInferenceAttributes(
         builder, 1, 4, 5, 2, 3, 6);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_inf",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
         bnInfAttr.Union()));
 
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "act",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         0)); //malformed!
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     HipdnnMiopenContext ctx;
 
@@ -1051,26 +1082,26 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanThrowsForMalformedFusedGraphFirs
 {
     // Create a 3-node graph with malformed first node (batchnorm inference)
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     createBatchnormFusionTensorAttributes(builder, tensorAttributes, 12, {10, 11});
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // Malformed batchnorm inference (null attributes)
-    auto node0 = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    auto node0 = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "malformed_bn_inference",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
         0);
     nodes.push_back(node0);
 
     // Valid pointwise
-    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto actAttr = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -1079,15 +1110,15 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanThrowsForMalformedFusedGraphFirs
         flatbuffers::Optional<int64_t>(6),
         flatbuffers::nullopt,
         11);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "pointwise",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttr.Union()));
 
     // Valid batchnorm backward
-    auto bnBwdAttr = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+    auto bnBwdAttr = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormBackwardAttributes(
         builder,
         11,
         1,
@@ -1098,25 +1129,25 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanThrowsForMalformedFusedGraphFirs
         7,
         8,
         9);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_backward",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
         bnBwdAttr.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     HipdnnMiopenContext ctx;
 
     EXPECT_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx),
@@ -1128,34 +1159,34 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanThrowsForMalformedFusedGraphSeco
 {
     // Create a 3-node graph with malformed second node (pointwise)
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     createBatchnormFusionTensorAttributes(builder, tensorAttributes, 12, {10, 11});
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // Valid batchnorm inference
-    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+    auto bnInfAttr = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormInferenceAttributes(
         builder, 1, 4, 5, 2, 3, 10);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_inference",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
         bnInfAttr.Union()));
 
     // Malformed pointwise (null attributes)
-    auto node1 = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    auto node1 = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "malformed_pointwise",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         0);
     nodes.push_back(node1);
 
     // Valid batchnorm backward
-    auto bnBwdAttr = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+    auto bnBwdAttr = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormBackwardAttributes(
         builder,
         11,
         1,
@@ -1166,25 +1197,25 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanThrowsForMalformedFusedGraphSeco
         7,
         8,
         9);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_backward",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
         bnBwdAttr.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     HipdnnMiopenContext ctx;
 
     EXPECT_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx),
@@ -1196,27 +1227,27 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanThrowsForMalformedFusedGraphThir
 {
     // Create a 3-node graph with malformed third node (batchnorm backward)
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     createBatchnormFusionTensorAttributes(builder, tensorAttributes, 12, {10, 11});
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // Valid batchnorm inference
-    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+    auto bnInfAttr = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormInferenceAttributes(
         builder, 1, 4, 5, 2, 3, 10);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_inference",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
         bnInfAttr.Union()));
 
     // Valid pointwise
-    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto actAttr = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -1225,34 +1256,34 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanThrowsForMalformedFusedGraphThir
         flatbuffers::Optional<int64_t>(6),
         flatbuffers::nullopt,
         11);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "pointwise",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttr.Union()));
 
     // Malformed batchnorm backward (null attributes)
-    auto node2 = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    auto node2 = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "malformed_bn_backward",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
         0);
     nodes.push_back(node2);
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     HipdnnMiopenContext ctx;
 
     EXPECT_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx),
@@ -1265,27 +1296,27 @@ TEST_F(TestMiopenBatchnormPlanBuilder,
 {
     // Fusion graph where BN inference output doesn't connect to activation
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     createBatchnormFusionTensorAttributes(builder, tensorAttributes, 12, {10, 11});
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // BN inference with output uid=10
-    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+    auto bnInfAttr = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormInferenceAttributes(
         builder, 1, 4, 5, 2, 3, 10);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_inf",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
         bnInfAttr.Union()));
 
     // Activation with input uid=999
-    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto actAttr = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -1294,15 +1325,15 @@ TEST_F(TestMiopenBatchnormPlanBuilder,
         flatbuffers::Optional<int64_t>(6),
         flatbuffers::nullopt,
         11);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "act",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttr.Union()));
 
     // BN backward
-    auto bnBwdAttr = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+    auto bnBwdAttr = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormBackwardAttributes(
         builder,
         11,
         1,
@@ -1313,25 +1344,25 @@ TEST_F(TestMiopenBatchnormPlanBuilder,
         7,
         8,
         9);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_bwd",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
         bnBwdAttr.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -1341,27 +1372,27 @@ TEST_F(TestMiopenBatchnormPlanBuilder,
 {
     // Fusion graph where activation output doesn't connect to BN backward dy
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     createBatchnormFusionTensorAttributes(builder, tensorAttributes, 12, {10, 11});
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // BN inference
-    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+    auto bnInfAttr = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormInferenceAttributes(
         builder, 1, 4, 5, 2, 3, 10);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_inf",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
         bnInfAttr.Union()));
 
     // Activation with output uid=11
-    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto actAttr = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -1370,15 +1401,15 @@ TEST_F(TestMiopenBatchnormPlanBuilder,
         flatbuffers::Optional<int64_t>(6),
         flatbuffers::nullopt,
         11);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "act",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttr.Union()));
 
     // BN backward with dy=999
-    auto bnBwdAttr = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+    auto bnBwdAttr = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormBackwardAttributes(
         builder,
         999, // Wrong dy
         1,
@@ -1389,25 +1420,25 @@ TEST_F(TestMiopenBatchnormPlanBuilder,
         7,
         8,
         9);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_bwd",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
         bnBwdAttr.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -1416,27 +1447,27 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseWhenBnBackwardXDi
 {
     // Fusion graph where BN backward uses different X than BN inference
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     createBatchnormFusionTensorAttributes(builder, tensorAttributes, 13, {10, 11});
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // BN inference with x=1
-    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+    auto bnInfAttr = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormInferenceAttributes(
         builder, 1, 4, 5, 2, 3, 10);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_inf",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
         bnInfAttr.Union()));
 
     // Activation
-    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto actAttr = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -1445,15 +1476,15 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseWhenBnBackwardXDi
         flatbuffers::Optional<int64_t>(6),
         flatbuffers::nullopt,
         11);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "act",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttr.Union()));
 
     // BN backward with x=12 (wrong - should be 1 like BN inference)
-    auto bnBwdAttr = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+    auto bnBwdAttr = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormBackwardAttributes(
         builder,
         11,
         12, // Wrong X
@@ -1464,25 +1495,25 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseWhenBnBackwardXDi
         7,
         8,
         9);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_bwd",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
         bnBwdAttr.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -1492,27 +1523,27 @@ TEST_F(TestMiopenBatchnormPlanBuilder,
 {
     // Fusion graph where BN backward uses different scale than BN inference
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     createBatchnormFusionTensorAttributes(builder, tensorAttributes, 13, {10, 11});
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // BN inference with scale=2
-    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+    auto bnInfAttr = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormInferenceAttributes(
         builder, 1, 4, 5, 2, 3, 10);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_inf",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
         bnInfAttr.Union()));
 
     // Activation
-    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto actAttr = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -1521,15 +1552,15 @@ TEST_F(TestMiopenBatchnormPlanBuilder,
         flatbuffers::Optional<int64_t>(6),
         flatbuffers::nullopt,
         11);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "act",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttr.Union()));
 
     // BN backward with scale=12 (wrong - should be 2 like BN inference)
-    auto bnBwdAttr = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+    auto bnBwdAttr = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormBackwardAttributes(
         builder,
         11,
         1,
@@ -1540,25 +1571,25 @@ TEST_F(TestMiopenBatchnormPlanBuilder,
         7,
         8,
         9);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_bwd",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
         bnBwdAttr.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -1567,27 +1598,27 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseWhenBnInferenceOu
 {
     // Fusion graph where BN inference output tensor is non-virtual (should be virtual)
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     createBatchnormFusionTensorAttributes(builder, tensorAttributes, 12, {11});
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // BN inference with output uid=10 (which is non-virtual - wrong!)
-    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+    auto bnInfAttr = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormInferenceAttributes(
         builder, 1, 4, 5, 2, 3, 10);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_inf",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
         bnInfAttr.Union()));
 
     // Activation
-    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto actAttr = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -1596,15 +1627,15 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseWhenBnInferenceOu
         flatbuffers::Optional<int64_t>(6),
         flatbuffers::nullopt,
         11);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "act",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttr.Union()));
 
     // BN backward
-    auto bnBwdAttr = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+    auto bnBwdAttr = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormBackwardAttributes(
         builder,
         11,
         1,
@@ -1615,25 +1646,25 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseWhenBnInferenceOu
         7,
         8,
         9);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_bwd",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
         bnBwdAttr.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -1642,27 +1673,27 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseWhenActivationOut
 {
     // Fusion graph where activation output tensor is non-virtual (should be virtual)
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     createBatchnormFusionTensorAttributes(builder, tensorAttributes, 12, {10});
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // BN inference
-    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+    auto bnInfAttr = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormInferenceAttributes(
         builder, 1, 4, 5, 2, 3, 10);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_inf",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
         bnInfAttr.Union()));
 
     // Activation with output=11 (which is non-virtual - wrong!)
-    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto actAttr = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -1671,15 +1702,15 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseWhenActivationOut
         flatbuffers::Optional<int64_t>(6),
         flatbuffers::nullopt,
         11);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "act",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttr.Union()));
 
     // BN backward
-    auto bnBwdAttr = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+    auto bnBwdAttr = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormBackwardAttributes(
         builder,
         11,
         1,
@@ -1690,25 +1721,25 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseWhenActivationOut
         7,
         8,
         9);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_bwd",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
         bnBwdAttr.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -1717,26 +1748,26 @@ TEST_F(TestMiopenBatchnormPlanBuilder,
        IsApplicableReturnsFalseForTwoNodeFusionWhenInfOutputNotMatchingActInput)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     createBatchnormFusionTensorAttributes(builder, tensorAttributes, 7, {6});
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // BN inference
-    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+    auto bnInfAttr = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormInferenceAttributes(
         builder, 1, 4, 5, 2, 3, 6);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_inf",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
         bnInfAttr.Union()));
 
-    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto actAttr = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -1745,25 +1776,25 @@ TEST_F(TestMiopenBatchnormPlanBuilder,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         7);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "act",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttr.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -1772,26 +1803,26 @@ TEST_F(TestMiopenBatchnormPlanBuilder,
        IsApplicableReturnsFalseForTwoNodeFusionWhenInfOutputIsNonVirtual)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     createBatchnormFusionTensorAttributes(builder, tensorAttributes, 7, {}); //node 6 not virtual
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // BN inference
-    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+    auto bnInfAttr = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormInferenceAttributes(
         builder, 1, 4, 5, 2, 3, 6);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_inf",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
         bnInfAttr.Union()));
 
-    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto actAttr = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -1800,25 +1831,25 @@ TEST_F(TestMiopenBatchnormPlanBuilder,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         7);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "act",
-        hipdnn_data_sdk::data_objects::DataType::UNSET,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttr.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -1830,27 +1861,29 @@ TEST_F(TestMiopenBatchnormPlanBuilder,
 TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsTrueForFusedTwoNodeGraphWithVariance)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     createBatchnormFusionTensorAttributes(builder, tensorAttributes, 7, {6});
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // BN inference with variance
-    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributesVarianceExt(
-        builder, 1, 2, 3, 4, 5, 6);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    auto bnInfAttr
+        = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormInferenceAttributesVarianceExt(
+            builder, 1, 2, 3, 4, 5, 6);
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_inf_var",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributesVarianceExt,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::
+            BatchnormInferenceAttributesVarianceExt,
         bnInfAttr.Union()));
 
     // Activation
-    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto actAttr = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -1859,25 +1892,25 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsTrueForFusedTwoNodeGra
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         7);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "act",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttr.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_TRUE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -1886,27 +1919,29 @@ TEST_F(TestMiopenBatchnormPlanBuilder,
        IsApplicableReturnsFalseForFusedTwoNodeGraphWithVarianceAndBrokenConnectivity)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     createBatchnormFusionTensorAttributes(builder, tensorAttributes, 7, {6});
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // BN inference with variance
-    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributesVarianceExt(
-        builder, 1, 2, 3, 4, 5, 6);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    auto bnInfAttr
+        = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormInferenceAttributesVarianceExt(
+            builder, 1, 2, 3, 4, 5, 6);
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_inf_var",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributesVarianceExt,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::
+            BatchnormInferenceAttributesVarianceExt,
         bnInfAttr.Union()));
 
     // Activation with wrong input
-    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto actAttr = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -1915,25 +1950,25 @@ TEST_F(TestMiopenBatchnormPlanBuilder,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         7);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "act",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttr.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -1942,27 +1977,29 @@ TEST_F(TestMiopenBatchnormPlanBuilder,
        IsApplicableReturnsFalseForFusedTwoNodeGraphWithVarianceAndNonVirtualIntermediate)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     createBatchnormFusionTensorAttributes(builder, tensorAttributes, 7, {}); // No virtual tensors
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // BN inference with variance
-    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributesVarianceExt(
-        builder, 1, 2, 3, 4, 5, 6);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    auto bnInfAttr
+        = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormInferenceAttributesVarianceExt(
+            builder, 1, 2, 3, 4, 5, 6);
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_inf_var",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributesVarianceExt,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::
+            BatchnormInferenceAttributesVarianceExt,
         bnInfAttr.Union()));
 
     // Activation
-    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto actAttr = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -1971,25 +2008,25 @@ TEST_F(TestMiopenBatchnormPlanBuilder,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         7);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "act",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttr.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -1998,27 +2035,29 @@ TEST_F(TestMiopenBatchnormPlanBuilder,
        IsApplicableReturnsFalseForFusedTwoNodeGraphWithVarianceAndUnsupportedActivation)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     createBatchnormFusionTensorAttributes(builder, tensorAttributes, 7, {6});
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // BN inference with variance
-    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributesVarianceExt(
-        builder, 1, 2, 3, 4, 5, 6);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    auto bnInfAttr
+        = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormInferenceAttributesVarianceExt(
+            builder, 1, 2, 3, 4, 5, 6);
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "bn_inf_var",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributesVarianceExt,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::
+            BatchnormInferenceAttributesVarianceExt,
         bnInfAttr.Union()));
 
     // Activation with unsupported MUL
-    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto actAttr = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::MUL, // Unsupported!
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::MUL, // Unsupported!
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
@@ -2027,25 +2066,25 @@ TEST_F(TestMiopenBatchnormPlanBuilder,
         flatbuffers::nullopt,
         flatbuffers::nullopt,
         7);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "act",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttr.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -2061,8 +2100,8 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsTrueFor3dNclInference)
 
     auto builder
         = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph(strides3D, dims3D);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_TRUE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -2073,8 +2112,8 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsTrueFor3dNlcBackward)
     std::vector<int64_t> strides3D = {42, 1, 3};
 
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormBwdGraph(strides3D, dims3D);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_TRUE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -2086,8 +2125,8 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsTrueFor3dNclVarianceIn
 
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormWithVarianceInferenceGraph(
         strides3D, dims3D);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_TRUE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -2099,8 +2138,8 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsTrueFor3dNlcFusedTwoNo
 
     auto builder
         = hipdnn_test_sdk::utilities::createValidBatchnormFwdInferActGraph(strides3D, dims3D);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_TRUE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -2112,8 +2151,8 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsTrueFor3dNclFusedThree
 
     auto builder
         = hipdnn_test_sdk::utilities::createValidBatchnormInferActBwdGraph(strides3D, dims3D);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_TRUE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
@@ -2125,8 +2164,8 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanSetsPlanFor3dNclInference)
 
     auto builder
         = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph(strides3D, dims3D);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     HipdnnMiopenContext ctx;
 
     EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx));
@@ -2139,8 +2178,8 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanSetsPlanFor3dNlcBackward)
     std::vector<int64_t> strides3D = {42, 1, 3};
 
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormBwdGraph(strides3D, dims3D);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     HipdnnMiopenContext ctx;
 
     EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx));
@@ -2154,8 +2193,8 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanSetsPlanFor3dNclVarianceInferenc
 
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormWithVarianceInferenceGraph(
         strides3D, dims3D);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     HipdnnMiopenContext ctx;
 
     EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx));
@@ -2169,8 +2208,8 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanSetsPlanFor3dNlcFusedTwoNodeGrap
 
     auto builder
         = hipdnn_test_sdk::utilities::createValidBatchnormFwdInferActGraph(strides3D, dims3D);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     HipdnnMiopenContext ctx;
 
     EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx));
@@ -2184,8 +2223,8 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanSetsPlanFor3dNclFusedThreeNodeGr
 
     auto builder
         = hipdnn_test_sdk::utilities::createValidBatchnormInferActBwdGraph(strides3D, dims3D);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     HipdnnMiopenContext ctx;
 
     EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx));

--- a/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenConvBwdPlan.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenConvBwdPlan.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier:  MIT
 
 #include <gtest/gtest.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 #include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
 #include <miopen/miopen.h>
@@ -28,8 +28,8 @@ TEST(TestConvBwdParams, InitializesAllTensorsFromValidGraph)
 {
     // Create a valid convolution graph
     auto builder = hipdnn_test_sdk::utilities::createValidConvBwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the convolution node and attributes
     const auto& node = graph.getNode(0);
@@ -68,8 +68,8 @@ TEST(TestConvBwdParams, ThrowsOnAssymetricPadding)
                                                                        convPostPadding,
                                                                        convStrides,
                                                                        convDilation);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the convolution node and attributes
     const auto& node = graph.getNode(0);
@@ -103,8 +103,8 @@ TEST(TestConvBwdParams, ThrowsOnInvalidPostPaddingVectorSize)
                                                                        convPostPadding,
                                                                        convStrides,
                                                                        convDilation);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the convolution node and attributes
     const auto& node = graph.getNode(0);
@@ -139,8 +139,8 @@ TEST(TestConvBwdParams, ThrowsOnInvalidPaddingVectorsSize)
                                                                        convPostPadding,
                                                                        convStrides,
                                                                        convDilation);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the convolution node and attributes
     const auto& node = graph.getNode(0);
@@ -174,8 +174,8 @@ TEST(TestConvBwdParams, ThrowsOnInvalidStrideVectorSize)
                                                                        convPostPadding,
                                                                        convStrides,
                                                                        convDilation);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the convolution node and attributes
     const auto& node = graph.getNode(0);
@@ -209,8 +209,8 @@ TEST(TestConvBwdParams, ThrowsOnInvalidDilationVectorSize)
                                                                        convPostPadding,
                                                                        convStrides,
                                                                        convDilation);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the convolution node and attributes
     const auto& node = graph.getNode(0);
@@ -226,8 +226,8 @@ TEST_F(TestGpuConvBwdPlan, CreatesPlanWithValidGraph)
 {
     // Create a valid convolution graph
     auto builder = hipdnn_test_sdk::utilities::createValidConvBwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the convolution node and attributes
     const auto& node = graph.getNode(0);
@@ -245,8 +245,8 @@ TEST_F(TestGpuConvBwdPlan, CreatesPlanWithValidGraph)
 TEST_F(TestGpuConvBwdPlan, PlanUsesDefaultWorkspaceSizeWhenNoLimitSet)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidConvBwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     auto* attrs = node.attributes_as_ConvolutionBwdAttributes();
@@ -265,8 +265,8 @@ TEST_F(TestGpuConvBwdPlan, PlanUsesDefaultWorkspaceSizeWhenNoLimitSet)
 TEST_F(TestGpuConvBwdPlan, PlanUsesKnobLimitOverDefault)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidConvBwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     auto* attrs = node.attributes_as_ConvolutionBwdAttributes();
@@ -307,8 +307,8 @@ TEST_F(TestGpuConvBwdPlan, ThrowsOnInvalidDims)
                                                                        convPostPadding,
                                                                        convStrides,
                                                                        convDilation);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the convolution node and attributes
     const auto& node = graph.getNode(0);

--- a/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenConvFwdBiasActivPlan.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenConvFwdBiasActivPlan.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier:  MIT
 
 #include <gtest/gtest.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 #include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
 #include <miopen/miopen.h>
@@ -12,7 +12,7 @@
 #include "engines/plans/MiopenConvFwdBiasActivPlan.hpp"
 
 using namespace miopen_plugin;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_data_sdk::utilities;
 
@@ -30,8 +30,8 @@ protected:
 TEST(TestConvFwdBiasActivParams, InitializeFromValidConvFwdActivGraph)
 {
     auto builder = createValidConvFwdActivGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node0 = graph.getNode(0);
     const auto* convAttr = node0.attributes_as_ConvolutionFwdAttributes();
@@ -47,8 +47,8 @@ TEST(TestConvFwdBiasActivParams, InitializeFromValidConvFwdActivGraph)
 TEST(TestConvFwdBiasActivParams, InitializeFromValidConvFwdBiasActivGraph)
 {
     auto builder = createValidConvFwdBiasActivGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node0 = graph.getNode(0);
     const auto* convAttr = node0.attributes_as_ConvolutionFwdAttributes();
@@ -85,8 +85,8 @@ TEST(TestConvFwdBiasActivParams, ThrowOnWrongActivationMode)
                                                     convStrides,
                                                     convDilation,
                                                     PointwiseMode::ADD); // Invalid activation mode
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node0 = graph.getNode(0);
     const auto* convAttr = node0.attributes_as_ConvolutionFwdAttributes();
@@ -107,8 +107,8 @@ TEST(TestConvFwdBiasActivParams, ThrowOnWrongActivationMode)
 TEST_F(TestGpuConvFwdBiasActivPlan, CreatePlanWithValidConvFwdActivGraph)
 {
     auto builder = createValidConvFwdActivGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node0 = graph.getNode(0);
     const auto* convAttr = node0.attributes_as_ConvolutionFwdAttributes();
@@ -127,8 +127,8 @@ TEST_F(TestGpuConvFwdBiasActivPlan, CreatePlanWithValidConvFwdActivGraph)
 TEST_F(TestGpuConvFwdBiasActivPlan, CreatePlanWithValidConvFwdActivGraphCompileOnly)
 {
     auto builder = createValidConvFwdActivGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node0 = graph.getNode(0);
     const auto* convAttr = node0.attributes_as_ConvolutionFwdAttributes();
@@ -147,8 +147,8 @@ TEST_F(TestGpuConvFwdBiasActivPlan, CreatePlanWithValidConvFwdActivGraphCompileO
 TEST_F(TestGpuConvFwdBiasActivPlan, CreatePlanWithValidConvFwdActivGraphWorkspaceOnly)
 {
     auto builder = createValidConvFwdActivGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node0 = graph.getNode(0);
     const auto* convAttr = node0.attributes_as_ConvolutionFwdAttributes();
@@ -167,8 +167,8 @@ TEST_F(TestGpuConvFwdBiasActivPlan, CreatePlanWithValidConvFwdActivGraphWorkspac
 TEST_F(TestGpuConvFwdBiasActivPlan, CreatePlanWithValidConvFwdBiasActivGraph)
 {
     auto builder = createValidConvFwdBiasActivGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node0 = graph.getNode(0);
     const auto* convAttr = node0.attributes_as_ConvolutionFwdAttributes();
@@ -191,8 +191,8 @@ TEST_F(TestGpuConvFwdBiasActivPlan, CreatePlanWithValidConvFwdBiasActivGraph)
 TEST_F(TestGpuConvFwdBiasActivPlan, CreatePlanWithValidConvFwdBiasActivGraphCompileOnly)
 {
     auto builder = createValidConvFwdBiasActivGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node0 = graph.getNode(0);
     const auto* convAttr = node0.attributes_as_ConvolutionFwdAttributes();
@@ -215,8 +215,8 @@ TEST_F(TestGpuConvFwdBiasActivPlan, CreatePlanWithValidConvFwdBiasActivGraphComp
 TEST_F(TestGpuConvFwdBiasActivPlan, CreatePlanWithValidConvFwdBiasActivGraphWorkspaceOnly)
 {
     auto builder = createValidConvFwdBiasActivGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node0 = graph.getNode(0);
     const auto* convAttr = node0.attributes_as_ConvolutionFwdAttributes();

--- a/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenConvFwdBiasActivPlanBuilder.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenConvFwdBiasActivPlanBuilder.cpp
@@ -21,7 +21,7 @@
 #include <unordered_map>
 
 using namespace miopen_plugin;
-using namespace hipdnn_data_sdk::flatbuffer_utilities;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_data_sdk::utilities;
 using namespace hipdnn_frontend::graph;
@@ -253,7 +253,7 @@ test_conv_common::ConvTestCase validConvTestCase5d()
 
 test_activation_common::ActivTestCase validActivTestCase()
 {
-    return {hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+    return {hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
             0.0,
             std::nullopt,
             std::nullopt,
@@ -504,7 +504,7 @@ std::vector<ConvolutionBiasActivationTestParam> testParams()
               validConvTestCase4d(),
               TensorLayout::NCHW,
               test_activation_common::ActivTestCase{
-                  hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD, std::nullopt, 0.0},
+                  hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD, std::nullopt, 0.0},
               hipdnn_frontend::DataType::FLOAT,
               {},
               {TypeKey::Y_CONV, TypeKey::Y_BIAS},
@@ -514,7 +514,7 @@ std::vector<ConvolutionBiasActivationTestParam> testParams()
               validConvTestCase4d(),
               TensorLayout::NCHW,
               test_activation_common::ActivTestCase{
-                  hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD, 0.0, 1.0},
+                  hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD, 0.0, 1.0},
               hipdnn_frontend::DataType::FLOAT,
               {},
               {TypeKey::Y_CONV, TypeKey::Y_BIAS},
@@ -524,7 +524,7 @@ std::vector<ConvolutionBiasActivationTestParam> testParams()
               validConvTestCase4d(),
               TensorLayout::NCHW,
               test_activation_common::ActivTestCase{
-                  hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+                  hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
                   std::nullopt,
                   std::nullopt,
                   1.0},
@@ -537,7 +537,7 @@ std::vector<ConvolutionBiasActivationTestParam> testParams()
               validConvTestCase4d(),
               TensorLayout::NCHW,
               test_activation_common::ActivTestCase{
-                  hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD, std::nullopt, 0.0},
+                  hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD, std::nullopt, 0.0},
               hipdnn_frontend::DataType::FLOAT,
               {},
               {TypeKey::Y_CONV, TypeKey::Y_BIAS},
@@ -547,7 +547,7 @@ std::vector<ConvolutionBiasActivationTestParam> testParams()
               validConvTestCase4d(),
               TensorLayout::NCHW,
               test_activation_common::ActivTestCase{
-                  hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD, 0.0, 1.0},
+                  hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD, 0.0, 1.0},
               hipdnn_frontend::DataType::FLOAT,
               {},
               {TypeKey::Y_CONV, TypeKey::Y_BIAS},
@@ -557,7 +557,7 @@ std::vector<ConvolutionBiasActivationTestParam> testParams()
               validConvTestCase4d(),
               TensorLayout::NCHW,
               test_activation_common::ActivTestCase{
-                  hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+                  hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
                   std::nullopt,
                   std::nullopt,
                   1.0},
@@ -599,40 +599,40 @@ TEST_F(TestMiopenConvFwdBiasActivPlanBuilder, IsApplicableReturnsFalseForUnsuppo
 {
     {
         auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
-        hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                                  builder.GetSize());
+        hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                         builder.GetSize());
 
         bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
         EXPECT_FALSE(applicable);
     }
     {
         auto builder = hipdnn_test_sdk::utilities::createValidBatchnormBwdGraph();
-        hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                                  builder.GetSize());
+        hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                         builder.GetSize());
 
         bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
         EXPECT_FALSE(applicable);
     }
     {
         auto builder = hipdnn_test_sdk::utilities::createValidConvFwdGraph();
-        hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                                  builder.GetSize());
+        hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                         builder.GetSize());
 
         bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
         EXPECT_FALSE(applicable);
     }
     {
         auto builder = hipdnn_test_sdk::utilities::createValidConvBwdGraph();
-        hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                                  builder.GetSize());
+        hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                         builder.GetSize());
 
         bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
         EXPECT_FALSE(applicable);
     }
     {
         auto builder = hipdnn_test_sdk::utilities::createValidConvWrwGraph();
-        hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                                  builder.GetSize());
+        hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                         builder.GetSize());
 
         bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
         EXPECT_FALSE(applicable);
@@ -678,8 +678,8 @@ TEST_F(TestMiopenConvFwdBiasActivPlanBuilder, GetWorkspaceSizeThrowsForWrongNode
 TEST_F(TestMiopenConvFwdBiasActivPlanBuilder, GetWorkspaceSizeThrowsForUnsupportedGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     HipdnnMiopenSettings settings;
     EXPECT_THROW(_planBuilder.getMaxWorkspaceSize(_dummyHandle, graph, settings),
@@ -713,8 +713,8 @@ TEST_F(TestMiopenConvFwdBiasActivPlanBuilder, BuildPlanThrowsForWrongNodeCountGr
 TEST_F(TestMiopenConvFwdBiasActivPlanBuilder, BuildPlanThrowsForUnsupportedGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     HipdnnMiopenContext ctx;
     MockEngineConfig mockConfig;
 

--- a/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenConvFwdPlan.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenConvFwdPlan.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier:  MIT
 
 #include <gtest/gtest.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 #include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
 #include <miopen/miopen.h>
@@ -28,8 +28,8 @@ TEST(TestConvFwdParams, InitializesAllTensorsFromValidGraph)
 {
     // Create a valid convolution graph
     auto builder = hipdnn_test_sdk::utilities::createValidConvFwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the convolution node and attributes
     const auto& node = graph.getNode(0);
@@ -68,8 +68,8 @@ TEST(TestConvFwdParams, ThrowsOnAssymetricPadding)
                                                                        convPostPadding,
                                                                        convStrides,
                                                                        convDilation);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the convolution node and attributes
     const auto& node = graph.getNode(0);
@@ -103,8 +103,8 @@ TEST(TestConvFwdParams, ThrowsOnInvalidPostPaddingVectorSize)
                                                                        convPostPadding,
                                                                        convStrides,
                                                                        convDilation);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the convolution node and attributes
     const auto& node = graph.getNode(0);
@@ -139,8 +139,8 @@ TEST(TestConvFwdParams, ThrowsOnInvalidPaddingVectorsSize)
                                                                        convPostPadding,
                                                                        convStrides,
                                                                        convDilation);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the convolution node and attributes
     const auto& node = graph.getNode(0);
@@ -174,8 +174,8 @@ TEST(TestConvFwdParams, ThrowsOnInvalidStrideVectorSize)
                                                                        convPostPadding,
                                                                        convStrides,
                                                                        convDilation);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the convolution node and attributes
     const auto& node = graph.getNode(0);
@@ -209,8 +209,8 @@ TEST(TestConvFwdParams, ThrowsOnInvalidDilationVectorSize)
                                                                        convPostPadding,
                                                                        convStrides,
                                                                        convDilation);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the convolution node and attributes
     const auto& node = graph.getNode(0);
@@ -226,8 +226,8 @@ TEST_F(TestGpuConvFwdPlan, CreatesPlanWithValidGraph)
 {
     // Create a valid convolution graph
     auto builder = hipdnn_test_sdk::utilities::createValidConvFwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the convolution node and attributes
     const auto& node = graph.getNode(0);
@@ -265,8 +265,8 @@ TEST_F(TestGpuConvFwdPlan, ThrowsOnInvalidDims)
                                                                        convPostPadding,
                                                                        convStrides,
                                                                        convDilation);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the convolution node and attributes
     const auto& node = graph.getNode(0);
@@ -285,8 +285,8 @@ TEST_F(TestGpuConvFwdPlan, ThrowsOnInvalidDims)
 TEST_F(TestGpuConvFwdPlan, PlanUsesDefaultWorkspaceSizeWhenNoLimitSet)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidConvFwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     auto* attrs = node.attributes_as_ConvolutionFwdAttributes();
@@ -305,8 +305,8 @@ TEST_F(TestGpuConvFwdPlan, PlanUsesDefaultWorkspaceSizeWhenNoLimitSet)
 TEST_F(TestGpuConvFwdPlan, PlanUsesKnobLimitOverDefault)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidConvFwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     auto* attrs = node.attributes_as_ConvolutionFwdAttributes();
@@ -328,7 +328,8 @@ TEST(TestConvFwdParams, AcceptsDeterministicEnabledFlag)
 {
     // Create a valid convolution graph
     auto builder = hipdnn_test_sdk::utilities::createValidConvFwdGraph();
-    hipdnn_plugin_sdk::GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the convolution node and attributes
     const auto& node = graph.getNode(0);

--- a/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenConvPlanBuilder.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenConvPlanBuilder.cpp
@@ -17,7 +17,7 @@
 #include "engines/plans/MiopenConvPlanBuilder.hpp"
 
 using namespace miopen_plugin;
-using namespace hipdnn_data_sdk::flatbuffer_utilities;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 using namespace hipdnn_test_sdk::utilities;
 
 class TestMiopenConvPlanBuilder : public ::testing::Test
@@ -36,7 +36,7 @@ protected:
     }
 
     void executePlan(const hipdnn_plugin_sdk::IPlan<HipdnnMiopenHandle>& plan,
-                     const hipdnn_data_sdk::flatbuffer_utilities::IGraph& graph)
+                     const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& graph)
     {
         size_t workspaceSize = plan.getWorkspaceSize(_handle);
         hipdnn_data_sdk::utilities::Workspace workspace(workspaceSize);
@@ -49,10 +49,11 @@ protected:
         {
             if(!tensorAttrPtr->virtual_())
             {
-                auto dims = hipdnn_data_sdk::utilities::convertFlatBufferVectorToStdVector(
+                auto dims = hipdnn_flatbuffers_sdk::utilities::convertFlatBufferVectorToStdVector(
                     tensorAttrPtr->dims());
-                auto strides = hipdnn_data_sdk::utilities::convertFlatBufferVectorToStdVector(
-                    tensorAttrPtr->strides());
+                auto strides
+                    = hipdnn_flatbuffers_sdk::utilities::convertFlatBufferVectorToStdVector(
+                        tensorAttrPtr->strides());
 
                 auto tensor = hipdnn_test_sdk::detail::createTensor(
                     tensorAttrPtr->data_type(), dims, strides);
@@ -83,8 +84,8 @@ TEST_F(TestMiopenConvPlanBuilder, IsApplicableReturnsFalseForMultiNodeGraph)
 TEST_F(TestMiopenConvPlanBuilder, IsApplicableReturnsFalseForUnsupportedGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
     EXPECT_FALSE(applicable);
@@ -94,8 +95,8 @@ TEST_F(TestGpuMiopenConvPlanBuilder, IsApplicableReturnsTrueForSupportedGraph)
 {
     {
         auto builder = hipdnn_test_sdk::utilities::createValidConvFwdGraph();
-        hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                                  builder.GetSize());
+        hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                         builder.GetSize());
 
         bool applicable = _planBuilder.isApplicable(_handle, graph);
         EXPECT_TRUE(applicable);
@@ -103,8 +104,8 @@ TEST_F(TestGpuMiopenConvPlanBuilder, IsApplicableReturnsTrueForSupportedGraph)
 
     {
         auto builder = hipdnn_test_sdk::utilities::createValidConvBwdGraph();
-        hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                                  builder.GetSize());
+        hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                         builder.GetSize());
 
         bool applicable = _planBuilder.isApplicable(_handle, graph);
         EXPECT_TRUE(applicable);
@@ -112,8 +113,8 @@ TEST_F(TestGpuMiopenConvPlanBuilder, IsApplicableReturnsTrueForSupportedGraph)
 
     {
         auto builder = hipdnn_test_sdk::utilities::createValidConvWrwGraph();
-        hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                                  builder.GetSize());
+        hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                         builder.GetSize());
 
         bool applicable = _planBuilder.isApplicable(_handle, graph);
         EXPECT_TRUE(applicable);
@@ -142,8 +143,8 @@ TEST_F(TestMiopenConvPlanBuilder, GetWorkspaceSizeRangeThrowsForMultiNodeGraph)
 TEST_F(TestMiopenConvPlanBuilder, GetWorkspaceSizeThrowsForUnsupportedGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     HipdnnMiopenSettings settings;
     EXPECT_THROW(_planBuilder.getMaxWorkspaceSize(_dummyHandle, graph, settings),
@@ -153,8 +154,8 @@ TEST_F(TestMiopenConvPlanBuilder, GetWorkspaceSizeThrowsForUnsupportedGraph)
 TEST_F(TestMiopenConvPlanBuilder, GetWorkspaceSizeRangeThrowsForUnsupportedGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     EXPECT_THROW(_planBuilder.getWorkspaceSizeRange(_dummyHandle, graph),
                  hipdnn_plugin_sdk::HipdnnPluginException);
@@ -164,8 +165,8 @@ TEST_F(TestGpuMiopenConvPlanBuilder, GetWorkspaceSizeReturnsValueForSupportedGra
 {
     {
         auto builder = hipdnn_test_sdk::utilities::createValidConvFwdGraph();
-        hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                                  builder.GetSize());
+        hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                         builder.GetSize());
 
         HipdnnMiopenSettings settings;
         EXPECT_NO_THROW(_planBuilder.getMaxWorkspaceSize(_handle, graph, settings));
@@ -173,8 +174,8 @@ TEST_F(TestGpuMiopenConvPlanBuilder, GetWorkspaceSizeReturnsValueForSupportedGra
 
     {
         auto builder = hipdnn_test_sdk::utilities::createValidConvBwdGraph();
-        hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                                  builder.GetSize());
+        hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                         builder.GetSize());
 
         HipdnnMiopenSettings settings;
         EXPECT_NO_THROW(_planBuilder.getMaxWorkspaceSize(_handle, graph, settings));
@@ -182,8 +183,8 @@ TEST_F(TestGpuMiopenConvPlanBuilder, GetWorkspaceSizeReturnsValueForSupportedGra
 
     {
         auto builder = hipdnn_test_sdk::utilities::createValidConvWrwGraph();
-        hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                                  builder.GetSize());
+        hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                         builder.GetSize());
 
         HipdnnMiopenSettings settings;
         EXPECT_NO_THROW(_planBuilder.getMaxWorkspaceSize(_handle, graph, settings));
@@ -205,8 +206,8 @@ TEST_F(TestMiopenConvPlanBuilder, BuildPlanThrowsForMultiNodeGraph)
 TEST_F(TestMiopenConvPlanBuilder, BuildPlanThrowsForUnsupportedGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     MockEngineConfig mockEngineConfig;
     HipdnnMiopenContext ctx;
 
@@ -220,12 +221,13 @@ TEST_F(TestMiopenConvPlanBuilder, IsApplicableReturnsFalseForUnsupportedComputeT
     flatbuffers::FlatBufferBuilder builder
         = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
 
-    auto mutableGraph = hipdnn_data_sdk::data_objects::GetMutableGraph(builder.GetBufferPointer());
+    auto mutableGraph
+        = hipdnn_flatbuffers_sdk::data_objects::GetMutableGraph(builder.GetBufferPointer());
     mutableGraph->mutable_nodes()->GetMutableObject(0)->mutate_compute_data_type(
-        hipdnn_data_sdk::data_objects::DataType::HALF);
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF);
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
     EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
 }
 
@@ -233,8 +235,8 @@ TEST_F(TestGpuMiopenConvPlanBuilder, BuildPlanCreatesValidPlanForSupportedGraph)
 {
     {
         auto builder = hipdnn_test_sdk::utilities::createValidConvFwdGraph();
-        hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                                  builder.GetSize());
+        hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                         builder.GetSize());
         MockEngineConfig mockEngineConfig;
         HipdnnMiopenContext ctx;
 
@@ -244,8 +246,8 @@ TEST_F(TestGpuMiopenConvPlanBuilder, BuildPlanCreatesValidPlanForSupportedGraph)
 
     {
         auto builder = hipdnn_test_sdk::utilities::createValidConvBwdGraph();
-        hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                                  builder.GetSize());
+        hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                         builder.GetSize());
         MockEngineConfig mockEngineConfig;
         HipdnnMiopenContext ctx;
 
@@ -255,8 +257,8 @@ TEST_F(TestGpuMiopenConvPlanBuilder, BuildPlanCreatesValidPlanForSupportedGraph)
 
     {
         auto builder = hipdnn_test_sdk::utilities::createValidConvWrwGraph();
-        hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                                  builder.GetSize());
+        hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                         builder.GetSize());
         MockEngineConfig mockEngineConfig;
         HipdnnMiopenContext ctx;
 
@@ -268,8 +270,8 @@ TEST_F(TestGpuMiopenConvPlanBuilder, BuildPlanCreatesValidPlanForSupportedGraph)
 TEST_F(TestGpuMiopenConvPlanBuilder, ActualWorkspaceSizeIsWithinRangeFwd)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidConvFwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     auto range = _planBuilder.getWorkspaceSizeRange(_handle, graph);
 
@@ -286,8 +288,8 @@ TEST_F(TestGpuMiopenConvPlanBuilder, ActualWorkspaceSizeIsWithinRangeFwd)
 TEST_F(TestGpuMiopenConvPlanBuilder, ActualWorkspaceSizeIsWithinRangeBwd)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidConvBwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     auto range = _planBuilder.getWorkspaceSizeRange(_handle, graph);
 
@@ -304,8 +306,8 @@ TEST_F(TestGpuMiopenConvPlanBuilder, ActualWorkspaceSizeIsWithinRangeBwd)
 TEST_F(TestGpuMiopenConvPlanBuilder, ActualWorkspaceSizeIsWithinRangeWrw)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidConvWrwGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     auto range = _planBuilder.getWorkspaceSizeRange(_handle, graph);
 
@@ -343,8 +345,8 @@ TEST_F(TestGpuMiopenConvPlanBuilder, PlanExecutesWithMinWorkspaceLimitFwd)
                                                                        convPostPadding,
                                                                        convStrides,
                                                                        convDilation);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     auto range = _planBuilder.getWorkspaceSizeRange(_handle, graph);
     ASSERT_NE(range.min, range.max) << "No workspace size range available for testing";
@@ -388,8 +390,8 @@ TEST_F(TestGpuMiopenConvPlanBuilder, PlanExecutesWithMinWorkspaceLimitBwd)
                                                                        convPostPadding,
                                                                        convStrides,
                                                                        convDilation);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     auto range = _planBuilder.getWorkspaceSizeRange(_handle, graph);
     ASSERT_NE(range.min, range.max) << "No workspace size range available for testing";
@@ -433,8 +435,8 @@ TEST_F(TestGpuMiopenConvPlanBuilder, PlanExecutesWithMinWorkspaceLimitWrw)
                                                                        convPostPadding,
                                                                        convStrides,
                                                                        convDilation);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     auto range = _planBuilder.getWorkspaceSizeRange(_handle, graph);
     ASSERT_NE(range.min, range.max) << "No workspace size range available for testing";
@@ -457,8 +459,8 @@ TEST_F(TestGpuMiopenConvPlanBuilder, PlanExecutesWithMinWorkspaceLimitWrw)
 TEST_F(TestGpuMiopenConvPlanBuilder, GetCustomKnobsReturnsWorkspaceSizeLimitKnob)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidConvFwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     auto customKnobs = _planBuilder.getCustomKnobs(_handle, graph);
     const auto range = _planBuilder.getWorkspaceSizeRange(_handle, graph);
@@ -466,7 +468,7 @@ TEST_F(TestGpuMiopenConvPlanBuilder, GetCustomKnobsReturnsWorkspaceSizeLimitKnob
     auto workspaceKnobIt
         = std::find_if(customKnobs.begin(),
                        customKnobs.end(),
-                       [](const hipdnn_data_sdk::data_objects::KnobT& knob) {
+                       [](const hipdnn_flatbuffers_sdk::data_objects::KnobT& knob) {
                            return knob.knob_id == hipdnn_plugin_sdk::WORKSPACE_SIZE_LIMIT_KNOB_NAME;
                        });
 
@@ -501,30 +503,31 @@ TEST_F(TestGpuMiopenConvPlanBuilder,
        InitializeExecutionSettingsThrowsOnInvalidWorkspaceSizeLimitKnobType)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidConvFwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     flatbuffers::FlatBufferBuilder configBuilder;
     auto knobIdOffset = configBuilder.CreateString("global.workspace_size_limit");
     auto stringValueOffset = configBuilder.CreateString("invalid_value");
     auto knobValue
-        = hipdnn_data_sdk::data_objects::CreateStringValue(configBuilder, stringValueOffset);
-    hipdnn_data_sdk::data_objects::KnobSettingBuilder knobSettingBuilder(configBuilder);
+        = hipdnn_flatbuffers_sdk::data_objects::CreateStringValue(configBuilder, stringValueOffset);
+    hipdnn_flatbuffers_sdk::data_objects::KnobSettingBuilder knobSettingBuilder(configBuilder);
     knobSettingBuilder.add_knob_id(knobIdOffset);
-    knobSettingBuilder.add_value_type(hipdnn_data_sdk::data_objects::KnobValue::StringValue);
+    knobSettingBuilder.add_value_type(hipdnn_flatbuffers_sdk::data_objects::KnobValue::StringValue);
     knobSettingBuilder.add_value(knobValue.Union());
     auto knobSetting = knobSettingBuilder.Finish();
 
-    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::KnobSetting>> knobsVector;
+    std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::KnobSetting>> knobsVector;
     knobsVector.push_back(knobSetting);
     auto knobs = configBuilder.CreateVector(knobsVector);
 
-    auto engineConfig = hipdnn_data_sdk::data_objects::CreateEngineConfig(configBuilder, 1, knobs);
+    auto engineConfig
+        = hipdnn_flatbuffers_sdk::data_objects::CreateEngineConfig(configBuilder, 1, knobs);
     configBuilder.Finish(engineConfig);
 
     auto buffer = configBuilder.Release();
-    hipdnn_data_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
-                                                                             buffer.size());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
+                                                                                    buffer.size());
 
     HipdnnMiopenSettings executionSettings;
     EXPECT_THROW(
@@ -535,28 +538,29 @@ TEST_F(TestGpuMiopenConvPlanBuilder,
 TEST_F(TestGpuMiopenConvPlanBuilder, InitializeExecutionSettingsThrowsOnNegativeWorkspaceSizeLimit)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidConvFwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     flatbuffers::FlatBufferBuilder configBuilder;
     auto knobIdOffset = configBuilder.CreateString("global.workspace_size_limit");
-    auto knobValue = hipdnn_data_sdk::data_objects::CreateIntValue(configBuilder, -1);
-    hipdnn_data_sdk::data_objects::KnobSettingBuilder knobSettingBuilder(configBuilder);
+    auto knobValue = hipdnn_flatbuffers_sdk::data_objects::CreateIntValue(configBuilder, -1);
+    hipdnn_flatbuffers_sdk::data_objects::KnobSettingBuilder knobSettingBuilder(configBuilder);
     knobSettingBuilder.add_knob_id(knobIdOffset);
-    knobSettingBuilder.add_value_type(hipdnn_data_sdk::data_objects::KnobValue::IntValue);
+    knobSettingBuilder.add_value_type(hipdnn_flatbuffers_sdk::data_objects::KnobValue::IntValue);
     knobSettingBuilder.add_value(knobValue.Union());
     auto knobSetting = knobSettingBuilder.Finish();
 
-    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::KnobSetting>> knobsVector;
+    std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::KnobSetting>> knobsVector;
     knobsVector.push_back(knobSetting);
     auto knobs = configBuilder.CreateVector(knobsVector);
 
-    auto engineConfig = hipdnn_data_sdk::data_objects::CreateEngineConfig(configBuilder, 1, knobs);
+    auto engineConfig
+        = hipdnn_flatbuffers_sdk::data_objects::CreateEngineConfig(configBuilder, 1, knobs);
     configBuilder.Finish(engineConfig);
 
     auto buffer = configBuilder.Release();
-    hipdnn_data_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
-                                                                             buffer.size());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
+                                                                                    buffer.size());
 
     HipdnnMiopenSettings executionSettings;
     EXPECT_THROW(
@@ -568,8 +572,8 @@ TEST_F(TestGpuMiopenConvPlanBuilder,
        InitializeExecutionSettingsThrowsOnWorkspaceSizeLimitBelowRange)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidConvFwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto range = _planBuilder.getWorkspaceSizeRange(_handle, graph);
 
@@ -581,24 +585,25 @@ TEST_F(TestGpuMiopenConvPlanBuilder,
 
     flatbuffers::FlatBufferBuilder configBuilder;
     auto knobIdOffset = configBuilder.CreateString("global.workspace_size_limit");
-    auto knobValue = hipdnn_data_sdk::data_objects::CreateIntValue(
+    auto knobValue = hipdnn_flatbuffers_sdk::data_objects::CreateIntValue(
         configBuilder, static_cast<int64_t>(range.min) - 1);
-    hipdnn_data_sdk::data_objects::KnobSettingBuilder knobSettingBuilder(configBuilder);
+    hipdnn_flatbuffers_sdk::data_objects::KnobSettingBuilder knobSettingBuilder(configBuilder);
     knobSettingBuilder.add_knob_id(knobIdOffset);
-    knobSettingBuilder.add_value_type(hipdnn_data_sdk::data_objects::KnobValue::IntValue);
+    knobSettingBuilder.add_value_type(hipdnn_flatbuffers_sdk::data_objects::KnobValue::IntValue);
     knobSettingBuilder.add_value(knobValue.Union());
     auto knobSetting = knobSettingBuilder.Finish();
 
-    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::KnobSetting>> knobsVector;
+    std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::KnobSetting>> knobsVector;
     knobsVector.push_back(knobSetting);
     auto knobs = configBuilder.CreateVector(knobsVector);
 
-    auto engineConfig = hipdnn_data_sdk::data_objects::CreateEngineConfig(configBuilder, 1, knobs);
+    auto engineConfig
+        = hipdnn_flatbuffers_sdk::data_objects::CreateEngineConfig(configBuilder, 1, knobs);
     configBuilder.Finish(engineConfig);
 
     auto buffer = configBuilder.Release();
-    hipdnn_data_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
-                                                                             buffer.size());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
+                                                                                    buffer.size());
 
     HipdnnMiopenSettings executionSettings;
     EXPECT_THROW(
@@ -610,8 +615,8 @@ TEST_F(TestGpuMiopenConvPlanBuilder,
        InitializeExecutionSettingsThrowsOnWorkspaceSizeLimitAboveRange)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidConvFwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto range = _planBuilder.getWorkspaceSizeRange(_handle, graph);
 
@@ -622,24 +627,25 @@ TEST_F(TestGpuMiopenConvPlanBuilder,
 
     flatbuffers::FlatBufferBuilder configBuilder;
     auto knobIdOffset = configBuilder.CreateString("global.workspace_size_limit");
-    auto knobValue = hipdnn_data_sdk::data_objects::CreateIntValue(
+    auto knobValue = hipdnn_flatbuffers_sdk::data_objects::CreateIntValue(
         configBuilder, static_cast<int64_t>(range.max) + 1);
-    hipdnn_data_sdk::data_objects::KnobSettingBuilder knobSettingBuilder(configBuilder);
+    hipdnn_flatbuffers_sdk::data_objects::KnobSettingBuilder knobSettingBuilder(configBuilder);
     knobSettingBuilder.add_knob_id(knobIdOffset);
-    knobSettingBuilder.add_value_type(hipdnn_data_sdk::data_objects::KnobValue::IntValue);
+    knobSettingBuilder.add_value_type(hipdnn_flatbuffers_sdk::data_objects::KnobValue::IntValue);
     knobSettingBuilder.add_value(knobValue.Union());
     auto knobSetting = knobSettingBuilder.Finish();
 
-    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::KnobSetting>> knobsVector;
+    std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::KnobSetting>> knobsVector;
     knobsVector.push_back(knobSetting);
     auto knobs = configBuilder.CreateVector(knobsVector);
 
-    auto engineConfig = hipdnn_data_sdk::data_objects::CreateEngineConfig(configBuilder, 1, knobs);
+    auto engineConfig
+        = hipdnn_flatbuffers_sdk::data_objects::CreateEngineConfig(configBuilder, 1, knobs);
     configBuilder.Finish(engineConfig);
 
     auto buffer = configBuilder.Release();
-    hipdnn_data_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
-                                                                             buffer.size());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
+                                                                                    buffer.size());
 
     HipdnnMiopenSettings executionSettings;
     EXPECT_THROW(
@@ -650,32 +656,33 @@ TEST_F(TestGpuMiopenConvPlanBuilder,
 TEST_F(TestGpuMiopenConvPlanBuilder, InitializeExecutionSettingsSetsWorkspaceSizeLimit)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidConvFwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto range = _planBuilder.getWorkspaceSizeRange(_handle, graph);
     const auto testWorkspaceSize = range.min + ((range.max - range.min) / 2);
 
     flatbuffers::FlatBufferBuilder configBuilder;
     auto knobIdOffset = configBuilder.CreateString("global.workspace_size_limit");
-    auto knobValue = hipdnn_data_sdk::data_objects::CreateIntValue(
+    auto knobValue = hipdnn_flatbuffers_sdk::data_objects::CreateIntValue(
         configBuilder, static_cast<int64_t>(testWorkspaceSize));
-    hipdnn_data_sdk::data_objects::KnobSettingBuilder knobSettingBuilder(configBuilder);
+    hipdnn_flatbuffers_sdk::data_objects::KnobSettingBuilder knobSettingBuilder(configBuilder);
     knobSettingBuilder.add_knob_id(knobIdOffset);
-    knobSettingBuilder.add_value_type(hipdnn_data_sdk::data_objects::KnobValue::IntValue);
+    knobSettingBuilder.add_value_type(hipdnn_flatbuffers_sdk::data_objects::KnobValue::IntValue);
     knobSettingBuilder.add_value(knobValue.Union());
     auto knobSetting = knobSettingBuilder.Finish();
 
-    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::KnobSetting>> knobsVector;
+    std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::KnobSetting>> knobsVector;
     knobsVector.push_back(knobSetting);
     auto knobs = configBuilder.CreateVector(knobsVector);
 
-    auto engineConfig = hipdnn_data_sdk::data_objects::CreateEngineConfig(configBuilder, 1, knobs);
+    auto engineConfig
+        = hipdnn_flatbuffers_sdk::data_objects::CreateEngineConfig(configBuilder, 1, knobs);
     configBuilder.Finish(engineConfig);
 
     auto buffer = configBuilder.Release();
-    hipdnn_data_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
-                                                                             buffer.size());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
+                                                                                    buffer.size());
 
     HipdnnMiopenSettings executionSettings;
     EXPECT_NO_THROW(
@@ -698,16 +705,17 @@ TEST_F(TestGpuMiopenConvPlanBuilder,
        InitializeExecutionSettingsDefaultsWorkspaceSizeLimitWhenNoKnob)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidConvFwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     flatbuffers::FlatBufferBuilder configBuilder;
-    auto engineConfig = hipdnn_data_sdk::data_objects::CreateEngineConfig(configBuilder, 1, 0);
+    auto engineConfig
+        = hipdnn_flatbuffers_sdk::data_objects::CreateEngineConfig(configBuilder, 1, 0);
     configBuilder.Finish(engineConfig);
 
     auto buffer = configBuilder.Release();
-    hipdnn_data_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
-                                                                             buffer.size());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
+                                                                                    buffer.size());
 
     HipdnnMiopenSettings executionSettings;
     EXPECT_NO_THROW(
@@ -724,16 +732,17 @@ TEST_F(TestGpuMiopenConvPlanBuilder,
 TEST_F(TestGpuMiopenConvPlanBuilder, InitializeExecutionSettingsSetsDefaultWorkspaceSize)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidConvFwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     flatbuffers::FlatBufferBuilder configBuilder;
-    auto engineConfig = hipdnn_data_sdk::data_objects::CreateEngineConfig(configBuilder, 1, 0);
+    auto engineConfig
+        = hipdnn_flatbuffers_sdk::data_objects::CreateEngineConfig(configBuilder, 1, 0);
     configBuilder.Finish(engineConfig);
 
     auto buffer = configBuilder.Release();
-    hipdnn_data_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
-                                                                             buffer.size());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
+                                                                                    buffer.size());
 
     HipdnnMiopenSettings settings;
     _planBuilder.initializeExecutionSettings(_handle, graph, configWrapper, settings);
@@ -750,31 +759,32 @@ TEST_F(TestGpuMiopenConvPlanBuilder, InitializeExecutionSettingsSetsDefaultWorks
 TEST_F(TestGpuMiopenConvPlanBuilder, InitializeExecutionSettingsSetDefaultWhenLimitIsSet)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidConvFwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto range = _planBuilder.getWorkspaceSizeRange(_handle, graph);
 
     flatbuffers::FlatBufferBuilder configBuilder;
     auto knobIdOffset = configBuilder.CreateString("global.workspace_size_limit");
-    auto knobValue = hipdnn_data_sdk::data_objects::CreateIntValue(configBuilder,
-                                                                   static_cast<int64_t>(range.max));
-    hipdnn_data_sdk::data_objects::KnobSettingBuilder knobSettingBuilder(configBuilder);
+    auto knobValue = hipdnn_flatbuffers_sdk::data_objects::CreateIntValue(
+        configBuilder, static_cast<int64_t>(range.max));
+    hipdnn_flatbuffers_sdk::data_objects::KnobSettingBuilder knobSettingBuilder(configBuilder);
     knobSettingBuilder.add_knob_id(knobIdOffset);
-    knobSettingBuilder.add_value_type(hipdnn_data_sdk::data_objects::KnobValue::IntValue);
+    knobSettingBuilder.add_value_type(hipdnn_flatbuffers_sdk::data_objects::KnobValue::IntValue);
     knobSettingBuilder.add_value(knobValue.Union());
     auto knobSetting = knobSettingBuilder.Finish();
 
-    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::KnobSetting>> knobsVector;
+    std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::KnobSetting>> knobsVector;
     knobsVector.push_back(knobSetting);
     auto knobs = configBuilder.CreateVector(knobsVector);
 
-    auto engineConfig = hipdnn_data_sdk::data_objects::CreateEngineConfig(configBuilder, 1, knobs);
+    auto engineConfig
+        = hipdnn_flatbuffers_sdk::data_objects::CreateEngineConfig(configBuilder, 1, knobs);
     configBuilder.Finish(engineConfig);
 
     auto buffer = configBuilder.Release();
-    hipdnn_data_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
-                                                                             buffer.size());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
+                                                                                    buffer.size());
 
     HipdnnMiopenSettings settings;
     _planBuilder.initializeExecutionSettings(_handle, graph, configWrapper, settings);
@@ -785,8 +795,8 @@ TEST_F(TestGpuMiopenConvPlanBuilder, InitializeExecutionSettingsSetDefaultWhenLi
 TEST_F(TestGpuMiopenConvPlanBuilder, GetMaxWorkspaceSizeReturnsCachedDefault)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidConvFwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const size_t cachedValue = 42;
     HipdnnMiopenSettings settings;
@@ -827,16 +837,17 @@ TEST(TestHipdnnMiopenSettings, SelectedWorkspaceSizeReturnsLimitWhenBothSet)
 TEST_F(TestGpuMiopenConvPlanBuilder, InitializeExecutionSettingsSetsDefaultWorkspaceSizeBwd)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidConvBwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     flatbuffers::FlatBufferBuilder configBuilder;
-    auto engineConfig = hipdnn_data_sdk::data_objects::CreateEngineConfig(configBuilder, 1, 0);
+    auto engineConfig
+        = hipdnn_flatbuffers_sdk::data_objects::CreateEngineConfig(configBuilder, 1, 0);
     configBuilder.Finish(engineConfig);
 
     auto buffer = configBuilder.Release();
-    hipdnn_data_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
-                                                                             buffer.size());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
+                                                                                    buffer.size());
 
     HipdnnMiopenSettings settings;
     _planBuilder.initializeExecutionSettings(_handle, graph, configWrapper, settings);
@@ -853,16 +864,17 @@ TEST_F(TestGpuMiopenConvPlanBuilder, InitializeExecutionSettingsSetsDefaultWorks
 TEST_F(TestGpuMiopenConvPlanBuilder, InitializeExecutionSettingsSetsDefaultWorkspaceSizeWrw)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidConvWrwGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     flatbuffers::FlatBufferBuilder configBuilder;
-    auto engineConfig = hipdnn_data_sdk::data_objects::CreateEngineConfig(configBuilder, 1, 0);
+    auto engineConfig
+        = hipdnn_flatbuffers_sdk::data_objects::CreateEngineConfig(configBuilder, 1, 0);
     configBuilder.Finish(engineConfig);
 
     auto buffer = configBuilder.Release();
-    hipdnn_data_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
-                                                                             buffer.size());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
+                                                                                    buffer.size());
 
     HipdnnMiopenSettings settings;
     _planBuilder.initializeExecutionSettings(_handle, graph, configWrapper, settings);
@@ -879,8 +891,8 @@ TEST_F(TestGpuMiopenConvPlanBuilder, InitializeExecutionSettingsSetsDefaultWorks
 TEST_F(TestGpuMiopenConvPlanBuilder, GetMaxWorkspaceSizeReturnsCachedDefaultBwd)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidConvBwdGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const size_t cachedValue = 42;
     HipdnnMiopenSettings settings;
@@ -893,8 +905,8 @@ TEST_F(TestGpuMiopenConvPlanBuilder, GetMaxWorkspaceSizeReturnsCachedDefaultBwd)
 TEST_F(TestGpuMiopenConvPlanBuilder, GetMaxWorkspaceSizeReturnsCachedDefaultWrw)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidConvWrwGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const size_t cachedValue = 42;
     HipdnnMiopenSettings settings;

--- a/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenConvWrwPlan.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenConvWrwPlan.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier:  MIT
 
 #include <gtest/gtest.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 #include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
 #include <miopen/miopen.h>
@@ -28,8 +28,8 @@ TEST(TestConvWrwParams, InitializesAllTensorsFromValidGraph)
 {
     // Create a valid convolution graph
     auto builder = hipdnn_test_sdk::utilities::createValidConvWrwGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the convolution node and attributes
     const auto& node = graph.getNode(0);
@@ -68,8 +68,8 @@ TEST(TestConvWrwParams, ThrowsOnAssymetricPadding)
                                                                        convPostPadding,
                                                                        convStrides,
                                                                        convDilation);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the convolution node and attributes
     const auto& node = graph.getNode(0);
@@ -103,8 +103,8 @@ TEST(TestConvWrwParams, ThrowsOnInvalidPostPaddingVectorSize)
                                                                        convPostPadding,
                                                                        convStrides,
                                                                        convDilation);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the convolution node and attributes
     const auto& node = graph.getNode(0);
@@ -139,8 +139,8 @@ TEST(TestConvWrwParams, ThrowsOnInvalidPaddingVectorsSize)
                                                                        convPostPadding,
                                                                        convStrides,
                                                                        convDilation);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the convolution node and attributes
     const auto& node = graph.getNode(0);
@@ -174,8 +174,8 @@ TEST(TestConvWrwParams, ThrowsOnInvalidStrideVectorSize)
                                                                        convPostPadding,
                                                                        convStrides,
                                                                        convDilation);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the convolution node and attributes
     const auto& node = graph.getNode(0);
@@ -209,8 +209,8 @@ TEST(TestConvWrwParams, ThrowsOnInvalidDilationVectorSize)
                                                                        convPostPadding,
                                                                        convStrides,
                                                                        convDilation);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the convolution node and attributes
     const auto& node = graph.getNode(0);
@@ -226,8 +226,8 @@ TEST_F(TestGpuConvWrwPlan, CreatesPlanWithValidGraph)
 {
     // Create a valid convolution graph
     auto builder = hipdnn_test_sdk::utilities::createValidConvWrwGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the convolution node and attributes
     const auto& node = graph.getNode(0);
@@ -245,8 +245,8 @@ TEST_F(TestGpuConvWrwPlan, CreatesPlanWithValidGraph)
 TEST_F(TestGpuConvWrwPlan, PlanUsesDefaultWorkspaceSizeWhenNoLimitSet)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidConvWrwGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     auto* attrs = node.attributes_as_ConvolutionWrwAttributes();
@@ -265,8 +265,8 @@ TEST_F(TestGpuConvWrwPlan, PlanUsesDefaultWorkspaceSizeWhenNoLimitSet)
 TEST_F(TestGpuConvWrwPlan, PlanUsesKnobLimitOverDefault)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidConvWrwGraph();
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     const auto& node = graph.getNode(0);
     auto* attrs = node.attributes_as_ConvolutionWrwAttributes();
@@ -307,8 +307,8 @@ TEST_F(TestGpuConvWrwPlan, ThrowsOnInvalidDims)
                                                                        convPostPadding,
                                                                        convStrides,
                                                                        convDilation);
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
-                                                              builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
 
     // Get the convolution node and attributes
     const auto& node = graph.getNode(0);

--- a/dnn-providers/miopen-provider/tests/mocks/MockEngine.hpp
+++ b/dnn-providers/miopen-provider/tests/mocks/MockEngine.hpp
@@ -24,26 +24,26 @@ public:
     MOCK_METHOD(bool,
                 isApplicable,
                 (HipdnnMiopenHandle & handle,
-                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph),
+                 const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph),
                 (const, override));
     MOCK_METHOD(void,
                 getDetails,
                 (HipdnnMiopenHandle & handle,
-                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                 const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                  hipdnnPluginConstData_t& detailsOut),
                 (const, override));
     MOCK_METHOD(size_t,
                 getMaxWorkspaceSize,
                 (const HipdnnMiopenHandle& handle,
-                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-                 const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig),
+                 const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+                 const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig),
                 (const, override));
 
     MOCK_METHOD(void,
                 initializeExecutionContext,
                 (const HipdnnMiopenHandle& handle,
-                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-                 const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+                 const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+                 const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
                  HipdnnMiopenContext& executionContext),
                 (const, override));
 };

--- a/dnn-providers/miopen-provider/tests/mocks/MockPlanBuilder.hpp
+++ b/dnn-providers/miopen-provider/tests/mocks/MockPlanBuilder.hpp
@@ -5,7 +5,7 @@
 
 #include <gmock/gmock.h>
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_plugin_sdk/interfaces/IPlanBuilder.hpp>
 
 #include "HipdnnMiopenContext.hpp"
@@ -23,35 +23,35 @@ public:
     MOCK_METHOD(bool,
                 isApplicable,
                 (const HipdnnMiopenHandle& handle,
-                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph),
+                 const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph),
                 (const, override));
     MOCK_METHOD(size_t,
                 getMaxWorkspaceSize,
                 (const HipdnnMiopenHandle& handle,
-                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                 const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                  const HipdnnMiopenSettings& executionSettings),
                 (const, override));
 
     MOCK_METHOD(void,
                 initializeExecutionSettings,
                 (const HipdnnMiopenHandle& handle,
-                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-                 const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+                 const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+                 const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
                  HipdnnMiopenSettings& executionSettings),
                 (const, override));
 
     MOCK_METHOD(void,
                 buildPlan,
                 (const HipdnnMiopenHandle& handle,
-                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-                 const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+                 const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+                 const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
                  HipdnnMiopenContext& executionContext),
                 (const, override));
 
-    MOCK_METHOD((std::vector<hipdnn_data_sdk::data_objects::KnobT>),
+    MOCK_METHOD((std::vector<hipdnn_flatbuffers_sdk::data_objects::KnobT>),
                 getCustomKnobs,
                 (const HipdnnMiopenHandle& handle,
-                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph),
+                 const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph),
                 (const, override));
 };
 

--- a/projects/hipdnn/plugin_sdk/CMakeLists.txt
+++ b/projects/hipdnn/plugin_sdk/CMakeLists.txt
@@ -19,7 +19,7 @@ add_library(hipdnn_plugin_sdk INTERFACE)
 # Generate version header
 hipdnn_generate_version_header(hipdnn_plugin_sdk)
 
-target_link_libraries(hipdnn_plugin_sdk INTERFACE hipdnn_data_sdk)
+target_link_libraries(hipdnn_plugin_sdk INTERFACE hipdnn_flatbuffers_sdk hipdnn_data_sdk)
 
 set(HIP_DNN_PLUGIN_SDK_INSTALL_INCLUDE_DIR "${CMAKE_INSTALL_INCLUDEDIR}/hipdnn/plugin_sdk")
 

--- a/projects/hipdnn/plugin_sdk/cmake/hipdnn_plugin_sdkConfig.cmake.in
+++ b/projects/hipdnn/plugin_sdk/cmake/hipdnn_plugin_sdkConfig.cmake.in
@@ -4,6 +4,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
+find_dependency(hipdnn_flatbuffers_sdk CONFIG REQUIRED)
 find_dependency(hipdnn_data_sdk @HIPDNN_PLUGIN_SDK_DATA_SDK_MIN_VERSION@ CONFIG REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/hipdnn_plugin_sdkTargets.cmake")

--- a/projects/hipdnn/plugin_sdk/include/hipdnn_plugin_sdk/EngineManager.hpp
+++ b/projects/hipdnn/plugin_sdk/include/hipdnn_plugin_sdk/EngineManager.hpp
@@ -8,8 +8,8 @@
 #include <unordered_map>
 #include <vector>
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 #include <hipdnn_plugin_sdk/interfaces/IEngine.hpp>
@@ -40,8 +40,8 @@ class EngineManager
 {
 public:
     using Engine = IEngine<THandle, TSettings, TContext>;
-    using IGraph = hipdnn_data_sdk::flatbuffer_utilities::IGraph;
-    using IEngineConfig = hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig;
+    using IGraph = hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph;
+    using IEngineConfig = hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig;
 
     EngineManager() = default;
     virtual ~EngineManager() = default;

--- a/projects/hipdnn/plugin_sdk/include/hipdnn_plugin_sdk/EnginePluginImpl.inl
+++ b/projects/hipdnn/plugin_sdk/include/hipdnn_plugin_sdk/EnginePluginImpl.inl
@@ -79,8 +79,8 @@
 
 #include <hip/hip_runtime.h>
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_data_sdk/logging/Logger.hpp>
 #include <hipdnn_plugin_sdk/EngineManager.hpp>
 #include <hipdnn_plugin_sdk/EnginePluginApi.h>
@@ -303,7 +303,7 @@ hipdnnPluginStatus_t
 
         auto* typedHandle = static_cast<HIPDNN_PLUGIN_HANDLE_TYPE*>(handle);
         auto& engineManager = typedHandle->getEngineManager();
-        hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper opGraphWrapper(opGraph->ptr,
+        hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper opGraphWrapper(opGraph->ptr,
                                                                            opGraph->size);
 
         auto applicableEngines = engineManager.getApplicableEngineIds(*typedHandle, opGraphWrapper);
@@ -344,7 +344,7 @@ hipdnnPluginStatus_t hipdnnEnginePluginGetEngineDetails(hipdnnEnginePluginHandle
 
         auto* typedHandle = static_cast<HIPDNN_PLUGIN_HANDLE_TYPE*>(handle);
         auto& engineManager = typedHandle->getEngineManager();
-        hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper opGraphWrapper(opGraph->ptr,
+        hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper opGraphWrapper(opGraph->ptr,
                                                                            opGraph->size);
 
         engineManager.getEngineDetails(*typedHandle, opGraphWrapper, engineId, *engineDetails);
@@ -390,9 +390,9 @@ hipdnnPluginStatus_t hipdnnEnginePluginGetWorkspaceSize(hipdnnEnginePluginHandle
         auto* typedHandle = static_cast<HIPDNN_PLUGIN_HANDLE_TYPE*>(handle);
         auto& engineManager = typedHandle->getEngineManager();
 
-        hipdnn_data_sdk::flatbuffer_utilities::EngineConfigWrapper engineConfigWrapper(
+        hipdnn_flatbuffers_sdk::flatbuffer_utilities::EngineConfigWrapper engineConfigWrapper(
             engineConfig->ptr, engineConfig->size);
-        hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper opGraphWrapper(opGraph->ptr,
+        hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper opGraphWrapper(opGraph->ptr,
                                                                            opGraph->size);
         *workspaceSize
             = engineManager.getMaxWorkspaceSize(*typedHandle, opGraphWrapper, engineConfigWrapper);
@@ -420,9 +420,9 @@ hipdnnPluginStatus_t
 
         auto* typedHandle = static_cast<HIPDNN_PLUGIN_HANDLE_TYPE*>(handle);
 
-        hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper opGraphWrapper(opGraph->ptr,
+        hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper opGraphWrapper(opGraph->ptr,
                                                                            opGraph->size);
-        hipdnn_data_sdk::flatbuffer_utilities::EngineConfigWrapper engineConfigWrapper(
+        hipdnn_flatbuffers_sdk::flatbuffer_utilities::EngineConfigWrapper engineConfigWrapper(
             engineConfig->ptr, engineConfig->size);
 
         auto& engineManager = typedHandle->getEngineManager();

--- a/projects/hipdnn/plugin_sdk/include/hipdnn_plugin_sdk/KnobFactory.hpp
+++ b/projects/hipdnn/plugin_sdk/include/hipdnn_plugin_sdk/KnobFactory.hpp
@@ -6,9 +6,9 @@
 #include <string>
 #include <vector>
 
-#include <hipdnn_data_sdk/data_objects/engine_details_generated.h>
-#include <hipdnn_data_sdk/data_objects/knob_value_generated.h>
 #include <hipdnn_data_sdk/utilities/StringUtil.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/engine_details_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/knob_value_generated.h>
 
 namespace hipdnn_plugin_sdk
 {
@@ -16,7 +16,7 @@ namespace hipdnn_plugin_sdk
 class KnobFactory
 {
 public:
-    static flatbuffers::Offset<hipdnn_data_sdk::data_objects::Knob>
+    static flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Knob>
         createIntKnob(flatbuffers::FlatBufferBuilder& builder,
                       const std::string& name,
                       const std::string& description,
@@ -30,23 +30,23 @@ public:
         auto knobIdStr = builder.CreateString(name);
         auto descStr = builder.CreateString(description);
         auto defaultValOffset
-            = hipdnn_data_sdk::data_objects::CreateIntValue(builder, defaultValue);
+            = hipdnn_flatbuffers_sdk::data_objects::CreateIntValue(builder, defaultValue);
         auto optionsVector = builder.CreateVector(options);
-        auto constraintOffset = hipdnn_data_sdk::data_objects::CreateIntConstraint(
+        auto constraintOffset = hipdnn_flatbuffers_sdk::data_objects::CreateIntConstraint(
             builder, min, max, step, optionsVector);
 
-        return hipdnn_data_sdk::data_objects::CreateKnob(
+        return hipdnn_flatbuffers_sdk::data_objects::CreateKnob(
             builder,
             knobIdStr,
             descStr,
-            hipdnn_data_sdk::data_objects::KnobValue::IntValue,
+            hipdnn_flatbuffers_sdk::data_objects::KnobValue::IntValue,
             defaultValOffset.Union(),
-            hipdnn_data_sdk::data_objects::KnobConstraint::IntConstraint,
+            hipdnn_flatbuffers_sdk::data_objects::KnobConstraint::IntConstraint,
             constraintOffset.Union(),
             deprecated);
     }
 
-    static flatbuffers::Offset<hipdnn_data_sdk::data_objects::Knob>
+    static flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Knob>
         createFloatKnob(flatbuffers::FlatBufferBuilder& builder,
                         const std::string& name,
                         const std::string& description,
@@ -57,23 +57,23 @@ public:
     {
         auto knobIdStr = builder.CreateString(name);
         auto descStr = builder.CreateString(description);
-        auto defaultValOffset = hipdnn_data_sdk::data_objects::CreateFloatValue(
+        auto defaultValOffset = hipdnn_flatbuffers_sdk::data_objects::CreateFloatValue(
             builder, static_cast<double>(defaultValue));
-        auto constraintOffset = hipdnn_data_sdk::data_objects::CreateFloatConstraint(
+        auto constraintOffset = hipdnn_flatbuffers_sdk::data_objects::CreateFloatConstraint(
             builder, static_cast<double>(min), static_cast<double>(max));
 
-        return hipdnn_data_sdk::data_objects::CreateKnob(
+        return hipdnn_flatbuffers_sdk::data_objects::CreateKnob(
             builder,
             knobIdStr,
             descStr,
-            hipdnn_data_sdk::data_objects::KnobValue::FloatValue,
+            hipdnn_flatbuffers_sdk::data_objects::KnobValue::FloatValue,
             defaultValOffset.Union(),
-            hipdnn_data_sdk::data_objects::KnobConstraint::FloatConstraint,
+            hipdnn_flatbuffers_sdk::data_objects::KnobConstraint::FloatConstraint,
             constraintOffset.Union(),
             deprecated);
     }
 
-    static flatbuffers::Offset<hipdnn_data_sdk::data_objects::Knob>
+    static flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Knob>
         createStringKnob(flatbuffers::FlatBufferBuilder& builder,
                          const std::string& name,
                          const std::string& description,
@@ -85,7 +85,7 @@ public:
         auto descStr = builder.CreateString(description);
         auto defaultValStr = builder.CreateString(defaultValue);
         auto defaultValOffset
-            = hipdnn_data_sdk::data_objects::CreateStringValue(builder, defaultValStr);
+            = hipdnn_flatbuffers_sdk::data_objects::CreateStringValue(builder, defaultValStr);
 
         std::vector<flatbuffers::Offset<flatbuffers::String>> optionsOffsets;
         optionsOffsets.reserve(options.size());
@@ -94,16 +94,16 @@ public:
             optionsOffsets.push_back(builder.CreateString(opt));
         }
         auto optionsVector = builder.CreateVector(optionsOffsets);
-        auto constraintOffset
-            = hipdnn_data_sdk::data_objects::CreateStringConstraint(builder, 0, optionsVector);
+        auto constraintOffset = hipdnn_flatbuffers_sdk::data_objects::CreateStringConstraint(
+            builder, 0, optionsVector);
 
-        return hipdnn_data_sdk::data_objects::CreateKnob(
+        return hipdnn_flatbuffers_sdk::data_objects::CreateKnob(
             builder,
             knobIdStr,
             descStr,
-            hipdnn_data_sdk::data_objects::KnobValue::StringValue,
+            hipdnn_flatbuffers_sdk::data_objects::KnobValue::StringValue,
             defaultValOffset.Union(),
-            hipdnn_data_sdk::data_objects::KnobConstraint::StringConstraint,
+            hipdnn_flatbuffers_sdk::data_objects::KnobConstraint::StringConstraint,
             constraintOffset.Union(),
             deprecated);
     }

--- a/projects/hipdnn/plugin_sdk/include/hipdnn_plugin_sdk/KnobSettingFactory.hpp
+++ b/projects/hipdnn/plugin_sdk/include/hipdnn_plugin_sdk/KnobSettingFactory.hpp
@@ -5,8 +5,8 @@
 
 #include <string>
 
-#include <hipdnn_data_sdk/data_objects/engine_config_generated.h>
-#include <hipdnn_data_sdk/data_objects/knob_value_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/engine_config_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/knob_value_generated.h>
 
 namespace hipdnn_plugin_sdk
 {
@@ -19,11 +19,11 @@ public:
     {
         flatbuffers::FlatBufferBuilder builder;
         auto knobIdOffset = builder.CreateString(knobId);
-        auto intValue = hipdnn_data_sdk::data_objects::CreateIntValue(builder, value);
-        auto knobSetting = hipdnn_data_sdk::data_objects::CreateKnobSetting(
+        auto intValue = hipdnn_flatbuffers_sdk::data_objects::CreateIntValue(builder, value);
+        auto knobSetting = hipdnn_flatbuffers_sdk::data_objects::CreateKnobSetting(
             builder,
             knobIdOffset,
-            hipdnn_data_sdk::data_objects::KnobValue::IntValue,
+            hipdnn_flatbuffers_sdk::data_objects::KnobValue::IntValue,
             intValue.Union());
         builder.Finish(knobSetting);
         return builder.Release();
@@ -34,11 +34,11 @@ public:
     {
         flatbuffers::FlatBufferBuilder builder;
         auto knobIdOffset = builder.CreateString(knobId);
-        auto floatValue = hipdnn_data_sdk::data_objects::CreateFloatValue(builder, value);
-        auto knobSetting = hipdnn_data_sdk::data_objects::CreateKnobSetting(
+        auto floatValue = hipdnn_flatbuffers_sdk::data_objects::CreateFloatValue(builder, value);
+        auto knobSetting = hipdnn_flatbuffers_sdk::data_objects::CreateKnobSetting(
             builder,
             knobIdOffset,
-            hipdnn_data_sdk::data_objects::KnobValue::FloatValue,
+            hipdnn_flatbuffers_sdk::data_objects::KnobValue::FloatValue,
             floatValue.Union());
         builder.Finish(knobSetting);
         return builder.Release();
@@ -51,11 +51,11 @@ public:
         auto knobIdOffset = builder.CreateString(knobId);
         auto strValueOffset = builder.CreateString(value);
         auto stringValue
-            = hipdnn_data_sdk::data_objects::CreateStringValue(builder, strValueOffset);
-        auto knobSetting = hipdnn_data_sdk::data_objects::CreateKnobSetting(
+            = hipdnn_flatbuffers_sdk::data_objects::CreateStringValue(builder, strValueOffset);
+        auto knobSetting = hipdnn_flatbuffers_sdk::data_objects::CreateKnobSetting(
             builder,
             knobIdOffset,
-            hipdnn_data_sdk::data_objects::KnobValue::StringValue,
+            hipdnn_flatbuffers_sdk::data_objects::KnobValue::StringValue,
             stringValue.Union());
         builder.Finish(knobSetting);
         return builder.Release();

--- a/projects/hipdnn/plugin_sdk/include/hipdnn_plugin_sdk/PluginGraphTestUtils.hpp
+++ b/projects/hipdnn/plugin_sdk/include/hipdnn_plugin_sdk/PluginGraphTestUtils.hpp
@@ -5,10 +5,10 @@
 
 #include <optional>
 
-#include <hipdnn_data_sdk/data_objects/engine_config_generated.h>
-#include <hipdnn_data_sdk/data_objects/engine_details_generated.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
 #include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/engine_config_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/engine_details_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
 
 namespace hipdnn_plugin_sdk

--- a/projects/hipdnn/plugin_sdk/include/hipdnn_plugin_sdk/interfaces/IEngine.hpp
+++ b/projects/hipdnn/plugin_sdk/include/hipdnn_plugin_sdk/interfaces/IEngine.hpp
@@ -7,8 +7,8 @@
 #include <cstdint>
 #include <memory>
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
 #include <hipdnn_plugin_sdk/interfaces/IPlan.hpp>
 
@@ -61,8 +61,9 @@ public:
      *
      */
     // NOLINTNEXTLINE(portability-template-virtual-member-function)
-    virtual bool isApplicable(THandle& handle,
-                              const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+    virtual bool isApplicable( // NOLINT(portability-template-virtual-member-function)
+        THandle& handle,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
         = 0;
 
     /**
@@ -80,7 +81,7 @@ public:
      */
     // NOLINTNEXTLINE(portability-template-virtual-member-function)
     virtual void getDetails(THandle& handle,
-                            const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                            const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                             hipdnnPluginConstData_t& detailsOut) const
         = 0;
 
@@ -99,8 +100,8 @@ public:
         // NOLINTNEXTLINE(portability-template-virtual-member-function)
         getMaxWorkspaceSize(
             const THandle& handle,
-            const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-            const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig) const
+            const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+            const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig) const
         = 0;
 
     /**
@@ -120,8 +121,8 @@ public:
     // NOLINTNEXTLINE(portability-template-virtual-member-function)
     virtual void initializeExecutionContext(
         const THandle& handle,
-        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-        const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
         TContext& executionContext) const
         = 0;
 };

--- a/projects/hipdnn/plugin_sdk/include/hipdnn_plugin_sdk/interfaces/IPlanBuilder.hpp
+++ b/projects/hipdnn/plugin_sdk/include/hipdnn_plugin_sdk/interfaces/IPlanBuilder.hpp
@@ -7,9 +7,9 @@
 #include <memory>
 #include <vector>
 
-#include <hipdnn_data_sdk/data_objects/knob_value_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/knob_value_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
 #include <hipdnn_plugin_sdk/interfaces/IPlan.hpp>
 
@@ -49,8 +49,9 @@ public:
      * @return true if this plan builder can handle the graph, false otherwise.
      */
     // NOLINTNEXTLINE(portability-template-virtual-member-function)
-    virtual bool isApplicable(const THandle& handle,
-                              const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+    virtual bool
+        isApplicable(const THandle& handle,
+                     const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
         = 0;
 
     /**
@@ -62,9 +63,10 @@ public:
      * @return The maximum workspace size in bytes.
      */
     // NOLINTNEXTLINE(portability-template-virtual-member-function)
-    virtual size_t getMaxWorkspaceSize(const THandle& handle,
-                                       const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-                                       const TSettings& executionSettings) const
+    virtual size_t
+        getMaxWorkspaceSize(const THandle& handle,
+                            const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+                            const TSettings& executionSettings) const
         = 0;
 
     /**
@@ -78,8 +80,8 @@ public:
     // NOLINTNEXTLINE(portability-template-virtual-member-function)
     virtual void initializeExecutionSettings(
         const THandle& handle,
-        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-        const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
         TSettings& executionSettings) const
         = 0;
 
@@ -99,8 +101,9 @@ public:
     // NOLINTNEXTLINE(portability-template-virtual-member-function)
     virtual void buildPlan(
         const THandle& handle,
-        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-        [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+        [[maybe_unused]] const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig&
+            engineConfig,
         TContext& executionContext) const
         = 0;
 
@@ -114,10 +117,10 @@ public:
      * @param opGraph The operation graph.
      * @return A vector of KnobT objects representing the custom knobs.
      */
-    virtual std::vector<hipdnn_data_sdk::data_objects::KnobT>
+    virtual std::vector<hipdnn_flatbuffers_sdk::data_objects::KnobT>
         // NOLINTNEXTLINE(portability-template-virtual-member-function)
         getCustomKnobs(const THandle& handle,
-                       const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+                       const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
         = 0;
 };
 

--- a/projects/hipdnn/plugin_sdk/tests/TestEngineManager.cpp
+++ b/projects/hipdnn/plugin_sdk/tests/TestEngineManager.cpp
@@ -4,7 +4,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
 #include <hipdnn_plugin_sdk/EngineManager.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 #include <hipdnn_test_sdk/utilities/MockEngineConfig.hpp>
@@ -49,29 +49,30 @@ public:
 
     bool isApplicable(
         TestHandle& /*handle*/,
-        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& /*opGraph*/) const override
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& /*opGraph*/) const override
     {
         return _applicable;
     }
 
     void getDetails(TestHandle& /*handle*/,
-                    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& /*opGraph*/,
+                    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& /*opGraph*/,
                     hipdnnPluginConstData_t& /*detailsOut*/) const override
     {
     }
 
     size_t getMaxWorkspaceSize(
         const TestHandle& /*handle*/,
-        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& /*opGraph*/,
-        const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& /*engineConfig*/) const override
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& /*opGraph*/,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& /*engineConfig*/)
+        const override
     {
         return _workspaceSize;
     }
 
     void initializeExecutionContext(
         const TestHandle& /*handle*/,
-        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& /*opGraph*/,
-        const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& /*engineConfig*/,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& /*opGraph*/,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& /*engineConfig*/,
         TestContext& /*executionContext*/) const override
     {
     }

--- a/projects/hipdnn/plugin_sdk/tests/TestKnobFactory.cpp
+++ b/projects/hipdnn/plugin_sdk/tests/TestKnobFactory.cpp
@@ -14,15 +14,16 @@ TEST(TestKnobFactory, CreateIntKnob)
         = KnobFactory::createIntKnob(builder, "int_knob", "description", 10, 0, 100, 1, options);
     builder.Finish(knob);
 
-    auto root
-        = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(builder.GetBufferPointer());
+    auto root = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::Knob>(
+        builder.GetBufferPointer());
 
     EXPECT_STREQ(root->knob_id()->c_str(), "int_knob");
     EXPECT_STREQ(root->description()->c_str(), "description");
-    EXPECT_EQ(root->default_value_type(), hipdnn_data_sdk::data_objects::KnobValue::IntValue);
+    EXPECT_EQ(root->default_value_type(),
+              hipdnn_flatbuffers_sdk::data_objects::KnobValue::IntValue);
     EXPECT_EQ(root->default_value_as_IntValue()->value(), 10);
     EXPECT_EQ(root->constraint_type(),
-              hipdnn_data_sdk::data_objects::KnobConstraint::IntConstraint);
+              hipdnn_flatbuffers_sdk::data_objects::KnobConstraint::IntConstraint);
     EXPECT_EQ(root->constraint_as_IntConstraint()->min_value(), 0);
     EXPECT_EQ(root->constraint_as_IntConstraint()->max_value(), 100);
     EXPECT_EQ(root->constraint_as_IntConstraint()->step(), 1);
@@ -43,8 +44,8 @@ TEST(TestKnobFactory, CreateIntKnobDeprecated)
         builder, "deprecated_int_knob", "deprecated description", 5, 0, 10, 1, options, true);
     builder.Finish(knob);
 
-    auto root
-        = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(builder.GetBufferPointer());
+    auto root = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::Knob>(
+        builder.GetBufferPointer());
 
     EXPECT_STREQ(root->knob_id()->c_str(), "deprecated_int_knob");
     EXPECT_TRUE(root->deprecated());
@@ -57,15 +58,16 @@ TEST(TestKnobFactory, CreateFloatKnob)
         = KnobFactory::createFloatKnob(builder, "float_knob", "description", 1.5f, 0.0f, 10.0f);
     builder.Finish(knob);
 
-    auto root
-        = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(builder.GetBufferPointer());
+    auto root = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::Knob>(
+        builder.GetBufferPointer());
 
     EXPECT_STREQ(root->knob_id()->c_str(), "float_knob");
     EXPECT_STREQ(root->description()->c_str(), "description");
-    EXPECT_EQ(root->default_value_type(), hipdnn_data_sdk::data_objects::KnobValue::FloatValue);
+    EXPECT_EQ(root->default_value_type(),
+              hipdnn_flatbuffers_sdk::data_objects::KnobValue::FloatValue);
     EXPECT_FLOAT_EQ(root->default_value_as_FloatValue()->value(), 1.5f);
     EXPECT_EQ(root->constraint_type(),
-              hipdnn_data_sdk::data_objects::KnobConstraint::FloatConstraint);
+              hipdnn_flatbuffers_sdk::data_objects::KnobConstraint::FloatConstraint);
     EXPECT_FLOAT_EQ(root->constraint_as_FloatConstraint()->min_value(), 0.0f);
     EXPECT_FLOAT_EQ(root->constraint_as_FloatConstraint()->max_value(), 10.0f);
     EXPECT_FALSE(root->deprecated());
@@ -78,8 +80,8 @@ TEST(TestKnobFactory, CreateFloatKnobDeprecated)
         builder, "deprecated_float_knob", "deprecated description", 0.5f, 0.0f, 1.0f, true);
     builder.Finish(knob);
 
-    auto root
-        = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(builder.GetBufferPointer());
+    auto root = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::Knob>(
+        builder.GetBufferPointer());
 
     EXPECT_STREQ(root->knob_id()->c_str(), "deprecated_float_knob");
     EXPECT_TRUE(root->deprecated());
@@ -93,15 +95,16 @@ TEST(TestKnobFactory, CreateStringKnob)
         = KnobFactory::createStringKnob(builder, "string_knob", "description", "option1", options);
     builder.Finish(knob);
 
-    auto root
-        = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(builder.GetBufferPointer());
+    auto root = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::Knob>(
+        builder.GetBufferPointer());
 
     EXPECT_STREQ(root->knob_id()->c_str(), "string_knob");
     EXPECT_STREQ(root->description()->c_str(), "description");
-    EXPECT_EQ(root->default_value_type(), hipdnn_data_sdk::data_objects::KnobValue::StringValue);
+    EXPECT_EQ(root->default_value_type(),
+              hipdnn_flatbuffers_sdk::data_objects::KnobValue::StringValue);
     EXPECT_STREQ(root->default_value_as_StringValue()->value()->c_str(), "option1");
     EXPECT_EQ(root->constraint_type(),
-              hipdnn_data_sdk::data_objects::KnobConstraint::StringConstraint);
+              hipdnn_flatbuffers_sdk::data_objects::KnobConstraint::StringConstraint);
     EXPECT_FALSE(root->deprecated());
 
     auto validValues = root->constraint_as_StringConstraint()->valid_values();
@@ -118,8 +121,8 @@ TEST(TestKnobFactory, CreateStringKnobDeprecated)
         builder, "deprecated_string_knob", "deprecated description", "a", options, true);
     builder.Finish(knob);
 
-    auto root
-        = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(builder.GetBufferPointer());
+    auto root = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::Knob>(
+        builder.GetBufferPointer());
 
     EXPECT_STREQ(root->knob_id()->c_str(), "deprecated_string_knob");
     EXPECT_TRUE(root->deprecated());

--- a/projects/hipdnn/plugin_sdk/tests/TestKnobSettingFactory.cpp
+++ b/projects/hipdnn/plugin_sdk/tests/TestKnobSettingFactory.cpp
@@ -10,10 +10,11 @@ TEST(TestKnobSettingFactory, CreateIntKnobSetting)
 {
     auto buffer = KnobSettingFactory::createIntKnobSetting("test.int_knob", 42);
 
-    auto root = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::KnobSetting>(buffer.data());
+    auto root
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::KnobSetting>(buffer.data());
 
     EXPECT_STREQ(root->knob_id()->c_str(), "test.int_knob");
-    EXPECT_EQ(root->value_type(), hipdnn_data_sdk::data_objects::KnobValue::IntValue);
+    EXPECT_EQ(root->value_type(), hipdnn_flatbuffers_sdk::data_objects::KnobValue::IntValue);
     EXPECT_EQ(root->value_as_IntValue()->value(), 42);
 }
 
@@ -21,7 +22,8 @@ TEST(TestKnobSettingFactory, CreateIntKnobSettingNegativeValue)
 {
     auto buffer = KnobSettingFactory::createIntKnobSetting("negative_knob", -100);
 
-    auto root = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::KnobSetting>(buffer.data());
+    auto root
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::KnobSetting>(buffer.data());
 
     EXPECT_STREQ(root->knob_id()->c_str(), "negative_knob");
     EXPECT_EQ(root->value_as_IntValue()->value(), -100);
@@ -31,10 +33,11 @@ TEST(TestKnobSettingFactory, CreateFloatKnobSetting)
 {
     auto buffer = KnobSettingFactory::createFloatKnobSetting("test.float_knob", 3.14159);
 
-    auto root = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::KnobSetting>(buffer.data());
+    auto root
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::KnobSetting>(buffer.data());
 
     EXPECT_STREQ(root->knob_id()->c_str(), "test.float_knob");
-    EXPECT_EQ(root->value_type(), hipdnn_data_sdk::data_objects::KnobValue::FloatValue);
+    EXPECT_EQ(root->value_type(), hipdnn_flatbuffers_sdk::data_objects::KnobValue::FloatValue);
     EXPECT_DOUBLE_EQ(root->value_as_FloatValue()->value(), 3.14159);
 }
 
@@ -42,7 +45,8 @@ TEST(TestKnobSettingFactory, CreateFloatKnobSettingZeroValue)
 {
     auto buffer = KnobSettingFactory::createFloatKnobSetting("zero_knob", 0.0);
 
-    auto root = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::KnobSetting>(buffer.data());
+    auto root
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::KnobSetting>(buffer.data());
 
     EXPECT_STREQ(root->knob_id()->c_str(), "zero_knob");
     EXPECT_DOUBLE_EQ(root->value_as_FloatValue()->value(), 0.0);
@@ -52,10 +56,11 @@ TEST(TestKnobSettingFactory, CreateStringKnobSetting)
 {
     auto buffer = KnobSettingFactory::createStringKnobSetting("test.string_knob", "fast");
 
-    auto root = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::KnobSetting>(buffer.data());
+    auto root
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::KnobSetting>(buffer.data());
 
     EXPECT_STREQ(root->knob_id()->c_str(), "test.string_knob");
-    EXPECT_EQ(root->value_type(), hipdnn_data_sdk::data_objects::KnobValue::StringValue);
+    EXPECT_EQ(root->value_type(), hipdnn_flatbuffers_sdk::data_objects::KnobValue::StringValue);
     EXPECT_STREQ(root->value_as_StringValue()->value()->c_str(), "fast");
 }
 
@@ -63,7 +68,8 @@ TEST(TestKnobSettingFactory, CreateStringKnobSettingEmptyValue)
 {
     auto buffer = KnobSettingFactory::createStringKnobSetting("empty_knob", "");
 
-    auto root = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::KnobSetting>(buffer.data());
+    auto root
+        = flatbuffers::GetRoot<hipdnn_flatbuffers_sdk::data_objects::KnobSetting>(buffer.data());
 
     EXPECT_STREQ(root->knob_id()->c_str(), "empty_knob");
     EXPECT_STREQ(root->value_as_StringValue()->value()->c_str(), "");

--- a/projects/hipdnn/test_sdk/CMakeLists.txt
+++ b/projects/hipdnn/test_sdk/CMakeLists.txt
@@ -20,7 +20,7 @@ add_library(hipdnn_test_sdk INTERFACE)
 hipdnn_generate_version_header(hipdnn_test_sdk)
 
 find_package(hip REQUIRED)
-target_link_libraries(hipdnn_test_sdk INTERFACE hipdnn_data_sdk hipdnn_frontend hip::host)
+target_link_libraries(hipdnn_test_sdk INTERFACE hipdnn_flatbuffers_sdk hipdnn_frontend hip::host)
 
 set(HIP_DNN_TEST_SDK_INSTALL_INCLUDE_DIR "${CMAKE_INSTALL_INCLUDEDIR}/hipdnn/test_sdk")
 

--- a/projects/hipdnn/test_sdk/cmake/hipdnn_test_sdkConfig.cmake.in
+++ b/projects/hipdnn/test_sdk/cmake/hipdnn_test_sdkConfig.cmake.in
@@ -4,6 +4,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
+find_dependency(hipdnn_flatbuffers_sdk CONFIG REQUIRED)
 find_dependency(hipdnn_data_sdk @HIPDNN_TEST_SDK_DATA_SDK_MIN_VERSION@ CONFIG REQUIRED)
 find_dependency(hipdnn_frontend CONFIG REQUIRED)
 

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceConvolution.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceConvolution.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_test_sdk/utilities/ConvolutionValidation.hpp>
 #include <hipdnn_test_sdk/utilities/detail/CpuFpReferenceUtilities.hpp>
 #include <stdexcept>
@@ -18,9 +18,9 @@ class CpuFpReferenceConvolution
 {
 public:
     // Check if this CPU implementation supports the given node configuration
-    static bool isApplicable(const hipdnn_data_sdk::data_objects::Node& node)
+    static bool isApplicable(const hipdnn_flatbuffers_sdk::data_objects::Node& node)
     {
-        using namespace hipdnn_data_sdk::data_objects;
+        using namespace hipdnn_flatbuffers_sdk::data_objects;
 
         bool validNode = (node.attributes_type() == NodeAttributes::ConvolutionFwdAttributes
                           || node.attributes_type() == NodeAttributes::ConvolutionBwdAttributes);

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceMatmul.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceMatmul.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_test_sdk/utilities/detail/CpuFpReferenceUtilities.hpp>
 
 #include <algorithm>
@@ -17,9 +17,9 @@ class CpuFpReferenceMatmul
 {
 public:
     // Check if this CPU implementation supports the given node configuration
-    static bool isApplicable(const hipdnn_data_sdk::data_objects::Node& node)
+    static bool isApplicable(const hipdnn_flatbuffers_sdk::data_objects::Node& node)
     {
-        using namespace hipdnn_data_sdk::data_objects;
+        using namespace hipdnn_flatbuffers_sdk::data_objects;
         return node.attributes_type() == NodeAttributes::MatmulAttributes;
     }
 

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceMiopenRmsValidation.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceMiopenRmsValidation.hpp
@@ -3,10 +3,10 @@
 
 #pragma once
 
-#include <hipdnn_data_sdk/data_objects/data_types_generated.h>
 #include <hipdnn_data_sdk/logging/Logger.hpp>
 #include <hipdnn_data_sdk/types.hpp>
 #include <hipdnn_data_sdk/utilities/TensorView.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/data_types_generated.h>
 #include <hipdnn_test_sdk/utilities/ReferenceValidationInterface.hpp>
 #include <hipdnn_test_sdk/utilities/VectorLoggingUtils.hpp>
 #include <hipdnn_test_sdk/utilities/detail/CpuFpReferenceUtilities.hpp>
@@ -147,20 +147,21 @@ private:
 };
 
 inline std::unique_ptr<hipdnn_test_sdk::utilities::IReferenceValidation>
-    createRmsValidator(hipdnn_data_sdk::data_objects::DataType dataType, float relativeTolerance)
+    createRmsValidator(hipdnn_flatbuffers_sdk::data_objects::DataType dataType,
+                       float relativeTolerance)
 {
     switch(dataType)
     {
-    case hipdnn_data_sdk::data_objects::DataType::FLOAT:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT:
         return std::make_unique<CpuFpReferenceMiopenRmsValidation<float>>(relativeTolerance);
-    case hipdnn_data_sdk::data_objects::DataType::HALF:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::HALF:
         return std::make_unique<CpuFpReferenceMiopenRmsValidation<hipdnn_data_sdk::types::half>>(
             hipdnn_data_sdk::types::half(relativeTolerance));
-    case hipdnn_data_sdk::data_objects::DataType::BFLOAT16:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16:
         return std::make_unique<
             CpuFpReferenceMiopenRmsValidation<hipdnn_data_sdk::types::bfloat16>>(
             hipdnn_data_sdk::types::bfloat16(relativeTolerance));
-    case hipdnn_data_sdk::data_objects::DataType::DOUBLE:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::DOUBLE:
         return std::make_unique<CpuFpReferenceMiopenRmsValidation<double>>(
             static_cast<double>(relativeTolerance));
     default:

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceReduction.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceReduction.hpp
@@ -4,9 +4,9 @@
 #pragma once
 
 #include <cstddef>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/data_objects/reduction_attributes_generated.h>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/reduction_attributes_generated.h>
 #include <hipdnn_test_sdk/utilities/detail/CpuFpReferenceUtilities.hpp>
 
 #include <algorithm>
@@ -21,16 +21,16 @@ namespace hipdnn_test_sdk::utilities
 class CpuFpReferenceReduction
 {
 public:
-    static bool isApplicable(const hipdnn_data_sdk::data_objects::Node& node)
+    static bool isApplicable(const hipdnn_flatbuffers_sdk::data_objects::Node& node)
     {
-        using namespace hipdnn_data_sdk::data_objects;
+        using namespace hipdnn_flatbuffers_sdk::data_objects;
         return node.attributes_type() == NodeAttributes::ReductionAttributes;
     }
 
     template <class XDataType, class YDataType, class ComputeDataType = float>
     static void reduce(const hipdnn_data_sdk::utilities::TensorBase<XDataType>& x,
                        hipdnn_data_sdk::utilities::TensorBase<YDataType>& y,
-                       hipdnn_data_sdk::data_objects::ReductionMode mode)
+                       hipdnn_flatbuffers_sdk::data_objects::ReductionMode mode)
     {
         validateInput(x, y);
         // Validate mode is supported/set.
@@ -178,9 +178,9 @@ private:
     }
 
     template <class ComputeDataType>
-    static ComputeDataType initAccumulator(hipdnn_data_sdk::data_objects::ReductionMode mode)
+    static ComputeDataType initAccumulator(hipdnn_flatbuffers_sdk::data_objects::ReductionMode mode)
     {
-        using hipdnn_data_sdk::data_objects::ReductionMode;
+        using hipdnn_flatbuffers_sdk::data_objects::ReductionMode;
         switch(mode)
         {
         case ReductionMode::ADD:
@@ -204,9 +204,9 @@ private:
     template <class ComputeDataType>
     static void accumulate(ComputeDataType& acc,
                            ComputeDataType val,
-                           hipdnn_data_sdk::data_objects::ReductionMode mode)
+                           hipdnn_flatbuffers_sdk::data_objects::ReductionMode mode)
     {
-        using hipdnn_data_sdk::data_objects::ReductionMode;
+        using hipdnn_flatbuffers_sdk::data_objects::ReductionMode;
         switch(mode)
         {
         case ReductionMode::ADD:
@@ -245,9 +245,9 @@ private:
     template <class ComputeDataType>
     static ComputeDataType finalize(ComputeDataType acc,
                                     int64_t count,
-                                    hipdnn_data_sdk::data_objects::ReductionMode mode)
+                                    hipdnn_flatbuffers_sdk::data_objects::ReductionMode mode)
     {
-        using hipdnn_data_sdk::data_objects::ReductionMode;
+        using hipdnn_flatbuffers_sdk::data_objects::ReductionMode;
         switch(mode)
         {
         case ReductionMode::AVG:

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp
@@ -3,10 +3,10 @@
 
 #pragma once
 
-#include <hipdnn_data_sdk/data_objects/data_types_generated.h>
 #include <hipdnn_data_sdk/logging/Logger.hpp>
 #include <hipdnn_data_sdk/types.hpp>
 #include <hipdnn_data_sdk/utilities/TensorView.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/data_types_generated.h>
 #include <hipdnn_test_sdk/utilities/ReferenceValidationInterface.hpp>
 #include <hipdnn_test_sdk/utilities/VectorLoggingUtils.hpp>
 #include <hipdnn_test_sdk/utilities/detail/CpuFpReferenceUtilities.hpp>
@@ -161,29 +161,29 @@ public:
 };
 
 inline std::unique_ptr<hipdnn_test_sdk::utilities::IReferenceValidation>
-    createAllCloseValidator(hipdnn_data_sdk::data_objects::DataType dataType,
+    createAllCloseValidator(hipdnn_flatbuffers_sdk::data_objects::DataType dataType,
                             float absoluteTolerance = std::numeric_limits<float>::epsilon(),
                             float relativeTolerance = std::numeric_limits<float>::epsilon())
 {
     switch(dataType)
     {
-    case hipdnn_data_sdk::data_objects::DataType::FLOAT:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT:
         return std::make_unique<CpuFpReferenceValidation<float>>(absoluteTolerance,
                                                                  relativeTolerance);
-    case hipdnn_data_sdk::data_objects::DataType::HALF:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::HALF:
         return std::make_unique<CpuFpReferenceValidation<hipdnn_data_sdk::types::half>>(
             absoluteTolerance, relativeTolerance);
-    case hipdnn_data_sdk::data_objects::DataType::BFLOAT16:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16:
         return std::make_unique<CpuFpReferenceValidation<hipdnn_data_sdk::types::bfloat16>>(
             absoluteTolerance, relativeTolerance);
-    case hipdnn_data_sdk::data_objects::DataType::DOUBLE:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::DOUBLE:
         return std::make_unique<CpuFpReferenceValidation<double>>(absoluteTolerance,
                                                                   relativeTolerance);
-    case hipdnn_data_sdk::data_objects::DataType::INT8:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::INT8:
         return std::make_unique<CpuIntReferenceValidation<int8_t>>();
-    case hipdnn_data_sdk::data_objects::DataType::UINT8:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::UINT8:
         return std::make_unique<CpuIntReferenceValidation<uint8_t>>();
-    case hipdnn_data_sdk::data_objects::DataType::INT32:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::INT32:
         return std::make_unique<CpuIntReferenceValidation<int32_t>>();
     default:
         throw std::runtime_error("Unsupported data type for allClose validator");

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/FlatbufferDatatypeMapping.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/FlatbufferDatatypeMapping.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <hipdnn_data_sdk/data_objects/data_types_generated.h>
 #include <hipdnn_data_sdk/types.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/data_types_generated.h>
 
 namespace hipdnn_test_sdk::utilities
 {
@@ -15,10 +15,10 @@ using hipdnn_data_sdk::types::half;
 namespace hipdnn_test_sdk::utilities
 {
 
-template <hipdnn_data_sdk::data_objects::DataType DT>
+template <hipdnn_flatbuffers_sdk::data_objects::DataType DT>
 constexpr auto datatypeToNative()
 {
-    using DataType = hipdnn_data_sdk::data_objects::DataType;
+    using DataType = hipdnn_flatbuffers_sdk::data_objects::DataType;
 
     if constexpr(DT == DataType::FLOAT)
     {
@@ -48,9 +48,9 @@ constexpr auto datatypeToNative()
 }
 
 inline std::variant<float, half, double, int32_t, bfloat16>
-    datatypeToNativeVariant(hipdnn_data_sdk::data_objects::DataType type)
+    datatypeToNativeVariant(hipdnn_flatbuffers_sdk::data_objects::DataType type)
 {
-    using DataType = hipdnn_data_sdk::data_objects::DataType;
+    using DataType = hipdnn_flatbuffers_sdk::data_objects::DataType;
 
     switch(type)
     {
@@ -75,27 +75,27 @@ inline std::variant<float, half, double, int32_t, bfloat16>
 }
 
 template <typename T>
-constexpr hipdnn_data_sdk::data_objects::DataType nativeTypeToDataType()
+constexpr hipdnn_flatbuffers_sdk::data_objects::DataType nativeTypeToDataType()
 {
     if constexpr(std::is_same_v<T, float>)
     {
-        return hipdnn_data_sdk::data_objects::DataType::FLOAT;
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT;
     }
     else if constexpr(std::is_same_v<T, half>)
     {
-        return hipdnn_data_sdk::data_objects::DataType::HALF;
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::HALF;
     }
     else if constexpr(std::is_same_v<T, double>)
     {
-        return hipdnn_data_sdk::data_objects::DataType::DOUBLE;
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::DOUBLE;
     }
     else if constexpr(std::is_same_v<T, int32_t>)
     {
-        return hipdnn_data_sdk::data_objects::DataType::INT32;
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::INT32;
     }
     else if constexpr(std::is_same_v<T, bfloat16>)
     {
-        return hipdnn_data_sdk::data_objects::DataType::BFLOAT16;
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16;
     }
     else
     {
@@ -103,7 +103,7 @@ constexpr hipdnn_data_sdk::data_objects::DataType nativeTypeToDataType()
     }
 }
 
-template <hipdnn_data_sdk::data_objects::DataType DT>
+template <hipdnn_flatbuffers_sdk::data_objects::DataType DT>
 using DataTypeToNative = decltype(datatypeToNative<DT>());
 
 template <typename T>

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp
@@ -5,113 +5,112 @@
 
 #include <optional>
 
-#include <hipdnn_data_sdk/data_objects/engine_config_generated.h>
-#include <hipdnn_data_sdk/data_objects/engine_details_generated.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/data_objects/reduction_attributes_generated.h>
 #include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/engine_config_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/engine_details_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/reduction_attributes_generated.h>
 
 namespace hipdnn_test_sdk::utilities
 {
 
 inline flatbuffers::FlatBufferBuilder createEmptyValidGraph()
 {
-    const std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    const std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
-    const std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    const std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
     flatbuffers::FlatBufferBuilder builder;
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
     return builder;
 }
 
-inline flatbuffers::FlatBufferBuilder
-    createValidBatchnormInferenceGraph(const std::vector<int64_t>& strides
-                                       = {150528, 50176, 224, 1},
-                                       const std::vector<int64_t>& dims = {1, 3, 224, 224},
-                                       hipdnn_data_sdk::data_objects::DataType inputDataType
-                                       = hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                                       hipdnn_data_sdk::data_objects::DataType computeDataType
-                                       = hipdnn_data_sdk::data_objects::DataType::FLOAT)
+inline flatbuffers::FlatBufferBuilder createValidBatchnormInferenceGraph(
+    const std::vector<int64_t>& strides = {150528, 50176, 224, 1},
+    const std::vector<int64_t>& dims = {1, 3, 224, 224},
+    hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType
+    = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+    hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType
+    = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     const std::vector<int64_t> derivedDims = hipdnn_data_sdk::utilities::getDerivedShape(dims);
     const std::vector<int64_t> derivedStrides = hipdnn_data_sdk::utilities::generateStrides(
         derivedDims, hipdnn_data_sdk::utilities::extractStrideOrder(strides));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 1, "x", inputDataType, &strides, &dims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 2, "y", inputDataType, &strides, &dims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         3,
         "scale",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         4,
         "bias",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         5,
         "est_mean",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         6,
         "est_variance",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
-    auto bnormAttributes
-        = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(builder,
-                                                                            1, // x uid
-                                                                            5, // mean uid
-                                                                            6, // inv_variance uid
-                                                                            3, // scale uid
-                                                                            4, // bias uid
-                                                                            2 // y uid
-        );
+    auto bnormAttributes = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormInferenceAttributes(
+        builder,
+        1, // x uid
+        5, // mean uid
+        6, // inv_variance uid
+        3, // scale uid
+        4, // bias uid
+        2 // y uid
+    );
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "batchnorm",
         computeDataType,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
         bnormAttributes.Union());
     nodes.push_back(node);
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
@@ -121,73 +120,73 @@ inline flatbuffers::FlatBufferBuilder
 inline flatbuffers::FlatBufferBuilder createValidBatchnormWithVarianceInferenceGraph(
     const std::vector<int64_t>& strides = {150528, 50176, 224, 1},
     const std::vector<int64_t>& dims = {1, 3, 224, 224},
-    hipdnn_data_sdk::data_objects::DataType inputDataType
-    = hipdnn_data_sdk::data_objects::DataType::FLOAT,
-    hipdnn_data_sdk::data_objects::DataType computeDataType
-    = hipdnn_data_sdk::data_objects::DataType::FLOAT)
+    hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType
+    = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+    hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType
+    = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     const std::vector<int64_t> derivedDims = hipdnn_data_sdk::utilities::getDerivedShape(dims);
     const std::vector<int64_t> derivedStrides = hipdnn_data_sdk::utilities::generateStrides(
         derivedDims, hipdnn_data_sdk::utilities::extractStrideOrder(strides));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 1, "x", inputDataType, &strides, &dims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 2, "y", inputDataType, &strides, &dims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         3,
         "scale",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         4,
         "bias",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         5,
         "est_mean",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         6,
         "variance",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
     // Epsilon (pass-by-value)
     const std::vector<int64_t> passByValueDims = {1};
-    const hipdnn_data_sdk::data_objects::Float32Value epsilonVal(1e-5f);
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    const hipdnn_flatbuffers_sdk::data_objects::Float32Value epsilonVal(1e-5f);
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         7,
         "epsilon",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &passByValueDims,
         &passByValueDims,
         false,
-        hipdnn_data_sdk::data_objects::TensorValue::Float32Value,
+        hipdnn_flatbuffers_sdk::data_objects::TensorValue::Float32Value,
         builder.CreateStruct(epsilonVal).Union()));
 
     auto bnormAttributes
-        = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributesVarianceExt(
+        = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormInferenceAttributesVarianceExt(
             builder,
             1, // x uid
             5, // mean uid
@@ -198,21 +197,22 @@ inline flatbuffers::FlatBufferBuilder createValidBatchnormWithVarianceInferenceG
             7 // epsilon uid
         );
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "batchnormWithVariance",
         computeDataType,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributesVarianceExt,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::
+            BatchnormInferenceAttributesVarianceExt,
         bnormAttributes.Union());
     nodes.push_back(node);
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
@@ -222,13 +222,13 @@ inline flatbuffers::FlatBufferBuilder createValidBatchnormWithVarianceInferenceG
 inline flatbuffers::FlatBufferBuilder createValidBatchnormWithVarianceInferenceActivGraph(
     const std::vector<int64_t>& strides = {150528, 50176, 224, 1},
     const std::vector<int64_t>& dims = {1, 3, 224, 224},
-    hipdnn_data_sdk::data_objects::DataType inputDataType
-    = hipdnn_data_sdk::data_objects::DataType::FLOAT,
-    hipdnn_data_sdk::data_objects::DataType computeDataType
-    = hipdnn_data_sdk::data_objects::DataType::FLOAT)
+    hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType
+    = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+    hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType
+    = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     const std::vector<int64_t> derivedDims = hipdnn_data_sdk::utilities::getDerivedShape(dims);
@@ -238,72 +238,72 @@ inline flatbuffers::FlatBufferBuilder createValidBatchnormWithVarianceInferenceA
     int64_t uid = 1;
 
     const auto xUid = uid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, xUid, "x", inputDataType, &strides, &dims));
 
     const auto yBnUid = uid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, yBnUid, "y_bn", inputDataType, &strides, &dims, true)); // virtual
 
     const auto scaleUid = uid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         scaleUid,
         "scale",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
     const auto biasUid = uid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         biasUid,
         "bias",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
     const auto meanUid = uid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         meanUid,
         "est_mean",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
     const auto varUid = uid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         varUid,
         "variance",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
     // Epsilon (pass-by-value)
     const std::vector<int64_t> passByValueDims = {1};
-    const hipdnn_data_sdk::data_objects::Float32Value epsilonVal(1e-5f);
+    const hipdnn_flatbuffers_sdk::data_objects::Float32Value epsilonVal(1e-5f);
     const auto epsUid = uid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         epsUid,
         "epsilon",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &passByValueDims,
         &passByValueDims,
         false,
-        hipdnn_data_sdk::data_objects::TensorValue::Float32Value,
+        hipdnn_flatbuffers_sdk::data_objects::TensorValue::Float32Value,
         builder.CreateStruct(epsilonVal).Union()));
 
     const auto yUid = uid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, yUid, "y", inputDataType, &strides, &dims));
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     auto bnormAttributes
-        = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributesVarianceExt(
+        = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormInferenceAttributesVarianceExt(
             builder,
             xUid,
             meanUid,
@@ -313,16 +313,17 @@ inline flatbuffers::FlatBufferBuilder createValidBatchnormWithVarianceInferenceA
             yBnUid, // Virtual output
             epsUid);
 
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "batchnormWithVariance",
         computeDataType,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributesVarianceExt,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::
+            BatchnormInferenceAttributesVarianceExt,
         bnormAttributes.Union()));
 
-    auto activAttributes = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto activAttributes = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
         flatbuffers::nullopt, // relu_lower_clip
         flatbuffers::nullopt, // relu_upper_clip
         flatbuffers::nullopt, // relu_lower_clip_slope
@@ -332,19 +333,19 @@ inline flatbuffers::FlatBufferBuilder createValidBatchnormWithVarianceInferenceA
         flatbuffers::nullopt, // in_2_tensor_uid
         yUid); // out_0_tensor_uid
 
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "activation",
         computeDataType,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         activAttributes.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
@@ -355,49 +356,51 @@ inline flatbuffers::FlatBufferBuilder
     createValidBatchnormBwdGraph(const std::vector<int64_t>& strides = {150528, 50176, 224, 1},
                                  const std::vector<int64_t>& dims = {1, 3, 224, 224},
                                  bool hasOptionalAttributes = true,
-                                 hipdnn_data_sdk::data_objects::DataType inputDataType
-                                 = hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                                 hipdnn_data_sdk::data_objects::DataType scaleBiasDataType
-                                 = hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                                 hipdnn_data_sdk::data_objects::DataType meanVarianceDataType
-                                 = hipdnn_data_sdk::data_objects::DataType::FLOAT)
+                                 hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType
+                                 = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                                 hipdnn_flatbuffers_sdk::data_objects::DataType scaleBiasDataType
+                                 = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                                 hipdnn_flatbuffers_sdk::data_objects::DataType meanVarianceDataType
+                                 = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     const std::vector<int64_t> derivedDims = hipdnn_data_sdk::utilities::getDerivedShape(dims);
     const std::vector<int64_t> derivedStrides = hipdnn_data_sdk::utilities::generateStrides(
         derivedDims, hipdnn_data_sdk::utilities::extractStrideOrder(strides));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 1, "x", inputDataType, &strides, &dims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 2, "dy", inputDataType, &strides, &dims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 3, "dx", inputDataType, &strides, &dims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 4, "scale", scaleBiasDataType, &derivedStrides, &derivedDims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 5, "dscale", scaleBiasDataType, &derivedStrides, &derivedDims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 6, "dbias", scaleBiasDataType, &derivedStrides, &derivedDims));
 
     if(hasOptionalAttributes)
     {
-        tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-            builder, 7, "mean", meanVarianceDataType, &derivedStrides, &derivedDims));
+        tensorAttributes.push_back(
+            hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+                builder, 7, "mean", meanVarianceDataType, &derivedStrides, &derivedDims));
 
-        tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-            builder, 8, "inv_variance", meanVarianceDataType, &derivedStrides, &derivedDims));
+        tensorAttributes.push_back(
+            hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+                builder, 8, "inv_variance", meanVarianceDataType, &derivedStrides, &derivedDims));
     }
 
-    auto bnormAttributes = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+    auto bnormAttributes = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormBackwardAttributes(
         builder,
         2, // dy_tensor_uid
         1, // x_tensor_uid
@@ -412,21 +415,21 @@ inline flatbuffers::FlatBufferBuilder
         6 // dbias_tensor_uid
     );
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "batchnorm_bwd",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
         bnormAttributes.Union());
     nodes.push_back(node);
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
@@ -436,13 +439,13 @@ inline flatbuffers::FlatBufferBuilder
 inline flatbuffers::FlatBufferBuilder createValidBatchnormFwdInferActGraph(
     const std::vector<int64_t>& strides = {150528, 50176, 224, 1},
     const std::vector<int64_t>& dims = {1, 3, 224, 224},
-    hipdnn_data_sdk::data_objects::DataType inputDataType
-    = hipdnn_data_sdk::data_objects::DataType::FLOAT,
-    hipdnn_data_sdk::data_objects::DataType intermediateDataType
-    = hipdnn_data_sdk::data_objects::DataType::FLOAT)
+    hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType
+    = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+    hipdnn_flatbuffers_sdk::data_objects::DataType intermediateDataType
+    = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     const std::vector<int64_t> derivedDims = hipdnn_data_sdk::utilities::getDerivedShape(dims);
@@ -450,31 +453,31 @@ inline flatbuffers::FlatBufferBuilder createValidBatchnormFwdInferActGraph(
         derivedDims, hipdnn_data_sdk::utilities::extractStrideOrder(strides));
 
     // inputs
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 1, "x", inputDataType, &strides, &dims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 2, "scale", intermediateDataType, &derivedStrides, &derivedDims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 3, "bias", intermediateDataType, &derivedStrides, &derivedDims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 4, "mean", intermediateDataType, &derivedStrides, &derivedDims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 5, "inv_variance", intermediateDataType, &derivedStrides, &derivedDims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 6, "y", inputDataType, &strides, &dims, true));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 7, "Dy", inputDataType, &strides, &dims, false)); // is_virtual = true
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // Node 0: Batchnorm Inference
-    auto bnInfAttributes = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+    auto bnInfAttributes = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormInferenceAttributes(
         builder,
         1, // x_tensor_uid
         4, // mean_tensor_uid
@@ -484,17 +487,17 @@ inline flatbuffers::FlatBufferBuilder createValidBatchnormFwdInferActGraph(
         6 // y_tensor_uid (BN_Y - virtual)
     );
 
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "batchnorm_inference",
         intermediateDataType,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
         bnInfAttributes.Union()));
 
     // Node 1: Pointwise (RELU_FWD)
-    auto pointwiseAttributes = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto pointwiseAttributes = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
         std::nullopt, // relu_lower_clip
         std::nullopt, // relu_upper_clip
         std::nullopt, // relu_lower_clip_slope
@@ -505,19 +508,19 @@ inline flatbuffers::FlatBufferBuilder createValidBatchnormFwdInferActGraph(
         7 // out_0_tensor_uid (Dy - not virtual)
     );
 
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "relu_fwd",
         intermediateDataType,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         pointwiseAttributes.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
@@ -528,13 +531,13 @@ inline flatbuffers::FlatBufferBuilder createValidBatchnormInferActBwdGraph(
     const std::vector<int64_t>& strides = {150528, 50176, 224, 1},
     const std::vector<int64_t>& dims = {1, 3, 224, 224},
     bool hasOptionalAttributes = true,
-    hipdnn_data_sdk::data_objects::DataType inputDataType
-    = hipdnn_data_sdk::data_objects::DataType::FLOAT,
-    hipdnn_data_sdk::data_objects::DataType intermediateDataType
-    = hipdnn_data_sdk::data_objects::DataType::FLOAT)
+    hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType
+    = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+    hipdnn_flatbuffers_sdk::data_objects::DataType intermediateDataType
+    = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     const std::vector<int64_t> derivedDims = hipdnn_data_sdk::utilities::getDerivedShape(dims);
@@ -542,48 +545,50 @@ inline flatbuffers::FlatBufferBuilder createValidBatchnormInferActBwdGraph(
         derivedDims, hipdnn_data_sdk::utilities::extractStrideOrder(strides));
 
     // inputs
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 1, "x", inputDataType, &strides, &dims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 2, "scale", intermediateDataType, &derivedStrides, &derivedDims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 3, "bias", intermediateDataType, &derivedStrides, &derivedDims));
 
     if(hasOptionalAttributes)
     {
-        tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-            builder, 4, "mean", intermediateDataType, &derivedStrides, &derivedDims));
+        tensorAttributes.push_back(
+            hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+                builder, 4, "mean", intermediateDataType, &derivedStrides, &derivedDims));
 
-        tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-            builder, 5, "inv_variance", intermediateDataType, &derivedStrides, &derivedDims));
+        tensorAttributes.push_back(
+            hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+                builder, 5, "inv_variance", intermediateDataType, &derivedStrides, &derivedDims));
     }
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 6, "dy", inputDataType, &strides, &dims));
 
     // output tensors
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 7, "dx", inputDataType, &strides, &dims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 8, "dscale", intermediateDataType, &derivedStrides, &derivedDims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 9, "dbias", intermediateDataType, &derivedStrides, &derivedDims));
 
     // virtual tensors
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 10, "BN_Y", inputDataType, &strides, &dims, true)); // is_virtual = true
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 11, "DX_drelu", inputDataType, &strides, &dims, true)); // is_virtual = true
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // Node 0: Batchnorm Inference
-    auto bnInfAttributes = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+    auto bnInfAttributes = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormInferenceAttributes(
         builder,
         1, // x_tensor_uid
         hasOptionalAttributes ? 4 : 0, // mean_tensor_uid
@@ -593,17 +598,17 @@ inline flatbuffers::FlatBufferBuilder createValidBatchnormInferActBwdGraph(
         10 // y_tensor_uid (BN_Y - virtual)
     );
 
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "batchnorm_inference",
         intermediateDataType,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
         bnInfAttributes.Union()));
 
     // Node 1: Pointwise (RELU_BWD)
-    auto pointwiseAttributes = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto pointwiseAttributes = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD,
         std::nullopt, // relu_lower_clip
         std::nullopt, // relu_upper_clip
         std::nullopt, // relu_lower_clip_slope
@@ -614,15 +619,15 @@ inline flatbuffers::FlatBufferBuilder createValidBatchnormInferActBwdGraph(
         11 // out_0_tensor_uid (DX_drelu - virtual)
     );
 
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "relu_bwd",
         intermediateDataType,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         pointwiseAttributes.Union()));
 
     // Node 2: Batchnorm Backward
-    auto bnBwdAttributes = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+    auto bnBwdAttributes = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormBackwardAttributes(
         builder,
         11, // dy_tensor_uid (DX_drelu)
         1, // x_tensor_uid
@@ -637,19 +642,19 @@ inline flatbuffers::FlatBufferBuilder createValidBatchnormInferActBwdGraph(
         9 // dbias_tensor_uid
     );
 
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "batchnorm_backward",
         intermediateDataType,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
         bnBwdAttributes.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
@@ -662,7 +667,7 @@ inline flatbuffers::FlatBufferBuilder
                                          bool withMeanVariance = true)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     const std::vector<int64_t> derivedDims = hipdnn_data_sdk::utilities::getDerivedShape(dims);
@@ -670,37 +675,37 @@ inline flatbuffers::FlatBufferBuilder
         derivedDims, hipdnn_data_sdk::utilities::extractStrideOrder(strides));
 
     // Required tensors
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 1, "x", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 2, "y", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "x", hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT, &strides, &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 2, "y", hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT, &strides, &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         3,
         "scale",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         4,
         "bias",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
     // Epsilon (pass-by-value)
     const std::vector<int64_t> passByValueDims = {1};
-    const hipdnn_data_sdk::data_objects::Float32Value epsilonVal(1e-5f);
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    const hipdnn_flatbuffers_sdk::data_objects::Float32Value epsilonVal(1e-5f);
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         5,
         "epsilon",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &passByValueDims,
         &passByValueDims,
         false,
-        hipdnn_data_sdk::data_objects::TensorValue::Float32Value,
+        hipdnn_flatbuffers_sdk::data_objects::TensorValue::Float32Value,
         builder.CreateStruct(epsilonVal).Union()));
 
     flatbuffers::Optional<int64_t> meanUid = flatbuffers::nullopt;
@@ -709,25 +714,27 @@ inline flatbuffers::FlatBufferBuilder
     if(withMeanVariance)
     {
         // Optional mean/variance output tensors
-        tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-            builder,
-            6,
-            "mean",
-            hipdnn_data_sdk::data_objects::DataType::FLOAT,
-            &derivedStrides,
-            &derivedDims));
-        tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-            builder,
-            7,
-            "inv_variance",
-            hipdnn_data_sdk::data_objects::DataType::FLOAT,
-            &derivedStrides,
-            &derivedDims));
+        tensorAttributes.push_back(
+            hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+                builder,
+                6,
+                "mean",
+                hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                &derivedStrides,
+                &derivedDims));
+        tensorAttributes.push_back(
+            hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+                builder,
+                7,
+                "inv_variance",
+                hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                &derivedStrides,
+                &derivedDims));
         meanUid = flatbuffers::Optional<int64_t>(6);
         invVarUid = flatbuffers::Optional<int64_t>(7);
     }
 
-    auto bnormAttributes = hipdnn_data_sdk::data_objects::CreateBatchnormAttributes(
+    auto bnormAttributes = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormAttributes(
         builder,
         1, // x_tensor_uid
         3, // scale_tensor_uid
@@ -744,21 +751,21 @@ inline flatbuffers::FlatBufferBuilder
         flatbuffers::nullopt // next_running_variance_tensor_uid
     );
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "batchnorm_training",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes,
         bnormAttributes.Union());
     nodes.push_back(node);
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
@@ -768,13 +775,13 @@ inline flatbuffers::FlatBufferBuilder
 inline flatbuffers::FlatBufferBuilder createValidBatchnormFwdTrainingActivGraph(
     bool withMeanVariance = true,
     bool withRunningStats = false,
-    hipdnn_data_sdk::data_objects::PointwiseMode activMode
-    = hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+    hipdnn_flatbuffers_sdk::data_objects::PointwiseMode activMode
+    = hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
     const std::vector<int64_t>& strides = {588, 196, 14, 1},
     const std::vector<int64_t>& dims = {1, 3, 14, 14})
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     const std::vector<int64_t> derivedDims = hipdnn_data_sdk::utilities::getDerivedShape(dims);
@@ -785,56 +792,66 @@ inline flatbuffers::FlatBufferBuilder createValidBatchnormFwdTrainingActivGraph(
 
     // Required tensors
     const auto xTensorUid = uid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, xTensorUid, "x", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        xTensorUid,
+        "x",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &strides,
+        &dims));
 
     const auto scaleTensorUid = uid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         scaleTensorUid,
         "scale",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
     const auto biasTensorUid = uid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         biasTensorUid,
         "bias",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
     // Epsilon (pass-by-value)
     const auto epsilonTensorUid = uid++;
-    const hipdnn_data_sdk::data_objects::Float32Value epsilonVal(1e-5f);
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributes(
+    const hipdnn_flatbuffers_sdk::data_objects::Float32Value epsilonVal(1e-5f);
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributes(
         builder,
         epsilonTensorUid,
         builder.CreateString("epsilon"),
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         0,
         0,
         false,
-        hipdnn_data_sdk::data_objects::TensorValue::Float32Value,
+        hipdnn_flatbuffers_sdk::data_objects::TensorValue::Float32Value,
         builder.CreateStruct(epsilonVal).Union()));
 
     // BN output (virtual - intermediate between BN and activation)
     const auto yBnTensorUid = uid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         yBnTensorUid,
         "y_bn",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &strides,
         &dims,
         true)); // virtual
 
     // Final activation output (non-virtual)
     const auto yTensorUid = uid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, yTensorUid, "y", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        yTensorUid,
+        "y",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &strides,
+        &dims));
 
     flatbuffers::Optional<int64_t> meanUid = flatbuffers::nullopt;
     flatbuffers::Optional<int64_t> invVarUid = flatbuffers::nullopt;
@@ -842,23 +859,25 @@ inline flatbuffers::FlatBufferBuilder createValidBatchnormFwdTrainingActivGraph(
     if(withMeanVariance)
     {
         const auto meanTensorUid = uid++;
-        tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-            builder,
-            meanTensorUid,
-            "mean",
-            hipdnn_data_sdk::data_objects::DataType::FLOAT,
-            &derivedStrides,
-            &derivedDims));
+        tensorAttributes.push_back(
+            hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+                builder,
+                meanTensorUid,
+                "mean",
+                hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                &derivedStrides,
+                &derivedDims));
         meanUid = flatbuffers::Optional<int64_t>(meanTensorUid);
 
         const auto invVarTensorUid = uid++;
-        tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-            builder,
-            invVarTensorUid,
-            "inv_variance",
-            hipdnn_data_sdk::data_objects::DataType::FLOAT,
-            &derivedStrides,
-            &derivedDims));
+        tensorAttributes.push_back(
+            hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+                builder,
+                invVarTensorUid,
+                "inv_variance",
+                hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                &derivedStrides,
+                &derivedDims));
         invVarUid = flatbuffers::Optional<int64_t>(invVarTensorUid);
     }
 
@@ -871,88 +890,92 @@ inline flatbuffers::FlatBufferBuilder createValidBatchnormFwdTrainingActivGraph(
     if(withRunningStats)
     {
         const auto prevMeanUid = uid++;
-        tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-            builder,
-            prevMeanUid,
-            "prev_running_mean",
-            hipdnn_data_sdk::data_objects::DataType::FLOAT,
-            &derivedStrides,
-            &derivedDims));
+        tensorAttributes.push_back(
+            hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+                builder,
+                prevMeanUid,
+                "prev_running_mean",
+                hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                &derivedStrides,
+                &derivedDims));
         prevRunningMeanUid = flatbuffers::Optional<int64_t>(prevMeanUid);
 
         const auto prevVarUid = uid++;
-        tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-            builder,
-            prevVarUid,
-            "prev_running_variance",
-            hipdnn_data_sdk::data_objects::DataType::FLOAT,
-            &derivedStrides,
-            &derivedDims));
+        tensorAttributes.push_back(
+            hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+                builder,
+                prevVarUid,
+                "prev_running_variance",
+                hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                &derivedStrides,
+                &derivedDims));
         prevRunningVarUid = flatbuffers::Optional<int64_t>(prevVarUid);
 
         const auto momUid = uid++;
-        const hipdnn_data_sdk::data_objects::Float32Value momentumVal(0.1f);
-        tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributes(
+        const hipdnn_flatbuffers_sdk::data_objects::Float32Value momentumVal(0.1f);
+        tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributes(
             builder,
             momUid,
             builder.CreateString("momentum"),
-            hipdnn_data_sdk::data_objects::DataType::FLOAT,
+            hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
             0,
             0,
             false,
-            hipdnn_data_sdk::data_objects::TensorValue::Float32Value,
+            hipdnn_flatbuffers_sdk::data_objects::TensorValue::Float32Value,
             builder.CreateStruct(momentumVal).Union()));
         momentumUid = flatbuffers::Optional<int64_t>(momUid);
 
         const auto nextMeanUid = uid++;
-        tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-            builder,
-            nextMeanUid,
-            "next_running_mean",
-            hipdnn_data_sdk::data_objects::DataType::FLOAT,
-            &derivedStrides,
-            &derivedDims));
+        tensorAttributes.push_back(
+            hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+                builder,
+                nextMeanUid,
+                "next_running_mean",
+                hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                &derivedStrides,
+                &derivedDims));
         nextRunningMeanUid = flatbuffers::Optional<int64_t>(nextMeanUid);
 
         const auto nextVarUid = uid++;
-        tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-            builder,
-            nextVarUid,
-            "next_running_variance",
-            hipdnn_data_sdk::data_objects::DataType::FLOAT,
-            &derivedStrides,
-            &derivedDims));
+        tensorAttributes.push_back(
+            hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+                builder,
+                nextVarUid,
+                "next_running_variance",
+                hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                &derivedStrides,
+                &derivedDims));
         nextRunningVarUid = flatbuffers::Optional<int64_t>(nextVarUid);
     }
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // Node 0: Batchnorm forward training
-    auto bnormAttributes
-        = hipdnn_data_sdk::data_objects::CreateBatchnormAttributes(builder,
-                                                                   xTensorUid,
-                                                                   scaleTensorUid,
-                                                                   biasTensorUid,
-                                                                   epsilonTensorUid,
-                                                                   0, // peer_stats_tensor_uid
-                                                                   prevRunningMeanUid,
-                                                                   prevRunningVarUid,
-                                                                   momentumUid,
-                                                                   yBnTensorUid, // Virtual output
-                                                                   meanUid,
-                                                                   invVarUid,
-                                                                   nextRunningMeanUid,
-                                                                   nextRunningVarUid);
+    auto bnormAttributes = hipdnn_flatbuffers_sdk::data_objects::CreateBatchnormAttributes(
+        builder,
+        xTensorUid,
+        scaleTensorUid,
+        biasTensorUid,
+        epsilonTensorUid,
+        0, // peer_stats_tensor_uid
+        prevRunningMeanUid,
+        prevRunningVarUid,
+        momentumUid,
+        yBnTensorUid, // Virtual output
+        meanUid,
+        invVarUid,
+        nextRunningMeanUid,
+        nextRunningVarUid);
 
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "batchnorm_training",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes,
         bnormAttributes.Union()));
 
     // Node 1: Activation
-    auto activAttributes = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto activAttributes = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
         activMode,
         flatbuffers::nullopt, // relu_lower_clip
@@ -964,19 +987,19 @@ inline flatbuffers::FlatBufferBuilder createValidBatchnormFwdTrainingActivGraph(
         flatbuffers::nullopt, // in_2_tensor_uid
         yTensorUid); // out_0_tensor_uid
 
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "activation",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         activAttributes.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
@@ -994,48 +1017,49 @@ inline flatbuffers::FlatBufferBuilder
                             const std::vector<int64_t>& convPostPadding = {0, 0},
                             const std::vector<int64_t>& convStrides = {1, 1},
                             const std::vector<int64_t>& convDilation = {1, 1},
-                            hipdnn_data_sdk::data_objects::DataType dataType
-                            = hipdnn_data_sdk::data_objects::DataType::FLOAT)
+                            hipdnn_flatbuffers_sdk::data_objects::DataType dataType
+                            = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 1, "x", dataType, &xStrides, &xDims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 2, "w", dataType, &wStrides, &wDims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 3, "y", dataType, &yStrides, &yDims));
 
-    auto convAttributes = hipdnn_data_sdk::data_objects::CreateConvolutionFwdAttributesDirect(
-        builder,
-        1, // x tensor uid
-        2, // w tensor uid
-        3, // y tensor uid
-        &convPrePadding,
-        &convPostPadding,
-        &convStrides,
-        &convDilation,
-        hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION);
+    auto convAttributes
+        = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionFwdAttributesDirect(
+            builder,
+            1, // x tensor uid
+            2, // w tensor uid
+            3, // y tensor uid
+            &convPrePadding,
+            &convPostPadding,
+            &convStrides,
+            &convDilation,
+            hipdnn_flatbuffers_sdk::data_objects::ConvMode::CROSS_CORRELATION);
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "conv_fwd",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::ConvolutionFwdAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::ConvolutionFwdAttributes,
         convAttributes.Union());
     nodes.push_back(node);
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
@@ -1053,48 +1077,49 @@ inline flatbuffers::FlatBufferBuilder
                             const std::vector<int64_t>& convPostPadding = {0, 0},
                             const std::vector<int64_t>& convStrides = {1, 1},
                             const std::vector<int64_t>& convDilation = {1, 1},
-                            hipdnn_data_sdk::data_objects::DataType dataType
-                            = hipdnn_data_sdk::data_objects::DataType::FLOAT)
+                            hipdnn_flatbuffers_sdk::data_objects::DataType dataType
+                            = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 1, "dy", dataType, &dyStrides, &dyDims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 2, "w", dataType, &wStrides, &wDims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 3, "dx", dataType, &dxStrides, &dxDims));
 
-    auto convAttributes = hipdnn_data_sdk::data_objects::CreateConvolutionBwdAttributesDirect(
-        builder,
-        1, // dy tensor uid
-        2, // w tensor uid
-        3, // dx tensor uid
-        &convPrePadding,
-        &convPostPadding,
-        &convStrides,
-        &convDilation,
-        hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION);
+    auto convAttributes
+        = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionBwdAttributesDirect(
+            builder,
+            1, // dy tensor uid
+            2, // w tensor uid
+            3, // dx tensor uid
+            &convPrePadding,
+            &convPostPadding,
+            &convStrides,
+            &convDilation,
+            hipdnn_flatbuffers_sdk::data_objects::ConvMode::CROSS_CORRELATION);
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "conv_bwd",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::ConvolutionBwdAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::ConvolutionBwdAttributes,
         convAttributes.Union());
     nodes.push_back(node);
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
@@ -1112,48 +1137,49 @@ inline flatbuffers::FlatBufferBuilder
                             const std::vector<int64_t>& convPostPadding = {0, 0},
                             const std::vector<int64_t>& convStrides = {1, 1},
                             const std::vector<int64_t>& convDilation = {1, 1},
-                            hipdnn_data_sdk::data_objects::DataType dataType
-                            = hipdnn_data_sdk::data_objects::DataType::FLOAT)
+                            hipdnn_flatbuffers_sdk::data_objects::DataType dataType
+                            = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 1, "x", dataType, &xStrides, &xDims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 2, "dy", dataType, &dyStrides, &dyDims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 3, "dw", dataType, &dwStrides, &dwDims));
 
-    auto convAttributes = hipdnn_data_sdk::data_objects::CreateConvolutionWrwAttributesDirect(
-        builder,
-        1, // x tensor uid
-        2, // dy tensor uid
-        3, // w tensor uid
-        &convPrePadding,
-        &convPostPadding,
-        &convStrides,
-        &convDilation,
-        hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION);
+    auto convAttributes
+        = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionWrwAttributesDirect(
+            builder,
+            1, // x tensor uid
+            2, // dy tensor uid
+            3, // w tensor uid
+            &convPrePadding,
+            &convPostPadding,
+            &convStrides,
+            &convDilation,
+            hipdnn_flatbuffers_sdk::data_objects::ConvMode::CROSS_CORRELATION);
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "conv_wrw",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::ConvolutionWrwAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::ConvolutionWrwAttributes,
         convAttributes.Union());
     nodes.push_back(node);
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
@@ -1166,10 +1192,10 @@ inline flatbuffers::FlatBufferBuilder createPointwiseGraph()
 {
     flatbuffers::FlatBufferBuilder builder;
 
-    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    auto pointwiseNode = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    auto pointwiseNode = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
-        hipdnn_data_sdk::data_objects::PointwiseMode::DIV, // operation
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::DIV, // operation
         1.f, // relu_lower_clip
         2.f, // relu_upper_clip
         3.f, // relu_lower_clip_slope
@@ -1182,37 +1208,38 @@ inline flatbuffers::FlatBufferBuilder createPointwiseGraph()
         5.f, // elu_alpha
         6.f); // softplus_beta
 
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
-        "hipdnn_data_sdk::data_objects::Node",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        "hipdnn_flatbuffers_sdk::data_objects::Node",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         pointwiseNode.Union()));
 
     const std::array tensorNames = {"axis", "in_0", "in_1", "in_2", "out_0"};
-    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>> tensors;
+    std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
+        tensors;
     tensors.reserve(tensorNames.size());
     int64_t tensorUid = 0;
     const std::vector<int64_t> dims = {1, 2, 3, 4};
     const std::vector<int64_t> strides = {5, 6, 7, 8};
     for(auto name : tensorNames)
     {
-        tensors.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        tensors.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
             builder,
             tensorUid++,
             name,
-            hipdnn_data_sdk::data_objects::DataType::UINT8,
+            hipdnn_flatbuffers_sdk::data_objects::DataType::UINT8,
             &strides,
             &dims,
             false));
     }
 
-    auto graph = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graph = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "PointwiseGraph",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensors,
         &nodes);
 
@@ -1233,32 +1260,32 @@ inline flatbuffers::FlatBufferBuilder
                                      const std::vector<int64_t>& convStrides,
                                      const std::vector<int64_t>& convDilation,
                                      bool doBias,
-                                     hipdnn_data_sdk::data_objects::PointwiseMode activMode,
+                                     hipdnn_flatbuffers_sdk::data_objects::PointwiseMode activMode,
                                      std::optional<float> reluLowerClip,
                                      std::optional<float> reluUpperClip,
                                      std::optional<float> reluLowerClipSlope,
                                      std::optional<float> swishBeta,
                                      std::optional<float> eluAlpha,
                                      std::optional<float> softplusBeta,
-                                     hipdnn_data_sdk::data_objects::DataType dataType)
+                                     hipdnn_flatbuffers_sdk::data_objects::DataType dataType)
 {
     flatbuffers::FlatBufferBuilder builder;
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
     int64_t tensorUid = 1;
 
     const auto xTensorUid = tensorUid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, xTensorUid, "x", dataType, &xStrides, &xDims));
 
     const auto wTensorUid = tensorUid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, wTensorUid, "w", dataType, &wStrides, &wDims));
 
     // Virtual y_conv tensor
     const auto yConvTensorUid = tensorUid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, yConvTensorUid, "y_conv", dataType, &yStrides, &yDims, true));
 
     int64_t biasTensorUid;
@@ -1270,42 +1297,45 @@ inline flatbuffers::FlatBufferBuilder
             biasDims, hipdnn_data_sdk::utilities::extractStrideOrder(yDims));
 
         biasTensorUid = tensorUid++;
-        tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-            builder, biasTensorUid, "bias", dataType, &biasStrides, &biasDims));
+        tensorAttributes.push_back(
+            hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+                builder, biasTensorUid, "bias", dataType, &biasStrides, &biasDims));
         // Virtual y_bias tensor
         yBiasTensorUid = tensorUid++;
-        tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-            builder, yBiasTensorUid, "y_bias", dataType, &yStrides, &yDims, true));
+        tensorAttributes.push_back(
+            hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+                builder, yBiasTensorUid, "y_bias", dataType, &yStrides, &yDims, true));
     }
 
     const auto yTensorUid = tensorUid;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, yTensorUid, "y", dataType, &yStrides, &yDims));
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
-    auto convAttributes = hipdnn_data_sdk::data_objects::CreateConvolutionFwdAttributesDirect(
-        builder,
-        xTensorUid,
-        wTensorUid,
-        yConvTensorUid,
-        &convPrePadding,
-        &convPostPadding,
-        &convStrides,
-        &convDilation,
-        hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    auto convAttributes
+        = hipdnn_flatbuffers_sdk::data_objects::CreateConvolutionFwdAttributesDirect(
+            builder,
+            xTensorUid,
+            wTensorUid,
+            yConvTensorUid,
+            &convPrePadding,
+            &convPostPadding,
+            &convStrides,
+            &convDilation,
+            hipdnn_flatbuffers_sdk::data_objects::ConvMode::CROSS_CORRELATION);
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "conv_fwd",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::ConvolutionFwdAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::ConvolutionFwdAttributes,
         convAttributes.Union()));
 
     if(doBias)
     {
-        auto biasAttributes = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        auto biasAttributes = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
             builder,
-            hipdnn_data_sdk::data_objects::PointwiseMode::ADD,
+            hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::ADD,
             flatbuffers::nullopt,
             flatbuffers::nullopt,
             flatbuffers::nullopt,
@@ -1314,15 +1344,15 @@ inline flatbuffers::FlatBufferBuilder
             biasTensorUid,
             flatbuffers::nullopt,
             yBiasTensorUid);
-        nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
             builder,
             "bias",
-            hipdnn_data_sdk::data_objects::DataType::FLOAT,
-            hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+            hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+            hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
             biasAttributes.Union()));
     }
 
-    auto activAttributes = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+    auto activAttributes = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
         builder,
         activMode,
         reluLowerClip,
@@ -1336,19 +1366,19 @@ inline flatbuffers::FlatBufferBuilder
         swishBeta,
         eluAlpha,
         softplusBeta);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "activ",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         activAttributes.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
@@ -1366,16 +1396,16 @@ inline flatbuffers::FlatBufferBuilder
                                  const std::vector<int64_t>& convPostPadding = {0, 0},
                                  const std::vector<int64_t>& convStrides = {1, 1},
                                  const std::vector<int64_t>& convDilation = {1, 1},
-                                 hipdnn_data_sdk::data_objects::PointwiseMode activMode
-                                 = hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+                                 hipdnn_flatbuffers_sdk::data_objects::PointwiseMode activMode
+                                 = hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
                                  std::optional<float> reluLowerClip = std::nullopt,
                                  std::optional<float> reluUpperClip = std::nullopt,
                                  std::optional<float> reluLowerClipSlope = std::nullopt,
                                  std::optional<float> swishBeta = std::nullopt,
                                  std::optional<float> eluAlpha = std::nullopt,
                                  std::optional<float> softplusBeta = std::nullopt,
-                                 hipdnn_data_sdk::data_objects::DataType dataType
-                                 = hipdnn_data_sdk::data_objects::DataType::FLOAT)
+                                 hipdnn_flatbuffers_sdk::data_objects::DataType dataType
+                                 = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT)
 {
     return createValidConvFwdBiasActivGraph(xDims,
                                             xStrides,
@@ -1398,27 +1428,27 @@ inline flatbuffers::FlatBufferBuilder
                                             dataType);
 }
 
-inline flatbuffers::FlatBufferBuilder
-    createValidConvFwdBiasActivGraph(const std::vector<int64_t>& xDims = {4, 4, 4, 4},
-                                     const std::vector<int64_t>& xStrides = {64, 16, 4, 1},
-                                     const std::vector<int64_t>& wDims = {4, 4, 1, 1},
-                                     const std::vector<int64_t>& wStrides = {4, 1, 1, 1},
-                                     const std::vector<int64_t>& yDims = {4, 4, 4, 4},
-                                     const std::vector<int64_t>& yStrides = {64, 16, 4, 1},
-                                     const std::vector<int64_t>& convPrePadding = {0, 0},
-                                     const std::vector<int64_t>& convPostPadding = {0, 0},
-                                     const std::vector<int64_t>& convStrides = {1, 1},
-                                     const std::vector<int64_t>& convDilation = {1, 1},
-                                     hipdnn_data_sdk::data_objects::PointwiseMode activMode
-                                     = hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
-                                     std::optional<float> reluLowerClip = std::nullopt,
-                                     std::optional<float> reluUpperClip = std::nullopt,
-                                     std::optional<float> reluLowerClipSlope = std::nullopt,
-                                     std::optional<float> swishBeta = std::nullopt,
-                                     std::optional<float> eluAlpha = std::nullopt,
-                                     std::optional<float> softplusBeta = std::nullopt,
-                                     hipdnn_data_sdk::data_objects::DataType dataType
-                                     = hipdnn_data_sdk::data_objects::DataType::FLOAT)
+inline flatbuffers::FlatBufferBuilder createValidConvFwdBiasActivGraph(
+    const std::vector<int64_t>& xDims = {4, 4, 4, 4},
+    const std::vector<int64_t>& xStrides = {64, 16, 4, 1},
+    const std::vector<int64_t>& wDims = {4, 4, 1, 1},
+    const std::vector<int64_t>& wStrides = {4, 1, 1, 1},
+    const std::vector<int64_t>& yDims = {4, 4, 4, 4},
+    const std::vector<int64_t>& yStrides = {64, 16, 4, 1},
+    const std::vector<int64_t>& convPrePadding = {0, 0},
+    const std::vector<int64_t>& convPostPadding = {0, 0},
+    const std::vector<int64_t>& convStrides = {1, 1},
+    const std::vector<int64_t>& convDilation = {1, 1},
+    hipdnn_flatbuffers_sdk::data_objects::PointwiseMode activMode
+    = hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
+    std::optional<float> reluLowerClip = std::nullopt,
+    std::optional<float> reluUpperClip = std::nullopt,
+    std::optional<float> reluLowerClipSlope = std::nullopt,
+    std::optional<float> swishBeta = std::nullopt,
+    std::optional<float> eluAlpha = std::nullopt,
+    std::optional<float> softplusBeta = std::nullopt,
+    hipdnn_flatbuffers_sdk::data_objects::DataType dataType
+    = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT)
 {
     return createValidConvFwdBiasActivGraph(xDims,
                                             xStrides,
@@ -1448,40 +1478,41 @@ inline flatbuffers::FlatBufferBuilder
                            const std::vector<int64_t>& bStrides = {5, 1},
                            const std::vector<int64_t>& cDims = {4, 5},
                            const std::vector<int64_t>& cStrides = {5, 1},
-                           hipdnn_data_sdk::data_objects::DataType dataType
-                           = hipdnn_data_sdk::data_objects::DataType::FLOAT)
+                           hipdnn_flatbuffers_sdk::data_objects::DataType dataType
+                           = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 1, "A", dataType, &aStrides, &aDims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 2, "B", dataType, &bStrides, &bDims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 3, "C", dataType, &cStrides, &cDims));
 
-    auto matmulAttributes = hipdnn_data_sdk::data_objects::CreateMatmulAttributes(builder,
-                                                                                  1, // A tensor uid
-                                                                                  2, // B tensor uid
-                                                                                  3 // C tensor uid
-    );
+    auto matmulAttributes
+        = hipdnn_flatbuffers_sdk::data_objects::CreateMatmulAttributes(builder,
+                                                                       1, // A tensor uid
+                                                                       2, // B tensor uid
+                                                                       3 // C tensor uid
+        );
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "matmul",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::MatmulAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::MatmulAttributes,
         matmulAttributes.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
@@ -1491,11 +1522,11 @@ inline flatbuffers::FlatBufferBuilder
 inline flatbuffers::FlatBufferBuilder
     createValidLayernormFpropGraph(const std::vector<int64_t>& strides = {588, 196, 14, 1},
                                    const std::vector<int64_t>& dims = {1, 3, 14, 14},
-                                   hipdnn_data_sdk::data_objects::DataType inputDataType
-                                   = hipdnn_data_sdk::data_objects::DataType::FLOAT)
+                                   hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType
+                                   = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     // For LayerNorm, scale and bias match the normalized dimensions (all dims except batch).
@@ -1505,66 +1536,66 @@ inline flatbuffers::FlatBufferBuilder
         = hipdnn_data_sdk::utilities::generateStrides(normalizedDims);
 
     // Required tensors
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 1, "x", inputDataType, &strides, &dims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 2, "y", inputDataType, &strides, &dims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         3,
         "scale",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &normalizedStrides,
         &normalizedDims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         4,
         "bias",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &normalizedStrides,
         &normalizedDims));
 
     // Epsilon (pass-by-value)
     const std::vector<int64_t> passByValueDims = {1};
-    const hipdnn_data_sdk::data_objects::Float32Value epsilonVal(1e-5f);
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    const hipdnn_flatbuffers_sdk::data_objects::Float32Value epsilonVal(1e-5f);
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         5,
         "epsilon",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &passByValueDims,
         &passByValueDims,
         false,
-        hipdnn_data_sdk::data_objects::TensorValue::Float32Value,
+        hipdnn_flatbuffers_sdk::data_objects::TensorValue::Float32Value,
         builder.CreateStruct(epsilonVal).Union()));
 
     auto layernormAttributes
-        = hipdnn_data_sdk::data_objects::CreateLayernormAttributes(builder,
-                                                                   1, // x tensor uid
-                                                                   3, // scale tensor uid
-                                                                   4, // bias tensor uid
-                                                                   5, // epsilon tensor uid
-                                                                   2 // y tensor uid
+        = hipdnn_flatbuffers_sdk::data_objects::CreateLayernormAttributes(builder,
+                                                                          1, // x tensor uid
+                                                                          3, // scale tensor uid
+                                                                          4, // bias tensor uid
+                                                                          5, // epsilon tensor uid
+                                                                          2 // y tensor uid
         );
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "layernorm",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::LayernormAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::LayernormAttributes,
         layernormAttributes.Union());
     nodes.push_back(node);
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
@@ -1574,13 +1605,13 @@ inline flatbuffers::FlatBufferBuilder
 inline flatbuffers::FlatBufferBuilder
     createValidRMSNormGraph(const std::vector<int64_t>& strides = {150528, 50176, 224, 1},
                             const std::vector<int64_t>& dims = {1, 3, 224, 224},
-                            hipdnn_data_sdk::data_objects::DataType inputDataType
-                            = hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                            hipdnn_data_sdk::data_objects::DataType computeDataType
-                            = hipdnn_data_sdk::data_objects::DataType::FLOAT)
+                            hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType
+                            = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                            hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType
+                            = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     std::vector<int64_t> derivedDims(dims);
@@ -1589,57 +1620,57 @@ inline flatbuffers::FlatBufferBuilder
     const std::vector<int64_t> derivedStrides = hipdnn_data_sdk::utilities::generateStrides(
         derivedDims, hipdnn_data_sdk::utilities::extractStrideOrder(strides));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 1, "x", inputDataType, &strides, &dims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 2, "y", inputDataType, &strides, &dims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         3,
         "scale",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
     // Epsilon (pass-by-value)
     const std::vector<int64_t> passByValueDims = {1};
-    const hipdnn_data_sdk::data_objects::Float32Value epsilonVal(1e-5f);
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    const hipdnn_flatbuffers_sdk::data_objects::Float32Value epsilonVal(1e-5f);
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         4,
         "epsilon",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &passByValueDims,
         &passByValueDims,
         false,
-        hipdnn_data_sdk::data_objects::TensorValue::Float32Value,
+        hipdnn_flatbuffers_sdk::data_objects::TensorValue::Float32Value,
         builder.CreateStruct(epsilonVal).Union()));
 
     auto rmsnormAttributes
-        = hipdnn_data_sdk::data_objects::CreateRMSNormAttributes(builder,
-                                                                 1, // x uid
-                                                                 3, // scale uid
-                                                                 4, // epsilon uid
-                                                                 2 // y uid
+        = hipdnn_flatbuffers_sdk::data_objects::CreateRMSNormAttributes(builder,
+                                                                        1, // x uid
+                                                                        3, // scale uid
+                                                                        4, // epsilon uid
+                                                                        2 // y uid
         );
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "rmsnorm",
         computeDataType,
-        hipdnn_data_sdk::data_objects::NodeAttributes::RMSNormAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::RMSNormAttributes,
         rmsnormAttributes.Union());
     nodes.push_back(node);
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
@@ -1650,13 +1681,13 @@ inline flatbuffers::FlatBufferBuilder
     createValidRMSNormBwdGraph(const std::vector<int64_t>& strides = {150528, 50176, 224, 1},
                                const std::vector<int64_t>& dims = {1, 3, 224, 224},
                                bool hasOptionalAttributes = true,
-                               hipdnn_data_sdk::data_objects::DataType inputDataType
-                               = hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                               hipdnn_data_sdk::data_objects::DataType computeDataType
-                               = hipdnn_data_sdk::data_objects::DataType::FLOAT)
+                               hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType
+                               = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                               hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType
+                               = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     const std::vector<int64_t> derivedDims = hipdnn_data_sdk::utilities::getDerivedShape(dims);
@@ -1670,84 +1701,87 @@ inline flatbuffers::FlatBufferBuilder
         statDims, hipdnn_data_sdk::utilities::extractStrideOrder(strides));
 
     // dy (gradient of output)
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 1, "dy", inputDataType, &strides, &dims));
 
     // x (original input)
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 2, "x", inputDataType, &strides, &dims));
 
     // scale
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         3,
         "scale",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
     // dx (gradient of input)
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 4, "dx", inputDataType, &strides, &dims));
 
     // dscale (gradient of scale)
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         5,
         "dscale",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &derivedStrides,
         &derivedDims));
 
     if(hasOptionalAttributes)
     {
         // inv_rms (inverse RMS from forward pass) - stat shape [N, 1, H, W]
-        tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-            builder,
-            6,
-            "inv_rms",
-            hipdnn_data_sdk::data_objects::DataType::FLOAT,
-            &statStrides,
-            &statDims));
+        tensorAttributes.push_back(
+            hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+                builder,
+                6,
+                "inv_rms",
+                hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                &statStrides,
+                &statDims));
 
         // dbias (gradient of bias)
-        tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-            builder,
-            7,
-            "dbias",
-            hipdnn_data_sdk::data_objects::DataType::FLOAT,
-            &derivedStrides,
-            &derivedDims));
+        tensorAttributes.push_back(
+            hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+                builder,
+                7,
+                "dbias",
+                hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                &derivedStrides,
+                &derivedDims));
     }
 
-    auto rmsnormBwdAttributes = hipdnn_data_sdk::data_objects::CreateRMSNormBackwardAttributes(
-        builder,
-        1, // dy uid
-        2, // x uid
-        3, // scale uid
-        hasOptionalAttributes ? flatbuffers::Optional<int64_t>(6)
-                              : flatbuffers::nullopt, // inv_rms uid
-        4, // dx uid
-        5, // dscale uid
-        hasOptionalAttributes ? flatbuffers::Optional<int64_t>(7)
-                              : flatbuffers::nullopt // dbias uid
-    );
+    auto rmsnormBwdAttributes
+        = hipdnn_flatbuffers_sdk::data_objects::CreateRMSNormBackwardAttributes(
+            builder,
+            1, // dy uid
+            2, // x uid
+            3, // scale uid
+            hasOptionalAttributes ? flatbuffers::Optional<int64_t>(6)
+                                  : flatbuffers::nullopt, // inv_rms uid
+            4, // dx uid
+            5, // dscale uid
+            hasOptionalAttributes ? flatbuffers::Optional<int64_t>(7)
+                                  : flatbuffers::nullopt // dbias uid
+        );
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "rmsnorm_bwd",
         computeDataType,
-        hipdnn_data_sdk::data_objects::NodeAttributes::RMSNormBackwardAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::RMSNormBackwardAttributes,
         rmsnormBwdAttributes.Union());
     nodes.push_back(node);
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
@@ -1762,30 +1796,30 @@ inline flatbuffers::FlatBufferBuilder
                                     const std::vector<int64_t>& cDims = {4, 5},
                                     const std::vector<int64_t>& cStrides = {5, 1},
                                     bool doBias = true,
-                                    hipdnn_data_sdk::data_objects::PointwiseMode activMode
-                                    = hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+                                    hipdnn_flatbuffers_sdk::data_objects::PointwiseMode activMode
+                                    = hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
                                     std::optional<float> reluLowerClip = std::nullopt,
                                     std::optional<float> reluUpperClip = std::nullopt,
                                     std::optional<float> swishBeta = std::nullopt,
-                                    hipdnn_data_sdk::data_objects::DataType dataType
-                                    = hipdnn_data_sdk::data_objects::DataType::FLOAT)
+                                    hipdnn_flatbuffers_sdk::data_objects::DataType dataType
+                                    = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT)
 {
     flatbuffers::FlatBufferBuilder builder;
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
     int64_t tensorUid = 1;
 
     const auto aTensorUid = tensorUid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, aTensorUid, "A", dataType, &aStrides, &aDims));
 
     const auto bTensorUid = tensorUid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, bTensorUid, "B", dataType, &bStrides, &bDims));
 
     const auto cMatmulTensorUid = tensorUid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, cMatmulTensorUid, "C_matmul", dataType, &cStrides, &cDims));
 
     int64_t biasTensorUid;
@@ -1797,35 +1831,37 @@ inline flatbuffers::FlatBufferBuilder
             biasDims, hipdnn_data_sdk::utilities::extractStrideOrder(cDims));
 
         biasTensorUid = tensorUid++;
-        tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-            builder, biasTensorUid, "bias", dataType, &biasStrides, &biasDims));
+        tensorAttributes.push_back(
+            hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+                builder, biasTensorUid, "bias", dataType, &biasStrides, &biasDims));
         cBiasTensorUid = tensorUid++;
-        tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-            builder, cBiasTensorUid, "C_bias", dataType, &cStrides, &cDims));
+        tensorAttributes.push_back(
+            hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+                builder, cBiasTensorUid, "C_bias", dataType, &cStrides, &cDims));
     }
 
     const auto cTensorUid = tensorUid;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, cTensorUid, "C", dataType, &cStrides, &cDims));
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
 
     // Node 0: MatMul
-    auto matmulAttributes = hipdnn_data_sdk::data_objects::CreateMatmulAttributes(
+    auto matmulAttributes = hipdnn_flatbuffers_sdk::data_objects::CreateMatmulAttributes(
         builder, aTensorUid, bTensorUid, cMatmulTensorUid);
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "matmul",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::MatmulAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::MatmulAttributes,
         matmulAttributes.Union()));
 
     // Node 1: Bias (optional)
     if(doBias)
     {
-        auto biasAttributes = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        auto biasAttributes = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
             builder,
-            hipdnn_data_sdk::data_objects::PointwiseMode::ADD,
+            hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::ADD,
             flatbuffers::nullopt,
             flatbuffers::nullopt,
             flatbuffers::nullopt,
@@ -1834,18 +1870,18 @@ inline flatbuffers::FlatBufferBuilder
             biasTensorUid,
             flatbuffers::nullopt,
             cBiasTensorUid);
-        nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
             builder,
             "bias",
-            hipdnn_data_sdk::data_objects::DataType::FLOAT,
-            hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+            hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+            hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
             biasAttributes.Union()));
     }
 
     // Node 2: Activation (supports RELU_FWD, GELU_FWD, SWISH_FWD, etc.)
-    if(activMode != hipdnn_data_sdk::data_objects::PointwiseMode::UNSET)
+    if(activMode != hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::UNSET)
     {
-        auto activAttributes = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        auto activAttributes = hipdnn_flatbuffers_sdk::data_objects::CreatePointwiseAttributes(
             builder,
             activMode,
             reluLowerClip,
@@ -1857,20 +1893,20 @@ inline flatbuffers::FlatBufferBuilder
             flatbuffers::nullopt, // in_2_tensor_uid
             cTensorUid,
             swishBeta); // swish_beta
-        nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
             builder,
             "activation",
-            hipdnn_data_sdk::data_objects::DataType::FLOAT,
-            hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+            hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+            hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes,
             activAttributes.Union()));
     }
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
@@ -1886,8 +1922,8 @@ inline flatbuffers::FlatBufferBuilder
                             const std::vector<int64_t>& vStrides = {8192, 1024, 64, 1},
                             const std::vector<int64_t>& oDims = {2, 8, 16, 64},
                             const std::vector<int64_t>& oStrides = {8192, 1024, 64, 1},
-                            hipdnn_data_sdk::data_objects::DataType dataType
-                            = hipdnn_data_sdk::data_objects::DataType::HALF,
+                            hipdnn_flatbuffers_sdk::data_objects::DataType dataType
+                            = hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
                             bool withAttnMask = false,
                             bool withScale = false,
                             bool withStats = false,
@@ -1896,25 +1932,25 @@ inline flatbuffers::FlatBufferBuilder
                             bool causalMask = false)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     int64_t uid = 1;
 
     const auto qUid = uid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, qUid, "q", dataType, &qStrides, &qDims));
 
     const auto kUid = uid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, kUid, "k", dataType, &kStrides, &kDims));
 
     const auto vUid = uid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, vUid, "v", dataType, &vStrides, &vDims));
 
     const auto oUid = uid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, oUid, "o", dataType, &oStrides, &oDims));
 
     flatbuffers::Optional<int64_t> attnMaskUid = flatbuffers::nullopt;
@@ -1925,8 +1961,9 @@ inline flatbuffers::FlatBufferBuilder
         const std::vector<int64_t> attnMaskStrides
             = {qDims[1] * qDims[2] * kDims[2], qDims[2] * kDims[2], kDims[2], 1};
         const auto maskUid = uid++;
-        tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-            builder, maskUid, "attn_mask", dataType, &attnMaskStrides, &attnMaskDims));
+        tensorAttributes.push_back(
+            hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+                builder, maskUid, "attn_mask", dataType, &attnMaskStrides, &attnMaskDims));
         attnMaskUid = flatbuffers::Optional<int64_t>(maskUid);
     }
 
@@ -1934,18 +1971,19 @@ inline flatbuffers::FlatBufferBuilder
     if(withScale)
     {
         const std::vector<int64_t> passByValueDims = {1};
-        const hipdnn_data_sdk::data_objects::Float32Value scaleVal(1.0f);
+        const hipdnn_flatbuffers_sdk::data_objects::Float32Value scaleVal(1.0f);
         const auto sUid = uid++;
-        tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-            builder,
-            sUid,
-            "scale",
-            hipdnn_data_sdk::data_objects::DataType::FLOAT,
-            &passByValueDims,
-            &passByValueDims,
-            false,
-            hipdnn_data_sdk::data_objects::TensorValue::Float32Value,
-            builder.CreateStruct(scaleVal).Union()));
+        tensorAttributes.push_back(
+            hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+                builder,
+                sUid,
+                "scale",
+                hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                &passByValueDims,
+                &passByValueDims,
+                false,
+                hipdnn_flatbuffers_sdk::data_objects::TensorValue::Float32Value,
+                builder.CreateStruct(scaleVal).Union()));
         scaleUid = flatbuffers::Optional<int64_t>(sUid);
     }
 
@@ -1956,12 +1994,13 @@ inline flatbuffers::FlatBufferBuilder
         const std::vector<int64_t> statsDims = {qDims[0], qDims[1], qDims[2], 1};
         const std::vector<int64_t> statsStrides = {qDims[1] * qDims[2], qDims[2], 1, 1};
         const auto stUid = uid++;
-        tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-            builder, stUid, "stats", dataType, &statsStrides, &statsDims));
+        tensorAttributes.push_back(
+            hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+                builder, stUid, "stats", dataType, &statsStrides, &statsDims));
         statsUid = flatbuffers::Optional<int64_t>(stUid);
     }
 
-    auto sdpaAttributes = hipdnn_data_sdk::data_objects::CreateSdpaAttributes(
+    auto sdpaAttributes = hipdnn_flatbuffers_sdk::data_objects::CreateSdpaAttributes(
         builder,
         qUid,
         kUid,
@@ -1996,76 +2035,77 @@ inline flatbuffers::FlatBufferBuilder
         paddingMask,
         causalMask);
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "sdpa_fwd",
         dataType,
-        hipdnn_data_sdk::data_objects::NodeAttributes::SdpaAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::SdpaAttributes,
         sdpaAttributes.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
     return builder;
 }
 
-inline flatbuffers::FlatBufferBuilder
-    createValidBlockScaleQuantizeGraph(const std::vector<int64_t>& strides = {65536, 1024, 32, 1},
-                                       const std::vector<int64_t>& dims = {2, 64, 32, 32},
-                                       hipdnn_data_sdk::data_objects::DataType inputDataType
-                                       = hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                                       hipdnn_data_sdk::data_objects::DataType computeDataType
-                                       = hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                                       flatbuffers::Optional<int64_t> axis = 1)
+inline flatbuffers::FlatBufferBuilder createValidBlockScaleQuantizeGraph(
+    const std::vector<int64_t>& strides = {65536, 1024, 32, 1},
+    const std::vector<int64_t>& dims = {2, 64, 32, 32},
+    hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType
+    = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+    hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType
+    = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+    flatbuffers::Optional<int64_t> axis = 1)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     const std::vector<int64_t> scaleDims = {2, 2, 32, 32};
     const std::vector<int64_t> scaleStrides = {2048, 1024, 32, 1};
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 1, "x", inputDataType, &strides, &dims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 2, "y", inputDataType, &strides, &dims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 3, "scale", inputDataType, &scaleStrides, &scaleDims));
 
     auto blockScaleQuantizeAttributes
-        = hipdnn_data_sdk::data_objects::CreateBlockScaleQuantizeAttributes(builder,
-                                                                            1, // x uid
-                                                                            2, // y uid
-                                                                            3, // scale uid
-                                                                            32, // block_size
-                                                                            axis,
-                                                                            false // transpose
+        = hipdnn_flatbuffers_sdk::data_objects::CreateBlockScaleQuantizeAttributes(
+            builder,
+            1, // x uid
+            2, // y uid
+            3, // scale uid
+            32, // block_size
+            axis,
+            false // transpose
         );
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "block_scale_quantize",
         computeDataType,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BlockScaleQuantizeAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BlockScaleQuantizeAttributes,
         blockScaleQuantizeAttributes.Union());
     nodes.push_back(node);
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
@@ -2076,40 +2116,40 @@ inline flatbuffers::FlatBufferBuilder createValidEngineDetails(int64_t engineId)
 {
     flatbuffers::FlatBufferBuilder builder;
     auto engineDetailsOffset
-        = hipdnn_data_sdk::data_objects::CreateEngineDetails(builder, engineId);
+        = hipdnn_flatbuffers_sdk::data_objects::CreateEngineDetails(builder, engineId);
     builder.Finish(engineDetailsOffset);
     return builder;
 }
 
-inline flatbuffers::FlatBufferBuilder
-    createValidBlockScaleDequantizeGraph(const std::vector<int64_t>& strides = {65536, 1024, 32, 1},
-                                         const std::vector<int64_t>& dims = {2, 64, 32, 32},
-                                         hipdnn_data_sdk::data_objects::DataType inputDataType
-                                         = hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                                         hipdnn_data_sdk::data_objects::DataType computeDataType
-                                         = hipdnn_data_sdk::data_objects::DataType::FLOAT)
+inline flatbuffers::FlatBufferBuilder createValidBlockScaleDequantizeGraph(
+    const std::vector<int64_t>& strides = {65536, 1024, 32, 1},
+    const std::vector<int64_t>& dims = {2, 64, 32, 32},
+    hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType
+    = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+    hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType
+    = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     const std::vector<int64_t> scaleDims = {2, 2, 32, 32};
     const std::vector<int64_t> scaleStrides = {2048, 1024, 32, 1};
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 1, "x", inputDataType, &strides, &dims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 2, "scale", inputDataType, &scaleStrides, &scaleDims));
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 3, "y", inputDataType, &strides, &dims));
 
     const std::vector<int32_t> blockSize = {32};
     auto blockSizeVector = builder.CreateVector(blockSize);
 
     auto blockScaleDequantizeAttributes
-        = hipdnn_data_sdk::data_objects::CreateBlockScaleDequantizeAttributes(
+        = hipdnn_flatbuffers_sdk::data_objects::CreateBlockScaleDequantizeAttributes(
             builder,
             1, // x uid
             2, // scale uid
@@ -2118,21 +2158,21 @@ inline flatbuffers::FlatBufferBuilder
             false // is_negative_scale
         );
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "block_scale_dequantize",
         computeDataType,
-        hipdnn_data_sdk::data_objects::NodeAttributes::BlockScaleDequantizeAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BlockScaleDequantizeAttributes,
         blockScaleDequantizeAttributes.Union());
     nodes.push_back(node);
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
@@ -2148,73 +2188,73 @@ inline flatbuffers::FlatBufferBuilder
                             const std::vector<int64_t>& vStrides = {8192, 1024, 64, 1},
                             const std::vector<int64_t>& oDims = {2, 8, 16, 64},
                             const std::vector<int64_t>& oStrides = {8192, 1024, 64, 1},
-                            hipdnn_data_sdk::data_objects::DataType dataType
-                            = hipdnn_data_sdk::data_objects::DataType::HALF)
+                            hipdnn_flatbuffers_sdk::data_objects::DataType dataType
+                            = hipdnn_flatbuffers_sdk::data_objects::DataType::HALF)
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     int64_t uid = 1;
 
     const auto qUid = uid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, qUid, "q", dataType, &qStrides, &qDims));
 
     const auto kUid = uid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, kUid, "k", dataType, &kStrides, &kDims));
 
     const auto vUid = uid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, vUid, "v", dataType, &vStrides, &vDims));
 
     const auto oUid = uid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, oUid, "o", dataType, &oStrides, &oDims));
 
     // dO has same shape as O
     const auto doUid = uid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, doUid, "do", dataType, &oStrides, &oDims));
 
     // Stats: [batch, num_heads, seq_q, 1]
     const std::vector<int64_t> statsDims = {qDims[0], qDims[1], qDims[2], 1};
     const std::vector<int64_t> statsStrides = {qDims[1] * qDims[2], qDims[2], 1, 1};
     const auto statsUid = uid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, statsUid, "stats", dataType, &statsStrides, &statsDims));
 
     // Output gradient tensors (same shapes as Q, K, V)
     const auto dqUid = uid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, dqUid, "dq", dataType, &qStrides, &qDims));
 
     const auto dkUid = uid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, dkUid, "dk", dataType, &kStrides, &kDims));
 
     const auto dvUid = uid++;
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, dvUid, "dv", dataType, &vStrides, &vDims));
 
-    auto sdpaBwdAttributes = hipdnn_data_sdk::data_objects::CreateSdpaBackwardAttributes(
+    auto sdpaBwdAttributes = hipdnn_flatbuffers_sdk::data_objects::CreateSdpaBackwardAttributes(
         builder, qUid, kUid, vUid, oUid, doUid, statsUid, dqUid, dkUid, dvUid);
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "sdpa_bwd",
         dataType,
-        hipdnn_data_sdk::data_objects::NodeAttributes::SdpaBackwardAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::SdpaBackwardAttributes,
         sdpaBwdAttributes.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::HALF,
-        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
@@ -2224,38 +2264,48 @@ inline flatbuffers::FlatBufferBuilder
 inline flatbuffers::FlatBufferBuilder createValidCustomOpGraph()
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     const std::vector<int64_t> dims = {4, 8};
     const std::vector<int64_t> strides = {8, 1};
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 1, "input_0", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 2, "output_0", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides, &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        1,
+        "input_0",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &strides,
+        &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        2,
+        "output_0",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &strides,
+        &dims));
 
     const std::vector<int64_t> inputUids = {1};
     const std::vector<int64_t> outputUids = {2};
     const std::vector<uint8_t> data = {0x01, 0x02};
 
-    auto customOpAttr = hipdnn_data_sdk::data_objects::CreateCustomOpAttributesDirect(
+    auto customOpAttr = hipdnn_flatbuffers_sdk::data_objects::CreateCustomOpAttributesDirect(
         builder, "my_plugin_op", &inputUids, &outputUids, &data);
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "custom_op",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::CustomOpAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::CustomOpAttributes,
         customOpAttr.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
@@ -2265,7 +2315,7 @@ inline flatbuffers::FlatBufferBuilder createValidCustomOpGraph()
 inline flatbuffers::FlatBufferBuilder createValidReductionGraph()
 {
     flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
     const std::vector<int64_t> inDims = {4, 8};
@@ -2273,33 +2323,38 @@ inline flatbuffers::FlatBufferBuilder createValidReductionGraph()
     const std::vector<int64_t> outDims = {1, 8};
     const std::vector<int64_t> outStrides = {8, 1};
 
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 1, "input", hipdnn_data_sdk::data_objects::DataType::FLOAT, &inStrides, &inDims));
-    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        1,
+        "input",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        &inStrides,
+        &inDims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder,
         2,
         "output",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &outStrides,
         &outDims));
 
-    auto reductionAttr = hipdnn_data_sdk::data_objects::CreateReductionAttributes(
-        builder, hipdnn_data_sdk::data_objects::ReductionMode::ADD, 1, 2);
+    auto reductionAttr = hipdnn_flatbuffers_sdk::data_objects::CreateReductionAttributes(
+        builder, hipdnn_flatbuffers_sdk::data_objects::ReductionMode::ADD, 1, 2);
 
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    nodes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
         builder,
         "reduction",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::NodeAttributes::ReductionAttributes,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::ReductionAttributes,
         reductionAttr.Union()));
 
-    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
         builder,
         "test",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
         &tensorAttributes,
         &nodes);
     builder.Finish(graphOffset);
@@ -2309,7 +2364,8 @@ inline flatbuffers::FlatBufferBuilder createValidReductionGraph()
 inline flatbuffers::FlatBufferBuilder createValidEngineConfig(int64_t configId)
 {
     flatbuffers::FlatBufferBuilder builder;
-    auto engineConfigOffset = hipdnn_data_sdk::data_objects::CreateEngineConfig(builder, configId);
+    auto engineConfigOffset
+        = hipdnn_flatbuffers_sdk::data_objects::CreateEngineConfig(builder, configId);
     builder.Finish(engineConfigOffset);
     return builder;
 }

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/LoadGraphAndTensors.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/LoadGraphAndTensors.hpp
@@ -5,12 +5,12 @@
 
 #include <filesystem>
 #include <fstream>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_data_sdk/logging/Logger.hpp>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
 #include <hipdnn_data_sdk/utilities/Visitor.hpp>
-#ifndef HIPDNN_DATA_SDK_SKIP_JSON_LIB
-#include <hipdnn_data_sdk/utilities/json/Graph.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#ifndef HIPDNN_FLATBUFFERS_SDK_SKIP_JSON_LIB
+#include <hipdnn_flatbuffers_sdk/utilities/json/Graph.hpp>
 #endif
 #include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
@@ -23,9 +23,9 @@
 namespace hipdnn_test_sdk::utilities
 {
 
-inline std::unique_ptr<hipdnn_data_sdk::utilities::ITensor>
-    tensorFromFileAndAttributes(const std::filesystem::path& filepath,
-                                const hipdnn_data_sdk::data_objects::TensorAttributes& attributes)
+inline std::unique_ptr<hipdnn_data_sdk::utilities::ITensor> tensorFromFileAndAttributes(
+    const std::filesystem::path& filepath,
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& attributes)
 {
     auto tensor = hipdnn_test_sdk::detail::createTensorFromAttribute(attributes);
     hipdnn_test_sdk::detail::fillTensorFromFile(*tensor, filepath);
@@ -39,15 +39,15 @@ struct GraphAndTensorMap
     std::unordered_map<int64_t, std::unique_ptr<hipdnn_data_sdk::utilities::ITensor>> tensorMap;
     std::vector<int64_t> outputTensorUids;
 
-    const hipdnn_data_sdk::data_objects::Graph& graph() const
+    const hipdnn_flatbuffers_sdk::data_objects::Graph& graph() const
     {
-        return *hipdnn_data_sdk::data_objects::GetGraph(graphBuffer.data());
+        return *hipdnn_flatbuffers_sdk::data_objects::GetGraph(graphBuffer.data());
     }
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper createGraphWrapper() const
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper createGraphWrapper() const
     {
-        return hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper{graphBuffer.data(),
-                                                                   graphBuffer.size()};
+        return hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper{graphBuffer.data(),
+                                                                          graphBuffer.size()};
     }
 
     std::vector<hipdnnPluginDeviceBuffer_t> deviceBuffers()
@@ -142,7 +142,7 @@ struct GraphAndTensorMap
     }
 };
 
-#ifndef HIPDNN_DATA_SDK_SKIP_JSON_LIB
+#ifndef HIPDNN_FLATBUFFERS_SDK_SKIP_JSON_LIB
 
 inline std::vector<int64_t> getOutputTensorUidsFromGraph(nlohmann::json graph)
 {
@@ -181,10 +181,11 @@ inline GraphAndTensorMap loadGraphAndTensors(const std::filesystem::path& path)
 
     flatbuffers::FlatBufferBuilder graphBuilder;
     auto graphOffset
-        = hipdnn_data_sdk::json::to<hipdnn_data_sdk::data_objects::Graph>(graphBuilder, graphJson);
+        = hipdnn_flatbuffers_sdk::json::to<hipdnn_flatbuffers_sdk::data_objects::Graph>(
+            graphBuilder, graphJson);
     graphBuilder.Finish(graphOffset);
 
-    auto graph = hipdnn_data_sdk::data_objects::GetGraph(graphBuilder.GetBufferPointer());
+    auto graph = hipdnn_flatbuffers_sdk::data_objects::GetGraph(graphBuilder.GetBufferPointer());
 
     auto outputTensorUids = getOutputTensorUidsFromGraph(graphJson);
 
@@ -204,6 +205,6 @@ inline GraphAndTensorMap loadGraphAndTensors(const std::filesystem::path& path)
     return {graphBuilder.Release(), std::move(tensorMap), outputTensorUids};
 }
 
-#endif // HIPDNN_DATA_SDK_SKIP_JSON_LIB
+#endif // HIPDNN_FLATBUFFERS_SDK_SKIP_JSON_LIB
 
 }

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/LoweringTestHelpers.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/LoweringTestHelpers.hpp
@@ -8,7 +8,7 @@
 #include <vector>
 
 #include <hipdnn_backend.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_test_sdk/utilities/TestableGraph.hpp>
 
 namespace hipdnn_tests
@@ -18,12 +18,12 @@ namespace hipdnn_tests
 /// retrieves the serialized binary graph, and deserializes it into a GraphT.
 /// Uses EXPECT macros internally; callers should verify the returned GraphT
 /// is well-formed (e.g., check tensors.size()).
-inline hipdnn_data_sdk::data_objects::GraphT lowerAndDeserialize(TestableGraphLowering& graph,
-                                                                 hipdnnHandle_t handle)
+inline hipdnn_flatbuffers_sdk::data_objects::GraphT
+    lowerAndDeserialize(TestableGraphLowering& graph, hipdnnHandle_t handle)
 {
     using hipdnn_frontend::ErrorCode;
 
-    hipdnn_data_sdk::data_objects::GraphT graphT;
+    hipdnn_flatbuffers_sdk::data_objects::GraphT graphT;
 
     auto result = graph.validate();
     EXPECT_EQ(result.code, ErrorCode::OK) << result.err_msg;
@@ -63,7 +63,7 @@ inline hipdnn_data_sdk::data_objects::GraphT lowerAndDeserialize(TestableGraphLo
         return graphT;
     }
 
-    auto graphFb = hipdnn_data_sdk::data_objects::GetGraph(serializedData.data());
+    auto graphFb = hipdnn_flatbuffers_sdk::data_objects::GetGraph(serializedData.data());
     EXPECT_NE(graphFb, nullptr); // NOLINT(readability-implicit-bool-conversion)
     if(graphFb != nullptr)
     {
@@ -74,10 +74,11 @@ inline hipdnn_data_sdk::data_objects::GraphT lowerAndDeserialize(TestableGraphLo
 }
 
 /// Builds a UID-to-TensorAttributesT lookup map from a deserialized GraphT.
-inline std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributesT*>
-    buildTensorMap(const hipdnn_data_sdk::data_objects::GraphT& graphT)
+inline std::unordered_map<int64_t, const hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT*>
+    buildTensorMap(const hipdnn_flatbuffers_sdk::data_objects::GraphT& graphT)
 {
-    std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributesT*> tensorMap;
+    std::unordered_map<int64_t, const hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT*>
+        tensorMap;
     for(const auto& t : graphT.tensors)
     {
         tensorMap[t->uid] = t.get();

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/MockEngineConfig.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/MockEngineConfig.hpp
@@ -5,27 +5,27 @@
 
 #include <gmock/gmock.h>
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
 
 namespace hipdnn_test_sdk::utilities
 {
 
-class MockEngineConfig : public hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig
+class MockEngineConfig : public hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig
 {
 public:
-    MOCK_METHOD(const hipdnn_data_sdk::data_objects::EngineConfig&,
+    MOCK_METHOD(const hipdnn_flatbuffers_sdk::data_objects::EngineConfig&,
                 getEngineConfig,
                 (),
                 (const, override));
     MOCK_METHOD(bool, isValid, (), (const, override));
     MOCK_METHOD(int64_t, engineId, (), (const, override));
     MOCK_METHOD(uint32_t, knobSettingCount, (), (const, override));
-    MOCK_METHOD(
-        (const std::vector<std::unique_ptr<hipdnn_data_sdk::flatbuffer_utilities::IKnobSetting>>&),
-        knobSettingWrappers,
-        (),
-        (const, override));
-    MOCK_METHOD(const hipdnn_data_sdk::flatbuffer_utilities::IKnobSetting&,
+    MOCK_METHOD((const std::vector<
+                    std::unique_ptr<hipdnn_flatbuffers_sdk::flatbuffer_utilities::IKnobSetting>>&),
+                knobSettingWrappers,
+                (),
+                (const, override));
+    MOCK_METHOD(const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IKnobSetting&,
                 getKnobSettingByName,
                 (const std::string& knobName),
                 (const, override));

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/MockGraph.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/MockGraph.hpp
@@ -5,39 +5,44 @@
 
 #include <gmock/gmock.h>
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 
 namespace hipdnn_test_sdk::utilities
 {
 
-class MockGraph : public hipdnn_data_sdk::flatbuffer_utilities::IGraph
+class MockGraph : public hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph
 {
 public:
-    MOCK_METHOD(const hipdnn_data_sdk::data_objects::Graph&, getGraph, (), (const, override));
+    MOCK_METHOD(const hipdnn_flatbuffers_sdk::data_objects::Graph&,
+                getGraph,
+                (),
+                (const, override));
     MOCK_METHOD(bool, isValid, (), (const, override));
     MOCK_METHOD(uint32_t, nodeCount, (), (const, override));
-    MOCK_METHOD(bool,
-                hasOnlySupportedAttributes,
-                (std::set<hipdnn_data_sdk::data_objects::NodeAttributes> supportedAttributes),
-                (const, override));
-    MOCK_METHOD(const hipdnn_data_sdk::data_objects::Node&,
+    MOCK_METHOD(
+        bool,
+        hasOnlySupportedAttributes,
+        (std::set<hipdnn_flatbuffers_sdk::data_objects::NodeAttributes> supportedAttributes),
+        (const, override));
+    MOCK_METHOD(const hipdnn_flatbuffers_sdk::data_objects::Node&,
                 getNode,
                 (uint32_t index),
                 (const, override));
-    MOCK_METHOD(const hipdnn_data_sdk::flatbuffer_utilities::INodeWrapper&,
+    MOCK_METHOD(const hipdnn_flatbuffers_sdk::flatbuffer_utilities::INodeWrapper&,
                 getNodeWrapper,
                 (uint32_t index),
                 (const, override));
-    MOCK_METHOD((const std::unordered_map<int64_t,
-                                          const hipdnn_data_sdk::data_objects::TensorAttributes*>&),
-                getTensorMap,
-                (),
-                (const, override));
     MOCK_METHOD(
-        const std::vector<std::unique_ptr<hipdnn_data_sdk::flatbuffer_utilities::INodeWrapper>>&,
-        nodeWrappers,
+        (const std::unordered_map<int64_t,
+                                  const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&),
+        getTensorMap,
         (),
         (const, override));
+    MOCK_METHOD(const std::vector<
+                    std::unique_ptr<hipdnn_flatbuffers_sdk::flatbuffer_utilities::INodeWrapper>>&,
+                nodeWrappers,
+                (),
+                (const, override));
 
     ~MockGraph() override = default;
 };

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/MockNode.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/MockNode.hpp
@@ -5,24 +5,27 @@
 
 #include <gmock/gmock.h>
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/NodeWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/NodeWrapper.hpp>
 
 namespace hipdnn_test_sdk::utilities
 {
 
-class MockNode : public hipdnn_data_sdk::flatbuffer_utilities::INodeWrapper
+class MockNode : public hipdnn_flatbuffers_sdk::flatbuffer_utilities::INodeWrapper
 {
 public:
     MOCK_METHOD(bool, isValid, (), (const, override));
-    MOCK_METHOD(const hipdnn_data_sdk::data_objects::Node&, node, (), (const, override));
+    MOCK_METHOD(const hipdnn_flatbuffers_sdk::data_objects::Node&, node, (), (const, override));
 
     MOCK_METHOD(const void*, attributes, (), (const, override));
-    MOCK_METHOD(hipdnn_data_sdk::data_objects::NodeAttributes,
+    MOCK_METHOD(hipdnn_flatbuffers_sdk::data_objects::NodeAttributes,
                 attributesType,
                 (),
                 (const, override));
     MOCK_METHOD(std::string, name, (), (const, override));
-    MOCK_METHOD(hipdnn_data_sdk::data_objects::DataType, computeDataType, (), (const, override));
+    MOCK_METHOD(hipdnn_flatbuffers_sdk::data_objects::DataType,
+                computeDataType,
+                (),
+                (const, override));
 };
 
 }

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/SdkFrontendTypeConversions.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/SdkFrontendTypeConversions.hpp
@@ -3,9 +3,9 @@
 
 #pragma once
 
-#include <hipdnn_data_sdk/data_objects/data_types_generated.h>
-#include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/data_types_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/pointwise_attributes_generated.h>
 #include <hipdnn_frontend/Types.hpp>
 #include <hipdnn_frontend/attributes/TensorAttributes.hpp>
 
@@ -16,81 +16,81 @@ namespace hipdnn_test_sdk::utilities
 // If new data types are added, update the mappings below.
 
 /// Convert frontend DataType to SDK DataType for use in test utilities
-inline hipdnn_data_sdk::data_objects::DataType
+inline hipdnn_flatbuffers_sdk::data_objects::DataType
     frontendToSdkDataType(const hipdnn_frontend::DataType& type)
 {
     switch(type)
     {
     case hipdnn_frontend::DataType::FLOAT:
-        return hipdnn_data_sdk::data_objects::DataType::FLOAT;
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT;
     case hipdnn_frontend::DataType::HALF:
-        return hipdnn_data_sdk::data_objects::DataType::HALF;
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::HALF;
     case hipdnn_frontend::DataType::BFLOAT16:
-        return hipdnn_data_sdk::data_objects::DataType::BFLOAT16;
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16;
     case hipdnn_frontend::DataType::DOUBLE:
-        return hipdnn_data_sdk::data_objects::DataType::DOUBLE;
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::DOUBLE;
     case hipdnn_frontend::DataType::UINT8:
-        return hipdnn_data_sdk::data_objects::DataType::UINT8;
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::UINT8;
     case hipdnn_frontend::DataType::INT32:
-        return hipdnn_data_sdk::data_objects::DataType::INT32;
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::INT32;
     case hipdnn_frontend::DataType::INT8:
-        return hipdnn_data_sdk::data_objects::DataType::INT8;
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::INT8;
     case hipdnn_frontend::DataType::FP8_E4M3:
-        return hipdnn_data_sdk::data_objects::DataType::FP8_E4M3;
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E4M3;
     case hipdnn_frontend::DataType::FP8_E5M2:
-        return hipdnn_data_sdk::data_objects::DataType::FP8_E5M2;
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E5M2;
     case hipdnn_frontend::DataType::FP8_E8M0:
-        return hipdnn_data_sdk::data_objects::DataType::FP8_E8M0;
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E8M0;
     case hipdnn_frontend::DataType::FP4_E2M1:
-        return hipdnn_data_sdk::data_objects::DataType::FP4_E2M1;
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::FP4_E2M1;
     case hipdnn_frontend::DataType::INT4:
-        return hipdnn_data_sdk::data_objects::DataType::INT4;
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::INT4;
     case hipdnn_frontend::DataType::FP6_E2M3:
-        return hipdnn_data_sdk::data_objects::DataType::FP6_E2M3;
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::FP6_E2M3;
     case hipdnn_frontend::DataType::FP6_E3M2:
-        return hipdnn_data_sdk::data_objects::DataType::FP6_E3M2;
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::FP6_E3M2;
     case hipdnn_frontend::DataType::INT64:
-        return hipdnn_data_sdk::data_objects::DataType::INT64;
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::INT64;
     default:
-        return hipdnn_data_sdk::data_objects::DataType::UNSET;
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET;
     }
 }
 
 /// Convert SDK DataType to frontend DataType for use in test utilities
 inline hipdnn_frontend::DataType
-    sdkToFrontendDataType(const hipdnn_data_sdk::data_objects::DataType& type)
+    sdkToFrontendDataType(const hipdnn_flatbuffers_sdk::data_objects::DataType& type)
 {
     switch(type)
     {
-    case hipdnn_data_sdk::data_objects::DataType::FLOAT:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT:
         return hipdnn_frontend::DataType::FLOAT;
-    case hipdnn_data_sdk::data_objects::DataType::HALF:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::HALF:
         return hipdnn_frontend::DataType::HALF;
-    case hipdnn_data_sdk::data_objects::DataType::BFLOAT16:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16:
         return hipdnn_frontend::DataType::BFLOAT16;
-    case hipdnn_data_sdk::data_objects::DataType::DOUBLE:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::DOUBLE:
         return hipdnn_frontend::DataType::DOUBLE;
-    case hipdnn_data_sdk::data_objects::DataType::UINT8:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::UINT8:
         return hipdnn_frontend::DataType::UINT8;
-    case hipdnn_data_sdk::data_objects::DataType::INT32:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::INT32:
         return hipdnn_frontend::DataType::INT32;
-    case hipdnn_data_sdk::data_objects::DataType::INT8:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::INT8:
         return hipdnn_frontend::DataType::INT8;
-    case hipdnn_data_sdk::data_objects::DataType::FP8_E4M3:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E4M3:
         return hipdnn_frontend::DataType::FP8_E4M3;
-    case hipdnn_data_sdk::data_objects::DataType::FP8_E5M2:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E5M2:
         return hipdnn_frontend::DataType::FP8_E5M2;
-    case hipdnn_data_sdk::data_objects::DataType::FP8_E8M0:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E8M0:
         return hipdnn_frontend::DataType::FP8_E8M0;
-    case hipdnn_data_sdk::data_objects::DataType::FP4_E2M1:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::FP4_E2M1:
         return hipdnn_frontend::DataType::FP4_E2M1;
-    case hipdnn_data_sdk::data_objects::DataType::INT4:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::INT4:
         return hipdnn_frontend::DataType::INT4;
-    case hipdnn_data_sdk::data_objects::DataType::FP6_E2M3:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::FP6_E2M3:
         return hipdnn_frontend::DataType::FP6_E2M3;
-    case hipdnn_data_sdk::data_objects::DataType::FP6_E3M2:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::FP6_E3M2:
         return hipdnn_frontend::DataType::FP6_E3M2;
-    case hipdnn_data_sdk::data_objects::DataType::INT64:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::INT64:
         return hipdnn_frontend::DataType::INT64;
     default:
         return hipdnn_frontend::DataType::NOT_SET;
@@ -98,213 +98,213 @@ inline hipdnn_frontend::DataType
 }
 
 /// Convert frontend PointwiseMode to SDK PointwiseMode for use in test utilities
-inline hipdnn_data_sdk::data_objects::PointwiseMode
+inline hipdnn_flatbuffers_sdk::data_objects::PointwiseMode
     frontendToSdkPointwiseMode(const hipdnn_frontend::PointwiseMode& mode)
 {
     switch(mode)
     {
     case hipdnn_frontend::PointwiseMode::NOT_SET:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::UNSET;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::UNSET;
     case hipdnn_frontend::PointwiseMode::ABS:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::ABS;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::ABS;
     case hipdnn_frontend::PointwiseMode::ADD:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::ADD;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::ADD;
     case hipdnn_frontend::PointwiseMode::ADD_SQUARE:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::ADD_SQUARE;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::ADD_SQUARE;
     case hipdnn_frontend::PointwiseMode::BINARY_SELECT:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::BINARY_SELECT;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::BINARY_SELECT;
     case hipdnn_frontend::PointwiseMode::CEIL:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::CEIL;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::CEIL;
     case hipdnn_frontend::PointwiseMode::CMP_EQ:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::CMP_EQ;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::CMP_EQ;
     case hipdnn_frontend::PointwiseMode::CMP_GE:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::CMP_GE;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::CMP_GE;
     case hipdnn_frontend::PointwiseMode::CMP_GT:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::CMP_GT;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::CMP_GT;
     case hipdnn_frontend::PointwiseMode::CMP_LE:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::CMP_LE;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::CMP_LE;
     case hipdnn_frontend::PointwiseMode::CMP_LT:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::CMP_LT;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::CMP_LT;
     case hipdnn_frontend::PointwiseMode::CMP_NEQ:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::CMP_NEQ;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::CMP_NEQ;
     case hipdnn_frontend::PointwiseMode::DIV:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::DIV;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::DIV;
     case hipdnn_frontend::PointwiseMode::ELU_BWD:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::ELU_BWD;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::ELU_BWD;
     case hipdnn_frontend::PointwiseMode::ELU_FWD:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::ELU_FWD;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::ELU_FWD;
     case hipdnn_frontend::PointwiseMode::ERF:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::ERF;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::ERF;
     case hipdnn_frontend::PointwiseMode::EXP:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::EXP;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::EXP;
     case hipdnn_frontend::PointwiseMode::FLOOR:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::FLOOR;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::FLOOR;
     case hipdnn_frontend::PointwiseMode::GELU_APPROX_TANH_BWD:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::GELU_APPROX_TANH_BWD;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::GELU_APPROX_TANH_BWD;
     case hipdnn_frontend::PointwiseMode::GELU_APPROX_TANH_FWD:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::GELU_APPROX_TANH_FWD;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::GELU_APPROX_TANH_FWD;
     case hipdnn_frontend::PointwiseMode::GELU_BWD:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::GELU_BWD;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::GELU_BWD;
     case hipdnn_frontend::PointwiseMode::GELU_FWD:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::GELU_FWD;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::GELU_FWD;
     case hipdnn_frontend::PointwiseMode::GEN_INDEX:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::GEN_INDEX;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::GEN_INDEX;
     case hipdnn_frontend::PointwiseMode::IDENTITY:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::IDENTITY;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::IDENTITY;
     case hipdnn_frontend::PointwiseMode::LOG:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::LOG;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::LOG;
     case hipdnn_frontend::PointwiseMode::LOGICAL_AND:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::LOGICAL_AND;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::LOGICAL_AND;
     case hipdnn_frontend::PointwiseMode::LOGICAL_NOT:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::LOGICAL_NOT;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::LOGICAL_NOT;
     case hipdnn_frontend::PointwiseMode::LOGICAL_OR:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::LOGICAL_OR;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::LOGICAL_OR;
     case hipdnn_frontend::PointwiseMode::MAX:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::MAX_OP;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::MAX_OP;
     case hipdnn_frontend::PointwiseMode::MIN:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::MIN_OP;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::MIN_OP;
     case hipdnn_frontend::PointwiseMode::MUL:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::MUL;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::MUL;
     case hipdnn_frontend::PointwiseMode::NEG:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::NEG;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::NEG;
     case hipdnn_frontend::PointwiseMode::RECIPROCAL:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::RECIPROCAL;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RECIPROCAL;
     case hipdnn_frontend::PointwiseMode::RELU_BWD:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD;
     case hipdnn_frontend::PointwiseMode::RELU_FWD:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD;
     case hipdnn_frontend::PointwiseMode::RSQRT:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::RSQRT;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RSQRT;
     case hipdnn_frontend::PointwiseMode::SIGMOID_BWD:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::SIGMOID_BWD;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SIGMOID_BWD;
     case hipdnn_frontend::PointwiseMode::SIGMOID_FWD:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::SIGMOID_FWD;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SIGMOID_FWD;
     case hipdnn_frontend::PointwiseMode::SIN:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::SIN;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SIN;
     case hipdnn_frontend::PointwiseMode::SOFTPLUS_BWD:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::SOFTPLUS_BWD;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SOFTPLUS_BWD;
     case hipdnn_frontend::PointwiseMode::SOFTPLUS_FWD:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::SOFTPLUS_FWD;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SOFTPLUS_FWD;
     case hipdnn_frontend::PointwiseMode::SQRT:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::SQRT;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SQRT;
     case hipdnn_frontend::PointwiseMode::SUB:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::SUB;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SUB;
     case hipdnn_frontend::PointwiseMode::SWISH_BWD:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::SWISH_BWD;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SWISH_BWD;
     case hipdnn_frontend::PointwiseMode::SWISH_FWD:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::SWISH_FWD;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SWISH_FWD;
     case hipdnn_frontend::PointwiseMode::TAN:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::TAN;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::TAN;
     case hipdnn_frontend::PointwiseMode::TANH_BWD:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::TANH_BWD;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::TANH_BWD;
     case hipdnn_frontend::PointwiseMode::TANH_FWD:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::TANH_FWD;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::TANH_FWD;
     default:
-        return hipdnn_data_sdk::data_objects::PointwiseMode::UNSET;
+        return hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::UNSET;
     }
 }
 
 /// Convert SDK PointwiseMode to frontend PointwiseMode for use in test utilities
 inline hipdnn_frontend::PointwiseMode
-    sdkToFrontendPointwiseMode(const hipdnn_data_sdk::data_objects::PointwiseMode& mode)
+    sdkToFrontendPointwiseMode(const hipdnn_flatbuffers_sdk::data_objects::PointwiseMode& mode)
 {
     switch(mode)
     {
-    case hipdnn_data_sdk::data_objects::PointwiseMode::UNSET:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::UNSET:
         return hipdnn_frontend::PointwiseMode::NOT_SET;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::ABS:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::ABS:
         return hipdnn_frontend::PointwiseMode::ABS;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::ADD:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::ADD:
         return hipdnn_frontend::PointwiseMode::ADD;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::ADD_SQUARE:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::ADD_SQUARE:
         return hipdnn_frontend::PointwiseMode::ADD_SQUARE;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::BINARY_SELECT:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::BINARY_SELECT:
         return hipdnn_frontend::PointwiseMode::BINARY_SELECT;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::CEIL:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::CEIL:
         return hipdnn_frontend::PointwiseMode::CEIL;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::CMP_EQ:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::CMP_EQ:
         return hipdnn_frontend::PointwiseMode::CMP_EQ;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::CMP_GE:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::CMP_GE:
         return hipdnn_frontend::PointwiseMode::CMP_GE;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::CMP_GT:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::CMP_GT:
         return hipdnn_frontend::PointwiseMode::CMP_GT;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::CMP_LE:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::CMP_LE:
         return hipdnn_frontend::PointwiseMode::CMP_LE;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::CMP_LT:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::CMP_LT:
         return hipdnn_frontend::PointwiseMode::CMP_LT;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::CMP_NEQ:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::CMP_NEQ:
         return hipdnn_frontend::PointwiseMode::CMP_NEQ;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::DIV:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::DIV:
         return hipdnn_frontend::PointwiseMode::DIV;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::ELU_BWD:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::ELU_BWD:
         return hipdnn_frontend::PointwiseMode::ELU_BWD;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::ELU_FWD:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::ELU_FWD:
         return hipdnn_frontend::PointwiseMode::ELU_FWD;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::ERF:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::ERF:
         return hipdnn_frontend::PointwiseMode::ERF;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::EXP:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::EXP:
         return hipdnn_frontend::PointwiseMode::EXP;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::FLOOR:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::FLOOR:
         return hipdnn_frontend::PointwiseMode::FLOOR;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::GELU_APPROX_TANH_BWD:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::GELU_APPROX_TANH_BWD:
         return hipdnn_frontend::PointwiseMode::GELU_APPROX_TANH_BWD;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::GELU_APPROX_TANH_FWD:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::GELU_APPROX_TANH_FWD:
         return hipdnn_frontend::PointwiseMode::GELU_APPROX_TANH_FWD;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::GELU_BWD:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::GELU_BWD:
         return hipdnn_frontend::PointwiseMode::GELU_BWD;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::GELU_FWD:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::GELU_FWD:
         return hipdnn_frontend::PointwiseMode::GELU_FWD;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::GEN_INDEX:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::GEN_INDEX:
         return hipdnn_frontend::PointwiseMode::GEN_INDEX;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::IDENTITY:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::IDENTITY:
         return hipdnn_frontend::PointwiseMode::IDENTITY;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::LOG:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::LOG:
         return hipdnn_frontend::PointwiseMode::LOG;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::LOGICAL_AND:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::LOGICAL_AND:
         return hipdnn_frontend::PointwiseMode::LOGICAL_AND;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::LOGICAL_NOT:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::LOGICAL_NOT:
         return hipdnn_frontend::PointwiseMode::LOGICAL_NOT;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::LOGICAL_OR:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::LOGICAL_OR:
         return hipdnn_frontend::PointwiseMode::LOGICAL_OR;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::MAX_OP:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::MAX_OP:
         return hipdnn_frontend::PointwiseMode::MAX;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::MIN_OP:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::MIN_OP:
         return hipdnn_frontend::PointwiseMode::MIN;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::MUL:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::MUL:
         return hipdnn_frontend::PointwiseMode::MUL;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::NEG:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::NEG:
         return hipdnn_frontend::PointwiseMode::NEG;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::RECIPROCAL:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RECIPROCAL:
         return hipdnn_frontend::PointwiseMode::RECIPROCAL;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD:
         return hipdnn_frontend::PointwiseMode::RELU_BWD;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD:
         return hipdnn_frontend::PointwiseMode::RELU_FWD;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::RSQRT:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RSQRT:
         return hipdnn_frontend::PointwiseMode::RSQRT;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::SIGMOID_BWD:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SIGMOID_BWD:
         return hipdnn_frontend::PointwiseMode::SIGMOID_BWD;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::SIGMOID_FWD:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SIGMOID_FWD:
         return hipdnn_frontend::PointwiseMode::SIGMOID_FWD;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::SIN:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SIN:
         return hipdnn_frontend::PointwiseMode::SIN;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::SOFTPLUS_BWD:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SOFTPLUS_BWD:
         return hipdnn_frontend::PointwiseMode::SOFTPLUS_BWD;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::SOFTPLUS_FWD:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SOFTPLUS_FWD:
         return hipdnn_frontend::PointwiseMode::SOFTPLUS_FWD;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::SQRT:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SQRT:
         return hipdnn_frontend::PointwiseMode::SQRT;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::SUB:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SUB:
         return hipdnn_frontend::PointwiseMode::SUB;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::SWISH_BWD:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SWISH_BWD:
         return hipdnn_frontend::PointwiseMode::SWISH_BWD;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::SWISH_FWD:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SWISH_FWD:
         return hipdnn_frontend::PointwiseMode::SWISH_FWD;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::TAN:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::TAN:
         return hipdnn_frontend::PointwiseMode::TAN;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::TANH_BWD:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::TANH_BWD:
         return hipdnn_frontend::PointwiseMode::TANH_BWD;
-    case hipdnn_data_sdk::data_objects::PointwiseMode::TANH_FWD:
+    case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::TANH_FWD:
         return hipdnn_frontend::PointwiseMode::TANH_FWD;
     default:
         return hipdnn_frontend::PointwiseMode::NOT_SET;

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/CpuReferenceGraphExecutor.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/CpuReferenceGraphExecutor.hpp
@@ -4,11 +4,8 @@
 #pragma once
 
 #include <cstring>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 
-#ifndef HIPDNN_DATA_SDK_SKIP_JSON_LIB
-#include <hipdnn_data_sdk/utilities/json/Graph.hpp>
-#endif
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormFwdInferencePlan.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormFwdInferenceWithVarianceSignatureKey.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionBwdPlan.hpp>
@@ -36,7 +33,8 @@ public:
                  size_t size,
                  const std::unordered_map<int64_t, void*>& variantPack)
     {
-        auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(graphBuffer, size);
+        auto graphWrap
+            = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(graphBuffer, size);
 
         std::vector<std::unique_ptr<detail::IGraphNodePlanExecutor>> planExecutors;
 
@@ -61,7 +59,8 @@ public:
 private:
     static std::unordered_map<int64_t, void*> populateVariantPackWithMissingVirtualTensors(
         const std::unordered_map<int64_t, void*>& variantPack,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap,
         std::vector<std::unique_ptr<hipdnn_data_sdk::utilities::ITensor>>& virtualTensors)
     {
@@ -81,8 +80,8 @@ private:
     }
 
     std::unique_ptr<detail::IGraphNodePlanExecutor>
-        buildPlanForNode(const hipdnn_data_sdk::flatbuffer_utilities::IGraph& graph,
-                         const hipdnn_data_sdk::data_objects::Node& node)
+        buildPlanForNode(const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& graph,
+                         const hipdnn_flatbuffers_sdk::data_objects::Node& node)
     {
         auto key = buildSignatureKey(node, graph.getTensorMap(), node.compute_data_type());
 
@@ -98,38 +97,40 @@ private:
     }
 
     static detail::PlanRegistrySignatureKey buildSignatureKey(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap,
-        const hipdnn_data_sdk::data_objects::DataType computeType)
+        const hipdnn_flatbuffers_sdk::data_objects::DataType computeType)
     {
         switch(node.attributes_type())
         {
-        case hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes:
+        case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes:
             return detail::BatchnormFwdInferenceSignatureKey(node, tensorMap);
-        case hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributesVarianceExt:
+        case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::
+            BatchnormInferenceAttributesVarianceExt:
             return detail::BatchnormFwdInferenceWithVarianceSignatureKey(node, tensorMap);
-        case hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes:
+        case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes:
             return detail::PointwiseSignatureKey(node, tensorMap);
-        case hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes:
+        case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes:
             return detail::BatchnormBwdSignatureKey(node, tensorMap);
-        case hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes:
+        case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes:
             return detail::BatchnormTrainSignatureKey(node, tensorMap);
-        case hipdnn_data_sdk::data_objects::NodeAttributes::ConvolutionFwdAttributes:
+        case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::ConvolutionFwdAttributes:
             return detail::ConvolutionFwdSignatureKey(node, tensorMap, computeType);
-        case hipdnn_data_sdk::data_objects::NodeAttributes::ConvolutionBwdAttributes:
+        case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::ConvolutionBwdAttributes:
             return detail::ConvolutionBwdSignatureKey(node, tensorMap, computeType);
-        case hipdnn_data_sdk::data_objects::NodeAttributes::ConvolutionWrwAttributes:
+        case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::ConvolutionWrwAttributes:
             return detail::ConvolutionWrwSignatureKey(node, tensorMap, computeType);
-        case hipdnn_data_sdk::data_objects::NodeAttributes::LayernormAttributes:
+        case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::LayernormAttributes:
             return detail::LayernormFpropSignatureKey(node, tensorMap);
-        case hipdnn_data_sdk::data_objects::NodeAttributes::MatmulAttributes:
+        case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::MatmulAttributes:
             return detail::MatmulSignatureKey(node, tensorMap, computeType);
-        case hipdnn_data_sdk::data_objects::NodeAttributes::RMSNormAttributes:
+        case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::RMSNormAttributes:
             return detail::RMSNormFwdSignatureKey(node, tensorMap);
-        case hipdnn_data_sdk::data_objects::NodeAttributes::SdpaAttributes:
+        case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::SdpaAttributes:
             return detail::SdpaFwdSignatureKey(node, tensorMap);
-        case hipdnn_data_sdk::data_objects::NodeAttributes::ReductionAttributes:
+        case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::ReductionAttributes:
             return detail::ReductionSignatureKey(node, tensorMap, computeType);
         default:
             throw std::runtime_error("Unsupported node type for signature key generation");

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/GraphTensorBundle.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/GraphTensorBundle.hpp
@@ -7,8 +7,8 @@
 #include <unordered_set>
 #include <vector>
 
-#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/tensor_attributes_generated.h>
 #include <hipdnn_test_sdk/utilities/FlatbufferDatatypeMapping.hpp>
 #include <hipdnn_test_sdk/utilities/detail/FlatbufferTensorAttributesUtils.hpp>
 
@@ -20,7 +20,8 @@ struct GraphTensorBundle
     GraphTensorBundle() = default;
 
     GraphTensorBundle(
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap)
     {
         for(const auto& [id, attr] : tensorMap)

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormBwdPlan.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormBwdPlan.hpp
@@ -6,8 +6,8 @@
 #include <functional>
 #include <variant>
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceBatchnorm.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferDatatypeMapping.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/IGraphNodePlanBuilder.hpp>
@@ -21,16 +21,16 @@ namespace hipdnn_test_sdk::detail
 struct BatchnormBwdParams
 {
     BatchnormBwdParams() = default;
-    BatchnormBwdParams(const hipdnn_data_sdk::data_objects::TensorAttributes& dyAttributes,
-                       const hipdnn_data_sdk::data_objects::TensorAttributes& xAttributes,
-                       const hipdnn_data_sdk::data_objects::TensorAttributes& scaleAttributes,
-                       const hipdnn_data_sdk::data_objects::TensorAttributes& dxAttributes,
-                       const hipdnn_data_sdk::data_objects::TensorAttributes& dscaleAttributes,
-                       const hipdnn_data_sdk::data_objects::TensorAttributes& dbiasAttributes,
-                       const hipdnn_data_sdk::data_objects::TensorAttributes* meanAttributes
-                       = nullptr,
-                       const hipdnn_data_sdk::data_objects::TensorAttributes* invVarianceAttributes
-                       = nullptr)
+    BatchnormBwdParams(
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& dyAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& xAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& scaleAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& dxAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& dscaleAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& dbiasAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* meanAttributes = nullptr,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* invVarianceAttributes
+        = nullptr)
         : dyTensor(unpackTensorAttributes(dyAttributes))
         , xTensor(unpackTensorAttributes(xAttributes))
         , scaleTensor(unpackTensorAttributes(scaleAttributes))
@@ -45,14 +45,15 @@ struct BatchnormBwdParams
         }
     }
 
-    BatchnormBwdParams(const hipdnn_data_sdk::data_objects::TensorAttributes& dyAttributes,
-                       const hipdnn_data_sdk::data_objects::TensorAttributes& xAttributes,
-                       const hipdnn_data_sdk::data_objects::TensorAttributes& meanAttributes,
-                       const hipdnn_data_sdk::data_objects::TensorAttributes& invVarianceAttributes,
-                       const hipdnn_data_sdk::data_objects::TensorAttributes& scaleAttributes,
-                       const hipdnn_data_sdk::data_objects::TensorAttributes& dxAttributes,
-                       const hipdnn_data_sdk::data_objects::TensorAttributes& dscaleAttributes,
-                       const hipdnn_data_sdk::data_objects::TensorAttributes& dbiasAttributes)
+    BatchnormBwdParams(
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& dyAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& xAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& meanAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& invVarianceAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& scaleAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& dxAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& dscaleAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& dbiasAttributes)
         : dyTensor(unpackTensorAttributes(dyAttributes))
         , xTensor(unpackTensorAttributes(xAttributes))
         , scaleTensor(unpackTensorAttributes(scaleAttributes))
@@ -64,14 +65,14 @@ struct BatchnormBwdParams
     {
     }
 
-    hipdnn_data_sdk::data_objects::TensorAttributesT dyTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT xTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT scaleTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT dxTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT dscaleTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT dbiasTensor;
-    std::optional<hipdnn_data_sdk::data_objects::TensorAttributesT> meanTensor;
-    std::optional<hipdnn_data_sdk::data_objects::TensorAttributesT> invVarianceTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT dyTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT xTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT scaleTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT dxTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT dscaleTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT dbiasTensor;
+    std::optional<hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT> meanTensor;
+    std::optional<hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT> invVarianceTensor;
 };
 
 template <typename DyDataType,
@@ -141,12 +142,12 @@ private:
     BatchnormBwdParams _params;
 };
 
-template <hipdnn_data_sdk::data_objects::DataType DyDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType XDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType ScaleBiasDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType MeanVarianceDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType OutputDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType ComputeDataTypeEnum>
+template <hipdnn_flatbuffers_sdk::data_objects::DataType DyDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType XDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType ScaleBiasDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType MeanVarianceDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType OutputDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum>
 class BatchnormBwdPlanBuilder : public IGraphNodePlanBuilder
 {
 public:
@@ -158,8 +159,9 @@ public:
     using ComputeDataType = utilities::DataTypeToNative<ComputeDataTypeEnum>;
 
     bool isApplicable(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap) const override
     {
         if(node.compute_data_type() != ComputeDataTypeEnum)
@@ -208,8 +210,8 @@ public:
     }
 
     std::unique_ptr<IGraphNodePlanExecutor>
-        buildNodePlan(const hipdnn_data_sdk::flatbuffer_utilities::IGraph& graph,
-                      const hipdnn_data_sdk::data_objects::Node& node) const override
+        buildNodePlan(const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& graph,
+                      const hipdnn_flatbuffers_sdk::data_objects::Node& node) const override
     {
         const auto* nodeAttributes = node.attributes_as_BatchnormBackwardAttributes();
         if(nodeAttributes == nullptr)
@@ -219,8 +221,8 @@ public:
 
         const auto& tensorMap = graph.getTensorMap();
 
-        const hipdnn_data_sdk::data_objects::TensorAttributes* meanAttr = nullptr;
-        const hipdnn_data_sdk::data_objects::TensorAttributes* invVarAttr = nullptr;
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* meanAttr = nullptr;
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* invVarAttr = nullptr;
 
         const bool hasMean = nodeAttributes->mean_tensor_uid().has_value();
         const bool hasInvVariance = nodeAttributes->inv_variance_tensor_uid().has_value();

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormBwdSignatureKey.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormBwdSignatureKey.hpp
@@ -4,9 +4,9 @@
 #pragma once
 
 #include <functional>
-#include <hipdnn_data_sdk/data_objects/data_types_generated.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/data_types_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormBwdPlan.hpp>
 #include <ostream>
 
@@ -15,22 +15,22 @@ namespace hipdnn_test_sdk::detail
 
 struct BatchnormBwdSignatureKey
 {
-    const hipdnn_data_sdk::data_objects::NodeAttributes nodeType
-        = hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes;
-    hipdnn_data_sdk::data_objects::DataType dyDataType;
-    hipdnn_data_sdk::data_objects::DataType xDataType;
-    hipdnn_data_sdk::data_objects::DataType scaleBiasDataType;
-    hipdnn_data_sdk::data_objects::DataType meanVarianceDataType;
-    hipdnn_data_sdk::data_objects::DataType outputDataType;
-    hipdnn_data_sdk::data_objects::DataType computeDataType;
+    const hipdnn_flatbuffers_sdk::data_objects::NodeAttributes nodeType
+        = hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes;
+    hipdnn_flatbuffers_sdk::data_objects::DataType dyDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType xDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType scaleBiasDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType meanVarianceDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType outputDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType;
 
     BatchnormBwdSignatureKey() = default;
-    constexpr BatchnormBwdSignatureKey(hipdnn_data_sdk::data_objects::DataType dy,
-                                       hipdnn_data_sdk::data_objects::DataType x,
-                                       hipdnn_data_sdk::data_objects::DataType scaleBias,
-                                       hipdnn_data_sdk::data_objects::DataType meanVariance,
-                                       hipdnn_data_sdk::data_objects::DataType output,
-                                       hipdnn_data_sdk::data_objects::DataType compute)
+    constexpr BatchnormBwdSignatureKey(hipdnn_flatbuffers_sdk::data_objects::DataType dy,
+                                       hipdnn_flatbuffers_sdk::data_objects::DataType x,
+                                       hipdnn_flatbuffers_sdk::data_objects::DataType scaleBias,
+                                       hipdnn_flatbuffers_sdk::data_objects::DataType meanVariance,
+                                       hipdnn_flatbuffers_sdk::data_objects::DataType output,
+                                       hipdnn_flatbuffers_sdk::data_objects::DataType compute)
         : dyDataType(dy)
         , xDataType(x)
         , scaleBiasDataType(scaleBias)
@@ -41,8 +41,9 @@ struct BatchnormBwdSignatureKey
     }
 
     BatchnormBwdSignatureKey(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap)
     {
         const auto* nodeAttributes = node.attributes_as_BatchnormBackwardAttributes();
@@ -129,70 +130,70 @@ struct BatchnormBwdSignatureKey
                            BatchnormBwdSignatureKey>
             map;
 
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
 
         return map;
     }
 
-    template <hipdnn_data_sdk::data_objects::DataType DyDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType InputDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType ScaleBiasDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType MeanVarianceDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType OutputDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType ComputeDataTypeEnum>
+    template <hipdnn_flatbuffers_sdk::data_objects::DataType DyDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType InputDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType ScaleBiasDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType MeanVarianceDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType OutputDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum>
     static void addPlanBuilder(std::unordered_map<BatchnormBwdSignatureKey,
                                                   std::unique_ptr<IGraphNodePlanBuilder>,
                                                   BatchnormBwdSignatureKey>& map)

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormFwdInferencePlan.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormFwdInferencePlan.hpp
@@ -6,9 +6,9 @@
 #include <functional>
 #include <variant>
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_data_sdk/utilities/Constants.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceBatchnorm.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferDatatypeMapping.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/IGraphNodePlanBuilder.hpp>
@@ -23,12 +23,12 @@ struct BatchnormFwdInferenceParams
 {
     BatchnormFwdInferenceParams() = default;
     BatchnormFwdInferenceParams(
-        const hipdnn_data_sdk::data_objects::TensorAttributes& xAttributes,
-        const hipdnn_data_sdk::data_objects::TensorAttributes& yAttributes,
-        const hipdnn_data_sdk::data_objects::TensorAttributes& scaleAttributes,
-        const hipdnn_data_sdk::data_objects::TensorAttributes& biasAttributes,
-        const hipdnn_data_sdk::data_objects::TensorAttributes& meanAttributes,
-        const hipdnn_data_sdk::data_objects::TensorAttributes& invVarianceAttributes)
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& xAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& yAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& scaleAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& biasAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& meanAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& invVarianceAttributes)
         : xTensor(unpackTensorAttributes(xAttributes))
         , yTensor(unpackTensorAttributes(yAttributes))
         , scaleTensor(unpackTensorAttributes(scaleAttributes))
@@ -38,12 +38,12 @@ struct BatchnormFwdInferenceParams
     {
     }
 
-    hipdnn_data_sdk::data_objects::TensorAttributesT xTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT yTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT scaleTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT biasTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT meanTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT invVarianceTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT xTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT yTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT scaleTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT biasTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT meanTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT invVarianceTensor;
 };
 
 template <typename XDataType,
@@ -96,11 +96,11 @@ private:
     BatchnormFwdInferenceParams _params;
 };
 
-template <hipdnn_data_sdk::data_objects::DataType XDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType ScaleBiasDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType MeanVarianceDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType OutputDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType ComputeDataTypeEnum>
+template <hipdnn_flatbuffers_sdk::data_objects::DataType XDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType ScaleBiasDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType MeanVarianceDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType OutputDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum>
 class BatchnormFwdInferencePlanBuilder : public IGraphNodePlanBuilder
 {
 public:
@@ -111,8 +111,9 @@ public:
     using ComputeDataType = utilities::DataTypeToNative<ComputeDataTypeEnum>;
 
     bool isApplicable(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap) const override
     {
         if(node.compute_data_type() != ComputeDataTypeEnum)
@@ -145,8 +146,8 @@ public:
     }
 
     std::unique_ptr<IGraphNodePlanExecutor>
-        buildNodePlan(const hipdnn_data_sdk::flatbuffer_utilities::IGraph& graph,
-                      const hipdnn_data_sdk::data_objects::Node& node) const override
+        buildNodePlan(const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& graph,
+                      const hipdnn_flatbuffers_sdk::data_objects::Node& node) const override
     {
         const auto* nodeAttributes = node.attributes_as_BatchnormInferenceAttributes();
         if(nodeAttributes == nullptr)

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormFwdInferenceSignatureKey.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormFwdInferenceSignatureKey.hpp
@@ -4,9 +4,9 @@
 #pragma once
 
 #include <functional>
-#include <hipdnn_data_sdk/data_objects/data_types_generated.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/data_types_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormFwdInferencePlan.hpp>
 #include <ostream>
 
@@ -15,21 +15,21 @@ namespace hipdnn_test_sdk::detail
 
 struct BatchnormFwdInferenceSignatureKey
 {
-    const hipdnn_data_sdk::data_objects::NodeAttributes nodeType
-        = hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes;
-    hipdnn_data_sdk::data_objects::DataType xDataType;
-    hipdnn_data_sdk::data_objects::DataType scaleBiasDataType;
-    hipdnn_data_sdk::data_objects::DataType meanVarianceDataType;
-    hipdnn_data_sdk::data_objects::DataType outputDataType;
-    hipdnn_data_sdk::data_objects::DataType computeDataType;
+    const hipdnn_flatbuffers_sdk::data_objects::NodeAttributes nodeType
+        = hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes;
+    hipdnn_flatbuffers_sdk::data_objects::DataType xDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType scaleBiasDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType meanVarianceDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType outputDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType;
 
     BatchnormFwdInferenceSignatureKey() = default;
     constexpr BatchnormFwdInferenceSignatureKey(
-        hipdnn_data_sdk::data_objects::DataType x,
-        hipdnn_data_sdk::data_objects::DataType scaleBias,
-        hipdnn_data_sdk::data_objects::DataType meanVariance,
-        hipdnn_data_sdk::data_objects::DataType output,
-        hipdnn_data_sdk::data_objects::DataType compute)
+        hipdnn_flatbuffers_sdk::data_objects::DataType x,
+        hipdnn_flatbuffers_sdk::data_objects::DataType scaleBias,
+        hipdnn_flatbuffers_sdk::data_objects::DataType meanVariance,
+        hipdnn_flatbuffers_sdk::data_objects::DataType output,
+        hipdnn_flatbuffers_sdk::data_objects::DataType compute)
         : xDataType(x)
         , scaleBiasDataType(scaleBias)
         , meanVarianceDataType(meanVariance)
@@ -39,8 +39,9 @@ struct BatchnormFwdInferenceSignatureKey
     }
 
     BatchnormFwdInferenceSignatureKey(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap)
     {
         const auto* nodeAttributes = node.attributes_as_BatchnormInferenceAttributes();
@@ -103,50 +104,50 @@ struct BatchnormFwdInferenceSignatureKey
                            BatchnormFwdInferenceSignatureKey>
             map;
 
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16>(map);
 
         return map;
     }
 
-    template <hipdnn_data_sdk::data_objects::DataType XDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType ScaleBiasDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType MeanVarianceDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType OutputDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType ComputeDataTypeEnum>
+    template <hipdnn_flatbuffers_sdk::data_objects::DataType XDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType ScaleBiasDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType MeanVarianceDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType OutputDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum>
     static void addPlanBuilder(std::unordered_map<BatchnormFwdInferenceSignatureKey,
                                                   std::unique_ptr<IGraphNodePlanBuilder>,
                                                   BatchnormFwdInferenceSignatureKey>& map)

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormFwdInferenceWithVariancePlan.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormFwdInferenceWithVariancePlan.hpp
@@ -6,10 +6,10 @@
 #include <functional>
 #include <variant>
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_data_sdk/utilities/Constants.hpp>
-#include <hipdnn_data_sdk/utilities/FlatbufferUtils.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/utilities/FlatbufferUtils.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceBatchnorm.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferDatatypeMapping.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/IGraphNodePlanBuilder.hpp>
@@ -24,13 +24,13 @@ struct BatchnormFwdInferenceWithVarianceParams
 {
     BatchnormFwdInferenceWithVarianceParams() = default;
     BatchnormFwdInferenceWithVarianceParams(
-        const hipdnn_data_sdk::data_objects::TensorAttributes& xAttributes,
-        const hipdnn_data_sdk::data_objects::TensorAttributes& yAttributes,
-        const hipdnn_data_sdk::data_objects::TensorAttributes& scaleAttributes,
-        const hipdnn_data_sdk::data_objects::TensorAttributes& biasAttributes,
-        const hipdnn_data_sdk::data_objects::TensorAttributes& meanAttributes,
-        const hipdnn_data_sdk::data_objects::TensorAttributes& varianceAttributes,
-        const hipdnn_data_sdk::data_objects::TensorAttributes& epsilonAttributes)
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& xAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& yAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& scaleAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& biasAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& meanAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& varianceAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& epsilonAttributes)
         : xTensor(unpackTensorAttributes(xAttributes))
         , yTensor(unpackTensorAttributes(yAttributes))
         , scaleTensor(unpackTensorAttributes(scaleAttributes))
@@ -41,13 +41,13 @@ struct BatchnormFwdInferenceWithVarianceParams
     {
     }
 
-    hipdnn_data_sdk::data_objects::TensorAttributesT xTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT yTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT scaleTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT biasTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT meanTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT varianceTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT epsilonTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT xTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT yTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT scaleTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT biasTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT meanTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT varianceTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT epsilonTensor;
 };
 
 template <typename XDataType,
@@ -88,7 +88,7 @@ public:
         auto shallowVarianceTensor = createShallowTensor<MeanVarianceDataType>(
             _params.varianceTensor, variantPack.at(_params.varianceTensor.uid));
 
-        const double epsilonVal = hipdnn_data_sdk::utilities::extractDoubleFromTensorValue(
+        const double epsilonVal = hipdnn_flatbuffers_sdk::utilities::extractDoubleFromTensorValue(
             _params.epsilonTensor, "Epsilon");
 
         utilities::CpuFpReferenceBatchnorm::fwdInferenceWithVariance(*shallowXTensor,
@@ -104,11 +104,11 @@ private:
     BatchnormFwdInferenceWithVarianceParams _params;
 };
 
-template <hipdnn_data_sdk::data_objects::DataType XDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType ScaleBiasDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType MeanVarianceDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType OutputDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType ComputeDataTypeEnum>
+template <hipdnn_flatbuffers_sdk::data_objects::DataType XDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType ScaleBiasDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType MeanVarianceDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType OutputDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum>
 class BatchnormFwdInferenceWithVariancePlanBuilder : public IGraphNodePlanBuilder
 {
 public:
@@ -119,8 +119,9 @@ public:
     using ComputeDataType = utilities::DataTypeToNative<ComputeDataTypeEnum>;
 
     bool isApplicable(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap) const override
     {
         if(node.compute_data_type() != ComputeDataTypeEnum)
@@ -151,14 +152,14 @@ public:
             tensorMap, nodeAttributes->variance_tensor_uid(), MeanVarianceDataTypeEnum);
         CHECK_TENSOR_TYPE(tensorMap,
                           nodeAttributes->epsilon_tensor_uid(),
-                          hipdnn_data_sdk::data_objects::DataType::DOUBLE);
+                          hipdnn_flatbuffers_sdk::data_objects::DataType::DOUBLE);
 
         return true;
     }
 
     std::unique_ptr<IGraphNodePlanExecutor>
-        buildNodePlan(const hipdnn_data_sdk::flatbuffer_utilities::IGraph& graph,
-                      const hipdnn_data_sdk::data_objects::Node& node) const override
+        buildNodePlan(const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& graph,
+                      const hipdnn_flatbuffers_sdk::data_objects::Node& node) const override
     {
         const auto* nodeAttributes = node.attributes_as_BatchnormInferenceAttributesVarianceExt();
         if(nodeAttributes == nullptr)

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormFwdInferenceWithVarianceSignatureKey.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormFwdInferenceWithVarianceSignatureKey.hpp
@@ -4,9 +4,9 @@
 #pragma once
 
 #include <functional>
-#include <hipdnn_data_sdk/data_objects/data_types_generated.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/data_types_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormFwdInferenceWithVariancePlan.hpp>
 #include <ostream>
 
@@ -15,21 +15,21 @@ namespace hipdnn_test_sdk::detail
 
 struct BatchnormFwdInferenceWithVarianceSignatureKey
 {
-    const hipdnn_data_sdk::data_objects::NodeAttributes nodeType
-        = hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributesVarianceExt;
-    hipdnn_data_sdk::data_objects::DataType xDataType;
-    hipdnn_data_sdk::data_objects::DataType scaleBiasDataType;
-    hipdnn_data_sdk::data_objects::DataType meanVarianceDataType;
-    hipdnn_data_sdk::data_objects::DataType outputDataType;
-    hipdnn_data_sdk::data_objects::DataType computeDataType;
+    const hipdnn_flatbuffers_sdk::data_objects::NodeAttributes nodeType = hipdnn_flatbuffers_sdk::
+        data_objects::NodeAttributes::BatchnormInferenceAttributesVarianceExt;
+    hipdnn_flatbuffers_sdk::data_objects::DataType xDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType scaleBiasDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType meanVarianceDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType outputDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType;
 
     BatchnormFwdInferenceWithVarianceSignatureKey() = default;
     constexpr BatchnormFwdInferenceWithVarianceSignatureKey(
-        hipdnn_data_sdk::data_objects::DataType x,
-        hipdnn_data_sdk::data_objects::DataType scaleBias,
-        hipdnn_data_sdk::data_objects::DataType meanVariance,
-        hipdnn_data_sdk::data_objects::DataType output,
-        hipdnn_data_sdk::data_objects::DataType compute)
+        hipdnn_flatbuffers_sdk::data_objects::DataType x,
+        hipdnn_flatbuffers_sdk::data_objects::DataType scaleBias,
+        hipdnn_flatbuffers_sdk::data_objects::DataType meanVariance,
+        hipdnn_flatbuffers_sdk::data_objects::DataType output,
+        hipdnn_flatbuffers_sdk::data_objects::DataType compute)
         : xDataType(x)
         , scaleBiasDataType(scaleBias)
         , meanVarianceDataType(meanVariance)
@@ -39,8 +39,9 @@ struct BatchnormFwdInferenceWithVarianceSignatureKey
     }
 
     BatchnormFwdInferenceWithVarianceSignatureKey(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap)
     {
         const auto* nodeAttributes = node.attributes_as_BatchnormInferenceAttributesVarianceExt();
@@ -103,50 +104,50 @@ struct BatchnormFwdInferenceWithVarianceSignatureKey
                            BatchnormFwdInferenceWithVarianceSignatureKey>
             map;
 
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16>(map);
 
         return map;
     }
 
-    template <hipdnn_data_sdk::data_objects::DataType XDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType ScaleBiasDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType MeanVarianceDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType OutputDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType ComputeDataTypeEnum>
+    template <hipdnn_flatbuffers_sdk::data_objects::DataType XDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType ScaleBiasDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType MeanVarianceDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType OutputDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum>
     static void
         addPlanBuilder(std::unordered_map<BatchnormFwdInferenceWithVarianceSignatureKey,
                                           std::unique_ptr<IGraphNodePlanBuilder>,

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormTrainPlan.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormTrainPlan.hpp
@@ -4,9 +4,9 @@
 #pragma once
 
 #include <functional>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
-#include <hipdnn_data_sdk/utilities/FlatbufferUtils.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/utilities/FlatbufferUtils.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceBatchnorm.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferDatatypeMapping.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/IGraphNodePlanBuilder.hpp>
@@ -24,21 +24,24 @@ struct BatchnormTrainParams
 {
     BatchnormTrainParams() = default;
     BatchnormTrainParams(
-        const hipdnn_data_sdk::data_objects::TensorAttributes& xAttributes,
-        const hipdnn_data_sdk::data_objects::TensorAttributes& scaleAttributes,
-        const hipdnn_data_sdk::data_objects::TensorAttributes& biasAttributes,
-        const hipdnn_data_sdk::data_objects::TensorAttributes& yAttributes,
-        const hipdnn_data_sdk::data_objects::TensorAttributes& epsilonAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& xAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& scaleAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& biasAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& yAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& epsilonAttributes,
         // Optional mean/variance tensors
-        const hipdnn_data_sdk::data_objects::TensorAttributes* meanAttributes = nullptr,
-        const hipdnn_data_sdk::data_objects::TensorAttributes* invVarianceAttributes = nullptr,
-        // Optional running mean/variance tensors
-        const hipdnn_data_sdk::data_objects::TensorAttributes* momentumAttributes = nullptr,
-        const hipdnn_data_sdk::data_objects::TensorAttributes* prevRunningMeanAttributes = nullptr,
-        const hipdnn_data_sdk::data_objects::TensorAttributes* prevRunningVarianceAttributes
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* meanAttributes = nullptr,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* invVarianceAttributes
         = nullptr,
-        const hipdnn_data_sdk::data_objects::TensorAttributes* nextRunningMeanAttributes = nullptr,
-        const hipdnn_data_sdk::data_objects::TensorAttributes* nextRunningVarianceAttributes
+        // Optional running mean/variance tensors
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* momentumAttributes = nullptr,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* prevRunningMeanAttributes
+        = nullptr,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* prevRunningVarianceAttributes
+        = nullptr,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* nextRunningMeanAttributes
+        = nullptr,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* nextRunningVarianceAttributes
         = nullptr)
         : xTensor(unpackTensorAttributes(xAttributes))
         , scaleTensor(unpackTensorAttributes(scaleAttributes))
@@ -73,18 +76,20 @@ struct BatchnormTrainParams
     {
     }
 
-    hipdnn_data_sdk::data_objects::TensorAttributesT xTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT scaleTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT biasTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT epsilonTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT yTensor;
-    std::optional<hipdnn_data_sdk::data_objects::TensorAttributesT> meanTensor;
-    std::optional<hipdnn_data_sdk::data_objects::TensorAttributesT> invVarianceTensor;
-    std::optional<hipdnn_data_sdk::data_objects::TensorAttributesT> momentumTensor;
-    std::optional<hipdnn_data_sdk::data_objects::TensorAttributesT> prevRunningMeanTensor;
-    std::optional<hipdnn_data_sdk::data_objects::TensorAttributesT> prevRunningVarianceTensor;
-    std::optional<hipdnn_data_sdk::data_objects::TensorAttributesT> nextRunningMeanTensor;
-    std::optional<hipdnn_data_sdk::data_objects::TensorAttributesT> nextRunningVarianceTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT xTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT scaleTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT biasTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT epsilonTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT yTensor;
+    std::optional<hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT> meanTensor;
+    std::optional<hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT> invVarianceTensor;
+    std::optional<hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT> momentumTensor;
+    std::optional<hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT> prevRunningMeanTensor;
+    std::optional<hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT>
+        prevRunningVarianceTensor;
+    std::optional<hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT> nextRunningMeanTensor;
+    std::optional<hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT>
+        nextRunningVarianceTensor;
 };
 
 template <typename XDataType,
@@ -134,7 +139,7 @@ public:
             _params.yTensor, variantPack.at(_params.yTensor.uid));
 
         // Extract epsilon from pass-by-value tensor (cast to double)
-        const double epsilon = hipdnn_data_sdk::utilities::extractDoubleFromTensorValue(
+        const double epsilon = hipdnn_flatbuffers_sdk::utilities::extractDoubleFromTensorValue(
             _params.epsilonTensor, "Epsilon");
 
         // Optional batch statistics tensors
@@ -178,7 +183,7 @@ public:
         double momentumValue = 0.1;
         if(_params.momentumTensor.has_value())
         {
-            momentumValue = hipdnn_data_sdk::utilities::extractDoubleFromTensorValue(
+            momentumValue = hipdnn_flatbuffers_sdk::utilities::extractDoubleFromTensorValue(
                 _params.momentumTensor.value(), "Momentum");
         }
 
@@ -229,11 +234,11 @@ private:
     BatchnormTrainParams<MeanVarianceDataType> _params;
 };
 
-template <hipdnn_data_sdk::data_objects::DataType XDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType ScaleBiasDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType MeanVarianceDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType OutputDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType ComputeDataTypeEnum>
+template <hipdnn_flatbuffers_sdk::data_objects::DataType XDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType ScaleBiasDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType MeanVarianceDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType OutputDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum>
 class BatchnormTrainPlanBuilder : public IGraphNodePlanBuilder
 {
 public:
@@ -244,8 +249,9 @@ public:
     using ComputeDataType = utilities::DataTypeToNative<ComputeDataTypeEnum>;
 
     bool isApplicable(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap) const override
     {
         if(node.compute_data_type() != ComputeDataTypeEnum)
@@ -331,8 +337,8 @@ public:
     }
 
     std::unique_ptr<IGraphNodePlanExecutor>
-        buildNodePlan(const hipdnn_data_sdk::flatbuffer_utilities::IGraph& graph,
-                      const hipdnn_data_sdk::data_objects::Node& node) const override
+        buildNodePlan(const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& graph,
+                      const hipdnn_flatbuffers_sdk::data_objects::Node& node) const override
     {
         const auto* nodeAttributes = node.attributes_as_BatchnormAttributes();
         if(nodeAttributes == nullptr)
@@ -342,13 +348,13 @@ public:
 
         const auto& tensorMap = graph.getTensorMap();
 
-        const hipdnn_data_sdk::data_objects::TensorAttributes* mean = nullptr;
-        const hipdnn_data_sdk::data_objects::TensorAttributes* invVariance = nullptr;
-        const hipdnn_data_sdk::data_objects::TensorAttributes* momentum = nullptr;
-        const hipdnn_data_sdk::data_objects::TensorAttributes* prevRunningMean = nullptr;
-        const hipdnn_data_sdk::data_objects::TensorAttributes* prevRunningVariance = nullptr;
-        const hipdnn_data_sdk::data_objects::TensorAttributes* nextRunningMean = nullptr;
-        const hipdnn_data_sdk::data_objects::TensorAttributes* nextRunningVariance = nullptr;
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* mean = nullptr;
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* invVariance = nullptr;
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* momentum = nullptr;
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* prevRunningMean = nullptr;
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* prevRunningVariance = nullptr;
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* nextRunningMean = nullptr;
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* nextRunningVariance = nullptr;
 
         if(nodeAttributes->mean_tensor_uid().has_value())
         {

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormTrainSignatureKey.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormTrainSignatureKey.hpp
@@ -4,9 +4,9 @@
 #pragma once
 
 #include <functional>
-#include <hipdnn_data_sdk/data_objects/data_types_generated.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/data_types_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormTrainPlan.hpp>
 #include <ostream>
 
@@ -15,20 +15,21 @@ namespace hipdnn_test_sdk::detail
 
 struct BatchnormTrainSignatureKey
 {
-    const hipdnn_data_sdk::data_objects::NodeAttributes nodeType
-        = hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes;
-    hipdnn_data_sdk::data_objects::DataType xDataType;
-    hipdnn_data_sdk::data_objects::DataType scaleBiasDataType;
-    hipdnn_data_sdk::data_objects::DataType meanVarianceDataType;
-    hipdnn_data_sdk::data_objects::DataType outputDataType;
-    hipdnn_data_sdk::data_objects::DataType computeDataType;
+    const hipdnn_flatbuffers_sdk::data_objects::NodeAttributes nodeType
+        = hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BatchnormAttributes;
+    hipdnn_flatbuffers_sdk::data_objects::DataType xDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType scaleBiasDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType meanVarianceDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType outputDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType;
 
     BatchnormTrainSignatureKey() = default;
-    constexpr BatchnormTrainSignatureKey(hipdnn_data_sdk::data_objects::DataType input,
-                                         hipdnn_data_sdk::data_objects::DataType scaleBias,
-                                         hipdnn_data_sdk::data_objects::DataType meanVariance,
-                                         hipdnn_data_sdk::data_objects::DataType output,
-                                         hipdnn_data_sdk::data_objects::DataType compute)
+    constexpr BatchnormTrainSignatureKey(
+        hipdnn_flatbuffers_sdk::data_objects::DataType input,
+        hipdnn_flatbuffers_sdk::data_objects::DataType scaleBias,
+        hipdnn_flatbuffers_sdk::data_objects::DataType meanVariance,
+        hipdnn_flatbuffers_sdk::data_objects::DataType output,
+        hipdnn_flatbuffers_sdk::data_objects::DataType compute)
         : xDataType(input)
         , scaleBiasDataType(scaleBias)
         , meanVarianceDataType(meanVariance)
@@ -38,8 +39,9 @@ struct BatchnormTrainSignatureKey
     }
 
     BatchnormTrainSignatureKey(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap)
     {
         const auto* nodeAttributes = node.attributes_as_BatchnormAttributes();
@@ -108,50 +110,50 @@ struct BatchnormTrainSignatureKey
                            BatchnormTrainSignatureKey>
             map;
 
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
 
         return map;
     }
 
-    template <hipdnn_data_sdk::data_objects::DataType XDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType ScaleBiasDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType MeanVarianceDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType OutputDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType ComputeDataTypeEnum>
+    template <hipdnn_flatbuffers_sdk::data_objects::DataType XDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType ScaleBiasDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType MeanVarianceDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType OutputDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum>
     static void addPlanBuilder(std::unordered_map<BatchnormTrainSignatureKey,
                                                   std::unique_ptr<IGraphNodePlanBuilder>,
                                                   BatchnormTrainSignatureKey>& map)

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionBwdPlan.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionBwdPlan.hpp
@@ -6,8 +6,8 @@
 #include <functional>
 #include <variant>
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceConvolution.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferDatatypeMapping.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/IGraphNodePlanBuilder.hpp>
@@ -21,14 +21,14 @@ namespace hipdnn_test_sdk::detail
 struct ConvolutionBwdParams
 {
     ConvolutionBwdParams() = default;
-    ConvolutionBwdParams(const hipdnn_data_sdk::data_objects::TensorAttributes& dxAttributes,
-                         const hipdnn_data_sdk::data_objects::TensorAttributes& wAttributes,
-                         const hipdnn_data_sdk::data_objects::TensorAttributes& dyAttributes,
+    ConvolutionBwdParams(const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& dxAttributes,
+                         const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& wAttributes,
+                         const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& dyAttributes,
                          const std::vector<int64_t>& prePadding,
                          const std::vector<int64_t>& postPadding,
                          const std::vector<int64_t>& stride,
                          const std::vector<int64_t>& dilation,
-                         const hipdnn_data_sdk::data_objects::ConvMode convolutionMode)
+                         const hipdnn_flatbuffers_sdk::data_objects::ConvMode convolutionMode)
         : dxTensor(unpackTensorAttributes(dxAttributes))
         , wTensor(unpackTensorAttributes(wAttributes))
         , dyTensor(unpackTensorAttributes(dyAttributes))
@@ -40,14 +40,14 @@ struct ConvolutionBwdParams
     {
     }
 
-    hipdnn_data_sdk::data_objects::TensorAttributesT dxTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT wTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT dyTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT dxTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT wTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT dyTensor;
     std::vector<int64_t> prePadding;
     std::vector<int64_t> postPadding;
     std::vector<int64_t> stride;
     std::vector<int64_t> dilation;
-    hipdnn_data_sdk::data_objects::ConvMode convMode;
+    hipdnn_flatbuffers_sdk::data_objects::ConvMode convMode;
 };
 
 template <typename DyDataType,
@@ -91,10 +91,10 @@ private:
     ConvolutionBwdParams _params;
 };
 
-template <hipdnn_data_sdk::data_objects::DataType DyDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType WDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType OutputDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType ComputeDataTypeEnum>
+template <hipdnn_flatbuffers_sdk::data_objects::DataType DyDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType WDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType OutputDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum>
 class ConvolutionBwdPlanBuilder : public IGraphNodePlanBuilder
 {
 public:
@@ -104,8 +104,9 @@ public:
     using ComputeDataType = utilities::DataTypeToNative<ComputeDataTypeEnum>;
 
     bool isApplicable(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap) const override
     {
         const auto* nodeAttributes = node.attributes_as_ConvolutionBwdAttributes();
@@ -126,8 +127,8 @@ public:
     }
 
     std::unique_ptr<IGraphNodePlanExecutor>
-        buildNodePlan(const hipdnn_data_sdk::flatbuffer_utilities::IGraph& graph,
-                      const hipdnn_data_sdk::data_objects::Node& node) const override
+        buildNodePlan(const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& graph,
+                      const hipdnn_flatbuffers_sdk::data_objects::Node& node) const override
     {
         const auto* nodeAttributes = node.attributes_as_ConvolutionBwdAttributes();
         if(nodeAttributes == nullptr)
@@ -136,18 +137,19 @@ public:
         }
 
         const auto& tensorMap = graph.getTensorMap();
-        ConvolutionBwdParams params(*tensorMap.at(nodeAttributes->dx_tensor_uid()),
-                                    *tensorMap.at(nodeAttributes->w_tensor_uid()),
-                                    *tensorMap.at(nodeAttributes->dy_tensor_uid()),
-                                    hipdnn_data_sdk::utilities::convertFlatBufferVectorToStdVector(
-                                        nodeAttributes->pre_padding()),
-                                    hipdnn_data_sdk::utilities::convertFlatBufferVectorToStdVector(
-                                        nodeAttributes->post_padding()),
-                                    hipdnn_data_sdk::utilities::convertFlatBufferVectorToStdVector(
-                                        nodeAttributes->stride()),
-                                    hipdnn_data_sdk::utilities::convertFlatBufferVectorToStdVector(
-                                        nodeAttributes->dilation()),
-                                    nodeAttributes->conv_mode());
+        ConvolutionBwdParams params(
+            *tensorMap.at(nodeAttributes->dx_tensor_uid()),
+            *tensorMap.at(nodeAttributes->w_tensor_uid()),
+            *tensorMap.at(nodeAttributes->dy_tensor_uid()),
+            hipdnn_flatbuffers_sdk::utilities::convertFlatBufferVectorToStdVector(
+                nodeAttributes->pre_padding()),
+            hipdnn_flatbuffers_sdk::utilities::convertFlatBufferVectorToStdVector(
+                nodeAttributes->post_padding()),
+            hipdnn_flatbuffers_sdk::utilities::convertFlatBufferVectorToStdVector(
+                nodeAttributes->stride()),
+            hipdnn_flatbuffers_sdk::utilities::convertFlatBufferVectorToStdVector(
+                nodeAttributes->dilation()),
+            nodeAttributes->conv_mode());
 
         return std::make_unique<
             ConvolutionBwdPlan<DyDataType, WDataType, OutputDataType, ComputeDataType>>(

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionBwdSignatureKey.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionBwdSignatureKey.hpp
@@ -4,9 +4,9 @@
 #pragma once
 
 #include <functional>
-#include <hipdnn_data_sdk/data_objects/data_types_generated.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/data_types_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionBwdPlan.hpp>
 #include <ostream>
 
@@ -15,19 +15,19 @@ namespace hipdnn_test_sdk::detail
 
 struct ConvolutionBwdSignatureKey
 {
-    const hipdnn_data_sdk::data_objects::NodeAttributes nodeType{
-        hipdnn_data_sdk::data_objects::NodeAttributes::ConvolutionBwdAttributes};
-    hipdnn_data_sdk::data_objects::DataType dyDataType;
-    hipdnn_data_sdk::data_objects::DataType wDataType;
-    hipdnn_data_sdk::data_objects::DataType outputDataType;
-    hipdnn_data_sdk::data_objects::DataType computeDataType;
+    const hipdnn_flatbuffers_sdk::data_objects::NodeAttributes nodeType{
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::ConvolutionBwdAttributes};
+    hipdnn_flatbuffers_sdk::data_objects::DataType dyDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType wDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType outputDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType;
 
     ConvolutionBwdSignatureKey() = default;
 
-    constexpr ConvolutionBwdSignatureKey(hipdnn_data_sdk::data_objects::DataType dy,
-                                         hipdnn_data_sdk::data_objects::DataType w,
-                                         hipdnn_data_sdk::data_objects::DataType output,
-                                         hipdnn_data_sdk::data_objects::DataType compute)
+    constexpr ConvolutionBwdSignatureKey(hipdnn_flatbuffers_sdk::data_objects::DataType dy,
+                                         hipdnn_flatbuffers_sdk::data_objects::DataType w,
+                                         hipdnn_flatbuffers_sdk::data_objects::DataType output,
+                                         hipdnn_flatbuffers_sdk::data_objects::DataType compute)
         : dyDataType(dy)
         , wDataType(w)
         , outputDataType(output)
@@ -36,10 +36,11 @@ struct ConvolutionBwdSignatureKey
     }
 
     ConvolutionBwdSignatureKey(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap,
-        const hipdnn_data_sdk::data_objects::DataType computeType)
+        const hipdnn_flatbuffers_sdk::data_objects::DataType computeType)
     {
         const auto* nodeAttributes = node.attributes_as_ConvolutionBwdAttributes();
         if(nodeAttributes == nullptr)
@@ -95,26 +96,26 @@ struct ConvolutionBwdSignatureKey
                            ConvolutionBwdSignatureKey>
             map;
 
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
 
         return map;
     }
 
-    template <hipdnn_data_sdk::data_objects::DataType DyDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType WDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType OutputDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType ComputeDataTypeEnum>
+    template <hipdnn_flatbuffers_sdk::data_objects::DataType DyDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType WDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType OutputDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum>
     static void addPlanBuilder(std::unordered_map<ConvolutionBwdSignatureKey,
                                                   std::unique_ptr<IGraphNodePlanBuilder>,
                                                   ConvolutionBwdSignatureKey>& map)

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionFwdPlan.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionFwdPlan.hpp
@@ -6,8 +6,8 @@
 #include <functional>
 #include <variant>
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceConvolution.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferDatatypeMapping.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/IGraphNodePlanBuilder.hpp>
@@ -21,14 +21,14 @@ namespace hipdnn_test_sdk::detail
 struct ConvolutionFwdParams
 {
     ConvolutionFwdParams() = default;
-    ConvolutionFwdParams(const hipdnn_data_sdk::data_objects::TensorAttributes& xAttributes,
-                         const hipdnn_data_sdk::data_objects::TensorAttributes& wAttributes,
-                         const hipdnn_data_sdk::data_objects::TensorAttributes& yAttributes,
+    ConvolutionFwdParams(const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& xAttributes,
+                         const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& wAttributes,
+                         const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& yAttributes,
                          const std::vector<int64_t>& prePadding,
                          const std::vector<int64_t>& postPadding,
                          const std::vector<int64_t>& stride,
                          const std::vector<int64_t>& dilation,
-                         const hipdnn_data_sdk::data_objects::ConvMode convolutionMode)
+                         const hipdnn_flatbuffers_sdk::data_objects::ConvMode convolutionMode)
         : xTensor(unpackTensorAttributes(xAttributes))
         , wTensor(unpackTensorAttributes(wAttributes))
         , yTensor(unpackTensorAttributes(yAttributes))
@@ -40,14 +40,14 @@ struct ConvolutionFwdParams
     {
     }
 
-    hipdnn_data_sdk::data_objects::TensorAttributesT xTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT wTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT yTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT xTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT wTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT yTensor;
     std::vector<int64_t> prePadding;
     std::vector<int64_t> postPadding;
     std::vector<int64_t> stride;
     std::vector<int64_t> dilation;
-    hipdnn_data_sdk::data_objects::ConvMode convMode;
+    hipdnn_flatbuffers_sdk::data_objects::ConvMode convMode;
 };
 
 template <typename XDataType, typename WDataType, typename OutputDataType, typename ComputeDataType>
@@ -88,10 +88,10 @@ private:
     ConvolutionFwdParams _params;
 };
 
-template <hipdnn_data_sdk::data_objects::DataType XDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType WDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType OutputDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType ComputeDataTypeEnum>
+template <hipdnn_flatbuffers_sdk::data_objects::DataType XDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType WDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType OutputDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum>
 class ConvolutionFwdPlanBuilder : public IGraphNodePlanBuilder
 {
 public:
@@ -101,8 +101,9 @@ public:
     using ComputeDataType = utilities::DataTypeToNative<ComputeDataTypeEnum>;
 
     bool isApplicable(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap) const override
     {
         const auto* nodeAttributes = node.attributes_as_ConvolutionFwdAttributes();
@@ -123,8 +124,8 @@ public:
     }
 
     std::unique_ptr<IGraphNodePlanExecutor>
-        buildNodePlan(const hipdnn_data_sdk::flatbuffer_utilities::IGraph& graph,
-                      const hipdnn_data_sdk::data_objects::Node& node) const override
+        buildNodePlan(const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& graph,
+                      const hipdnn_flatbuffers_sdk::data_objects::Node& node) const override
     {
         const auto* nodeAttributes = node.attributes_as_ConvolutionFwdAttributes();
         if(nodeAttributes == nullptr)
@@ -133,18 +134,19 @@ public:
         }
 
         const auto& tensorMap = graph.getTensorMap();
-        ConvolutionFwdParams params(*tensorMap.at(nodeAttributes->x_tensor_uid()),
-                                    *tensorMap.at(nodeAttributes->w_tensor_uid()),
-                                    *tensorMap.at(nodeAttributes->y_tensor_uid()),
-                                    hipdnn_data_sdk::utilities::convertFlatBufferVectorToStdVector(
-                                        nodeAttributes->pre_padding()),
-                                    hipdnn_data_sdk::utilities::convertFlatBufferVectorToStdVector(
-                                        nodeAttributes->post_padding()),
-                                    hipdnn_data_sdk::utilities::convertFlatBufferVectorToStdVector(
-                                        nodeAttributes->stride()),
-                                    hipdnn_data_sdk::utilities::convertFlatBufferVectorToStdVector(
-                                        nodeAttributes->dilation()),
-                                    nodeAttributes->conv_mode());
+        ConvolutionFwdParams params(
+            *tensorMap.at(nodeAttributes->x_tensor_uid()),
+            *tensorMap.at(nodeAttributes->w_tensor_uid()),
+            *tensorMap.at(nodeAttributes->y_tensor_uid()),
+            hipdnn_flatbuffers_sdk::utilities::convertFlatBufferVectorToStdVector(
+                nodeAttributes->pre_padding()),
+            hipdnn_flatbuffers_sdk::utilities::convertFlatBufferVectorToStdVector(
+                nodeAttributes->post_padding()),
+            hipdnn_flatbuffers_sdk::utilities::convertFlatBufferVectorToStdVector(
+                nodeAttributes->stride()),
+            hipdnn_flatbuffers_sdk::utilities::convertFlatBufferVectorToStdVector(
+                nodeAttributes->dilation()),
+            nodeAttributes->conv_mode());
 
         return std::make_unique<
             ConvolutionFwdPlan<XDataType, WDataType, OutputDataType, ComputeDataType>>(

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionFwdSignatureKey.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionFwdSignatureKey.hpp
@@ -4,9 +4,9 @@
 #pragma once
 
 #include <functional>
-#include <hipdnn_data_sdk/data_objects/data_types_generated.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/data_types_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionFwdPlan.hpp>
 #include <ostream>
 
@@ -15,18 +15,18 @@ namespace hipdnn_test_sdk::detail
 
 struct ConvolutionFwdSignatureKey
 {
-    const hipdnn_data_sdk::data_objects::NodeAttributes nodeType{
-        hipdnn_data_sdk::data_objects::NodeAttributes::ConvolutionFwdAttributes};
-    hipdnn_data_sdk::data_objects::DataType xDataType;
-    hipdnn_data_sdk::data_objects::DataType wDataType;
-    hipdnn_data_sdk::data_objects::DataType outputDataType;
-    hipdnn_data_sdk::data_objects::DataType computeDataType;
+    const hipdnn_flatbuffers_sdk::data_objects::NodeAttributes nodeType{
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::ConvolutionFwdAttributes};
+    hipdnn_flatbuffers_sdk::data_objects::DataType xDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType wDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType outputDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType;
 
     ConvolutionFwdSignatureKey() = default;
-    constexpr ConvolutionFwdSignatureKey(hipdnn_data_sdk::data_objects::DataType x,
-                                         hipdnn_data_sdk::data_objects::DataType w,
-                                         hipdnn_data_sdk::data_objects::DataType output,
-                                         hipdnn_data_sdk::data_objects::DataType compute)
+    constexpr ConvolutionFwdSignatureKey(hipdnn_flatbuffers_sdk::data_objects::DataType x,
+                                         hipdnn_flatbuffers_sdk::data_objects::DataType w,
+                                         hipdnn_flatbuffers_sdk::data_objects::DataType output,
+                                         hipdnn_flatbuffers_sdk::data_objects::DataType compute)
         : xDataType(x)
         , wDataType(w)
         , outputDataType(output)
@@ -35,10 +35,11 @@ struct ConvolutionFwdSignatureKey
     }
 
     ConvolutionFwdSignatureKey(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap,
-        const hipdnn_data_sdk::data_objects::DataType computeType)
+        const hipdnn_flatbuffers_sdk::data_objects::DataType computeType)
     {
         const auto* nodeAttributes = node.attributes_as_ConvolutionFwdAttributes();
         if(nodeAttributes == nullptr)
@@ -94,34 +95,34 @@ struct ConvolutionFwdSignatureKey
             map;
 
         // X, W, Y, Compute
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
 
         return map;
     }
 
-    template <hipdnn_data_sdk::data_objects::DataType XDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType WDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType OutputDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType ComputeDataTypeEnum>
+    template <hipdnn_flatbuffers_sdk::data_objects::DataType XDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType WDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType OutputDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum>
     static void addPlanBuilder(std::unordered_map<ConvolutionFwdSignatureKey,
                                                   std::unique_ptr<IGraphNodePlanBuilder>,
                                                   ConvolutionFwdSignatureKey>& map)

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionWrwPlan.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionWrwPlan.hpp
@@ -6,8 +6,8 @@
 #include <functional>
 #include <variant>
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceConvolution.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferDatatypeMapping.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/IGraphNodePlanBuilder.hpp>
@@ -21,14 +21,14 @@ namespace hipdnn_test_sdk::detail
 struct ConvolutionWrwParams
 {
     ConvolutionWrwParams() = default;
-    ConvolutionWrwParams(const hipdnn_data_sdk::data_objects::TensorAttributes& xAttributes,
-                         const hipdnn_data_sdk::data_objects::TensorAttributes& dwAttributes,
-                         const hipdnn_data_sdk::data_objects::TensorAttributes& dyAttributes,
+    ConvolutionWrwParams(const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& xAttributes,
+                         const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& dwAttributes,
+                         const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& dyAttributes,
                          const std::vector<int64_t>& prePadding,
                          const std::vector<int64_t>& postPadding,
                          const std::vector<int64_t>& stride,
                          const std::vector<int64_t>& dilation,
-                         const hipdnn_data_sdk::data_objects::ConvMode convolutionMode)
+                         const hipdnn_flatbuffers_sdk::data_objects::ConvMode convolutionMode)
         : xTensor(unpackTensorAttributes(xAttributes))
         , dwTensor(unpackTensorAttributes(dwAttributes))
         , dyTensor(unpackTensorAttributes(dyAttributes))
@@ -40,14 +40,14 @@ struct ConvolutionWrwParams
     {
     }
 
-    hipdnn_data_sdk::data_objects::TensorAttributesT xTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT dwTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT dyTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT xTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT dwTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT dyTensor;
     std::vector<int64_t> prePadding;
     std::vector<int64_t> postPadding;
     std::vector<int64_t> stride;
     std::vector<int64_t> dilation;
-    hipdnn_data_sdk::data_objects::ConvMode convMode;
+    hipdnn_flatbuffers_sdk::data_objects::ConvMode convMode;
 };
 
 template <typename XDataType,
@@ -91,10 +91,10 @@ private:
     ConvolutionWrwParams _params;
 };
 
-template <hipdnn_data_sdk::data_objects::DataType XDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType DyDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType OutputDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType ComputeDataTypeEnum>
+template <hipdnn_flatbuffers_sdk::data_objects::DataType XDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType DyDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType OutputDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum>
 class ConvolutionWrwPlanBuilder : public IGraphNodePlanBuilder
 {
 public:
@@ -104,8 +104,9 @@ public:
     using ComputeDataType = utilities::DataTypeToNative<ComputeDataTypeEnum>;
 
     bool isApplicable(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap) const override
     {
         const auto* nodeAttributes = node.attributes_as_ConvolutionWrwAttributes();
@@ -126,8 +127,8 @@ public:
     }
 
     std::unique_ptr<IGraphNodePlanExecutor>
-        buildNodePlan(const hipdnn_data_sdk::flatbuffer_utilities::IGraph& graph,
-                      const hipdnn_data_sdk::data_objects::Node& node) const override
+        buildNodePlan(const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& graph,
+                      const hipdnn_flatbuffers_sdk::data_objects::Node& node) const override
     {
         const auto* nodeAttributes = node.attributes_as_ConvolutionWrwAttributes();
         if(nodeAttributes == nullptr)
@@ -136,18 +137,19 @@ public:
         }
 
         const auto& tensorMap = graph.getTensorMap();
-        ConvolutionWrwParams params(*tensorMap.at(nodeAttributes->x_tensor_uid()),
-                                    *tensorMap.at(nodeAttributes->dw_tensor_uid()),
-                                    *tensorMap.at(nodeAttributes->dy_tensor_uid()),
-                                    hipdnn_data_sdk::utilities::convertFlatBufferVectorToStdVector(
-                                        nodeAttributes->pre_padding()),
-                                    hipdnn_data_sdk::utilities::convertFlatBufferVectorToStdVector(
-                                        nodeAttributes->post_padding()),
-                                    hipdnn_data_sdk::utilities::convertFlatBufferVectorToStdVector(
-                                        nodeAttributes->stride()),
-                                    hipdnn_data_sdk::utilities::convertFlatBufferVectorToStdVector(
-                                        nodeAttributes->dilation()),
-                                    nodeAttributes->conv_mode());
+        ConvolutionWrwParams params(
+            *tensorMap.at(nodeAttributes->x_tensor_uid()),
+            *tensorMap.at(nodeAttributes->dw_tensor_uid()),
+            *tensorMap.at(nodeAttributes->dy_tensor_uid()),
+            hipdnn_flatbuffers_sdk::utilities::convertFlatBufferVectorToStdVector(
+                nodeAttributes->pre_padding()),
+            hipdnn_flatbuffers_sdk::utilities::convertFlatBufferVectorToStdVector(
+                nodeAttributes->post_padding()),
+            hipdnn_flatbuffers_sdk::utilities::convertFlatBufferVectorToStdVector(
+                nodeAttributes->stride()),
+            hipdnn_flatbuffers_sdk::utilities::convertFlatBufferVectorToStdVector(
+                nodeAttributes->dilation()),
+            nodeAttributes->conv_mode());
 
         return std::make_unique<
             ConvolutionWrwPlan<XDataType, DyDataType, OutputDataType, ComputeDataType>>(

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionWrwSignatureKey.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionWrwSignatureKey.hpp
@@ -4,9 +4,9 @@
 #pragma once
 
 #include <functional>
-#include <hipdnn_data_sdk/data_objects/data_types_generated.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/data_types_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionWrwPlan.hpp>
 #include <ostream>
 
@@ -15,19 +15,19 @@ namespace hipdnn_test_sdk::detail
 
 struct ConvolutionWrwSignatureKey
 {
-    const hipdnn_data_sdk::data_objects::NodeAttributes nodeType{
-        hipdnn_data_sdk::data_objects::NodeAttributes::ConvolutionWrwAttributes};
-    hipdnn_data_sdk::data_objects::DataType xDataType;
-    hipdnn_data_sdk::data_objects::DataType dyDataType;
-    hipdnn_data_sdk::data_objects::DataType outputDataType;
-    hipdnn_data_sdk::data_objects::DataType computeDataType;
+    const hipdnn_flatbuffers_sdk::data_objects::NodeAttributes nodeType{
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::ConvolutionWrwAttributes};
+    hipdnn_flatbuffers_sdk::data_objects::DataType xDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType dyDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType outputDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType;
 
     ConvolutionWrwSignatureKey() = default;
 
-    constexpr ConvolutionWrwSignatureKey(hipdnn_data_sdk::data_objects::DataType x,
-                                         hipdnn_data_sdk::data_objects::DataType dy,
-                                         hipdnn_data_sdk::data_objects::DataType output,
-                                         hipdnn_data_sdk::data_objects::DataType compute)
+    constexpr ConvolutionWrwSignatureKey(hipdnn_flatbuffers_sdk::data_objects::DataType x,
+                                         hipdnn_flatbuffers_sdk::data_objects::DataType dy,
+                                         hipdnn_flatbuffers_sdk::data_objects::DataType output,
+                                         hipdnn_flatbuffers_sdk::data_objects::DataType compute)
         : xDataType(x)
         , dyDataType(dy)
         , outputDataType(output)
@@ -36,10 +36,11 @@ struct ConvolutionWrwSignatureKey
     }
 
     ConvolutionWrwSignatureKey(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap,
-        const hipdnn_data_sdk::data_objects::DataType computeType)
+        const hipdnn_flatbuffers_sdk::data_objects::DataType computeType)
     {
         const auto* nodeAttributes = node.attributes_as_ConvolutionWrwAttributes();
         if(nodeAttributes == nullptr)
@@ -95,34 +96,34 @@ struct ConvolutionWrwSignatureKey
                            ConvolutionWrwSignatureKey>
             map;
 
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16>(map);
 
         return map;
     }
 
-    template <hipdnn_data_sdk::data_objects::DataType XDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType DyDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType OutputDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType ComputeDataTypeEnum>
+    template <hipdnn_flatbuffers_sdk::data_objects::DataType XDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType DyDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType OutputDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum>
     static void addPlanBuilder(std::unordered_map<ConvolutionWrwSignatureKey,
                                                   std::unique_ptr<IGraphNodePlanBuilder>,
                                                   ConvolutionWrwSignatureKey>& map)

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/IGraphNodePlanBuilder.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/IGraphNodePlanBuilder.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/IGraphNodePlanExecutor.hpp>
 
 namespace hipdnn_test_sdk::detail
@@ -15,14 +15,15 @@ class IGraphNodePlanBuilder
 public:
     virtual ~IGraphNodePlanBuilder() = default;
     virtual bool isApplicable(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap) const
         = 0;
 
     virtual std::unique_ptr<IGraphNodePlanExecutor>
-        buildNodePlan(const hipdnn_data_sdk::flatbuffer_utilities::IGraph& graph,
-                      const hipdnn_data_sdk::data_objects::Node& node) const
+        buildNodePlan(const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& graph,
+                      const hipdnn_flatbuffers_sdk::data_objects::Node& node) const
         = 0;
 };
 

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/LayernormFpropPlan.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/LayernormFpropPlan.hpp
@@ -5,9 +5,9 @@
 
 #include <optional>
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
-#include <hipdnn_data_sdk/utilities/FlatbufferUtils.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/utilities/FlatbufferUtils.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceLayernorm.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferDatatypeMapping.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/IGraphNodePlanBuilder.hpp>
@@ -22,14 +22,15 @@ struct LayernormFpropParams
 {
     LayernormFpropParams() = default;
     LayernormFpropParams(
-        const hipdnn_data_sdk::data_objects::TensorAttributes& xAttributes,
-        const hipdnn_data_sdk::data_objects::TensorAttributes& yAttributes,
-        const hipdnn_data_sdk::data_objects::TensorAttributes& epsilonAttributes,
-        const hipdnn_data_sdk::data_objects::TensorAttributes& scaleAttributes,
-        const hipdnn_data_sdk::data_objects::TensorAttributes& biasAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& xAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& yAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& epsilonAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& scaleAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& biasAttributes,
         const int64_t normalizedDimCount,
-        const hipdnn_data_sdk::data_objects::TensorAttributes* meanAttributes = nullptr,
-        const hipdnn_data_sdk::data_objects::TensorAttributes* invVarianceAttributes = nullptr)
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* meanAttributes = nullptr,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* invVarianceAttributes
+        = nullptr)
         : xTensor(unpackTensorAttributes(xAttributes))
         , yTensor(unpackTensorAttributes(yAttributes))
         , epsilonTensor(unpackTensorAttributes(epsilonAttributes))
@@ -45,14 +46,14 @@ struct LayernormFpropParams
     {
     }
 
-    hipdnn_data_sdk::data_objects::TensorAttributesT xTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT yTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT epsilonTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT scaleTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT biasTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT xTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT yTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT epsilonTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT scaleTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT biasTensor;
     int64_t normalizedDimCount;
-    std::optional<hipdnn_data_sdk::data_objects::TensorAttributesT> meanTensor;
-    std::optional<hipdnn_data_sdk::data_objects::TensorAttributesT> invVarianceTensor;
+    std::optional<hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT> meanTensor;
+    std::optional<hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT> invVarianceTensor;
 };
 
 template <typename XDataType,
@@ -91,7 +92,7 @@ public:
             _params.yTensor, variantPack.at(_params.yTensor.uid));
 
         // Extract epsilon from pass-by-value tensor (cast to double)
-        const double epsilon = hipdnn_data_sdk::utilities::extractDoubleFromTensorValue(
+        const double epsilon = hipdnn_flatbuffers_sdk::utilities::extractDoubleFromTensorValue(
             _params.epsilonTensor, "Epsilon");
 
         // Scale tensor (required)
@@ -138,11 +139,11 @@ private:
     LayernormFpropParams _params;
 };
 
-template <hipdnn_data_sdk::data_objects::DataType XDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType ScaleBiasDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType MeanInvVarianceDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType OutputDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType ComputeDataTypeEnum>
+template <hipdnn_flatbuffers_sdk::data_objects::DataType XDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType ScaleBiasDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType MeanInvVarianceDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType OutputDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum>
 class LayernormFpropPlanBuilder : public IGraphNodePlanBuilder
 {
 public:
@@ -153,8 +154,9 @@ public:
     using ComputeDataType = utilities::DataTypeToNative<ComputeDataTypeEnum>;
 
     bool isApplicable(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap) const override
     {
         if(node.compute_data_type() != ComputeDataTypeEnum)
@@ -200,8 +202,8 @@ public:
     }
 
     std::unique_ptr<IGraphNodePlanExecutor>
-        buildNodePlan(const hipdnn_data_sdk::flatbuffer_utilities::IGraph& graph,
-                      const hipdnn_data_sdk::data_objects::Node& node) const override
+        buildNodePlan(const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& graph,
+                      const hipdnn_flatbuffers_sdk::data_objects::Node& node) const override
     {
         const auto* nodeAttributes = node.attributes_as_LayernormAttributes();
         if(nodeAttributes == nullptr)
@@ -211,8 +213,8 @@ public:
 
         const auto& tensorMap = graph.getTensorMap();
 
-        const hipdnn_data_sdk::data_objects::TensorAttributes* mean = nullptr;
-        const hipdnn_data_sdk::data_objects::TensorAttributes* invVariance = nullptr;
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* mean = nullptr;
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* invVariance = nullptr;
 
         if(nodeAttributes->mean_tensor_uid().has_value())
         {

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/LayernormFpropSignatureKey.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/LayernormFpropSignatureKey.hpp
@@ -3,9 +3,9 @@
 
 #pragma once
 
-#include <hipdnn_data_sdk/data_objects/data_types_generated.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/data_types_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/LayernormFpropPlan.hpp>
 #include <ostream>
 
@@ -14,20 +14,21 @@ namespace hipdnn_test_sdk::detail
 
 struct LayernormFpropSignatureKey
 {
-    const hipdnn_data_sdk::data_objects::NodeAttributes nodeType
-        = hipdnn_data_sdk::data_objects::NodeAttributes::LayernormAttributes;
-    hipdnn_data_sdk::data_objects::DataType xDataType;
-    hipdnn_data_sdk::data_objects::DataType scaleBiasDataType;
-    hipdnn_data_sdk::data_objects::DataType meanInvVarianceDataType;
-    hipdnn_data_sdk::data_objects::DataType outputDataType;
-    hipdnn_data_sdk::data_objects::DataType computeDataType;
+    const hipdnn_flatbuffers_sdk::data_objects::NodeAttributes nodeType
+        = hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::LayernormAttributes;
+    hipdnn_flatbuffers_sdk::data_objects::DataType xDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType scaleBiasDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType meanInvVarianceDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType outputDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType;
 
     LayernormFpropSignatureKey() = default;
-    constexpr LayernormFpropSignatureKey(hipdnn_data_sdk::data_objects::DataType x,
-                                         hipdnn_data_sdk::data_objects::DataType scaleBias,
-                                         hipdnn_data_sdk::data_objects::DataType meanInvVariance,
-                                         hipdnn_data_sdk::data_objects::DataType output,
-                                         hipdnn_data_sdk::data_objects::DataType compute)
+    constexpr LayernormFpropSignatureKey(
+        hipdnn_flatbuffers_sdk::data_objects::DataType x,
+        hipdnn_flatbuffers_sdk::data_objects::DataType scaleBias,
+        hipdnn_flatbuffers_sdk::data_objects::DataType meanInvVariance,
+        hipdnn_flatbuffers_sdk::data_objects::DataType output,
+        hipdnn_flatbuffers_sdk::data_objects::DataType compute)
         : xDataType(x)
         , scaleBiasDataType(scaleBias)
         , meanInvVarianceDataType(meanInvVariance)
@@ -37,8 +38,9 @@ struct LayernormFpropSignatureKey
     }
 
     LayernormFpropSignatureKey(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap)
     {
         const auto* nodeAttributes = node.attributes_as_LayernormAttributes();
@@ -110,61 +112,61 @@ struct LayernormFpropSignatureKey
                            LayernormFpropSignatureKey>
             map;
 
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16>(map);
         // MIOpen-compatible: all tensors same type, compute in float
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
 
         return map;
     }
 
-    template <hipdnn_data_sdk::data_objects::DataType XDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType ScaleBiasDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType MeanInvVarianceDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType OutputDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType ComputeDataTypeEnum>
+    template <hipdnn_flatbuffers_sdk::data_objects::DataType XDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType ScaleBiasDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType MeanInvVarianceDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType OutputDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum>
     static void addPlanBuilder(std::unordered_map<LayernormFpropSignatureKey,
                                                   std::unique_ptr<IGraphNodePlanBuilder>,
                                                   LayernormFpropSignatureKey>& map)

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/MatmulPlan.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/MatmulPlan.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceMatmul.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferDatatypeMapping.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/IGraphNodePlanBuilder.hpp>
@@ -17,18 +17,18 @@ namespace hipdnn_test_sdk::detail
 struct MatmulParams
 {
     MatmulParams() = default;
-    MatmulParams(const hipdnn_data_sdk::data_objects::TensorAttributes& aAttributes,
-                 const hipdnn_data_sdk::data_objects::TensorAttributes& bAttributes,
-                 const hipdnn_data_sdk::data_objects::TensorAttributes& cAttributes)
+    MatmulParams(const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& aAttributes,
+                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& bAttributes,
+                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& cAttributes)
         : aTensor(unpackTensorAttributes(aAttributes))
         , bTensor(unpackTensorAttributes(bAttributes))
         , cTensor(unpackTensorAttributes(cAttributes))
     {
     }
 
-    hipdnn_data_sdk::data_objects::TensorAttributesT aTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT bTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT cTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT aTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT bTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT cTensor;
 };
 
 template <typename ADataType, typename BDataType, typename CDataType, typename ComputeDataType>
@@ -62,10 +62,10 @@ private:
     MatmulParams _params;
 };
 
-template <hipdnn_data_sdk::data_objects::DataType ADataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType BDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType CDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType ComputeDataTypeEnum>
+template <hipdnn_flatbuffers_sdk::data_objects::DataType ADataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType BDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType CDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum>
 class MatmulPlanBuilder : public IGraphNodePlanBuilder
 {
 public:
@@ -75,8 +75,9 @@ public:
     using ComputeDataType = utilities::DataTypeToNative<ComputeDataTypeEnum>;
 
     bool isApplicable(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap) const override
     {
         if(node.compute_data_type() != ComputeDataTypeEnum)
@@ -102,8 +103,8 @@ public:
     }
 
     std::unique_ptr<IGraphNodePlanExecutor>
-        buildNodePlan(const hipdnn_data_sdk::flatbuffer_utilities::IGraph& graph,
-                      const hipdnn_data_sdk::data_objects::Node& node) const override
+        buildNodePlan(const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& graph,
+                      const hipdnn_flatbuffers_sdk::data_objects::Node& node) const override
     {
         const auto* nodeAttributes = node.attributes_as_MatmulAttributes();
         if(nodeAttributes == nullptr)

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/MatmulSignatureKey.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/MatmulSignatureKey.hpp
@@ -6,9 +6,9 @@
 #include <functional>
 #include <ostream>
 
-#include <hipdnn_data_sdk/data_objects/data_types_generated.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/data_types_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/MatmulPlan.hpp>
 
 namespace hipdnn_test_sdk::detail
@@ -16,20 +16,20 @@ namespace hipdnn_test_sdk::detail
 
 struct MatmulSignatureKey
 {
-    const hipdnn_data_sdk::data_objects::NodeAttributes nodeType{
-        hipdnn_data_sdk::data_objects::NodeAttributes::MatmulAttributes};
+    const hipdnn_flatbuffers_sdk::data_objects::NodeAttributes nodeType{
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::MatmulAttributes};
 
-    hipdnn_data_sdk::data_objects::DataType aDataType;
-    hipdnn_data_sdk::data_objects::DataType bDataType;
-    hipdnn_data_sdk::data_objects::DataType cDataType;
-    hipdnn_data_sdk::data_objects::DataType computeDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType aDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType bDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType cDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType;
 
     MatmulSignatureKey() = default;
 
-    constexpr MatmulSignatureKey(hipdnn_data_sdk::data_objects::DataType a,
-                                 hipdnn_data_sdk::data_objects::DataType b,
-                                 hipdnn_data_sdk::data_objects::DataType c,
-                                 hipdnn_data_sdk::data_objects::DataType compute)
+    constexpr MatmulSignatureKey(hipdnn_flatbuffers_sdk::data_objects::DataType a,
+                                 hipdnn_flatbuffers_sdk::data_objects::DataType b,
+                                 hipdnn_flatbuffers_sdk::data_objects::DataType c,
+                                 hipdnn_flatbuffers_sdk::data_objects::DataType compute)
         : aDataType(a)
         , bDataType(b)
         , cDataType(c)
@@ -38,10 +38,11 @@ struct MatmulSignatureKey
     }
 
     MatmulSignatureKey(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap,
-        const hipdnn_data_sdk::data_objects::DataType computeType)
+        const hipdnn_flatbuffers_sdk::data_objects::DataType computeType)
     {
         const auto* nodeAttributes = node.attributes_as_MatmulAttributes();
         if(nodeAttributes == nullptr)
@@ -95,38 +96,38 @@ struct MatmulSignatureKey
                            MatmulSignatureKey>
             map;
 
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
 
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
 
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
 
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
 
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
 
         return map;
     }
 
-    template <hipdnn_data_sdk::data_objects::DataType ADataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType BDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType CDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType ComputeDataTypeEnum>
+    template <hipdnn_flatbuffers_sdk::data_objects::DataType ADataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType BDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType CDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum>
     static void addPlanBuilder(std::unordered_map<MatmulSignatureKey,
                                                   std::unique_ptr<IGraphNodePlanBuilder>,
                                                   MatmulSignatureKey>& map)

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/PointwisePlan.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/PointwisePlan.hpp
@@ -6,9 +6,9 @@
 #include <functional>
 #include <variant>
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
-#include <hipdnn_data_sdk/utilities/PointwiseValidation.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/utilities/PointwiseValidation.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferDatatypeMapping.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/IGraphNodePlanBuilder.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/IGraphNodePlanExecutor.hpp>
@@ -24,16 +24,17 @@ namespace hipdnn_test_sdk::detail
 struct PointwiseParams
 {
     PointwiseParams() = default;
-    PointwiseParams(const hipdnn_data_sdk::data_objects::PointwiseMode pointwiseMode,
-                    const hipdnn_data_sdk::data_objects::TensorAttributes& in0Attributes,
-                    const hipdnn_data_sdk::data_objects::TensorAttributes* optionalIn1Attributes,
-                    const hipdnn_data_sdk::data_objects::TensorAttributes& out0Attributes,
-                    std::optional<float> reluLowerClipLocal,
-                    std::optional<float> reluUpperClipLocal,
-                    std::optional<float> reluLowerClipSlopeLocal,
-                    std::optional<float> swishBetaLocal,
-                    std::optional<float> eluAlphaLocal,
-                    std::optional<float> softplusBetaLocal)
+    PointwiseParams(
+        const hipdnn_flatbuffers_sdk::data_objects::PointwiseMode pointwiseMode,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& in0Attributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* optionalIn1Attributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& out0Attributes,
+        std::optional<float> reluLowerClipLocal,
+        std::optional<float> reluUpperClipLocal,
+        std::optional<float> reluLowerClipSlopeLocal,
+        std::optional<float> swishBetaLocal,
+        std::optional<float> eluAlphaLocal,
+        std::optional<float> softplusBetaLocal)
         : in0Tensor(unpackTensorAttributes(in0Attributes))
         , out0Tensor(unpackTensorAttributes(out0Attributes))
         , mode(pointwiseMode)
@@ -50,10 +51,10 @@ struct PointwiseParams
         }
     }
 
-    hipdnn_data_sdk::data_objects::TensorAttributesT in0Tensor;
-    std::optional<hipdnn_data_sdk::data_objects::TensorAttributesT> in1Tensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT out0Tensor;
-    hipdnn_data_sdk::data_objects::PointwiseMode mode;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT in0Tensor;
+    std::optional<hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT> in1Tensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT out0Tensor;
+    hipdnn_flatbuffers_sdk::data_objects::PointwiseMode mode;
 
     std::optional<float> reluLowerClip;
     std::optional<float> reluUpperClip;
@@ -99,12 +100,12 @@ private:
         auto shallowOut0Tensor = createShallowTensor<OutputType>(
             _params.out0Tensor, variantPack.at(_params.out0Tensor.uid));
 
-        if(hipdnn_data_sdk::utilities::isUnaryPointwiseMode(_params.mode))
+        if(hipdnn_flatbuffers_sdk::utilities::isUnaryPointwiseMode(_params.mode))
         {
             utilities::CpuReferencePointwiseImpl<OutputType, Input0Type>::pointwiseCompute(
                 _params.mode, *shallowOut0Tensor, *shallowIn0Tensor);
         }
-        else if(hipdnn_data_sdk::utilities::isBinaryPointwiseMode(_params.mode))
+        else if(hipdnn_flatbuffers_sdk::utilities::isBinaryPointwiseMode(_params.mode))
         {
             if(!_params.in1Tensor.has_value())
             {
@@ -132,7 +133,7 @@ private:
         auto shallowOut0Tensor = createShallowTensor<OutputType>(
             _params.out0Tensor, variantPack.at(_params.out0Tensor.uid));
 
-        if(hipdnn_data_sdk::utilities::isUnaryPointwiseMode(_params.mode))
+        if(hipdnn_flatbuffers_sdk::utilities::isUnaryPointwiseMode(_params.mode))
         {
             utilities::CpuReferencePointwiseImpl<OutputType, Input0Type>::pointwiseCompute(
                 _params.mode,
@@ -149,7 +150,7 @@ private:
                 static_cast<OutputType>(_params.swishBeta.has_value() ? _params.swishBeta.value()
                                                                       : 1.0f));
         }
-        else if(hipdnn_data_sdk::utilities::isBinaryPointwiseMode(_params.mode))
+        else if(hipdnn_flatbuffers_sdk::utilities::isBinaryPointwiseMode(_params.mode))
         {
             if(!_params.in1Tensor.has_value())
             {
@@ -183,10 +184,10 @@ private:
     PointwiseParams _params;
 };
 
-template <hipdnn_data_sdk::data_objects::DataType Input0DataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType Input1DataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType ComputeDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType OutputDataTypeEnum>
+template <hipdnn_flatbuffers_sdk::data_objects::DataType Input0DataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType Input1DataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType OutputDataTypeEnum>
 class PointwisePlanBuilder : public IGraphNodePlanBuilder
 {
 public:
@@ -196,8 +197,9 @@ public:
     using OutputType = utilities::DataTypeToNative<OutputDataTypeEnum>;
 
     bool isApplicable(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap) const override
     {
         if(node.compute_data_type() != ComputeDataTypeEnum)
@@ -214,13 +216,15 @@ public:
         // Check that the operation is implemented
         auto mode = nodeAttributes->operation();
         bool isImplemented = false;
-        if(hipdnn_data_sdk::utilities::isUnaryPointwiseMode(mode))
+        if(hipdnn_flatbuffers_sdk::utilities::isUnaryPointwiseMode(mode))
         {
-            isImplemented = hipdnn_data_sdk::utilities::isImplementedUnaryPointwiseMode(mode);
+            isImplemented
+                = hipdnn_flatbuffers_sdk::utilities::isImplementedUnaryPointwiseMode(mode);
         }
-        else if(hipdnn_data_sdk::utilities::isBinaryPointwiseMode(mode))
+        else if(hipdnn_flatbuffers_sdk::utilities::isBinaryPointwiseMode(mode))
         {
-            isImplemented = hipdnn_data_sdk::utilities::isImplementedBinaryPointwiseMode(mode);
+            isImplemented
+                = hipdnn_flatbuffers_sdk::utilities::isImplementedBinaryPointwiseMode(mode);
         }
 
         if(!isImplemented)
@@ -237,7 +241,7 @@ public:
         CHECK_TENSOR_TYPE(tensorMap, nodeAttributes->out_0_tensor_uid(), OutputDataTypeEnum);
 
         // Check optional tensors based on operation mode
-        if(hipdnn_data_sdk::utilities::isBinaryPointwiseMode(mode))
+        if(hipdnn_flatbuffers_sdk::utilities::isBinaryPointwiseMode(mode))
         {
             CHECK_OPTIONAL_TENSOR_EXISTS(tensorMap, nodeAttributes->in_1_tensor_uid());
             CHECK_OPTIONAL_TENSOR_TYPE(
@@ -248,8 +252,8 @@ public:
     }
 
     std::unique_ptr<IGraphNodePlanExecutor>
-        buildNodePlan(const hipdnn_data_sdk::flatbuffer_utilities::IGraph& graph,
-                      const hipdnn_data_sdk::data_objects::Node& node) const override
+        buildNodePlan(const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& graph,
+                      const hipdnn_flatbuffers_sdk::data_objects::Node& node) const override
     {
         const auto* nodeAttributes = node.attributes_as_PointwiseAttributes();
         if(nodeAttributes == nullptr)

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/PointwiseSignatureKey.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/PointwiseSignatureKey.hpp
@@ -4,11 +4,11 @@
 #pragma once
 
 #include <functional>
-#include <hipdnn_data_sdk/data_objects/data_types_generated.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
-#include <hipdnn_data_sdk/utilities/PointwiseValidation.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/data_types_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/pointwise_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+#include <hipdnn_flatbuffers_sdk/utilities/PointwiseValidation.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/PointwisePlan.hpp>
 #include <ostream>
 
@@ -17,22 +17,22 @@ namespace hipdnn_test_sdk::detail
 
 struct PointwiseSignatureKey
 {
-    const hipdnn_data_sdk::data_objects::NodeAttributes nodeType
-        = hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes;
-    hipdnn_data_sdk::data_objects::PointwiseMode operation;
-    hipdnn_data_sdk::data_objects::DataType inputDataType;
-    hipdnn_data_sdk::data_objects::DataType computeDataType;
-    hipdnn_data_sdk::data_objects::DataType outputDataType;
-    hipdnn_data_sdk::data_objects::DataType input1DataType
-        = hipdnn_data_sdk::data_objects::DataType::UNSET; // For binary ops
+    const hipdnn_flatbuffers_sdk::data_objects::NodeAttributes nodeType
+        = hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::PointwiseAttributes;
+    hipdnn_flatbuffers_sdk::data_objects::PointwiseMode operation;
+    hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType outputDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType input1DataType
+        = hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET; // For binary ops
 
     PointwiseSignatureKey() = default;
-    constexpr PointwiseSignatureKey(hipdnn_data_sdk::data_objects::PointwiseMode op,
-                                    hipdnn_data_sdk::data_objects::DataType input,
-                                    hipdnn_data_sdk::data_objects::DataType compute,
-                                    hipdnn_data_sdk::data_objects::DataType output,
-                                    hipdnn_data_sdk::data_objects::DataType input1
-                                    = hipdnn_data_sdk::data_objects::DataType::UNSET)
+    constexpr PointwiseSignatureKey(hipdnn_flatbuffers_sdk::data_objects::PointwiseMode op,
+                                    hipdnn_flatbuffers_sdk::data_objects::DataType input,
+                                    hipdnn_flatbuffers_sdk::data_objects::DataType compute,
+                                    hipdnn_flatbuffers_sdk::data_objects::DataType output,
+                                    hipdnn_flatbuffers_sdk::data_objects::DataType input1
+                                    = hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET)
         : operation(op)
         , inputDataType(input)
         , computeDataType(compute)
@@ -42,8 +42,9 @@ struct PointwiseSignatureKey
     }
 
     PointwiseSignatureKey(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap)
     {
         const auto* nodeAttributes = node.attributes_as_PointwiseAttributes();
@@ -74,7 +75,7 @@ struct PointwiseSignatureKey
         outputDataType = outputTensorAttr->data_type();
 
         // Get second input tensor if this is a binary operation
-        if(hipdnn_data_sdk::utilities::isBinaryPointwiseMode(operation))
+        if(hipdnn_flatbuffers_sdk::utilities::isBinaryPointwiseMode(operation))
         {
             if(nodeAttributes->in_1_tensor_uid().has_value())
             {
@@ -125,163 +126,164 @@ struct PointwiseSignatureKey
                            PointwiseSignatureKey>
             map;
         // Add plan builders for implemented unary operations (input/compute/output)
-        addUnaryPlanBuilders<hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                             hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                             hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addUnaryPlanBuilders<hipdnn_data_sdk::data_objects::DataType::HALF,
-                             hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                             hipdnn_data_sdk::data_objects::DataType::HALF>(map);
-        addUnaryPlanBuilders<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                             hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                             hipdnn_data_sdk::data_objects::DataType::BFLOAT16>(map);
-        addUnaryPlanBuilders<hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                             hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                             hipdnn_data_sdk::data_objects::DataType::HALF>(map);
-        addUnaryPlanBuilders<hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                             hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                             hipdnn_data_sdk::data_objects::DataType::BFLOAT16>(map);
+        addUnaryPlanBuilders<hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                             hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                             hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addUnaryPlanBuilders<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                             hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                             hipdnn_flatbuffers_sdk::data_objects::DataType::HALF>(map);
+        addUnaryPlanBuilders<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                             hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                             hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16>(map);
+        addUnaryPlanBuilders<hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                             hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                             hipdnn_flatbuffers_sdk::data_objects::DataType::HALF>(map);
+        addUnaryPlanBuilders<hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                             hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                             hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16>(map);
 
         // Add plan builders for implemented binary operations (input0/input1/compute/output)
-        addBinaryPlanBuilders<hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                              hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                              hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                              hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addBinaryPlanBuilders<hipdnn_data_sdk::data_objects::DataType::HALF,
-                              hipdnn_data_sdk::data_objects::DataType::HALF,
-                              hipdnn_data_sdk::data_objects::DataType::HALF,
-                              hipdnn_data_sdk::data_objects::DataType::HALF>(map);
-        addBinaryPlanBuilders<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                              hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                              hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                              hipdnn_data_sdk::data_objects::DataType::BFLOAT16>(map);
-        addBinaryPlanBuilders<hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                              hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                              hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                              hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addBinaryPlanBuilders<hipdnn_data_sdk::data_objects::DataType::HALF,
-                              hipdnn_data_sdk::data_objects::DataType::HALF,
-                              hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                              hipdnn_data_sdk::data_objects::DataType::HALF>(map);
-        addBinaryPlanBuilders<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                              hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                              hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                              hipdnn_data_sdk::data_objects::DataType::BFLOAT16>(map);
-        addBinaryPlanBuilders<hipdnn_data_sdk::data_objects::DataType::HALF,
-                              hipdnn_data_sdk::data_objects::DataType::HALF,
-                              hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                              hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addBinaryPlanBuilders<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                              hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                              hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                              hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addBinaryPlanBuilders<hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                              hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                              hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                              hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addBinaryPlanBuilders<hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                              hipdnn_data_sdk::data_objects::DataType::HALF,
-                              hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                              hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addBinaryPlanBuilders<hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                              hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                              hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                              hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addBinaryPlanBuilders<hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                              hipdnn_data_sdk::data_objects::DataType::HALF,
-                              hipdnn_data_sdk::data_objects::DataType::HALF,
-                              hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
+        addBinaryPlanBuilders<hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addBinaryPlanBuilders<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::HALF>(map);
+        addBinaryPlanBuilders<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16>(map);
+        addBinaryPlanBuilders<hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addBinaryPlanBuilders<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::HALF>(map);
+        addBinaryPlanBuilders<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16>(map);
+        addBinaryPlanBuilders<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addBinaryPlanBuilders<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addBinaryPlanBuilders<hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addBinaryPlanBuilders<hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addBinaryPlanBuilders<hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addBinaryPlanBuilders<hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
 
         return map;
     }
 
 private:
-    template <hipdnn_data_sdk::data_objects::DataType InputDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType ComputeDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType OutputDataTypeEnum>
+    template <hipdnn_flatbuffers_sdk::data_objects::DataType InputDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType OutputDataTypeEnum>
     static void addUnaryPlanBuilders(std::unordered_map<PointwiseSignatureKey,
                                                         std::unique_ptr<IGraphNodePlanBuilder>,
                                                         PointwiseSignatureKey>& map)
     {
         // Add all implemented unary operations
-        addUnaryPlanBuilder<hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        addUnaryPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD,
                             InputDataTypeEnum,
                             ComputeDataTypeEnum,
                             OutputDataTypeEnum>(map);
-        addUnaryPlanBuilder<hipdnn_data_sdk::data_objects::PointwiseMode::SIGMOID_FWD,
+        addUnaryPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SIGMOID_FWD,
                             InputDataTypeEnum,
                             ComputeDataTypeEnum,
                             OutputDataTypeEnum>(map);
-        addUnaryPlanBuilder<hipdnn_data_sdk::data_objects::PointwiseMode::TANH_FWD,
+        addUnaryPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::TANH_FWD,
                             InputDataTypeEnum,
                             ComputeDataTypeEnum,
                             OutputDataTypeEnum>(map);
-        addUnaryPlanBuilder<hipdnn_data_sdk::data_objects::PointwiseMode::ABS,
+        addUnaryPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::ABS,
                             InputDataTypeEnum,
                             ComputeDataTypeEnum,
                             OutputDataTypeEnum>(map);
-        addUnaryPlanBuilder<hipdnn_data_sdk::data_objects::PointwiseMode::NEG,
+        addUnaryPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::NEG,
                             InputDataTypeEnum,
                             ComputeDataTypeEnum,
                             OutputDataTypeEnum>(map);
-        addUnaryPlanBuilder<hipdnn_data_sdk::data_objects::PointwiseMode::GELU_FWD,
+        addUnaryPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::GELU_FWD,
                             InputDataTypeEnum,
                             ComputeDataTypeEnum,
                             OutputDataTypeEnum>(map);
-        addUnaryPlanBuilder<hipdnn_data_sdk::data_objects::PointwiseMode::GELU_APPROX_TANH_FWD,
-                            InputDataTypeEnum,
-                            ComputeDataTypeEnum,
-                            OutputDataTypeEnum>(map);
-        addUnaryPlanBuilder<hipdnn_data_sdk::data_objects::PointwiseMode::SWISH_FWD,
+        addUnaryPlanBuilder<
+            hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::GELU_APPROX_TANH_FWD,
+            InputDataTypeEnum,
+            ComputeDataTypeEnum,
+            OutputDataTypeEnum>(map);
+        addUnaryPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SWISH_FWD,
                             InputDataTypeEnum,
                             ComputeDataTypeEnum,
                             OutputDataTypeEnum>(map);
     }
 
-    template <hipdnn_data_sdk::data_objects::DataType Input0DataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType Input1DataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType ComputeDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType OutputDataTypeEnum>
+    template <hipdnn_flatbuffers_sdk::data_objects::DataType Input0DataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType Input1DataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType OutputDataTypeEnum>
     static void addBinaryPlanBuilders(std::unordered_map<PointwiseSignatureKey,
                                                          std::unique_ptr<IGraphNodePlanBuilder>,
                                                          PointwiseSignatureKey>& map)
     {
         // Add all implemented binary operations
-        addBinaryPlanBuilder<hipdnn_data_sdk::data_objects::PointwiseMode::ADD,
+        addBinaryPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::ADD,
                              Input0DataTypeEnum,
                              Input1DataTypeEnum,
                              ComputeDataTypeEnum,
                              OutputDataTypeEnum>(map);
-        addBinaryPlanBuilder<hipdnn_data_sdk::data_objects::PointwiseMode::SUB,
+        addBinaryPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SUB,
                              Input0DataTypeEnum,
                              Input1DataTypeEnum,
                              ComputeDataTypeEnum,
                              OutputDataTypeEnum>(map);
-        addBinaryPlanBuilder<hipdnn_data_sdk::data_objects::PointwiseMode::MUL,
+        addBinaryPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::MUL,
                              Input0DataTypeEnum,
                              Input1DataTypeEnum,
                              ComputeDataTypeEnum,
                              OutputDataTypeEnum>(map);
-        addBinaryPlanBuilder<hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+        addBinaryPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD,
                              Input0DataTypeEnum,
                              Input1DataTypeEnum,
                              ComputeDataTypeEnum,
                              OutputDataTypeEnum>(map);
-        addBinaryPlanBuilder<hipdnn_data_sdk::data_objects::PointwiseMode::SIGMOID_BWD,
+        addBinaryPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SIGMOID_BWD,
                              Input0DataTypeEnum,
                              Input1DataTypeEnum,
                              ComputeDataTypeEnum,
                              OutputDataTypeEnum>(map);
-        addBinaryPlanBuilder<hipdnn_data_sdk::data_objects::PointwiseMode::TANH_BWD,
+        addBinaryPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::TANH_BWD,
                              Input0DataTypeEnum,
                              Input1DataTypeEnum,
                              ComputeDataTypeEnum,
                              OutputDataTypeEnum>(map);
     }
 
-    template <hipdnn_data_sdk::data_objects::PointwiseMode ModeEnum,
-              hipdnn_data_sdk::data_objects::DataType InputDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType ComputeDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType OutputDataTypeEnum>
+    template <hipdnn_flatbuffers_sdk::data_objects::PointwiseMode ModeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType InputDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType OutputDataTypeEnum>
     static void addUnaryPlanBuilder(std::unordered_map<PointwiseSignatureKey,
                                                        std::unique_ptr<IGraphNodePlanBuilder>,
                                                        PointwiseSignatureKey>& map)
@@ -294,11 +296,11 @@ private:
                                                     OutputDataTypeEnum>>();
     }
 
-    template <hipdnn_data_sdk::data_objects::PointwiseMode ModeEnum,
-              hipdnn_data_sdk::data_objects::DataType Input0DataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType Input1DataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType ComputeDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType OutputDataTypeEnum>
+    template <hipdnn_flatbuffers_sdk::data_objects::PointwiseMode ModeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType Input0DataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType Input1DataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType OutputDataTypeEnum>
     static void addBinaryPlanBuilder(std::unordered_map<PointwiseSignatureKey,
                                                         std::unique_ptr<IGraphNodePlanBuilder>,
                                                         PointwiseSignatureKey>& map)
@@ -317,7 +319,7 @@ private:
 
 inline std::ostream& operator<<(std::ostream& os, const PointwiseSignatureKey& key)
 {
-    if(key.input1DataType != hipdnn_data_sdk::data_objects::DataType::UNSET)
+    if(key.input1DataType != hipdnn_flatbuffers_sdk::data_objects::DataType::UNSET)
     {
         // Binary operation
         os << "Pointwise(op=" << key.operation << ", in0=" << key.inputDataType

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/RMSNormFwdPlan.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/RMSNormFwdPlan.hpp
@@ -7,9 +7,9 @@
 #include <optional>
 #include <variant>
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
-#include <hipdnn_data_sdk/utilities/FlatbufferUtils.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/utilities/FlatbufferUtils.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceRMSNorm.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferDatatypeMapping.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/IGraphNodePlanBuilder.hpp>
@@ -22,14 +22,13 @@ namespace hipdnn_test_sdk::detail
 
 struct RMSNormFwdParams
 {
-    RMSNormFwdParams(const hipdnn_data_sdk::data_objects::TensorAttributes& xAttributes,
-                     const hipdnn_data_sdk::data_objects::TensorAttributes& scaleAttributes,
-                     const hipdnn_data_sdk::data_objects::TensorAttributes& epsilonAttributes,
-                     const hipdnn_data_sdk::data_objects::TensorAttributes& yAttributes,
-                     const hipdnn_data_sdk::data_objects::TensorAttributes* invRmsAttributes
-                     = nullptr,
-                     const hipdnn_data_sdk::data_objects::TensorAttributes* biasAttributes
-                     = nullptr)
+    RMSNormFwdParams(
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& xAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& scaleAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& epsilonAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& yAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* invRmsAttributes = nullptr,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* biasAttributes = nullptr)
         : xTensor(unpackTensorAttributes(xAttributes))
         , scaleTensor(unpackTensorAttributes(scaleAttributes))
         , epsilonTensor(unpackTensorAttributes(epsilonAttributes))
@@ -43,12 +42,12 @@ struct RMSNormFwdParams
     {
     }
 
-    hipdnn_data_sdk::data_objects::TensorAttributesT xTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT scaleTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT epsilonTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT yTensor;
-    std::optional<hipdnn_data_sdk::data_objects::TensorAttributesT> invRmsTensor;
-    std::optional<hipdnn_data_sdk::data_objects::TensorAttributesT> biasTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT xTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT scaleTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT epsilonTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT yTensor;
+    std::optional<hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT> invRmsTensor;
+    std::optional<hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT> biasTensor;
 };
 
 template <typename XDataType,
@@ -84,7 +83,7 @@ public:
         auto shallowScaleTensor = createShallowTensor<ScaleDataType>(
             _params.scaleTensor, variantPack.at(_params.scaleTensor.uid));
 
-        const double epsilon = hipdnn_data_sdk::utilities::extractDoubleFromTensorValue(
+        const double epsilon = hipdnn_flatbuffers_sdk::utilities::extractDoubleFromTensorValue(
             _params.epsilonTensor, "Epsilon");
 
         std::unique_ptr<hipdnn_data_sdk::utilities::TensorBase<ScaleDataType>> shallowBiasTensor;
@@ -116,10 +115,10 @@ private:
     RMSNormFwdParams _params;
 };
 
-template <hipdnn_data_sdk::data_objects::DataType XDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType ScaleDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType OutputDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType ComputeDataTypeEnum>
+template <hipdnn_flatbuffers_sdk::data_objects::DataType XDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType ScaleDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType OutputDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum>
 class RMSNormFwdPlanBuilder : public IGraphNodePlanBuilder
 {
 public:
@@ -129,8 +128,9 @@ public:
     using ComputeDataType = utilities::DataTypeToNative<ComputeDataTypeEnum>;
 
     bool isApplicable(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap) const override
     {
         if(node.compute_data_type() != ComputeDataTypeEnum)
@@ -173,8 +173,8 @@ public:
     }
 
     std::unique_ptr<IGraphNodePlanExecutor>
-        buildNodePlan(const hipdnn_data_sdk::flatbuffer_utilities::IGraph& graph,
-                      const hipdnn_data_sdk::data_objects::Node& node) const override
+        buildNodePlan(const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& graph,
+                      const hipdnn_flatbuffers_sdk::data_objects::Node& node) const override
     {
         const auto* nodeAttributes = node.attributes_as_RMSNormAttributes();
         if(nodeAttributes == nullptr)

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/RMSNormFwdSignatureKey.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/RMSNormFwdSignatureKey.hpp
@@ -4,9 +4,9 @@
 #pragma once
 
 #include <functional>
-#include <hipdnn_data_sdk/data_objects/data_types_generated.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/data_types_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/RMSNormFwdPlan.hpp>
 #include <ostream>
 
@@ -15,18 +15,18 @@ namespace hipdnn_test_sdk::detail
 
 struct RMSNormFwdSignatureKey
 {
-    const hipdnn_data_sdk::data_objects::NodeAttributes nodeType
-        = hipdnn_data_sdk::data_objects::NodeAttributes::RMSNormAttributes;
-    hipdnn_data_sdk::data_objects::DataType xDataType;
-    hipdnn_data_sdk::data_objects::DataType scaleDataType;
-    hipdnn_data_sdk::data_objects::DataType outputDataType;
-    hipdnn_data_sdk::data_objects::DataType computeDataType;
+    const hipdnn_flatbuffers_sdk::data_objects::NodeAttributes nodeType
+        = hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::RMSNormAttributes;
+    hipdnn_flatbuffers_sdk::data_objects::DataType xDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType scaleDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType outputDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType;
 
     RMSNormFwdSignatureKey() = default;
-    constexpr RMSNormFwdSignatureKey(hipdnn_data_sdk::data_objects::DataType x,
-                                     hipdnn_data_sdk::data_objects::DataType scale,
-                                     hipdnn_data_sdk::data_objects::DataType output,
-                                     hipdnn_data_sdk::data_objects::DataType compute)
+    constexpr RMSNormFwdSignatureKey(hipdnn_flatbuffers_sdk::data_objects::DataType x,
+                                     hipdnn_flatbuffers_sdk::data_objects::DataType scale,
+                                     hipdnn_flatbuffers_sdk::data_objects::DataType output,
+                                     hipdnn_flatbuffers_sdk::data_objects::DataType compute)
         : xDataType(x)
         , scaleDataType(scale)
         , outputDataType(output)
@@ -35,8 +35,9 @@ struct RMSNormFwdSignatureKey
     }
 
     RMSNormFwdSignatureKey(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap)
     {
         const auto* nodeAttributes = node.attributes_as_RMSNormAttributes();
@@ -92,42 +93,42 @@ struct RMSNormFwdSignatureKey
                            RMSNormFwdSignatureKey>
             map;
 
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16>(map);
 
         return map;
     }
 
-    template <hipdnn_data_sdk::data_objects::DataType XDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType ScaleDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType OutputDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType ComputeDataTypeEnum>
+    template <hipdnn_flatbuffers_sdk::data_objects::DataType XDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType ScaleDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType OutputDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum>
     static void addPlanBuilder(std::unordered_map<RMSNormFwdSignatureKey,
                                                   std::unique_ptr<IGraphNodePlanBuilder>,
                                                   RMSNormFwdSignatureKey>& map)

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ReductionPlan.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ReductionPlan.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/data_objects/reduction_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/reduction_attributes_generated.h>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceReduction.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferDatatypeMapping.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/IGraphNodePlanBuilder.hpp>
@@ -18,19 +18,19 @@ namespace hipdnn_test_sdk::detail
 struct ReductionParams
 {
     ReductionParams() = default;
-    ReductionParams(const hipdnn_data_sdk::data_objects::TensorAttributes& xAttributes,
-                    const hipdnn_data_sdk::data_objects::TensorAttributes& yAttributes,
-                    hipdnn_data_sdk::data_objects::ReductionMode reductionMode)
+    ReductionParams(const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& xAttributes,
+                    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& yAttributes,
+                    hipdnn_flatbuffers_sdk::data_objects::ReductionMode reductionMode)
         : xTensor(unpackTensorAttributes(xAttributes))
         , yTensor(unpackTensorAttributes(yAttributes))
         , mode(reductionMode)
     {
     }
 
-    hipdnn_data_sdk::data_objects::TensorAttributesT xTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT yTensor;
-    hipdnn_data_sdk::data_objects::ReductionMode mode
-        = hipdnn_data_sdk::data_objects::ReductionMode::NOT_SET;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT xTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT yTensor;
+    hipdnn_flatbuffers_sdk::data_objects::ReductionMode mode
+        = hipdnn_flatbuffers_sdk::data_objects::ReductionMode::NOT_SET;
 };
 
 template <typename XDataType, typename YDataType, typename ComputeDataType>
@@ -62,9 +62,9 @@ private:
     ReductionParams _params;
 };
 
-template <hipdnn_data_sdk::data_objects::DataType XDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType YDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType ComputeDataTypeEnum>
+template <hipdnn_flatbuffers_sdk::data_objects::DataType XDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType YDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum>
 class ReductionPlanBuilder : public IGraphNodePlanBuilder
 {
 public:
@@ -73,8 +73,9 @@ public:
     using ComputeDataType = utilities::DataTypeToNative<ComputeDataTypeEnum>;
 
     bool isApplicable(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap) const override
     {
         if(node.compute_data_type() != ComputeDataTypeEnum)
@@ -98,8 +99,8 @@ public:
     }
 
     std::unique_ptr<IGraphNodePlanExecutor>
-        buildNodePlan(const hipdnn_data_sdk::flatbuffer_utilities::IGraph& graph,
-                      const hipdnn_data_sdk::data_objects::Node& node) const override
+        buildNodePlan(const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& graph,
+                      const hipdnn_flatbuffers_sdk::data_objects::Node& node) const override
     {
         const auto* nodeAttributes = node.attributes_as_ReductionAttributes();
         if(nodeAttributes == nullptr)

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ReductionSignatureKey.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ReductionSignatureKey.hpp
@@ -6,9 +6,9 @@
 #include <functional>
 #include <ostream>
 
-#include <hipdnn_data_sdk/data_objects/data_types_generated.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/data_types_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ReductionPlan.hpp>
 
 namespace hipdnn_test_sdk::detail
@@ -16,18 +16,18 @@ namespace hipdnn_test_sdk::detail
 
 struct ReductionSignatureKey
 {
-    const hipdnn_data_sdk::data_objects::NodeAttributes nodeType{
-        hipdnn_data_sdk::data_objects::NodeAttributes::ReductionAttributes};
+    const hipdnn_flatbuffers_sdk::data_objects::NodeAttributes nodeType{
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::ReductionAttributes};
 
-    hipdnn_data_sdk::data_objects::DataType xDataType;
-    hipdnn_data_sdk::data_objects::DataType yDataType;
-    hipdnn_data_sdk::data_objects::DataType computeDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType xDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType yDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType;
 
     ReductionSignatureKey() = default;
 
-    constexpr ReductionSignatureKey(hipdnn_data_sdk::data_objects::DataType x,
-                                    hipdnn_data_sdk::data_objects::DataType y,
-                                    hipdnn_data_sdk::data_objects::DataType compute)
+    constexpr ReductionSignatureKey(hipdnn_flatbuffers_sdk::data_objects::DataType x,
+                                    hipdnn_flatbuffers_sdk::data_objects::DataType y,
+                                    hipdnn_flatbuffers_sdk::data_objects::DataType compute)
         : xDataType(x)
         , yDataType(y)
         , computeDataType(compute)
@@ -35,10 +35,11 @@ struct ReductionSignatureKey
     }
 
     ReductionSignatureKey(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap,
-        const hipdnn_data_sdk::data_objects::DataType computeType)
+        const hipdnn_flatbuffers_sdk::data_objects::DataType computeType)
     {
         const auto* nodeAttributes = node.attributes_as_ReductionAttributes();
         if(nodeAttributes == nullptr)
@@ -88,32 +89,32 @@ struct ReductionSignatureKey
                            ReductionSignatureKey>
             map;
 
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
 
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
 
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
 
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
 
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
 
         return map;
     }
 
-    template <hipdnn_data_sdk::data_objects::DataType XDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType YDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType ComputeDataTypeEnum>
+    template <hipdnn_flatbuffers_sdk::data_objects::DataType XDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType YDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum>
     static void addPlanBuilder(std::unordered_map<ReductionSignatureKey,
                                                   std::unique_ptr<IGraphNodePlanBuilder>,
                                                   ReductionSignatureKey>& map)

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/SdpaFwdPlan.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/SdpaFwdPlan.hpp
@@ -5,9 +5,9 @@
 
 #include <optional>
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/data_objects/sdpa_attributes_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/sdpa_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceSdpa.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferDatatypeMapping.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/IGraphNodePlanBuilder.hpp>
@@ -20,13 +20,13 @@ namespace hipdnn_test_sdk::detail
 
 struct SdpaFwdParams
 {
-    SdpaFwdParams(const hipdnn_data_sdk::data_objects::TensorAttributes& qAttributes,
-                  const hipdnn_data_sdk::data_objects::TensorAttributes& kAttributes,
-                  const hipdnn_data_sdk::data_objects::TensorAttributes& vAttributes,
-                  const hipdnn_data_sdk::data_objects::TensorAttributes& oAttributes,
+    SdpaFwdParams(const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& qAttributes,
+                  const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& kAttributes,
+                  const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& vAttributes,
+                  const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& oAttributes,
                   std::optional<float> attnScaleValue,
                   bool causalMask,
-                  const hipdnn_data_sdk::data_objects::TensorAttributes* attnMaskAttributes
+                  const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* attnMaskAttributes
                   = nullptr)
         : qTensor(unpackTensorAttributes(qAttributes))
         , kTensor(unpackTensorAttributes(kAttributes))
@@ -40,13 +40,13 @@ struct SdpaFwdParams
     {
     }
 
-    hipdnn_data_sdk::data_objects::TensorAttributesT qTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT kTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT vTensor;
-    hipdnn_data_sdk::data_objects::TensorAttributesT oTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT qTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT kTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT vTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT oTensor;
     std::optional<float> attnScaleValue;
     bool causalMask;
-    std::optional<hipdnn_data_sdk::data_objects::TensorAttributesT> attnMaskTensor;
+    std::optional<hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT> attnMaskTensor;
 };
 
 template <typename QDataType, typename KDataType, typename VDataType, typename ODataType>
@@ -95,10 +95,10 @@ private:
     SdpaFwdParams _params;
 };
 
-template <hipdnn_data_sdk::data_objects::DataType QDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType KDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType VDataTypeEnum,
-          hipdnn_data_sdk::data_objects::DataType ODataTypeEnum>
+template <hipdnn_flatbuffers_sdk::data_objects::DataType QDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType KDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType VDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType ODataTypeEnum>
 class SdpaFwdPlanBuilder : public IGraphNodePlanBuilder
 {
 public:
@@ -108,8 +108,9 @@ public:
     using ODataType = utilities::DataTypeToNative<ODataTypeEnum>;
 
     bool isApplicable(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap) const override
     {
         const auto* nodeAttributes = node.attributes_as_SdpaAttributes();
@@ -192,8 +193,8 @@ public:
     }
 
     std::unique_ptr<IGraphNodePlanExecutor>
-        buildNodePlan(const hipdnn_data_sdk::flatbuffer_utilities::IGraph& graph,
-                      const hipdnn_data_sdk::data_objects::Node& node) const override
+        buildNodePlan(const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& graph,
+                      const hipdnn_flatbuffers_sdk::data_objects::Node& node) const override
     {
         const auto* nodeAttributes = node.attributes_as_SdpaAttributes();
         if(nodeAttributes == nullptr)

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/SdpaFwdSignatureKey.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/SdpaFwdSignatureKey.hpp
@@ -6,9 +6,9 @@
 #include <ostream>
 #include <unordered_map>
 
-#include <hipdnn_data_sdk/data_objects/data_types_generated.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/data_types_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/SdpaFwdPlan.hpp>
 
 namespace hipdnn_test_sdk::detail
@@ -16,18 +16,18 @@ namespace hipdnn_test_sdk::detail
 
 struct SdpaFwdSignatureKey
 {
-    const hipdnn_data_sdk::data_objects::NodeAttributes nodeType
-        = hipdnn_data_sdk::data_objects::NodeAttributes::SdpaAttributes;
-    hipdnn_data_sdk::data_objects::DataType qDataType;
-    hipdnn_data_sdk::data_objects::DataType kDataType;
-    hipdnn_data_sdk::data_objects::DataType vDataType;
-    hipdnn_data_sdk::data_objects::DataType oDataType;
+    const hipdnn_flatbuffers_sdk::data_objects::NodeAttributes nodeType
+        = hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::SdpaAttributes;
+    hipdnn_flatbuffers_sdk::data_objects::DataType qDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType kDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType vDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType oDataType;
 
     SdpaFwdSignatureKey() = default;
-    constexpr SdpaFwdSignatureKey(hipdnn_data_sdk::data_objects::DataType q,
-                                  hipdnn_data_sdk::data_objects::DataType k,
-                                  hipdnn_data_sdk::data_objects::DataType v,
-                                  hipdnn_data_sdk::data_objects::DataType o)
+    constexpr SdpaFwdSignatureKey(hipdnn_flatbuffers_sdk::data_objects::DataType q,
+                                  hipdnn_flatbuffers_sdk::data_objects::DataType k,
+                                  hipdnn_flatbuffers_sdk::data_objects::DataType v,
+                                  hipdnn_flatbuffers_sdk::data_objects::DataType o)
         : qDataType(q)
         , kDataType(k)
         , vDataType(v)
@@ -36,8 +36,9 @@ struct SdpaFwdSignatureKey
     }
 
     SdpaFwdSignatureKey(
-        const hipdnn_data_sdk::data_objects::Node& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap)
     {
         const auto* nodeAttributes = node.attributes_as_SdpaAttributes();
@@ -94,34 +95,34 @@ struct SdpaFwdSignatureKey
                            SdpaFwdSignatureKey>
             map;
 
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::HALF,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
-        addPlanBuilder<hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
-                       hipdnn_data_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
 
         return map;
     }
 
-    template <hipdnn_data_sdk::data_objects::DataType QDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType KDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType VDataTypeEnum,
-              hipdnn_data_sdk::data_objects::DataType ODataTypeEnum>
+    template <hipdnn_flatbuffers_sdk::data_objects::DataType QDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType KDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType VDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType ODataTypeEnum>
     static void addPlanBuilder(std::unordered_map<SdpaFwdSignatureKey,
                                                   std::unique_ptr<IGraphNodePlanBuilder>,
                                                   SdpaFwdSignatureKey>& map)

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/detail/FlatbufferTensorAttributesUtils.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/detail/FlatbufferTensorAttributesUtils.hpp
@@ -3,33 +3,32 @@
 
 #pragma once
 
-#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
-#include <hipdnn_data_sdk/utilities/FlatbufferUtils.hpp>
 #include <hipdnn_data_sdk/utilities/ShallowTensor.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/utilities/FlatbufferUtils.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferDatatypeMapping.hpp>
 
 namespace hipdnn_test_sdk::detail
 {
 
-inline hipdnn_data_sdk::data_objects::TensorAttributesT
-    unpackTensorAttributes(const hipdnn_data_sdk::data_objects::TensorAttributes& tensorAttributes)
+inline hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT unpackTensorAttributes(
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& tensorAttributes)
 {
-    hipdnn_data_sdk::data_objects::TensorAttributesT tensorAttributesT;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT tensorAttributesT;
     tensorAttributes.UnPackTo(&tensorAttributesT);
     return tensorAttributesT;
 }
 
 template <typename T>
-inline std::unique_ptr<hipdnn_data_sdk::utilities::ShallowTensor<T>>
-    createShallowTensor(const hipdnn_data_sdk::data_objects::TensorAttributesT& tensorDetails,
-                        void* ptr)
+inline std::unique_ptr<hipdnn_data_sdk::utilities::ShallowTensor<T>> createShallowTensor(
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT& tensorDetails, void* ptr)
 {
     return std::make_unique<hipdnn_data_sdk::utilities::ShallowTensor<T>>(
         ptr, tensorDetails.dims, tensorDetails.strides);
 }
 
 inline std::unique_ptr<hipdnn_data_sdk::utilities::ITensor>
-    createTensor(hipdnn_data_sdk::data_objects::DataType dataType,
+    createTensor(hipdnn_flatbuffers_sdk::data_objects::DataType dataType,
                  const std::vector<int64_t>& dims,
                  const std::vector<int64_t>& strides)
 {
@@ -37,47 +36,48 @@ inline std::unique_ptr<hipdnn_data_sdk::utilities::ITensor>
     using namespace hipdnn_data_sdk::types;
     switch(dataType)
     {
-    case hipdnn_data_sdk::data_objects::DataType::FLOAT:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT:
         return std::make_unique<Tensor<float>>(dims, strides);
-    case hipdnn_data_sdk::data_objects::DataType::HALF:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::HALF:
         return std::make_unique<Tensor<half>>(dims, strides);
-    case hipdnn_data_sdk::data_objects::DataType::BFLOAT16:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16:
         return std::make_unique<Tensor<bfloat16>>(dims, strides);
-    case hipdnn_data_sdk::data_objects::DataType::DOUBLE:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::DOUBLE:
         return std::make_unique<Tensor<double>>(dims, strides);
-    case hipdnn_data_sdk::data_objects::DataType::UINT8:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::UINT8:
         return std::make_unique<Tensor<uint8_t>>(dims, strides);
-    case hipdnn_data_sdk::data_objects::DataType::INT32:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::INT32:
         return std::make_unique<Tensor<int32_t>>(dims, strides);
-    case hipdnn_data_sdk::data_objects::DataType::INT8:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::INT8:
         return std::make_unique<Tensor<int8_t>>(dims, strides);
-    case hipdnn_data_sdk::data_objects::DataType::FP8_E4M3:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E4M3:
         return std::make_unique<Tensor<fp8_e4m3>>(dims, strides);
-    case hipdnn_data_sdk::data_objects::DataType::FP8_E5M2:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E5M2:
         return std::make_unique<Tensor<fp8_e5m2>>(dims, strides);
-    case hipdnn_data_sdk::data_objects::DataType::INT64:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::INT64:
         return std::make_unique<Tensor<int64_t>>(dims, strides);
-    case hipdnn_data_sdk::data_objects::DataType::FP8_E8M0:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E8M0:
         return std::make_unique<Tensor<fp8_e8m0>>(dims, strides);
-    case hipdnn_data_sdk::data_objects::DataType::FP4_E2M1:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::FP4_E2M1:
         return std::make_unique<Tensor<fp4_e2m1>>(dims, strides);
-    case hipdnn_data_sdk::data_objects::DataType::INT4:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::INT4:
         return std::make_unique<Tensor<uint8_t>>(dims, strides);
-    case hipdnn_data_sdk::data_objects::DataType::FP6_E2M3:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::FP6_E2M3:
         return std::make_unique<Tensor<fp6_e2m3>>(dims, strides);
-    case hipdnn_data_sdk::data_objects::DataType::FP6_E3M2:
+    case hipdnn_flatbuffers_sdk::data_objects::DataType::FP6_E3M2:
         return std::make_unique<Tensor<fp6_e3m2>>(dims, strides);
     default:
         throw std::runtime_error("Unsupported data type for tensor");
     }
 }
 
-inline std::unique_ptr<hipdnn_data_sdk::utilities::ITensor>
-    createTensorFromAttribute(const hipdnn_data_sdk::data_objects::TensorAttributes& attribute)
+inline std::unique_ptr<hipdnn_data_sdk::utilities::ITensor> createTensorFromAttribute(
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& attribute)
 {
-    auto dims = hipdnn_data_sdk::utilities::convertFlatBufferVectorToStdVector(attribute.dims());
-    auto strides
-        = hipdnn_data_sdk::utilities::convertFlatBufferVectorToStdVector(attribute.strides());
+    auto dims
+        = hipdnn_flatbuffers_sdk::utilities::convertFlatBufferVectorToStdVector(attribute.dims());
+    auto strides = hipdnn_flatbuffers_sdk::utilities::convertFlatBufferVectorToStdVector(
+        attribute.strides());
 
     return createTensor(attribute.data_type(), dims, strides);
 }

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/pointwise/CpuReferencePointwise.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/pointwise/CpuReferencePointwise.hpp
@@ -13,14 +13,14 @@ template <class DeviceExecutor, class OutputType, class... InputTypes>
 class ReferencePointwiseImpl
 {
 public:
-    static bool isApplicable(const hipdnn_data_sdk::data_objects::Node& node)
+    static bool isApplicable(const hipdnn_flatbuffers_sdk::data_objects::Node& node)
     {
         return ReferencePointwiseBase<DeviceExecutor, OutputType, InputTypes...>::isApplicable(
             node);
     }
 
     template <typename... Args>
-    static void pointwiseCompute(hipdnn_data_sdk::data_objects::PointwiseMode operation,
+    static void pointwiseCompute(hipdnn_flatbuffers_sdk::data_objects::PointwiseMode operation,
                                  hipdnn_data_sdk::utilities::TensorBase<OutputType>& output,
                                  Args&&... args)
     {

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/pointwise/PointwiseErrorClassification.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/pointwise/PointwiseErrorClassification.hpp
@@ -5,7 +5,7 @@
 
 #include <stdexcept>
 
-#include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/pointwise_attributes_generated.h>
 #include <hipdnn_test_sdk/utilities/DynamicTolerances.hpp>
 
 namespace hipdnn_test_sdk::utilities::pointwise
@@ -23,9 +23,10 @@ namespace hipdnn_test_sdk::utilities::pointwise
 /// - COMPOSITE_FWD (E fwd): compound nonlinear — gelu, gelu_approx_tanh, softplus, swish
 /// - COMPOSITE_BWD (E bwd): compound backward — gelu_bwd, gelu_approx_tanh_bwd, softplus_bwd,
 ///   swish_bwd
-inline PointwiseErrorClass classifyPointwiseOp(hipdnn_data_sdk::data_objects::PointwiseMode mode)
+inline PointwiseErrorClass
+    classifyPointwiseOp(hipdnn_flatbuffers_sdk::data_objects::PointwiseMode mode)
 {
-    using hipdnn_data_sdk::data_objects::PointwiseMode;
+    using hipdnn_flatbuffers_sdk::data_objects::PointwiseMode;
 
     switch(mode)
     {
@@ -108,9 +109,9 @@ inline PointwiseErrorClass classifyPointwiseOp(hipdnn_data_sdk::data_objects::Po
 /// - SIGMOID_FWD: output in [0, 1]
 /// - TANH_FWD: output in [-1, 1]
 /// - ERF: output in [-1, 1]
-inline bool isBoundedOutput(hipdnn_data_sdk::data_objects::PointwiseMode mode)
+inline bool isBoundedOutput(hipdnn_flatbuffers_sdk::data_objects::PointwiseMode mode)
 {
-    using hipdnn_data_sdk::data_objects::PointwiseMode;
+    using hipdnn_flatbuffers_sdk::data_objects::PointwiseMode;
 
     switch(mode)
     {

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/pointwise/ReferencePointwiseBase.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/pointwise/ReferencePointwiseBase.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <hipdnn_data_sdk/utilities/PointwiseValidation.hpp>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_flatbuffers_sdk/utilities/PointwiseValidation.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 #include <hipdnn_test_sdk/utilities/detail/CpuFpReferenceUtilities.hpp>
 #include <hipdnn_test_sdk/utilities/pointwise/PointwiseOperationFunctors.hpp>
@@ -18,9 +18,9 @@ template <class DeviceExecutor, class OutputType, class... InputTypes>
 class ReferencePointwiseBase
 {
 public:
-    static bool isApplicable(const hipdnn_data_sdk::data_objects::Node& node)
+    static bool isApplicable(const hipdnn_flatbuffers_sdk::data_objects::Node& node)
     {
-        using namespace hipdnn_data_sdk::data_objects;
+        using namespace hipdnn_flatbuffers_sdk::data_objects;
 
         if(node.attributes_type() != NodeAttributes::PointwiseAttributes)
         {
@@ -43,7 +43,7 @@ public:
 
     // Unary operations
     template <typename InputType, typename ComputeType = double>
-    static void pointwiseCompute(hipdnn_data_sdk::data_objects::PointwiseMode operation,
+    static void pointwiseCompute(hipdnn_flatbuffers_sdk::data_objects::PointwiseMode operation,
                                  hipdnn_data_sdk::utilities::TensorBase<OutputType>& output,
                                  const hipdnn_data_sdk::utilities::TensorBase<InputType>& input)
     {
@@ -51,7 +51,7 @@ public:
     }
 
     template <typename InputType, typename ParamType, typename ComputeType = double>
-    static void pointwiseCompute(hipdnn_data_sdk::data_objects::PointwiseMode operation,
+    static void pointwiseCompute(hipdnn_flatbuffers_sdk::data_objects::PointwiseMode operation,
                                  hipdnn_data_sdk::utilities::TensorBase<OutputType>& output,
                                  const hipdnn_data_sdk::utilities::TensorBase<InputType>& input,
                                  const ParamType lowerClip,
@@ -67,7 +67,7 @@ public:
 
     // Binary operations
     template <typename Input1Type, typename Input2Type, typename ComputeType = double>
-    static void pointwiseCompute(hipdnn_data_sdk::data_objects::PointwiseMode operation,
+    static void pointwiseCompute(hipdnn_flatbuffers_sdk::data_objects::PointwiseMode operation,
                                  hipdnn_data_sdk::utilities::TensorBase<OutputType>& output,
                                  const hipdnn_data_sdk::utilities::TensorBase<Input1Type>& input1,
                                  const hipdnn_data_sdk::utilities::TensorBase<Input2Type>& input2)
@@ -81,7 +81,7 @@ public:
               typename Input2Type,
               typename ParamType,
               typename ComputeType = double>
-    static void pointwiseCompute(hipdnn_data_sdk::data_objects::PointwiseMode operation,
+    static void pointwiseCompute(hipdnn_flatbuffers_sdk::data_objects::PointwiseMode operation,
                                  hipdnn_data_sdk::utilities::TensorBase<OutputType>& output,
                                  const hipdnn_data_sdk::utilities::TensorBase<Input1Type>& input1,
                                  const hipdnn_data_sdk::utilities::TensorBase<Input2Type>& input2,
@@ -98,7 +98,7 @@ public:
 private:
     template <typename InputType, typename ComputeType>
     static void
-        executeUnaryOperation(hipdnn_data_sdk::data_objects::PointwiseMode operation,
+        executeUnaryOperation(hipdnn_flatbuffers_sdk::data_objects::PointwiseMode operation,
                               hipdnn_data_sdk::utilities::TensorBase<OutputType>& output,
                               const hipdnn_data_sdk::utilities::TensorBase<InputType>& input)
     {
@@ -106,31 +106,31 @@ private:
 
         switch(operation)
         {
-        case hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD:
+        case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD:
             policy.executeUnary(input, output, pointwise::ReluForward<ComputeType>{});
             break;
-        case hipdnn_data_sdk::data_objects::PointwiseMode::SIGMOID_FWD:
+        case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SIGMOID_FWD:
             policy.executeUnary(input, output, pointwise::SigmoidForward<ComputeType>{});
             break;
-        case hipdnn_data_sdk::data_objects::PointwiseMode::TANH_FWD:
+        case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::TANH_FWD:
             policy.executeUnary(input, output, pointwise::TanhForward<ComputeType>{});
             break;
-        case hipdnn_data_sdk::data_objects::PointwiseMode::ABS:
+        case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::ABS:
             policy.executeUnary(input, output, pointwise::AbsoluteValue{});
             break;
-        case hipdnn_data_sdk::data_objects::PointwiseMode::NEG:
+        case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::NEG:
             policy.executeUnary(input, output, pointwise::Negation{});
             break;
-        case hipdnn_data_sdk::data_objects::PointwiseMode::IDENTITY:
+        case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::IDENTITY:
             policy.executeUnary(input, output, pointwise::Identity{});
             break;
-        case hipdnn_data_sdk::data_objects::PointwiseMode::GELU_FWD:
+        case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::GELU_FWD:
             policy.executeUnary(input, output, pointwise::GeluForward<ComputeType>{});
             break;
-        case hipdnn_data_sdk::data_objects::PointwiseMode::GELU_APPROX_TANH_FWD:
+        case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::GELU_APPROX_TANH_FWD:
             policy.executeUnary(input, output, pointwise::GeluApproxTanhForward<ComputeType>{});
             break;
-        case hipdnn_data_sdk::data_objects::PointwiseMode::SWISH_FWD:
+        case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SWISH_FWD:
             policy.executeUnary(input, output, pointwise::SwishForward<ComputeType>{});
             break;
         default:
@@ -143,7 +143,7 @@ private:
 
     template <typename InputType, typename ParamType, typename ComputeType>
     static void executeParameterizedUnaryOperation(
-        hipdnn_data_sdk::data_objects::PointwiseMode operation,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode operation,
         hipdnn_data_sdk::utilities::TensorBase<OutputType>& output,
         const hipdnn_data_sdk::utilities::TensorBase<InputType>& input,
         const ParamType lowerClip,
@@ -155,7 +155,7 @@ private:
 
         switch(operation)
         {
-        case hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD:
+        case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_FWD:
             policy.executeUnary(
                 input,
                 output,
@@ -163,7 +163,7 @@ private:
                                                     static_cast<ComputeType>(upperClip),
                                                     static_cast<ComputeType>(lowerSlope)});
             break;
-        case hipdnn_data_sdk::data_objects::PointwiseMode::SWISH_FWD:
+        case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SWISH_FWD:
             policy.executeUnary(
                 input,
                 output,
@@ -179,7 +179,7 @@ private:
 
     template <typename Input1Type, typename Input2Type, typename ComputeType>
     static void
-        executeBinaryOperation(hipdnn_data_sdk::data_objects::PointwiseMode operation,
+        executeBinaryOperation(hipdnn_flatbuffers_sdk::data_objects::PointwiseMode operation,
                                hipdnn_data_sdk::utilities::TensorBase<OutputType>& output,
                                const hipdnn_data_sdk::utilities::TensorBase<Input1Type>& input1,
                                const hipdnn_data_sdk::utilities::TensorBase<Input2Type>& input2)
@@ -188,24 +188,24 @@ private:
 
         switch(operation)
         {
-        case hipdnn_data_sdk::data_objects::PointwiseMode::ADD:
+        case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::ADD:
             policy.executeBinaryBroadcast(input1, input2, output, pointwise::Add{});
             break;
-        case hipdnn_data_sdk::data_objects::PointwiseMode::SUB:
+        case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SUB:
             policy.executeBinaryBroadcast(input1, input2, output, pointwise::Subtract{});
             break;
-        case hipdnn_data_sdk::data_objects::PointwiseMode::MUL:
+        case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::MUL:
             policy.executeBinaryBroadcast(input1, input2, output, pointwise::Multiply{});
             break;
-        case hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD:
+        case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD:
             policy.executeBinaryBroadcast(
                 input1, input2, output, pointwise::ReluBackward<ComputeType>{});
             break;
-        case hipdnn_data_sdk::data_objects::PointwiseMode::SIGMOID_BWD:
+        case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::SIGMOID_BWD:
             policy.executeBinaryBroadcast(
                 input1, input2, output, pointwise::SigmoidBackward<ComputeType>{});
             break;
-        case hipdnn_data_sdk::data_objects::PointwiseMode::TANH_BWD:
+        case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::TANH_BWD:
             policy.executeBinaryBroadcast(
                 input1, input2, output, pointwise::TanhBackward<ComputeType>{});
             break;
@@ -219,7 +219,7 @@ private:
 
     template <typename Input1Type, typename Input2Type, typename ParamType, typename ComputeType>
     static void executeParameterizedBinaryOperation(
-        hipdnn_data_sdk::data_objects::PointwiseMode operation,
+        hipdnn_flatbuffers_sdk::data_objects::PointwiseMode operation,
         hipdnn_data_sdk::utilities::TensorBase<OutputType>& output,
         const hipdnn_data_sdk::utilities::TensorBase<Input1Type>& input1,
         const hipdnn_data_sdk::utilities::TensorBase<Input2Type>& input2,
@@ -231,7 +231,7 @@ private:
 
         switch(operation)
         {
-        case hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD:
+        case hipdnn_flatbuffers_sdk::data_objects::PointwiseMode::RELU_BWD:
             policy.executeBinaryBroadcast(input1,
                                           input2,
                                           output,
@@ -248,8 +248,8 @@ private:
         policy.markOutputModified(output);
     }
 
-    static bool
-        canExecuteUnaryOperation(const hipdnn_data_sdk::data_objects::PointwiseAttributes* attrs)
+    static bool canExecuteUnaryOperation(
+        const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes* attrs)
     {
         return attrs->in_0_tensor_uid() != 0 && // Required: first input
                !attrs->in_1_tensor_uid() && // Must NOT be set
@@ -257,8 +257,8 @@ private:
                attrs->out_0_tensor_uid() != 0; // Required: output
     }
 
-    static bool
-        canExecuteBinaryOperation(const hipdnn_data_sdk::data_objects::PointwiseAttributes* attrs)
+    static bool canExecuteBinaryOperation(
+        const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes* attrs)
     {
         return attrs->in_0_tensor_uid() != 0 && // Required: first input
                attrs->in_1_tensor_uid() && // Must be set
@@ -267,8 +267,8 @@ private:
                attrs->out_0_tensor_uid() != 0; // Required: output
     }
 
-    static bool
-        canExecuteTernaryOperation(const hipdnn_data_sdk::data_objects::PointwiseAttributes* attrs)
+    static bool canExecuteTernaryOperation(
+        const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes* attrs)
     {
         return attrs->in_0_tensor_uid() != 0 && // Required: first input
                attrs->in_1_tensor_uid() && // Must be set
@@ -278,9 +278,10 @@ private:
                attrs->out_0_tensor_uid() != 0; // Required: output
     }
 
-    static bool canExecuteOperation(const hipdnn_data_sdk::data_objects::PointwiseAttributes* attrs)
+    static bool
+        canExecuteOperation(const hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes* attrs)
     {
-        using namespace hipdnn_data_sdk::data_objects;
+        using namespace hipdnn_flatbuffers_sdk::data_objects;
 
         if(attrs == nullptr)
         {
@@ -288,16 +289,18 @@ private:
         }
 
         const PointwiseMode operation = attrs->operation();
+        const auto dataSdkOperation
+            = static_cast<hipdnn_flatbuffers_sdk::data_objects::PointwiseMode>(operation);
 
-        if(hipdnn_data_sdk::utilities::isImplementedUnaryPointwiseMode(operation))
+        if(hipdnn_flatbuffers_sdk::utilities::isImplementedUnaryPointwiseMode(dataSdkOperation))
         {
             return canExecuteUnaryOperation(attrs);
         }
-        if(hipdnn_data_sdk::utilities::isImplementedBinaryPointwiseMode(operation))
+        if(hipdnn_flatbuffers_sdk::utilities::isImplementedBinaryPointwiseMode(dataSdkOperation))
         {
             return canExecuteBinaryOperation(attrs);
         }
-        if(hipdnn_data_sdk::utilities::isImplementedTernaryPointwiseMode(operation))
+        if(hipdnn_flatbuffers_sdk::utilities::isImplementedTernaryPointwiseMode(dataSdkOperation))
         {
             return canExecuteTernaryOperation(attrs);
         }

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceBatchnorm.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceBatchnorm.cpp
@@ -20,7 +20,7 @@
 #endif
 
 using namespace hipdnn_test_sdk::utilities;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
 using namespace hipdnn_data_sdk::types;
 using hipdnn_test_sdk::detail::safeTestTypeCast;

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceConvolution.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceConvolution.cpp
@@ -11,7 +11,7 @@
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceConvolution.hpp>
 
 using namespace hipdnn_test_sdk::utilities;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
 using namespace hipdnn_data_sdk::types;
 using hipdnn_test_sdk::detail::safeTestTypeCast;

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceMatmul.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceMatmul.cpp
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier:  MIT
 
 #include <gtest/gtest.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_data_sdk/types.hpp>
 #include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceMatmul.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 #include <hipdnn_test_sdk/utilities/TestTolerances.hpp>
@@ -19,9 +19,9 @@
 #include <vector>
 
 using namespace hipdnn_test_sdk::utilities;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
-using namespace hipdnn_data_sdk::flatbuffer_utilities;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 using namespace hipdnn_sdk_test_utils;
 using namespace hipdnn_data_sdk::types;
 using hipdnn_test_sdk::detail::safeTestTypeCast;
@@ -77,8 +77,8 @@ TEST_F(TestCpuFpReferenceMatmul, IsApplicable)
         auto [serializedGraph, serErr] = graph->to_binary();
         ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
 
-        const hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graphWrap(serializedGraph.data(),
-                                                                            serializedGraph.size());
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graphWrap(
+            serializedGraph.data(), serializedGraph.size());
         EXPECT_TRUE(CpuFpReferenceMatmul::isApplicable(graphWrap.getNode(0)));
     }
 
@@ -99,8 +99,8 @@ TEST_F(TestCpuFpReferenceMatmul, IsApplicable)
         auto [serializedGraph, serErr] = graph->to_binary();
         ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
 
-        const hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graphWrap(serializedGraph.data(),
-                                                                            serializedGraph.size());
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graphWrap(
+            serializedGraph.data(), serializedGraph.size());
         EXPECT_FALSE(CpuFpReferenceMatmul::isApplicable(graphWrap.getNode(0)));
     }
 }

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceReduction.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceReduction.cpp
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 #include <gtest/gtest.h>
-#include <hipdnn_data_sdk/data_objects/reduction_attributes_generated.h>
 #include <hipdnn_data_sdk/types.hpp>
 #include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/reduction_attributes_generated.h>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceReduction.hpp>
 #include <hipdnn_test_sdk/utilities/detail/CpuFpReferenceUtilities.hpp>
 
@@ -13,7 +13,7 @@
 #include <vector>
 
 using namespace hipdnn_test_sdk::utilities;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
 using namespace hipdnn_data_sdk::types;
 using hipdnn_test_sdk::detail::safeTestTypeCast;

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuReferencePointwise.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuReferencePointwise.cpp
@@ -13,7 +13,7 @@
 
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_data_sdk::utilities;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::types;
 using hipdnn_test_sdk::detail::safeTestTypeCast;
 

--- a/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerancesConv.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerancesConv.cpp
@@ -329,7 +329,7 @@ TEST(TestCalculateConvWrwTolerance, DetectsFailure)
     EXPECT_GT(tol, 0.09f);
 
     auto validator = hipdnn_test_sdk::utilities::createAllCloseValidator(
-        hipdnn_data_sdk::data_objects::DataType::FLOAT, tol, 0);
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT, tol, 0);
 
     bool valid = validator->allClose(*baseline, *actualPassing);
     EXPECT_TRUE(valid);
@@ -708,7 +708,7 @@ TEST(TestCalculateConvDgradTolerance, DetectsFailure)
     EXPECT_GT(tol, 0.1f);
 
     auto validator = hipdnn_test_sdk::utilities::createAllCloseValidator(
-        hipdnn_data_sdk::data_objects::DataType::FLOAT, tol, 0);
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT, tol, 0);
 
     bool valid = validator->allClose(*baseline, *actualPassing);
     EXPECT_TRUE(valid);
@@ -1058,7 +1058,7 @@ TEST(TestCalculateConvFpropTolerance, DetectsFailure)
     EXPECT_GT(tol, 0.09f);
 
     auto validator = hipdnn_test_sdk::utilities::createAllCloseValidator(
-        hipdnn_data_sdk::data_objects::DataType::FLOAT, tol, 0);
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT, tol, 0);
 
     {
         SCOPED_TRACE("Validator should have passed");

--- a/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerancesPointwise.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerancesPointwise.cpp
@@ -335,7 +335,7 @@ TEST(TestCalculatePointwiseTolerance, DetectsFailure)
         1.0, PointwiseErrorClass::TRANSCENDENTAL_FWD);
 
     auto validator = hipdnn_test_sdk::utilities::createAllCloseValidator(
-        hipdnn_data_sdk::data_objects::DataType::FLOAT, tol, 0);
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT, tol, 0);
 
     bool valid = validator->allClose(*baseline, *actualPassing);
     EXPECT_TRUE(valid);
@@ -372,9 +372,9 @@ TEST(TestCalculatePointwiseTolerance, BackwardToleranceExceedsForward)
 // and isBoundedOutput for code coverage.
 // =================================================================================================
 
-using hipdnn_data_sdk::data_objects::EnumNamesPointwiseMode;
-using hipdnn_data_sdk::data_objects::EnumValuesPointwiseMode;
-using hipdnn_data_sdk::data_objects::PointwiseMode;
+using hipdnn_flatbuffers_sdk::data_objects::EnumNamesPointwiseMode;
+using hipdnn_flatbuffers_sdk::data_objects::EnumValuesPointwiseMode;
+using hipdnn_flatbuffers_sdk::data_objects::PointwiseMode;
 
 // Verify one representative per error class for correctness
 TEST(TestClassifyPointwiseOp, OnePerClassCorrect)

--- a/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerancesRMSNorm.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerancesRMSNorm.cpp
@@ -303,7 +303,7 @@ TEST(TestCalculateRMSNormFwdTolerance, DetectsFailure)
     EXPECT_GT(tol, 1e-6f);
 
     auto validator = hipdnn_test_sdk::utilities::createAllCloseValidator(
-        hipdnn_data_sdk::data_objects::DataType::FLOAT, tol, 0);
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT, tol, 0);
 
     bool valid = validator->allClose(*baseline, *actualPassing);
     EXPECT_TRUE(valid);

--- a/projects/hipdnn/test_sdk/tests/utilities/TestFlatbufferDatatypeMapping.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestFlatbufferDatatypeMapping.cpp
@@ -7,7 +7,7 @@
 #include <hipdnn_test_sdk/utilities/FlatbufferDatatypeMapping.hpp>
 
 using namespace hipdnn_test_sdk::utilities;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 
 // Compile-time checks for DataType to Native type mapping
 static_assert(std::is_same_v<DataTypeToNative<DataType::FLOAT>, float>);

--- a/projects/hipdnn/test_sdk/tests/utilities/TestFlatbufferTensorAttributesUtils.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestFlatbufferTensorAttributesUtils.cpp
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier:  MIT
 
 #include <gtest/gtest.h>
-#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
 #include <hipdnn_data_sdk/utilities/ShallowTensor.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/tensor_attributes_generated.h>
 #include <hipdnn_test_sdk/utilities/detail/FlatbufferTensorAttributesUtils.hpp>
 
 using namespace hipdnn_test_sdk::detail;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 
 TEST(TestFlatbufferTensorAttributesUtils, UnpackTensorAttributes)
 {

--- a/projects/hipdnn/test_sdk/tests/utilities/TestGraphTestHelpers.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestGraphTestHelpers.cpp
@@ -74,18 +74,18 @@ TEST(TestBuildConvFpropGraph, GraphHasOneNode)
 
 TEST(TestBuildTensorMap, EmptyGraph)
 {
-    const hipdnn_data_sdk::data_objects::GraphT graphT;
+    const hipdnn_flatbuffers_sdk::data_objects::GraphT graphT;
     auto tensorMap = hipdnn_tests::buildTensorMap(graphT);
     EXPECT_TRUE(tensorMap.empty());
 }
 
 TEST(TestBuildTensorMap, MapsUidsToTensors)
 {
-    hipdnn_data_sdk::data_objects::GraphT graphT;
+    hipdnn_flatbuffers_sdk::data_objects::GraphT graphT;
 
-    auto t1 = std::make_unique<hipdnn_data_sdk::data_objects::TensorAttributesT>();
+    auto t1 = std::make_unique<hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT>();
     t1->uid = 10;
-    auto t2 = std::make_unique<hipdnn_data_sdk::data_objects::TensorAttributesT>();
+    auto t2 = std::make_unique<hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT>();
     t2->uid = 20;
 
     graphT.tensors.push_back(std::move(t1));

--- a/projects/hipdnn/test_sdk/tests/utilities/TestLoadGraphAndTensors.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestLoadGraphAndTensors.cpp
@@ -84,9 +84,11 @@ TEST(TestLoadGraphAndTensors, Valid)
 
     auto res = loadGraphAndTensors(filepath);
 
-    EXPECT_EQ(res.graph().compute_data_type(), data_objects::DataType::FLOAT);
-    EXPECT_EQ(res.graph().io_data_type(), data_objects::DataType::FLOAT);
-    EXPECT_EQ(res.graph().intermediate_data_type(), data_objects::DataType::FLOAT);
+    EXPECT_EQ(res.graph().compute_data_type(),
+              hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT);
+    EXPECT_EQ(res.graph().io_data_type(), hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT);
+    EXPECT_EQ(res.graph().intermediate_data_type(),
+              hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT);
     EXPECT_EQ(res.graph().nodes()->size(), 1);
     EXPECT_EQ(res.graph().tensors()->size(), 6);
 

--- a/projects/hipdnn/test_sdk/tests/utilities/TestSdkFrontendTypeConversions.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestSdkFrontendTypeConversions.cpp
@@ -10,7 +10,7 @@ using hipdnn_test_sdk::utilities::sdkToFrontendDataType;
 using hipdnn_test_sdk::utilities::sdkToFrontendPointwiseMode;
 
 namespace fe = hipdnn_frontend;
-namespace sdk = hipdnn_data_sdk::data_objects;
+namespace sdk = hipdnn_flatbuffers_sdk::data_objects;
 
 // ============================================================================
 // DataType round-trip tests

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/BatchnormGraphUtils.hpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/BatchnormGraphUtils.hpp
@@ -17,10 +17,10 @@ static std::tuple<std::shared_ptr<hipdnn_frontend::graph::Graph>,
                   std::unordered_map<int64_t, void*>>
     buildBatchnormTrainGraph(
         BatchnormTrainTensorBundle<InputType, ScaleBiasType, MeanVarianceType>& tensorBundle,
-        hipdnn_data_sdk::data_objects::DataType inputDataType,
-        hipdnn_data_sdk::data_objects::DataType scaleBiasDataType,
-        hipdnn_data_sdk::data_objects::DataType meanVarianceDataType,
-        hipdnn_data_sdk::data_objects::DataType computeDataType,
+        hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType,
+        hipdnn_flatbuffers_sdk::data_objects::DataType scaleBiasDataType,
+        hipdnn_flatbuffers_sdk::data_objects::DataType meanVarianceDataType,
+        hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType,
         bool useOptionalTensors)
 {
     auto graph = std::make_shared<hipdnn_frontend::graph::Graph>();
@@ -167,14 +167,14 @@ static std::tuple<std::shared_ptr<hipdnn_frontend::graph::Graph>,
     return std::make_tuple(graph, variantPack);
 }
 
-inline std::shared_ptr<hipdnn_frontend::graph::Graph>
-    buildBatchnormFwdInferenceGraph(hipdnn_data_sdk::data_objects::DataType inputDataType,
-                                    hipdnn_data_sdk::data_objects::DataType scaleBiasDataType,
-                                    hipdnn_data_sdk::data_objects::DataType meanVarianceDataType,
-                                    hipdnn_data_sdk::data_objects::DataType computeDataType,
-                                    const std::vector<int64_t>& dims,
-                                    const hipdnn_data_sdk::utilities::TensorLayout& layout,
-                                    bool isOutputVirtual = false)
+inline std::shared_ptr<hipdnn_frontend::graph::Graph> buildBatchnormFwdInferenceGraph(
+    hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType,
+    hipdnn_flatbuffers_sdk::data_objects::DataType scaleBiasDataType,
+    hipdnn_flatbuffers_sdk::data_objects::DataType meanVarianceDataType,
+    hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType,
+    const std::vector<int64_t>& dims,
+    const hipdnn_data_sdk::utilities::TensorLayout& layout,
+    bool isOutputVirtual = false)
 {
     auto graph = std::make_shared<hipdnn_frontend::graph::Graph>();
     graph->set_name("BatchnormFwdInferenceTest");
@@ -252,10 +252,10 @@ inline std::shared_ptr<hipdnn_frontend::graph::Graph>
 }
 
 inline std::shared_ptr<hipdnn_frontend::graph::Graph> buildBatchnormFwdInferenceWithVarianceGraph(
-    hipdnn_data_sdk::data_objects::DataType inputDataType,
-    hipdnn_data_sdk::data_objects::DataType scaleBiasDataType,
-    hipdnn_data_sdk::data_objects::DataType meanVarianceDataType,
-    hipdnn_data_sdk::data_objects::DataType computeDataType,
+    hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType,
+    hipdnn_flatbuffers_sdk::data_objects::DataType scaleBiasDataType,
+    hipdnn_flatbuffers_sdk::data_objects::DataType meanVarianceDataType,
+    hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType,
     const std::vector<int64_t>& dims,
     const hipdnn_data_sdk::utilities::TensorLayout& layout,
     bool isOutputVirtual = false)
@@ -353,10 +353,10 @@ static std::tuple<std::shared_ptr<hipdnn_frontend::graph::Graph>,
                   std::unordered_map<int64_t, void*>>
     buildBatchnormBwdGraph(
         BatchnormBwdTensorBundle<InputType, ScaleBiasType, MeanVarianceType>& tensorBundle,
-        hipdnn_data_sdk::data_objects::DataType inputDataType,
-        hipdnn_data_sdk::data_objects::DataType scaleBiasDataType,
-        hipdnn_data_sdk::data_objects::DataType meanVarianceDataType,
-        hipdnn_data_sdk::data_objects::DataType computeDataType)
+        hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType,
+        hipdnn_flatbuffers_sdk::data_objects::DataType scaleBiasDataType,
+        hipdnn_flatbuffers_sdk::data_objects::DataType meanVarianceDataType,
+        hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType)
 {
     auto graph = std::make_shared<hipdnn_frontend::graph::Graph>();
     graph->set_name("BatchnormBwdTest");

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/BatchnormTensorBundles.hpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/BatchnormTensorBundles.hpp
@@ -3,9 +3,9 @@
 
 #pragma once
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/NodeWrapper.hpp>
 #include <hipdnn_data_sdk/utilities/Constants.hpp>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/NodeWrapper.hpp>
 #include <hipdnn_frontend/Graph.hpp>
 #include <hipdnn_frontend/Utilities.hpp>
 #include <hipdnn_frontend/attributes/TensorAttributes.hpp>
@@ -18,14 +18,15 @@ namespace hipdnn_sdk_test_utils
 struct BatchnormFwdTensorBundle : public hipdnn_test_sdk::utilities::GraphTensorBundle
 {
     BatchnormFwdTensorBundle(
-        const hipdnn_data_sdk::flatbuffer_utilities::INodeWrapper& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::INodeWrapper& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap,
         unsigned int seed)
         : hipdnn_test_sdk::utilities::GraphTensorBundle(tensorMap)
     {
-        const auto& attributes
-            = node.attributesAs<hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes>();
+        const auto& attributes = node.attributesAs<
+            hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes>();
 
         randomizeTensor(attributes.x_tensor_uid(), 0.0f, 1.0f, seed);
         randomizeTensor(attributes.scale_tensor_uid(), 0.0f, 1.0f, seed);
@@ -38,14 +39,15 @@ struct BatchnormFwdTensorBundle : public hipdnn_test_sdk::utilities::GraphTensor
 struct BatchnormFwdWithVarianceTensorBundle : public hipdnn_test_sdk::utilities::GraphTensorBundle
 {
     BatchnormFwdWithVarianceTensorBundle(
-        const hipdnn_data_sdk::flatbuffer_utilities::INodeWrapper& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::INodeWrapper& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap,
         unsigned int seed)
         : hipdnn_test_sdk::utilities::GraphTensorBundle(tensorMap)
     {
         const auto& attributes = node.attributesAs<
-            hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt>();
+            hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributesVarianceExt>();
 
         randomizeTensor(attributes.x_tensor_uid(), 0.0f, 1.0f, seed);
         randomizeTensor(attributes.scale_tensor_uid(), 0.0f, 1.0f, seed);

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/ConvolutionGraphUtils.hpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/ConvolutionGraphUtils.hpp
@@ -16,8 +16,8 @@ template <typename InputType>
 static std::tuple<std::shared_ptr<hipdnn_frontend::graph::Graph>,
                   std::unordered_map<int64_t, void*>>
     buildConvolutionFwdGraph(ConvolutionFwdTensorBundle<InputType>& tensorBundle,
-                             hipdnn_data_sdk::data_objects::DataType inputDataType,
-                             hipdnn_data_sdk::data_objects::DataType accumulatorDataType)
+                             hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType,
+                             hipdnn_flatbuffers_sdk::data_objects::DataType accumulatorDataType)
 {
     const std::vector<int64_t> strides = {1, 1};
     const std::vector<int64_t> dilation = {1, 1};
@@ -72,8 +72,8 @@ template <typename InputType>
 static std::tuple<std::shared_ptr<hipdnn_frontend::graph::Graph>,
                   std::unordered_map<int64_t, void*>>
     buildConvolutionBwdGraph(ConvolutionBwdTensorBundle<InputType>& tensorBundle,
-                             hipdnn_data_sdk::data_objects::DataType inputDataType,
-                             hipdnn_data_sdk::data_objects::DataType accumulatorDataType)
+                             hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType,
+                             hipdnn_flatbuffers_sdk::data_objects::DataType accumulatorDataType)
 {
     const std::vector<int64_t> strides = {1, 1};
     const std::vector<int64_t> dilation = {1, 1};
@@ -130,8 +130,8 @@ template <typename InputType>
 static std::tuple<std::shared_ptr<hipdnn_frontend::graph::Graph>,
                   std::unordered_map<int64_t, void*>>
     buildConvolutionWrwGraph(ConvolutionWrwTensorBundle<InputType>& tensorBundle,
-                             hipdnn_data_sdk::data_objects::DataType inputDataType,
-                             hipdnn_data_sdk::data_objects::DataType accumulatorDataType)
+                             hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType,
+                             hipdnn_flatbuffers_sdk::data_objects::DataType accumulatorDataType)
 {
     const std::vector<int64_t> strides = {1, 1};
     const std::vector<int64_t> dilation = {1, 1};

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/LayernormGraphUtils.hpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/LayernormGraphUtils.hpp
@@ -14,10 +14,10 @@ namespace hipdnn_sdk_test_utils
 {
 
 inline std::shared_ptr<hipdnn_frontend::graph::Graph>
-    buildLayernormFpropGraph(hipdnn_data_sdk::data_objects::DataType inputDataType,
-                             hipdnn_data_sdk::data_objects::DataType scaleBiasDataType,
-                             hipdnn_data_sdk::data_objects::DataType meanInvVarianceDataType,
-                             hipdnn_data_sdk::data_objects::DataType computeDataType,
+    buildLayernormFpropGraph(hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType,
+                             hipdnn_flatbuffers_sdk::data_objects::DataType scaleBiasDataType,
+                             hipdnn_flatbuffers_sdk::data_objects::DataType meanInvVarianceDataType,
+                             hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType,
                              const std::vector<int64_t>& dims,
                              const int64_t normalizedDimCount,
                              const hipdnn_data_sdk::utilities::TensorLayout& layout,

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/LayernormTensorBundles.hpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/LayernormTensorBundles.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/NodeWrapper.hpp>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/NodeWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/Seeds.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/GraphTensorBundle.hpp>
 
@@ -14,14 +14,15 @@ namespace hipdnn_sdk_test_utils
 struct LayernormFpropTensorBundle : public hipdnn_test_sdk::utilities::GraphTensorBundle
 {
     LayernormFpropTensorBundle(
-        const hipdnn_data_sdk::flatbuffer_utilities::INodeWrapper& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::INodeWrapper& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap,
         unsigned int seed)
         : hipdnn_test_sdk::utilities::GraphTensorBundle(tensorMap)
     {
         const auto& attributes
-            = node.attributesAs<hipdnn_data_sdk::data_objects::LayernormAttributes>();
+            = node.attributesAs<hipdnn_flatbuffers_sdk::data_objects::LayernormAttributes>();
 
         randomizeTensor(attributes.x_tensor_uid(), 0.0f, 1.0f, seed);
         randomizeTensor(attributes.scale_tensor_uid(), 0.0f, 1.0f, seed);

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/MatmulGraphUtils.hpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/MatmulGraphUtils.hpp
@@ -16,8 +16,8 @@ template <typename InputType>
 static std::tuple<std::shared_ptr<hipdnn_frontend::graph::Graph>,
                   std::unordered_map<int64_t, void*>>
     buildMatmulGraph(MatmulTensorBundle<InputType>& tensorBundle,
-                     hipdnn_data_sdk::data_objects::DataType inputDataType,
-                     hipdnn_data_sdk::data_objects::DataType computeDataType)
+                     hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType,
+                     hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType)
 {
     auto graph = std::make_shared<hipdnn_frontend::graph::Graph>();
     graph->set_name("MatmulTest");

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/PointwiseGraphUtils.hpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/PointwiseGraphUtils.hpp
@@ -3,9 +3,9 @@
 
 #pragma once
 
-#include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
-#include <hipdnn_data_sdk/flatbuffer_utilities/NodeWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/pointwise_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/NodeWrapper.hpp>
 #include <hipdnn_frontend/Graph.hpp>
 #include <hipdnn_frontend/Utilities.hpp>
 #include <hipdnn_frontend/attributes/TensorAttributes.hpp>
@@ -23,9 +23,9 @@ inline std::tuple<std::shared_ptr<hipdnn_frontend::graph::Graph>,
                   std::unordered_map<int64_t, void*>>
     buildPointwiseUnaryGraph(const std::vector<int64_t>& inputDims,
                              const std::vector<int64_t>& outputDims,
-                             hipdnn_data_sdk::data_objects::DataType input0DataType,
-                             hipdnn_data_sdk::data_objects::DataType accumulatorDataType,
-                             hipdnn_data_sdk::data_objects::DataType outputDataType,
+                             hipdnn_flatbuffers_sdk::data_objects::DataType input0DataType,
+                             hipdnn_flatbuffers_sdk::data_objects::DataType accumulatorDataType,
+                             hipdnn_flatbuffers_sdk::data_objects::DataType outputDataType,
                              hipdnn_frontend::PointwiseMode operation,
                              unsigned int seed = hipdnn_test_sdk::utilities::getGlobalTestSeed(),
                              const hipdnn_data_sdk::utilities::TensorLayout& layout
@@ -113,9 +113,10 @@ inline std::tuple<std::shared_ptr<hipdnn_frontend::graph::Graph>,
     {
         throw std::runtime_error("Graph serialization failed: " + serErr.get_message());
     }
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
-    auto nodeWrap = hipdnn_data_sdk::flatbuffer_utilities::NodeWrapper(&graphWrap.getNode(0));
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
+    auto nodeWrap
+        = hipdnn_flatbuffers_sdk::flatbuffer_utilities::NodeWrapper(&graphWrap.getNode(0));
 
     PointwiseUnaryTensorBundle tensorBundle(nodeWrap, graphWrap.getTensorMap(), seed);
     auto variantPack = tensorBundle.toHostVariantPack();
@@ -129,10 +130,10 @@ inline std::tuple<std::shared_ptr<hipdnn_frontend::graph::Graph>,
     buildPointwiseBinaryGraph(const std::vector<int64_t>& input1Dims,
                               const std::vector<int64_t>& input2Dims,
                               const std::vector<int64_t>& outputDims,
-                              hipdnn_data_sdk::data_objects::DataType input0DataType,
-                              hipdnn_data_sdk::data_objects::DataType input1DataType,
-                              hipdnn_data_sdk::data_objects::DataType accumulatorDataType,
-                              hipdnn_data_sdk::data_objects::DataType outputDataType,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType input0DataType,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType input1DataType,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType accumulatorDataType,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType outputDataType,
                               hipdnn_frontend::PointwiseMode operation,
                               unsigned int seed = hipdnn_test_sdk::utilities::getGlobalTestSeed(),
                               const hipdnn_data_sdk::utilities::TensorLayout& layout
@@ -233,9 +234,10 @@ inline std::tuple<std::shared_ptr<hipdnn_frontend::graph::Graph>,
     {
         throw std::runtime_error("Graph serialization failed: " + serErr.get_message());
     }
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
-    auto nodeWrap = hipdnn_data_sdk::flatbuffer_utilities::NodeWrapper(&graphWrap.getNode(0));
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
+    auto nodeWrap
+        = hipdnn_flatbuffers_sdk::flatbuffer_utilities::NodeWrapper(&graphWrap.getNode(0));
 
     PointwiseBinaryTensorBundle tensorBundle(nodeWrap, graphWrap.getTensorMap(), seed);
     auto variantPack = tensorBundle.toHostVariantPack();

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/PointwiseTensorBundles.hpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/PointwiseTensorBundles.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/NodeWrapper.hpp>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/NodeWrapper.hpp>
 #include <hipdnn_frontend/Graph.hpp>
 #include <hipdnn_frontend/Utilities.hpp>
 #include <hipdnn_frontend/attributes/TensorAttributes.hpp>
@@ -16,14 +16,15 @@ namespace hipdnn_sdk_test_utils
 struct PointwiseUnaryTensorBundle : public hipdnn_test_sdk::utilities::GraphTensorBundle
 {
     PointwiseUnaryTensorBundle(
-        const hipdnn_data_sdk::flatbuffer_utilities::INodeWrapper& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::INodeWrapper& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap,
         unsigned int seed)
         : hipdnn_test_sdk::utilities::GraphTensorBundle(tensorMap)
     {
         const auto& attributes
-            = node.attributesAs<hipdnn_data_sdk::data_objects::PointwiseAttributes>();
+            = node.attributesAs<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>();
 
         randomizeTensor(attributes.in_0_tensor_uid(), -2.0f, 2.0f, seed);
         // Output tensor not randomized - computed by operation
@@ -33,14 +34,15 @@ struct PointwiseUnaryTensorBundle : public hipdnn_test_sdk::utilities::GraphTens
 struct PointwiseBinaryTensorBundle : public hipdnn_test_sdk::utilities::GraphTensorBundle
 {
     PointwiseBinaryTensorBundle(
-        const hipdnn_data_sdk::flatbuffer_utilities::INodeWrapper& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::INodeWrapper& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap,
         unsigned int seed)
         : hipdnn_test_sdk::utilities::GraphTensorBundle(tensorMap)
     {
         const auto& attributes
-            = node.attributesAs<hipdnn_data_sdk::data_objects::PointwiseAttributes>();
+            = node.attributesAs<hipdnn_flatbuffers_sdk::data_objects::PointwiseAttributes>();
 
         randomizeTensor(attributes.in_0_tensor_uid(), -1.0f, 1.0f, seed);
         randomizeTensor(attributes.in_1_tensor_uid().value(), -1.0f, 1.0f, seed + 1);

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/RMSNormGraphUtils.hpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/RMSNormGraphUtils.hpp
@@ -13,9 +13,9 @@ namespace hipdnn_sdk_test_utils
 {
 
 inline std::shared_ptr<hipdnn_frontend::graph::Graph>
-    buildRMSNormFwdGraph(hipdnn_data_sdk::data_objects::DataType inputDataType,
-                         hipdnn_data_sdk::data_objects::DataType scaleDataType,
-                         hipdnn_data_sdk::data_objects::DataType computeDataType,
+    buildRMSNormFwdGraph(hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType,
+                         hipdnn_flatbuffers_sdk::data_objects::DataType scaleDataType,
+                         hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType,
                          const std::vector<int64_t>& dims,
                          const hipdnn_data_sdk::utilities::TensorLayout& layout)
 {
@@ -93,9 +93,9 @@ inline std::shared_ptr<hipdnn_frontend::graph::Graph>
 }
 
 inline std::shared_ptr<hipdnn_frontend::graph::Graph>
-    buildRMSNormFwdGraphWithBias(hipdnn_data_sdk::data_objects::DataType inputDataType,
-                                 hipdnn_data_sdk::data_objects::DataType scaleDataType,
-                                 hipdnn_data_sdk::data_objects::DataType computeDataType,
+    buildRMSNormFwdGraphWithBias(hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType,
+                                 hipdnn_flatbuffers_sdk::data_objects::DataType scaleDataType,
+                                 hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType,
                                  const std::vector<int64_t>& dims,
                                  const hipdnn_data_sdk::utilities::TensorLayout& layout)
 {

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/RMSNormTensorBundles.hpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/RMSNormTensorBundles.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/NodeWrapper.hpp>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/NodeWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/Seeds.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/GraphTensorBundle.hpp>
 
@@ -14,14 +14,15 @@ namespace hipdnn_sdk_test_utils
 struct RMSNormFwdTensorBundle : public hipdnn_test_sdk::utilities::GraphTensorBundle
 {
     RMSNormFwdTensorBundle(
-        const hipdnn_data_sdk::flatbuffer_utilities::INodeWrapper& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::INodeWrapper& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap,
         unsigned int seed)
         : hipdnn_test_sdk::utilities::GraphTensorBundle(tensorMap)
     {
         const auto& attributes
-            = node.attributesAs<hipdnn_data_sdk::data_objects::RMSNormAttributes>();
+            = node.attributesAs<hipdnn_flatbuffers_sdk::data_objects::RMSNormAttributes>();
 
         randomizeTensor(attributes.x_tensor_uid(), 0.0f, 1.0f, seed);
         randomizeTensor(attributes.scale_tensor_uid(), 0.0f, 1.0f, seed);
@@ -31,14 +32,15 @@ struct RMSNormFwdTensorBundle : public hipdnn_test_sdk::utilities::GraphTensorBu
 struct RMSNormFwdWithBiasTensorBundle : public hipdnn_test_sdk::utilities::GraphTensorBundle
 {
     RMSNormFwdWithBiasTensorBundle(
-        const hipdnn_data_sdk::flatbuffer_utilities::INodeWrapper& node,
-        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::INodeWrapper& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
             tensorMap,
         unsigned int seed)
         : hipdnn_test_sdk::utilities::GraphTensorBundle(tensorMap)
     {
         const auto& attributes
-            = node.attributesAs<hipdnn_data_sdk::data_objects::RMSNormAttributes>();
+            = node.attributesAs<hipdnn_flatbuffers_sdk::data_objects::RMSNormAttributes>();
 
         randomizeTensor(attributes.x_tensor_uid(), 0.0f, 1.0f, seed);
         randomizeTensor(attributes.scale_tensor_uid(), 0.0f, 1.0f, seed);

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/ReductionGraphUtils.hpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/ReductionGraphUtils.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "ReductionTensorBundles.hpp"
+#include <hipdnn_flatbuffers_sdk/data_objects/data_types_generated.h>
 #include <hipdnn_frontend/Graph.hpp>
 #include <hipdnn_frontend/Utilities.hpp>
 #include <hipdnn_frontend/attributes/ReductionAttributes.hpp>
@@ -17,8 +18,8 @@ template <typename InputType>
 static std::tuple<std::shared_ptr<hipdnn_frontend::graph::Graph>,
                   std::unordered_map<int64_t, void*>>
     buildReductionGraph(ReductionTensorBundle<InputType>& tensorBundle,
-                        hipdnn_data_sdk::data_objects::DataType inputDataType,
-                        hipdnn_data_sdk::data_objects::DataType computeDataType,
+                        hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType,
+                        hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType,
                         hipdnn_frontend::ReductionMode mode = hipdnn_frontend::ReductionMode::ADD)
 {
     auto graph = std::make_shared<hipdnn_frontend::graph::Graph>();

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/SdpaGraphUtils.hpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/SdpaGraphUtils.hpp
@@ -18,7 +18,7 @@ template <typename InputType>
 static std::tuple<std::shared_ptr<hipdnn_frontend::graph::Graph>,
                   std::unordered_map<int64_t, void*>>
     buildSdpaFwdGraph(SdpaFwdTensorBundle<InputType>& tensorBundle,
-                      hipdnn_data_sdk::data_objects::DataType dataType,
+                      hipdnn_flatbuffers_sdk::data_objects::DataType dataType,
                       bool causalMask = false)
 {
     const auto frontendDataType = hipdnn_test_sdk::utilities::sdkToFrontendDataType(dataType);

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestBatchnormBwdPlan.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestBatchnormBwdPlan.cpp
@@ -5,8 +5,8 @@
 
 #include "BatchnormGraphUtils.hpp"
 #include "BatchnormTensorBundles.hpp"
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
 #include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceBatchnorm.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
 #include <hipdnn_test_sdk/utilities/Seeds.hpp>
@@ -15,19 +15,20 @@
 
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_test_sdk::detail;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
-using namespace hipdnn_data_sdk::flatbuffer_utilities;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 using namespace ::testing;
 using namespace hipdnn_sdk_test_utils;
 
 class TestBatchnormBwdPlan : public ::testing::Test
 {
 protected:
-    static void initTensorValues(hipdnn_data_sdk::data_objects::TensorAttributesT& tensorAttr,
-                                 DataType dataType,
-                                 const Tensor<float>& tensor,
-                                 int64_t uid)
+    static void
+        initTensorValues(hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT& tensorAttr,
+                         DataType dataType,
+                         const Tensor<float>& tensor,
+                         int64_t uid)
     {
         tensorAttr.data_type = dataType;
         tensorAttr.dims = tensor.dims();
@@ -103,8 +104,8 @@ TEST(TestBatchnormBwdPlanBuilder, PlanConstruction)
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
 
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const BatchnormBwdPlanBuilder<DataType::FLOAT,
                                   DataType::FLOAT,
@@ -181,8 +182,8 @@ TEST(TestBatchnormBwdPlanBuilder, IsApplicable)
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
 
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const BatchnormBwdPlanBuilder<DataType::FLOAT,
                                   DataType::FLOAT,

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestBatchnormBwdSignatureKey.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestBatchnormBwdSignatureKey.cpp
@@ -7,12 +7,12 @@
 
 #include "BatchnormGraphUtils.hpp"
 #include "BatchnormTensorBundles.hpp"
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormBwdSignatureKey.hpp>
 
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_test_sdk::detail;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
 using namespace hipdnn_sdk_test_utils;
 
@@ -207,8 +207,8 @@ TEST(TestBatchnormBwdSignatureKey, CreateFromNodeAndTensorMap)
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
 
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const BatchnormBwdSignatureKey keyFromNode(graphWrap.getNode(0), graphWrap.getTensorMap());
 

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestBatchnormFwdInferencePlan.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestBatchnormFwdInferencePlan.cpp
@@ -5,9 +5,9 @@
 
 #include "BatchnormGraphUtils.hpp"
 #include "BatchnormTensorBundles.hpp"
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
 #include <hipdnn_data_sdk/utilities/Constants.hpp>
 #include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceBatchnorm.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
 #include <hipdnn_test_sdk/utilities/Seeds.hpp>
@@ -16,20 +16,21 @@
 
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_test_sdk::detail;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
-using namespace hipdnn_data_sdk::flatbuffer_utilities;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 using namespace ::testing;
 using namespace hipdnn_sdk_test_utils;
 
 class TestBatchnormFwdPlan : public ::testing::Test
 {
 protected:
-    static void initTensorValues(hipdnn_data_sdk::data_objects::TensorAttributesT& tensorAttr,
-                                 DataType dataType,
-                                 const std::vector<int64_t>& dims,
-                                 const std::vector<int64_t>& strides,
-                                 int64_t uid)
+    static void
+        initTensorValues(hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT& tensorAttr,
+                         DataType dataType,
+                         const std::vector<int64_t>& dims,
+                         const std::vector<int64_t>& strides,
+                         int64_t uid)
     {
         tensorAttr.data_type = dataType;
         tensorAttr.dims = dims;
@@ -57,7 +58,7 @@ TEST_F(TestBatchnormFwdPlan, ExecutePlan)
     BatchnormFwdTensorBundle directTensorBundle(node, graphWrapper.getTensorMap(), seed);
 
     const auto& attributes
-        = node.attributesAs<hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes>();
+        = node.attributesAs<hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributes>();
     const auto& tensorMap = graphWrapper.getTensorMap();
     BatchnormFwdInferenceParams params(*tensorMap.at(attributes.x_tensor_uid()),
                                        *tensorMap.at(attributes.y_tensor_uid()),

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestBatchnormFwdInferenceSignatureKey.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestBatchnormFwdInferenceSignatureKey.cpp
@@ -7,12 +7,12 @@
 
 #include "BatchnormGraphUtils.hpp"
 #include "BatchnormTensorBundles.hpp"
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormFwdInferenceSignatureKey.hpp>
 
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_test_sdk::detail;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
 using namespace hipdnn_sdk_test_utils;
 
@@ -113,8 +113,8 @@ TEST(TestBatchnormFwdInferenceSignatureKey, CreateFromNodeAndTensorMap)
                                                  TensorLayout::NHWC);
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const BatchnormFwdInferenceSignatureKey keyFromNode(graphWrap.getNode(0),
                                                         graphWrap.getTensorMap());

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestBatchnormFwdInferenceWithVariancePlan.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestBatchnormFwdInferenceWithVariancePlan.cpp
@@ -5,10 +5,11 @@
 
 #include "BatchnormGraphUtils.hpp"
 #include "BatchnormTensorBundles.hpp"
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
 #include <hipdnn_data_sdk/utilities/Constants.hpp>
 #include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/utilities/FlatbufferUtils.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceBatchnorm.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
 #include <hipdnn_test_sdk/utilities/Seeds.hpp>
@@ -18,9 +19,9 @@
 
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_test_sdk::detail;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
-using namespace hipdnn_data_sdk::flatbuffer_utilities;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 using namespace ::testing;
 using namespace hipdnn_sdk_test_utils;
 
@@ -48,7 +49,7 @@ TEST_F(TestBatchnormFwdWithVariancePlan, ExecutePlan)
         node, graphWrapper.getTensorMap(), seed);
 
     const auto& attributes = node.attributesAs<
-        hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt>();
+        hipdnn_flatbuffers_sdk::data_objects::BatchnormInferenceAttributesVarianceExt>();
     const auto& tensorMap = graphWrapper.getTensorMap();
     BatchnormFwdInferenceWithVarianceParams params(*tensorMap.at(attributes.x_tensor_uid()),
                                                    *tensorMap.at(attributes.y_tensor_uid()),
@@ -75,8 +76,8 @@ TEST_F(TestBatchnormFwdWithVariancePlan, ExecutePlan)
     auto shallowYTensor = createShallowTensor<float>(
         params.yTensor, directTensorBundle.tensors[attributes.y_tensor_uid()]->rawHostData());
 
-    const double epsilon
-        = hipdnn_data_sdk::utilities::extractDoubleFromTensorValue(params.epsilonTensor, "Epsilon");
+    const double epsilon = hipdnn_flatbuffers_sdk::utilities::extractDoubleFromTensorValue(
+        params.epsilonTensor, "Epsilon");
 
     CpuFpReferenceBatchnorm::fwdInferenceWithVariance(*shallowXTensor,
                                                       *shallowScaleTensor,

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestBatchnormTrainPlan.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestBatchnormTrainPlan.cpp
@@ -5,9 +5,9 @@
 
 #include "BatchnormGraphUtils.hpp"
 #include "BatchnormTensorBundles.hpp"
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
 #include <hipdnn_data_sdk/utilities/Constants.hpp>
 #include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceBatchnorm.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
 #include <hipdnn_test_sdk/utilities/Seeds.hpp>
@@ -16,19 +16,20 @@
 
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_test_sdk::detail;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
-using namespace hipdnn_data_sdk::flatbuffer_utilities;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 using namespace ::testing;
 using namespace hipdnn_sdk_test_utils;
 
 class TestBatchnormTrainPlan : public ::testing::Test
 {
 protected:
-    static void initTensorValues(hipdnn_data_sdk::data_objects::TensorAttributesT& tensorAttr,
-                                 DataType dataType,
-                                 const Tensor<float>& tensor,
-                                 int64_t uid)
+    static void
+        initTensorValues(hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT& tensorAttr,
+                         DataType dataType,
+                         const Tensor<float>& tensor,
+                         int64_t uid)
     {
         tensorAttr.data_type = dataType;
         tensorAttr.dims = tensor.dims();
@@ -53,7 +54,7 @@ TEST_F(TestBatchnormTrainPlan, ExecutePlan)
     initTensorValues(params.scaleTensor, DataType::FLOAT, planTensorBundle.scaleTensor, 2);
     initTensorValues(params.biasTensor, DataType::FLOAT, planTensorBundle.biasTensor, 3);
     initTensorValues(params.epsilonTensor, DataType::DOUBLE, planTensorBundle.epsilonTensor, 4);
-    params.epsilonTensor.value.Set(hipdnn_data_sdk::data_objects::Float64Value(epsilon));
+    params.epsilonTensor.value.Set(hipdnn_flatbuffers_sdk::data_objects::Float64Value(epsilon));
     initTensorValues(params.yTensor, DataType::FLOAT, planTensorBundle.yTensor, 5);
 
     // Initialize optional mean and invVariance tensors
@@ -109,8 +110,8 @@ TEST(TestBatchnormTrainPlanBuilder, PlanConstruction)
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
 
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const BatchnormTrainPlanBuilder<DataType::FLOAT,
                                     DataType::FLOAT,
@@ -139,8 +140,8 @@ TEST(TestBatchnormTrainPlanBuilder, IsApplicable)
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
 
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const BatchnormTrainPlanBuilder<DataType::FLOAT,
                                     DataType::FLOAT,

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestBatchnormTrainSignatureKey.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestBatchnormTrainSignatureKey.cpp
@@ -7,12 +7,12 @@
 
 #include "BatchnormGraphUtils.hpp"
 #include "BatchnormTensorBundles.hpp"
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormTrainSignatureKey.hpp>
 
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_test_sdk::detail;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
 using namespace hipdnn_sdk_test_utils;
 
@@ -114,8 +114,8 @@ TEST(TestBatchnormTrainSignatureKey, CreateFromNodeAndTensorMap)
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
 
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const BatchnormTrainSignatureKey keyFromNode(graphWrap.getNode(0), graphWrap.getTensorMap());
 

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestConvolutionBwdPlan.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestConvolutionBwdPlan.cpp
@@ -5,8 +5,8 @@
 
 #include "ConvolutionGraphUtils.hpp"
 #include "ConvolutionTensorBundles.hpp"
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
 #include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceConvolution.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
 #include <hipdnn_test_sdk/utilities/DynamicTolerances.hpp>
@@ -16,19 +16,20 @@
 
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_test_sdk::detail;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
-using namespace hipdnn_data_sdk::flatbuffer_utilities;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 using namespace ::testing;
 using namespace hipdnn_sdk_test_utils;
 
 class TestConvolutionBwdPlan : public ::testing::Test
 {
 protected:
-    static void initTensorValues(hipdnn_data_sdk::data_objects::TensorAttributesT& tensorAttr,
-                                 DataType dataType,
-                                 const Tensor<float>& tensor,
-                                 int64_t uid)
+    static void
+        initTensorValues(hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT& tensorAttr,
+                         DataType dataType,
+                         const Tensor<float>& tensor,
+                         int64_t uid)
     {
         tensorAttr.data_type = dataType;
         tensorAttr.dims = tensor.dims();
@@ -106,8 +107,8 @@ TEST(TestConvolutionBwdPlanBuilder, PlanConstruction)
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
 
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const ConvolutionBwdPlanBuilder<DataType::FLOAT,
                                     DataType::FLOAT,
@@ -136,8 +137,8 @@ TEST(TestConvolutionBwdPlanBuilder, IsApplicable)
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
 
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const ConvolutionBwdPlanBuilder<DataType::FLOAT,
                                     DataType::FLOAT,

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestConvolutionBwdSignatureKey.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestConvolutionBwdSignatureKey.cpp
@@ -7,12 +7,12 @@
 
 #include "ConvolutionGraphUtils.hpp"
 #include "ConvolutionTensorBundles.hpp"
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionBwdSignatureKey.hpp>
 
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_test_sdk::detail;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
 using namespace hipdnn_sdk_test_utils;
 
@@ -95,8 +95,8 @@ TEST(TestConvolutionBwdSignatureKey, CreateFromNodeAndTensorMap)
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
 
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const ConvolutionBwdSignatureKey keyFromNode(
         graphWrap.getNode(0), graphWrap.getTensorMap(), DataType::FLOAT);

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestConvolutionFwdPlan.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestConvolutionFwdPlan.cpp
@@ -5,8 +5,8 @@
 
 #include "ConvolutionGraphUtils.hpp"
 #include "ConvolutionTensorBundles.hpp"
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
 #include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceConvolution.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
 #include <hipdnn_test_sdk/utilities/Seeds.hpp>
@@ -15,19 +15,20 @@
 
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_test_sdk::detail;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
-using namespace hipdnn_data_sdk::flatbuffer_utilities;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 using namespace ::testing;
 using namespace hipdnn_sdk_test_utils;
 
 class TestConvolutionFwdPlan : public ::testing::Test
 {
 protected:
-    static void initTensorValues(hipdnn_data_sdk::data_objects::TensorAttributesT& tensorAttr,
-                                 DataType dataType,
-                                 const Tensor<float>& tensor,
-                                 int64_t uid)
+    static void
+        initTensorValues(hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT& tensorAttr,
+                         DataType dataType,
+                         const Tensor<float>& tensor,
+                         int64_t uid)
     {
         tensorAttr.data_type = dataType;
         tensorAttr.dims = tensor.dims();
@@ -98,8 +99,8 @@ TEST(TestConvolutionFwdPlanBuilder, PlanConstruction)
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
 
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const ConvolutionFwdPlanBuilder<DataType::FLOAT,
                                     DataType::FLOAT,
@@ -128,8 +129,8 @@ TEST(TestConvolutionFwdPlanBuilder, IsApplicable)
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
 
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const ConvolutionFwdPlanBuilder<DataType::FLOAT,
                                     DataType::FLOAT,

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestConvolutionFwdSignatureKey.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestConvolutionFwdSignatureKey.cpp
@@ -7,12 +7,12 @@
 
 #include "ConvolutionGraphUtils.hpp"
 #include "ConvolutionTensorBundles.hpp"
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionFwdSignatureKey.hpp>
 
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_test_sdk::detail;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
 using namespace hipdnn_sdk_test_utils;
 
@@ -95,8 +95,8 @@ TEST(TestConvolutionFwdSignatureKey, CreateFromNodeAndTensorMap)
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
 
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const ConvolutionFwdSignatureKey keyFromNode(
         graphWrap.getNode(0), graphWrap.getTensorMap(), DataType::FLOAT);

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestConvolutionWrwPlan.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestConvolutionWrwPlan.cpp
@@ -5,8 +5,8 @@
 
 #include "ConvolutionGraphUtils.hpp"
 #include "ConvolutionTensorBundles.hpp"
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
 #include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceConvolution.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
 #include <hipdnn_test_sdk/utilities/Seeds.hpp>
@@ -15,19 +15,20 @@
 
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_test_sdk::detail;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
-using namespace hipdnn_data_sdk::flatbuffer_utilities;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 using namespace ::testing;
 using namespace hipdnn_sdk_test_utils;
 
 class TestConvolutionWrwPlan : public ::testing::Test
 {
 protected:
-    static void initTensorValues(hipdnn_data_sdk::data_objects::TensorAttributesT& tensorAttr,
-                                 DataType dataType,
-                                 const Tensor<float>& tensor,
-                                 int64_t uid)
+    static void
+        initTensorValues(hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT& tensorAttr,
+                         DataType dataType,
+                         const Tensor<float>& tensor,
+                         int64_t uid)
     {
         tensorAttr.data_type = dataType;
         tensorAttr.dims = tensor.dims();
@@ -98,8 +99,8 @@ TEST(TestConvolutionWrwPlanBuilder, PlanConstruction)
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
 
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const ConvolutionWrwPlanBuilder<DataType::FLOAT,
                                     DataType::FLOAT,
@@ -128,8 +129,8 @@ TEST(TestConvolutionWrwPlanBuilder, IsApplicable)
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
 
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const ConvolutionWrwPlanBuilder<DataType::FLOAT,
                                     DataType::FLOAT,

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestConvolutionWrwSignatureKey.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestConvolutionWrwSignatureKey.cpp
@@ -7,12 +7,12 @@
 
 #include "ConvolutionGraphUtils.hpp"
 #include "ConvolutionTensorBundles.hpp"
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionWrwSignatureKey.hpp>
 
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_test_sdk::detail;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
 using namespace hipdnn_sdk_test_utils;
 
@@ -95,8 +95,8 @@ TEST(TestConvolutionWrwSignatureKey, CreateFromNodeAndTensorMap)
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
 
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const ConvolutionWrwSignatureKey keyFromNode(
         graphWrap.getNode(0), graphWrap.getTensorMap(), DataType::FLOAT);

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestCpuReferenceGraphExecutor.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestCpuReferenceGraphExecutor.cpp
@@ -14,32 +14,33 @@
 #include "PointwiseGraphUtils.hpp"
 #include "PointwiseTensorBundles.hpp"
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_data_sdk/types.hpp>
 #include <hipdnn_data_sdk/utilities/ShallowTensor.hpp>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
 #include <hipdnn_data_sdk/utilities/TensorView.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 #include <hipdnn_test_sdk/utilities/Seeds.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/CpuReferenceGraphExecutor.hpp>
 
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_test_sdk::detail;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
 using namespace ::testing;
 using namespace hipdnn_sdk_test_utils;
-using namespace hipdnn_data_sdk::flatbuffer_utilities;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 using hipdnn_data_sdk::types::bfloat16;
 using hipdnn_data_sdk::types::half;
 
 class TestCpuReferenceGraphExecutor
 {
 public:
-    static void runBatchnormFwdTest(hipdnn_data_sdk::data_objects::DataType inputDataType,
-                                    hipdnn_data_sdk::data_objects::DataType scaleBiasDataType,
-                                    hipdnn_data_sdk::data_objects::DataType meanVarianceDataType,
-                                    hipdnn_data_sdk::data_objects::DataType computeDataType)
+    static void
+        runBatchnormFwdTest(hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType,
+                            hipdnn_flatbuffers_sdk::data_objects::DataType scaleBiasDataType,
+                            hipdnn_flatbuffers_sdk::data_objects::DataType meanVarianceDataType,
+                            hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType)
     {
         const unsigned int seed = getGlobalTestSeed();
 
@@ -135,8 +136,9 @@ public:
     }
 
     template <typename InputType, typename AccumulatorType>
-    static void runConvolutionFwdTest(hipdnn_data_sdk::data_objects::DataType inputDataType,
-                                      hipdnn_data_sdk::data_objects::DataType accumulatorDataType)
+    static void
+        runConvolutionFwdTest(hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType accumulatorDataType)
     {
         const std::vector<int64_t> xDims = {1, 1, 2, 2};
         const std::vector<int64_t> wDims = {1, 1, 1, 1};
@@ -161,8 +163,9 @@ public:
     }
 
     template <typename InputType, typename AccumulatorType>
-    static void runConvolutionBwdTest(hipdnn_data_sdk::data_objects::DataType inputDataType,
-                                      hipdnn_data_sdk::data_objects::DataType accumulatorDataType)
+    static void
+        runConvolutionBwdTest(hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType accumulatorDataType)
     {
         const std::vector<int64_t> dxDims = {1, 1, 2, 2};
         const std::vector<int64_t> wDims = {1, 1, 1, 1};
@@ -187,8 +190,9 @@ public:
     }
 
     template <typename InputType, typename AccumulatorType>
-    static void runConvolutionWrwTest(hipdnn_data_sdk::data_objects::DataType inputDataType,
-                                      hipdnn_data_sdk::data_objects::DataType accumulatorDataType)
+    static void
+        runConvolutionWrwTest(hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType accumulatorDataType)
     {
         const std::vector<int64_t> xDims = {1, 1, 2, 2};
         const std::vector<int64_t> dwDims = {1, 1, 1, 1};
@@ -213,8 +217,8 @@ public:
     }
 
     template <typename inputType, typename ComputeType>
-    static void runMatmulTest(hipdnn_data_sdk::data_objects::DataType inputDataType,
-                              hipdnn_data_sdk::data_objects::DataType computeDataType)
+    static void runMatmulTest(hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType,
+                              hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType)
     {
         const std::vector<int64_t> aDims = {2, 5, 3};
         const std::vector<int64_t> bDims = {2, 3, 4};

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestFusedOperationsCpuGraphExecutor.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestFusedOperationsCpuGraphExecutor.cpp
@@ -17,7 +17,7 @@
 
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_test_sdk::detail;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
 using namespace ::testing;
 

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestGraphTensorBundle.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestGraphTensorBundle.cpp
@@ -4,16 +4,16 @@
 #include <gtest/gtest.h>
 
 #include "BatchnormGraphUtils.hpp"
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_data_sdk/types.hpp>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
 #include <hipdnn_data_sdk/utilities/TensorView.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/GraphTensorBundle.hpp>
 
 using namespace hipdnn_test_sdk::utilities;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
-using namespace hipdnn_data_sdk::flatbuffer_utilities;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 using namespace ::testing;
 using namespace hipdnn_sdk_test_utils;
 

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestLayernormFpropPlan.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestLayernormFpropPlan.cpp
@@ -5,9 +5,9 @@
 
 #include "LayernormGraphUtils.hpp"
 #include "LayernormTensorBundles.hpp"
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
 #include <hipdnn_data_sdk/utilities/Constants.hpp>
 #include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceLayernorm.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
 #include <hipdnn_test_sdk/utilities/Seeds.hpp>
@@ -16,9 +16,9 @@
 
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_test_sdk::detail;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
-using namespace hipdnn_data_sdk::flatbuffer_utilities;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 using namespace ::testing;
 using namespace hipdnn_sdk_test_utils;
 
@@ -47,7 +47,7 @@ TEST_F(TestLayernormFpropPlan, ExecutePlan)
     LayernormFpropTensorBundle directTensorBundle(node, graphWrapper.getTensorMap(), seed);
 
     const auto& attributes
-        = node.attributesAs<hipdnn_data_sdk::data_objects::LayernormAttributes>();
+        = node.attributesAs<hipdnn_flatbuffers_sdk::data_objects::LayernormAttributes>();
     const auto& tensorMap = graphWrapper.getTensorMap();
     LayernormFpropParams params(*tensorMap.at(attributes.x_tensor_uid()),
                                 *tensorMap.at(attributes.y_tensor_uid()),
@@ -108,7 +108,7 @@ TEST_F(TestLayernormFpropPlan, ExecutePlanOnePaddedNormalizedDimCount2)
     LayernormFpropTensorBundle directTensorBundle(node, graphWrapper.getTensorMap(), seed);
 
     const auto& attributes
-        = node.attributesAs<hipdnn_data_sdk::data_objects::LayernormAttributes>();
+        = node.attributesAs<hipdnn_flatbuffers_sdk::data_objects::LayernormAttributes>();
     const auto& tensorMap = graphWrapper.getTensorMap();
     LayernormFpropParams params(*tensorMap.at(attributes.x_tensor_uid()),
                                 *tensorMap.at(attributes.y_tensor_uid()),
@@ -168,11 +168,11 @@ TEST_F(TestLayernormFpropPlan, ExecutePlanTrainingPhase)
     LayernormFpropTensorBundle directTensorBundle(node, graphWrapper.getTensorMap(), seed);
 
     const auto& attributes
-        = node.attributesAs<hipdnn_data_sdk::data_objects::LayernormAttributes>();
+        = node.attributesAs<hipdnn_flatbuffers_sdk::data_objects::LayernormAttributes>();
     const auto& tensorMap = graphWrapper.getTensorMap();
 
-    const hipdnn_data_sdk::data_objects::TensorAttributes* meanAttr = nullptr;
-    const hipdnn_data_sdk::data_objects::TensorAttributes* invVarianceAttr = nullptr;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* meanAttr = nullptr;
+    const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes* invVarianceAttr = nullptr;
     if(attributes.mean_tensor_uid().has_value())
     {
         meanAttr = tensorMap.at(attributes.mean_tensor_uid().value());

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestLayernormFpropSignatureKey.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestLayernormFpropSignatureKey.cpp
@@ -7,12 +7,12 @@
 
 #include "LayernormGraphUtils.hpp"
 #include "LayernormTensorBundles.hpp"
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/LayernormFpropSignatureKey.hpp>
 
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_test_sdk::detail;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
 using namespace hipdnn_sdk_test_utils;
 
@@ -115,8 +115,8 @@ TEST(TestLayernormFpropSignatureKey, CreateFromNodeAndTensorMap)
                                           TensorLayout::NHWC);
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const LayernormFpropSignatureKey keyFromNode(graphWrap.getNode(0), graphWrap.getTensorMap());
 

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestMatmulPlan.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestMatmulPlan.cpp
@@ -6,9 +6,9 @@
 #include "MatmulGraphUtils.hpp"
 #include "MatmulTensorBundles.hpp"
 #include "PointwiseGraphUtils.hpp"
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceMatmul.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
 #include <hipdnn_test_sdk/utilities/DynamicTolerances.hpp>
@@ -19,18 +19,19 @@
 using namespace hipdnn_sdk_test_utils;
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_test_sdk::detail;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
-using namespace hipdnn_data_sdk::flatbuffer_utilities;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 using namespace ::testing;
 
 class TestMatmulPlan : public ::testing::Test
 {
 protected:
-    static void initTensorValues(hipdnn_data_sdk::data_objects::TensorAttributesT& tensorAttr,
-                                 DataType dataType,
-                                 const Tensor<float>& tensor,
-                                 int64_t uid)
+    static void
+        initTensorValues(hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT& tensorAttr,
+                         DataType dataType,
+                         const Tensor<float>& tensor,
+                         int64_t uid)
     {
         tensorAttr.data_type = dataType;
         tensorAttr.dims = tensor.dims();

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestMatmulSignatureKey.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestMatmulSignatureKey.cpp
@@ -7,12 +7,12 @@
 
 #include "MatmulGraphUtils.hpp"
 #include "MatmulTensorBundles.hpp"
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/MatmulSignatureKey.hpp>
 
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_test_sdk::detail;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
 using namespace hipdnn_sdk_test_utils;
 
@@ -91,8 +91,8 @@ TEST(TestMatmulSignatureKey, CreateFromNodeAndTensorMap)
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
 
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const MatmulSignatureKey keyFromNode(
         graphWrap.getNode(0), graphWrap.getTensorMap(), DataType::FLOAT);

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestPlanRegistrySignatureKey.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestPlanRegistrySignatureKey.cpp
@@ -8,7 +8,7 @@
 #include <unordered_map>
 
 using namespace hipdnn_test_sdk::detail;
-using hipdnn_data_sdk::data_objects::DataType;
+using hipdnn_flatbuffers_sdk::data_objects::DataType;
 
 TEST(TestPlanRegistrySignatureKey, HashAndEqualityFwdInference)
 {

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestPointwiseOperationsCpuGraphExecutor.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestPointwiseOperationsCpuGraphExecutor.cpp
@@ -10,20 +10,20 @@
 #include "PointwiseGraphUtils.hpp"
 #include "PointwiseTensorBundles.hpp"
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_data_sdk/types.hpp>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
 #include <hipdnn_test_sdk/utilities/Seeds.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/CpuReferenceGraphExecutor.hpp>
 
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_test_sdk::detail;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
 using namespace ::testing;
 using namespace hipdnn_sdk_test_utils;
-using namespace hipdnn_data_sdk::flatbuffer_utilities;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 using hipdnn_data_sdk::types::bfloat16;
 using hipdnn_data_sdk::types::half;
 

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestPointwisePlan.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestPointwisePlan.cpp
@@ -5,9 +5,9 @@
 
 #include "PointwiseGraphUtils.hpp"
 #include "PointwiseTensorBundles.hpp"
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
 #include <hipdnn_test_sdk/utilities/Seeds.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/CpuReferenceGraphExecutor.hpp>
@@ -16,9 +16,9 @@
 
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_test_sdk::detail;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
-using namespace hipdnn_data_sdk::flatbuffer_utilities;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 using namespace ::testing;
 using namespace hipdnn_sdk_test_utils;
 
@@ -231,8 +231,8 @@ TEST(TestPointwisePlanBuilder, PlanConstructionUnary)
 
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const PointwisePlanBuilder<DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT>
         patient;
@@ -263,8 +263,8 @@ TEST(TestPointwisePlanBuilder, PlanConstructionBinary)
 
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const PointwisePlanBuilder<DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT>
         patient;
@@ -292,8 +292,8 @@ TEST(TestPointwisePlanBuilder, PlanConstructionUnaryGelu)
 
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const PointwisePlanBuilder<DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT>
         patient;
@@ -321,8 +321,8 @@ TEST(TestPointwisePlanBuilder, PlanConstructionUnaryGeluApproxTanh)
 
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const PointwisePlanBuilder<DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT>
         patient;
@@ -350,8 +350,8 @@ TEST(TestPointwisePlanBuilder, PlanConstructionUnarySwish)
 
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const PointwisePlanBuilder<DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT>
         patient;
@@ -379,8 +379,8 @@ TEST(TestPointwisePlanBuilder, IsApplicableUnary)
 
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const PointwisePlanBuilder<DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT>
         floatPlanBuilder;
@@ -412,8 +412,8 @@ TEST(TestPointwisePlanBuilder, IsApplicableBinary)
 
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const PointwisePlanBuilder<DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT>
         floatPlanBuilder;
@@ -442,8 +442,8 @@ TEST(TestPointwisePlanBuilder, IsApplicableUnaryGelu)
 
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const PointwisePlanBuilder<DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT>
         floatPlanBuilder;
@@ -471,8 +471,8 @@ TEST(TestPointwisePlanBuilder, IsApplicableUnaryGeluApproxTanh)
 
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const PointwisePlanBuilder<DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT>
         floatPlanBuilder;
@@ -500,8 +500,8 @@ TEST(TestPointwisePlanBuilder, IsApplicableUnarySwish)
 
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const PointwisePlanBuilder<DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT>
         floatPlanBuilder;
@@ -529,8 +529,8 @@ TEST(TestPointwisePlanBuilder, UnsupportedOperation)
 
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const PointwisePlanBuilder<DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT>
         planBuilder;
@@ -559,8 +559,8 @@ TEST(TestPointwisePlanBuilder, PlanBuilderThrowsIfEluAlphaValueSet)
 
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const PointwisePlanBuilder<DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT>
         planBuilder;
@@ -591,8 +591,8 @@ TEST(TestPointwisePlanBuilder, PlanBuilderThrowsIfSoftPlusBetaValueSet)
 
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const PointwisePlanBuilder<DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT>
         planBuilder;

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestPointwiseSignatureKey.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestPointwiseSignatureKey.cpp
@@ -7,14 +7,15 @@
 
 #include "PointwiseGraphUtils.hpp"
 #include "PointwiseTensorBundles.hpp"
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_data_sdk/types.hpp>
-#include <hipdnn_data_sdk/utilities/PointwiseValidation.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/utilities/PointwiseValidation.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/PointwiseSignatureKey.hpp>
 
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_test_sdk::detail;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::utilities;
 using namespace hipdnn_data_sdk::utilities;
 using namespace hipdnn_sdk_test_utils;
 
@@ -117,8 +118,8 @@ TEST(TestPointwiseSignatureKey, CreateFromNodeAndTensorMapUnary)
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
 
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const PointwiseSignatureKey keyFromNode(graphWrap.getNode(0), graphWrap.getTensorMap());
 
@@ -160,8 +161,8 @@ TEST(TestPointwiseSignatureKey, CreateFromNodeAndTensorMapBinary)
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
 
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const PointwiseSignatureKey keyFromNode(graphWrap.getNode(0), graphWrap.getTensorMap());
 
@@ -233,8 +234,8 @@ TEST(TestPointwiseSignatureKey, UnorderedSetUsage)
 
 TEST(TestPointwiseSignatureKey, DifferentOperationsAreDifferent)
 {
-    auto unaryModesBitset = hipdnn_data_sdk::utilities::getUnaryModesBitset();
-    auto binaryModesBitset = hipdnn_data_sdk::utilities::getBinaryModesBitset();
+    auto unaryModesBitset = hipdnn_flatbuffers_sdk::utilities::getUnaryModesBitset();
+    auto binaryModesBitset = hipdnn_flatbuffers_sdk::utilities::getBinaryModesBitset();
 
     // Test that all supported operations create different keys
     std::unordered_set<PointwiseSignatureKey, PointwiseSignatureKey> uniqueKeys;

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestRMSNormFwdPlan.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestRMSNormFwdPlan.cpp
@@ -5,9 +5,9 @@
 
 #include "RMSNormGraphUtils.hpp"
 #include "RMSNormTensorBundles.hpp"
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/utilities/FlatbufferUtils.hpp>
 #include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/utilities/FlatbufferUtils.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceRMSNorm.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
 #include <hipdnn_test_sdk/utilities/DynamicTolerances.hpp>
@@ -17,9 +17,9 @@
 
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_test_sdk::detail;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
-using namespace hipdnn_data_sdk::flatbuffer_utilities;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 using namespace ::testing;
 using namespace hipdnn_sdk_test_utils;
 namespace rmsnorm = hipdnn_test_sdk::utilities::rmsnorm;
@@ -37,7 +37,8 @@ TEST(TestRMSNormFwdPlan, ExecutePlan)
     RMSNormFwdTensorBundle planTensorBundle(node, graphWrapper.getTensorMap(), seed);
     RMSNormFwdTensorBundle directTensorBundle(node, graphWrapper.getTensorMap(), seed);
 
-    const auto& attributes = node.attributesAs<hipdnn_data_sdk::data_objects::RMSNormAttributes>();
+    const auto& attributes
+        = node.attributesAs<hipdnn_flatbuffers_sdk::data_objects::RMSNormAttributes>();
     const auto& tensorMap = graphWrapper.getTensorMap();
 
     const auto* invRmsPtr = attributes.inv_rms_tensor_uid().has_value()
@@ -51,8 +52,8 @@ TEST(TestRMSNormFwdPlan, ExecutePlan)
 
     const std::unordered_map<int64_t, void*> variantPack = planTensorBundle.toHostVariantPack();
 
-    const double epsilon
-        = hipdnn_data_sdk::utilities::extractDoubleFromTensorValue(params.epsilonTensor, "Epsilon");
+    const double epsilon = hipdnn_flatbuffers_sdk::utilities::extractDoubleFromTensorValue(
+        params.epsilonTensor, "Epsilon");
 
     auto shallowXTensor = createShallowTensor<float>(
         params.xTensor, directTensorBundle.tensors[attributes.x_tensor_uid()]->rawHostData());
@@ -129,7 +130,8 @@ TEST(TestRMSNormFwdPlan, ExecutePlanWithBias)
     RMSNormFwdWithBiasTensorBundle planTensorBundle(node, graphWrapper.getTensorMap(), seed);
     RMSNormFwdWithBiasTensorBundle directTensorBundle(node, graphWrapper.getTensorMap(), seed);
 
-    const auto& attributes = node.attributesAs<hipdnn_data_sdk::data_objects::RMSNormAttributes>();
+    const auto& attributes
+        = node.attributesAs<hipdnn_flatbuffers_sdk::data_objects::RMSNormAttributes>();
     const auto& tensorMap = graphWrapper.getTensorMap();
 
     const auto* invRmsBiasPtr = attributes.inv_rms_tensor_uid().has_value()
@@ -145,7 +147,8 @@ TEST(TestRMSNormFwdPlan, ExecutePlanWithBias)
                             invRmsBiasPtr,
                             biasPtr);
 
-    const double epsilon = extractDoubleFromTensorValue(params.epsilonTensor, "Epsilon");
+    const double epsilon = hipdnn_flatbuffers_sdk::utilities::extractDoubleFromTensorValue(
+        params.epsilonTensor, "Epsilon");
 
     auto shallowXTensor = createShallowTensor<float>(
         params.xTensor, directTensorBundle.tensors[attributes.x_tensor_uid()]->rawHostData());

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestRMSNormFwdSignatureKey.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestRMSNormFwdSignatureKey.cpp
@@ -7,12 +7,12 @@
 
 #include "RMSNormGraphUtils.hpp"
 #include "RMSNormTensorBundles.hpp"
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/RMSNormFwdSignatureKey.hpp>
 
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_test_sdk::detail;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
 using namespace hipdnn_sdk_test_utils;
 
@@ -98,8 +98,8 @@ TEST(TestRMSNormFwdSignatureKey, CreateFromNodeAndTensorMap)
         DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, dims, TensorLayout::NHWC);
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const RMSNormFwdSignatureKey keyFromNode(graphWrap.getNode(0), graphWrap.getTensorMap());
 

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestReductionPlan.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestReductionPlan.cpp
@@ -6,9 +6,9 @@
 #include "PointwiseGraphUtils.hpp"
 #include "ReductionGraphUtils.hpp"
 #include "ReductionTensorBundles.hpp"
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceReduction.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
 #include <hipdnn_test_sdk/utilities/Seeds.hpp>
@@ -17,9 +17,9 @@
 using namespace hipdnn_sdk_test_utils;
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_test_sdk::detail;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
-using namespace hipdnn_data_sdk::flatbuffer_utilities;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 using namespace ::testing;
 
 class TestReductionPlan : public ::testing::Test

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestReductionSignatureKey.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestReductionSignatureKey.cpp
@@ -6,12 +6,12 @@
 
 #include "ReductionGraphUtils.hpp"
 #include "ReductionTensorBundles.hpp"
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ReductionSignatureKey.hpp>
 
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_test_sdk::detail;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
 using namespace hipdnn_sdk_test_utils;
 
@@ -84,8 +84,8 @@ TEST(TestReductionSignatureKey, CreateFromNodeAndTensorMap)
     auto& graph = std::get<0>(graphTuple);
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const ReductionSignatureKey keyFromNode(
         graphWrap.getNode(0), graphWrap.getTensorMap(), DataType::FLOAT);

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestSdpaFwdPlan.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestSdpaFwdPlan.cpp
@@ -5,8 +5,8 @@
 
 #include "SdpaGraphUtils.hpp"
 #include "SdpaTensorBundles.hpp"
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceSdpa.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
 #include <hipdnn_test_sdk/utilities/Seeds.hpp>
@@ -14,8 +14,8 @@
 
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_test_sdk::detail;
-using namespace hipdnn_data_sdk::data_objects;
-using namespace hipdnn_data_sdk::flatbuffer_utilities;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 using namespace ::testing;
 using namespace hipdnn_sdk_test_utils;
 

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestSdpaFwdSignatureKey.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestSdpaFwdSignatureKey.cpp
@@ -7,12 +7,12 @@
 
 #include "SdpaGraphUtils.hpp"
 #include "SdpaTensorBundles.hpp"
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/SdpaFwdSignatureKey.hpp>
 
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_test_sdk::detail;
-using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
 using namespace hipdnn_data_sdk::utilities;
 using namespace hipdnn_sdk_test_utils;
 
@@ -100,8 +100,8 @@ TEST(TestSdpaFwdSignatureKey, CreateFromNodeAndTensorMap)
     auto& graph = std::get<0>(graphTuple);
     auto [serializedGraph, serErr] = graph->to_binary();
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
-    auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(serializedGraph.data(),
-                                                                         serializedGraph.size());
+    auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        serializedGraph.data(), serializedGraph.size());
 
     const SdpaFwdSignatureKey keyFromNode(graphWrap.getNode(0), graphWrap.getTensorMap());
 

--- a/projects/hipdnn/tests/frontend/IntegrationBatchnormBackwardDescriptorLowering.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationBatchnormBackwardDescriptorLowering.cpp
@@ -8,8 +8,8 @@
 #include <unordered_set>
 #include <vector>
 
-#include <hipdnn_data_sdk/data_objects/batchnorm_backward_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/batchnorm_backward_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_frontend.hpp>
 #include <hipdnn_test_sdk/utilities/IntegrationTestFixture.hpp>
 #include <hipdnn_test_sdk/utilities/LoweringTestHelpers.hpp>
@@ -23,8 +23,8 @@ using namespace hipdnn_frontend;
 using namespace hipdnn_frontend::graph;
 using hipdnn_tests::IntegrationTestFixture;
 using hipdnn_tests::toVec;
-using DataTypeSdk = hipdnn_data_sdk::data_objects::DataType;
-using NodeAttrType = hipdnn_data_sdk::data_objects::NodeAttributes;
+using DataTypeSdk = hipdnn_flatbuffers_sdk::data_objects::DataType;
+using NodeAttrType = hipdnn_flatbuffers_sdk::data_objects::NodeAttributes;
 using hipdnn_tests::buildTensorMap;
 using hipdnn_tests::lowerAndDeserialize;
 using hipdnn_tests::TestableGraphLowering;

--- a/projects/hipdnn/tests/frontend/IntegrationBatchnormDescriptorLowering.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationBatchnormDescriptorLowering.cpp
@@ -8,8 +8,8 @@
 #include <unordered_set>
 #include <vector>
 
-#include <hipdnn_data_sdk/data_objects/batchnorm_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/batchnorm_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_frontend.hpp>
 #include <hipdnn_test_sdk/constants/BatchnormConstants.hpp>
 #include <hipdnn_test_sdk/utilities/IntegrationTestFixture.hpp>
@@ -25,8 +25,8 @@ using namespace hipdnn_frontend::graph;
 using namespace hipdnn_tests::constants;
 using hipdnn_tests::IntegrationTestFixture;
 using hipdnn_tests::toVec;
-using DataTypeSdk = hipdnn_data_sdk::data_objects::DataType;
-using NodeAttrType = hipdnn_data_sdk::data_objects::NodeAttributes;
+using DataTypeSdk = hipdnn_flatbuffers_sdk::data_objects::DataType;
+using NodeAttrType = hipdnn_flatbuffers_sdk::data_objects::NodeAttributes;
 using hipdnn_tests::buildTensorMap;
 using hipdnn_tests::lowerAndDeserialize;
 using hipdnn_tests::TestableGraphLowering;

--- a/projects/hipdnn/tests/frontend/IntegrationBatchnormInferenceDescriptorLowering.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationBatchnormInferenceDescriptorLowering.cpp
@@ -8,8 +8,8 @@
 #include <unordered_set>
 #include <vector>
 
-#include <hipdnn_data_sdk/data_objects/batchnorm_inference_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/batchnorm_inference_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_frontend.hpp>
 #include <hipdnn_test_sdk/utilities/IntegrationTestFixture.hpp>
 #include <hipdnn_test_sdk/utilities/LoweringTestHelpers.hpp>
@@ -23,8 +23,8 @@ using namespace hipdnn_frontend;
 using namespace hipdnn_frontend::graph;
 using hipdnn_tests::IntegrationTestFixture;
 using hipdnn_tests::toVec;
-using DataTypeSdk = hipdnn_data_sdk::data_objects::DataType;
-using NodeAttrType = hipdnn_data_sdk::data_objects::NodeAttributes;
+using DataTypeSdk = hipdnn_flatbuffers_sdk::data_objects::DataType;
+using NodeAttrType = hipdnn_flatbuffers_sdk::data_objects::NodeAttributes;
 using hipdnn_tests::buildTensorMap;
 using hipdnn_tests::lowerAndDeserialize;
 using hipdnn_tests::TestableGraphLowering;

--- a/projects/hipdnn/tests/frontend/IntegrationBatchnormInferenceNodeVarianceExtDescriptorLowering.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationBatchnormInferenceNodeVarianceExtDescriptorLowering.cpp
@@ -8,8 +8,8 @@
 #include <unordered_set>
 #include <vector>
 
-#include <hipdnn_data_sdk/data_objects/batchnorm_inference_attributes_variance_ext_generated.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/batchnorm_inference_attributes_variance_ext_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_frontend.hpp>
 #include <hipdnn_test_sdk/constants/BnInfVarExtConstants.hpp>
 #include <hipdnn_test_sdk/utilities/IntegrationTestFixture.hpp>
@@ -25,8 +25,8 @@ using namespace hipdnn_frontend::graph;
 using namespace hipdnn_tests::constants;
 using hipdnn_tests::IntegrationTestFixture;
 using hipdnn_tests::toVec;
-using DataTypeSdk = hipdnn_data_sdk::data_objects::DataType;
-using NodeAttrType = hipdnn_data_sdk::data_objects::NodeAttributes;
+using DataTypeSdk = hipdnn_flatbuffers_sdk::data_objects::DataType;
+using NodeAttrType = hipdnn_flatbuffers_sdk::data_objects::NodeAttributes;
 using hipdnn_tests::buildTensorMap;
 using hipdnn_tests::lowerAndDeserialize;
 using hipdnn_tests::TestableGraphLowering;

--- a/projects/hipdnn/tests/frontend/IntegrationBlockScaleDequantizeDescriptorLowering.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationBlockScaleDequantizeDescriptorLowering.cpp
@@ -8,8 +8,8 @@
 #include <unordered_set>
 #include <vector>
 
-#include <hipdnn_data_sdk/data_objects/block_scale_dequantize_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/block_scale_dequantize_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_frontend.hpp>
 #include <hipdnn_test_sdk/constants/BlockScaleDequantizeConstants.hpp>
 #include <hipdnn_test_sdk/utilities/IntegrationTestFixture.hpp>
@@ -25,8 +25,8 @@ using namespace hipdnn_frontend::graph;
 using namespace hipdnn_tests::constants;
 using hipdnn_tests::IntegrationTestFixture;
 using hipdnn_tests::toVec;
-using DataTypeSdk = hipdnn_data_sdk::data_objects::DataType;
-using NodeAttrType = hipdnn_data_sdk::data_objects::NodeAttributes;
+using DataTypeSdk = hipdnn_flatbuffers_sdk::data_objects::DataType;
+using NodeAttrType = hipdnn_flatbuffers_sdk::data_objects::NodeAttributes;
 using hipdnn_tests::buildTensorMap;
 using hipdnn_tests::lowerAndDeserialize;
 using hipdnn_tests::TestableGraphLowering;

--- a/projects/hipdnn/tests/frontend/IntegrationBlockScaleQuantizeDescriptorLowering.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationBlockScaleQuantizeDescriptorLowering.cpp
@@ -8,8 +8,8 @@
 #include <unordered_set>
 #include <vector>
 
-#include <hipdnn_data_sdk/data_objects/block_scale_quantize_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/block_scale_quantize_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_frontend.hpp>
 #include <hipdnn_test_sdk/constants/BlockScaleQuantizeConstants.hpp>
 #include <hipdnn_test_sdk/utilities/IntegrationTestFixture.hpp>
@@ -25,8 +25,8 @@ using namespace hipdnn_frontend::graph;
 using namespace hipdnn_tests::constants;
 using hipdnn_tests::IntegrationTestFixture;
 using hipdnn_tests::toVec;
-using DataTypeSdk = hipdnn_data_sdk::data_objects::DataType;
-using NodeAttrType = hipdnn_data_sdk::data_objects::NodeAttributes;
+using DataTypeSdk = hipdnn_flatbuffers_sdk::data_objects::DataType;
+using NodeAttrType = hipdnn_flatbuffers_sdk::data_objects::NodeAttributes;
 using hipdnn_tests::buildTensorMap;
 using hipdnn_tests::lowerAndDeserialize;
 using hipdnn_tests::TestableGraphLowering;

--- a/projects/hipdnn/tests/frontend/IntegrationConvFpropDescriptorLowering.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationConvFpropDescriptorLowering.cpp
@@ -8,8 +8,8 @@
 #include <unordered_set>
 #include <vector>
 
-#include <hipdnn_data_sdk/data_objects/convolution_fwd_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/convolution_fwd_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_frontend.hpp>
 #include <hipdnn_test_sdk/constants/ConvFpropConstants.hpp>
 #include <hipdnn_test_sdk/utilities/IntegrationTestFixture.hpp>
@@ -25,9 +25,9 @@ using namespace hipdnn_frontend::graph;
 using hipdnn_tests::IntegrationTestFixture;
 using hipdnn_tests::toVec;
 using namespace hipdnn_tests::constants;
-using DataTypeSdk = hipdnn_data_sdk::data_objects::DataType;
-using ConvModeSdk = hipdnn_data_sdk::data_objects::ConvMode;
-using NodeAttrType = hipdnn_data_sdk::data_objects::NodeAttributes;
+using DataTypeSdk = hipdnn_flatbuffers_sdk::data_objects::DataType;
+using ConvModeSdk = hipdnn_flatbuffers_sdk::data_objects::ConvMode;
+using NodeAttrType = hipdnn_flatbuffers_sdk::data_objects::NodeAttributes;
 using hipdnn_tests::buildTensorMap;
 using hipdnn_tests::lowerAndDeserialize;
 using hipdnn_tests::TestableGraphLowering;

--- a/projects/hipdnn/tests/frontend/IntegrationConvolutionDgradDescriptorLowering.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationConvolutionDgradDescriptorLowering.cpp
@@ -8,8 +8,8 @@
 #include <unordered_set>
 #include <vector>
 
-#include <hipdnn_data_sdk/data_objects/convolution_bwd_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/convolution_bwd_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_frontend.hpp>
 #include <hipdnn_test_sdk/utilities/IntegrationTestFixture.hpp>
 #include <hipdnn_test_sdk/utilities/LoweringTestHelpers.hpp>
@@ -24,9 +24,9 @@ using namespace hipdnn_frontend;
 using namespace hipdnn_frontend::graph;
 using hipdnn_tests::IntegrationTestFixture;
 using hipdnn_tests::toVec;
-using DataTypeSdk = hipdnn_data_sdk::data_objects::DataType;
-using NodeAttrType = hipdnn_data_sdk::data_objects::NodeAttributes;
-using ConvModeSdk = hipdnn_data_sdk::data_objects::ConvMode;
+using DataTypeSdk = hipdnn_flatbuffers_sdk::data_objects::DataType;
+using NodeAttrType = hipdnn_flatbuffers_sdk::data_objects::NodeAttributes;
+using ConvModeSdk = hipdnn_flatbuffers_sdk::data_objects::ConvMode;
 using hipdnn_tests::buildTensorMap;
 using hipdnn_tests::lowerAndDeserialize;
 using hipdnn_tests::TestableGraphLowering;

--- a/projects/hipdnn/tests/frontend/IntegrationConvolutionWgradDescriptorLowering.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationConvolutionWgradDescriptorLowering.cpp
@@ -8,8 +8,8 @@
 #include <unordered_set>
 #include <vector>
 
-#include <hipdnn_data_sdk/data_objects/convolution_wrw_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/convolution_wrw_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_frontend.hpp>
 #include <hipdnn_test_sdk/constants/ConvWgradConstants.hpp>
 #include <hipdnn_test_sdk/utilities/IntegrationTestFixture.hpp>
@@ -24,9 +24,9 @@ using namespace hipdnn_frontend;
 using namespace hipdnn_frontend::graph;
 using namespace hipdnn_tests::constants;
 using hipdnn_tests::toVec;
-using DataTypeSdk = hipdnn_data_sdk::data_objects::DataType;
-using NodeAttrType = hipdnn_data_sdk::data_objects::NodeAttributes;
-using ConvModeSdk = hipdnn_data_sdk::data_objects::ConvMode;
+using DataTypeSdk = hipdnn_flatbuffers_sdk::data_objects::DataType;
+using NodeAttrType = hipdnn_flatbuffers_sdk::data_objects::NodeAttributes;
+using ConvModeSdk = hipdnn_flatbuffers_sdk::data_objects::ConvMode;
 using hipdnn_tests::buildTensorMap;
 using hipdnn_tests::IntegrationTestFixture;
 using hipdnn_tests::lowerAndDeserialize;

--- a/projects/hipdnn/tests/frontend/IntegrationCustomOpDescriptorLowering.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationCustomOpDescriptorLowering.cpp
@@ -8,8 +8,8 @@
 #include <unordered_set>
 #include <vector>
 
-#include <hipdnn_data_sdk/data_objects/custom_op_attributes_generated.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/custom_op_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_frontend.hpp>
 #include <hipdnn_test_sdk/constants/CustomOpConstants.hpp>
 #include <hipdnn_test_sdk/utilities/IntegrationTestFixture.hpp>
@@ -22,8 +22,8 @@
 using namespace hipdnn_frontend;
 using namespace hipdnn_frontend::graph;
 using namespace hipdnn_tests::constants;
-using DataTypeSdk = hipdnn_data_sdk::data_objects::DataType;
-using NodeAttrType = hipdnn_data_sdk::data_objects::NodeAttributes;
+using DataTypeSdk = hipdnn_flatbuffers_sdk::data_objects::DataType;
+using NodeAttrType = hipdnn_flatbuffers_sdk::data_objects::NodeAttributes;
 using hipdnn_tests::buildTensorMap;
 using hipdnn_tests::IntegrationTestFixture;
 using hipdnn_tests::lowerAndDeserialize;

--- a/projects/hipdnn/tests/frontend/IntegrationGraphKnobSettingsDescriptorLowering.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationGraphKnobSettingsDescriptorLowering.cpp
@@ -9,18 +9,18 @@
 #include <test_plugins/TestPluginConstants.hpp>
 #include <test_plugins/TestPluginKnobRecorder.hpp>
 
-#include <hipdnn_data_sdk/data_objects/engine_config_generated.h>
-#include <hipdnn_data_sdk/data_objects/knob_value_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/engine_config_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/knob_value_generated.h>
 #include <hipdnn_test_sdk/utilities/IntegrationTestFixture.hpp>
 #include <hipdnn_test_sdk/utilities/TestableGraph.hpp>
 
 using namespace hipdnn_frontend;
 using namespace hipdnn_frontend::graph;
-using hipdnn_data_sdk::data_objects::EngineConfigT;
-using hipdnn_data_sdk::data_objects::FloatValueT;
-using hipdnn_data_sdk::data_objects::IntValueT;
-using hipdnn_data_sdk::data_objects::KnobSettingT;
-using hipdnn_data_sdk::data_objects::StringValueT;
+using hipdnn_flatbuffers_sdk::data_objects::EngineConfigT;
+using hipdnn_flatbuffers_sdk::data_objects::FloatValueT;
+using hipdnn_flatbuffers_sdk::data_objects::IntValueT;
+using hipdnn_flatbuffers_sdk::data_objects::KnobSettingT;
+using hipdnn_flatbuffers_sdk::data_objects::StringValueT;
 using hipdnn_tests::IntegrationTestFixture;
 using hipdnn_tests::TestableGraphKnobLowering;
 

--- a/projects/hipdnn/tests/frontend/IntegrationLayerNormDescriptorLowering.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationLayerNormDescriptorLowering.cpp
@@ -8,8 +8,8 @@
 #include <unordered_set>
 #include <vector>
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/data_objects/layernorm_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/layernorm_attributes_generated.h>
 #include <hipdnn_frontend.hpp>
 #include <hipdnn_test_sdk/constants/LayernormConstants.hpp>
 #include <hipdnn_test_sdk/utilities/IntegrationTestFixture.hpp>
@@ -24,9 +24,9 @@ using namespace hipdnn_frontend;
 using namespace hipdnn_frontend::graph;
 using namespace hipdnn_tests::constants;
 using hipdnn_tests::toVec;
-using DataTypeSdk = hipdnn_data_sdk::data_objects::DataType;
-using NodeAttrType = hipdnn_data_sdk::data_objects::NodeAttributes;
-using NormFwdPhaseSdk = hipdnn_data_sdk::data_objects::NormFwdPhase;
+using DataTypeSdk = hipdnn_flatbuffers_sdk::data_objects::DataType;
+using NodeAttrType = hipdnn_flatbuffers_sdk::data_objects::NodeAttributes;
+using NormFwdPhaseSdk = hipdnn_flatbuffers_sdk::data_objects::NormFwdPhase;
 using hipdnn_tests::buildTensorMap;
 using hipdnn_tests::IntegrationTestFixture;
 using hipdnn_tests::lowerAndDeserialize;

--- a/projects/hipdnn/tests/frontend/IntegrationMatmulDescriptorLowering.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationMatmulDescriptorLowering.cpp
@@ -8,8 +8,8 @@
 #include <unordered_set>
 #include <vector>
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/data_objects/matmul_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/matmul_attributes_generated.h>
 #include <hipdnn_frontend.hpp>
 #include <hipdnn_test_sdk/constants/MatmulConstants.hpp>
 #include <hipdnn_test_sdk/utilities/IntegrationTestFixture.hpp>
@@ -24,8 +24,8 @@ using namespace hipdnn_frontend;
 using namespace hipdnn_frontend::graph;
 using namespace hipdnn_tests::constants;
 using hipdnn_tests::toVec;
-using DataTypeSdk = hipdnn_data_sdk::data_objects::DataType;
-using NodeAttrType = hipdnn_data_sdk::data_objects::NodeAttributes;
+using DataTypeSdk = hipdnn_flatbuffers_sdk::data_objects::DataType;
+using NodeAttrType = hipdnn_flatbuffers_sdk::data_objects::NodeAttributes;
 using hipdnn_tests::buildTensorMap;
 using hipdnn_tests::IntegrationTestFixture;
 using hipdnn_tests::lowerAndDeserialize;

--- a/projects/hipdnn/tests/frontend/IntegrationPointwiseDescriptorLowering.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationPointwiseDescriptorLowering.cpp
@@ -8,8 +8,8 @@
 #include <unordered_set>
 #include <vector>
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/pointwise_attributes_generated.h>
 #include <hipdnn_frontend.hpp>
 #include <hipdnn_test_sdk/constants/PointwiseConstants.hpp>
 #include <hipdnn_test_sdk/utilities/IntegrationTestFixture.hpp>
@@ -24,9 +24,9 @@ using namespace hipdnn_frontend;
 using namespace hipdnn_frontend::graph;
 using hipdnn_tests::toVec;
 using namespace hipdnn_tests::constants;
-using DataTypeSdk = hipdnn_data_sdk::data_objects::DataType;
-using NodeAttrType = hipdnn_data_sdk::data_objects::NodeAttributes;
-using PointwiseModeSdk = hipdnn_data_sdk::data_objects::PointwiseMode;
+using DataTypeSdk = hipdnn_flatbuffers_sdk::data_objects::DataType;
+using NodeAttrType = hipdnn_flatbuffers_sdk::data_objects::NodeAttributes;
+using PointwiseModeSdk = hipdnn_flatbuffers_sdk::data_objects::PointwiseMode;
 using hipdnn_tests::buildTensorMap;
 using hipdnn_tests::IntegrationTestFixture;
 using hipdnn_tests::lowerAndDeserialize;

--- a/projects/hipdnn/tests/frontend/IntegrationRMSNormDescriptorLowering.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationRMSNormDescriptorLowering.cpp
@@ -8,8 +8,8 @@
 #include <unordered_set>
 #include <vector>
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/data_objects/rmsnorm_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/rmsnorm_attributes_generated.h>
 #include <hipdnn_frontend.hpp>
 #include <hipdnn_test_sdk/constants/RMSNormConstants.hpp>
 #include <hipdnn_test_sdk/utilities/IntegrationTestFixture.hpp>
@@ -24,9 +24,9 @@ using namespace hipdnn_frontend;
 using namespace hipdnn_frontend::graph;
 using namespace hipdnn_tests::constants;
 using hipdnn_tests::toVec;
-using DataTypeSdk = hipdnn_data_sdk::data_objects::DataType;
-using NodeAttrType = hipdnn_data_sdk::data_objects::NodeAttributes;
-using NormFwdPhaseSdk = hipdnn_data_sdk::data_objects::NormFwdPhase;
+using DataTypeSdk = hipdnn_flatbuffers_sdk::data_objects::DataType;
+using NodeAttrType = hipdnn_flatbuffers_sdk::data_objects::NodeAttributes;
+using NormFwdPhaseSdk = hipdnn_flatbuffers_sdk::data_objects::NormFwdPhase;
 using hipdnn_tests::buildTensorMap;
 using hipdnn_tests::IntegrationTestFixture;
 using hipdnn_tests::lowerAndDeserialize;

--- a/projects/hipdnn/tests/frontend/IntegrationReductionDescriptorLowering.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationReductionDescriptorLowering.cpp
@@ -7,8 +7,8 @@
 #include <unordered_map>
 #include <vector>
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/data_objects/reduction_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/reduction_attributes_generated.h>
 #include <hipdnn_frontend.hpp>
 #include <hipdnn_test_sdk/constants/ReductionConstants.hpp>
 #include <hipdnn_test_sdk/utilities/IntegrationTestFixture.hpp>
@@ -23,9 +23,9 @@ using namespace hipdnn_frontend;
 using namespace hipdnn_frontend::graph;
 using namespace hipdnn_tests::constants;
 using hipdnn_tests::toVec;
-using DataTypeSdk = hipdnn_data_sdk::data_objects::DataType;
-using NodeAttrType = hipdnn_data_sdk::data_objects::NodeAttributes;
-using ReductionModeSdk = hipdnn_data_sdk::data_objects::ReductionMode;
+using DataTypeSdk = hipdnn_flatbuffers_sdk::data_objects::DataType;
+using NodeAttrType = hipdnn_flatbuffers_sdk::data_objects::NodeAttributes;
+using ReductionModeSdk = hipdnn_flatbuffers_sdk::data_objects::ReductionMode;
 using hipdnn_tests::buildTensorMap;
 using hipdnn_tests::IntegrationTestFixture;
 using hipdnn_tests::lowerAndDeserialize;
@@ -42,7 +42,7 @@ protected:
     /// Builds and lowers a graph, returning the deserialized GraphT.
     /// Callers set up attrs before calling; this creates tensors, calls the
     /// graph method, validates, lowers, serializes, and deserializes.
-    hipdnn_data_sdk::data_objects::GraphT buildAndDeserialize(ReductionAttributes& attrs)
+    hipdnn_flatbuffers_sdk::data_objects::GraphT buildAndDeserialize(ReductionAttributes& attrs)
     {
         auto graph = std::make_shared<TestableGraphLowering>();
         graph->set_name("ReductionIntegrationTest")

--- a/projects/hipdnn/tests/frontend/IntegrationSdpaBwdDescriptorLowering.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationSdpaBwdDescriptorLowering.cpp
@@ -8,8 +8,8 @@
 #include <unordered_set>
 #include <vector>
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/data_objects/sdpa_backward_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/sdpa_backward_attributes_generated.h>
 #include <hipdnn_frontend.hpp>
 #include <hipdnn_test_sdk/constants/SdpaBwdConstants.hpp>
 #include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
@@ -21,9 +21,9 @@ using namespace hipdnn_frontend;
 using namespace hipdnn_frontend::graph;
 using namespace hipdnn_tests::constants;
 using hipdnn_tests::toVec;
-using DataTypeSdk = hipdnn_data_sdk::data_objects::DataType;
-using NodeAttrType = hipdnn_data_sdk::data_objects::NodeAttributes;
-using DiagonalAlignmentSdk = hipdnn_data_sdk::data_objects::DiagonalAlignment;
+using DataTypeSdk = hipdnn_flatbuffers_sdk::data_objects::DataType;
+using NodeAttrType = hipdnn_flatbuffers_sdk::data_objects::NodeAttributes;
+using DiagonalAlignmentSdk = hipdnn_flatbuffers_sdk::data_objects::DiagonalAlignment;
 
 namespace
 {
@@ -134,9 +134,9 @@ TEST_F(IntegrationSdpaBwdDescriptorLowering, SdpaBwdGraphRoundTrip)
               HIPDNN_STATUS_SUCCESS);
 
     // -- Deserialize into GraphT --
-    auto graphFb = hipdnn_data_sdk::data_objects::GetGraph(serializedData.data());
+    auto graphFb = hipdnn_flatbuffers_sdk::data_objects::GetGraph(serializedData.data());
     ASSERT_NE(graphFb, nullptr);
-    hipdnn_data_sdk::data_objects::GraphT graphT;
+    hipdnn_flatbuffers_sdk::data_objects::GraphT graphT;
     graphFb->UnPackTo(&graphT);
 
     // -- Verify graph-level attributes --
@@ -147,7 +147,8 @@ TEST_F(IntegrationSdpaBwdDescriptorLowering, SdpaBwdGraphRoundTrip)
     // -- Verify tensors (Q, K, V, O, dO, Stats, dQ, dK, dV = 9 tensors) --
     ASSERT_EQ(graphT.tensors.size(), 9u);
 
-    std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributesT*> tensorMap;
+    std::unordered_map<int64_t, const hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT*>
+        tensorMap;
     for(const auto& t : graphT.tensors)
     {
         tensorMap[t->uid] = t.get();
@@ -422,13 +423,14 @@ TEST_F(IntegrationSdpaBwdDescriptorLowering, SdpaBwdWithAllOptionalTensorsAndSca
               HIPDNN_STATUS_SUCCESS);
 
     // -- Deserialize into GraphT --
-    hipdnn_data_sdk::data_objects::GraphT graphT;
-    hipdnn_data_sdk::data_objects::GetGraph(serializedData.data())->UnPackTo(&graphT);
+    hipdnn_flatbuffers_sdk::data_objects::GraphT graphT;
+    hipdnn_flatbuffers_sdk::data_objects::GetGraph(serializedData.data())->UnPackTo(&graphT);
 
     // 9 required + 10 optional input/output tensors (including scale) = 19
     ASSERT_EQ(graphT.tensors.size(), 19u);
 
-    std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributesT*> tensorMap;
+    std::unordered_map<int64_t, const hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT*>
+        tensorMap;
     for(const auto& t : graphT.tensors)
     {
         tensorMap[t->uid] = t.get();
@@ -654,8 +656,8 @@ TEST_F(IntegrationSdpaBwdDescriptorLowering, AutoAssignedUidsPreservedInRoundTri
                   rawDesc, serializedSize, &serializedSize, serializedData.data()),
               HIPDNN_STATUS_SUCCESS);
 
-    hipdnn_data_sdk::data_objects::GraphT graphT;
-    hipdnn_data_sdk::data_objects::GetGraph(serializedData.data())->UnPackTo(&graphT);
+    hipdnn_flatbuffers_sdk::data_objects::GraphT graphT;
+    hipdnn_flatbuffers_sdk::data_objects::GetGraph(serializedData.data())->UnPackTo(&graphT);
 
     // Q + K + V + O + dO + Stats + dQ + dK + dV = 9 tensors
     ASSERT_EQ(graphT.tensors.size(), 9u);

--- a/projects/hipdnn/tests/frontend/IntegrationSdpaFwdDescriptorLowering.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationSdpaFwdDescriptorLowering.cpp
@@ -8,8 +8,8 @@
 #include <unordered_set>
 #include <vector>
 
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/data_objects/sdpa_attributes_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/sdpa_attributes_generated.h>
 #include <hipdnn_frontend.hpp>
 #include <hipdnn_test_sdk/constants/SdpaFwdConstants.hpp>
 #include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
@@ -21,10 +21,10 @@ using namespace hipdnn_frontend;
 using namespace hipdnn_frontend::graph;
 using namespace hipdnn_tests::constants;
 using hipdnn_tests::toVec;
-using DataTypeSdk = hipdnn_data_sdk::data_objects::DataType;
-using NodeAttrType = hipdnn_data_sdk::data_objects::NodeAttributes;
-using DiagonalAlignmentSdk = hipdnn_data_sdk::data_objects::DiagonalAlignment;
-using AttentionImplementationSdk = hipdnn_data_sdk::data_objects::AttentionImplementation;
+using DataTypeSdk = hipdnn_flatbuffers_sdk::data_objects::DataType;
+using NodeAttrType = hipdnn_flatbuffers_sdk::data_objects::NodeAttributes;
+using DiagonalAlignmentSdk = hipdnn_flatbuffers_sdk::data_objects::DiagonalAlignment;
+using AttentionImplementationSdk = hipdnn_flatbuffers_sdk::data_objects::AttentionImplementation;
 
 namespace
 {
@@ -40,12 +40,12 @@ public:
 // Builds an SDPA graph with standard Q/K/V tensors, validates, lowers via
 // descriptors, serializes, and returns the deserialized GraphT.
 // The caller configures optional tensors and scalars on sdpaAttrs before calling.
-hipdnn_data_sdk::data_objects::GraphT buildAndDeserializeSdpaGraph(hipdnnHandle_t handle,
-                                                                   SdpaAttributes sdpaAttrs,
-                                                                   DataType tensorDataType
-                                                                   = DataType::FLOAT)
+hipdnn_flatbuffers_sdk::data_objects::GraphT buildAndDeserializeSdpaGraph(hipdnnHandle_t handle,
+                                                                          SdpaAttributes sdpaAttrs,
+                                                                          DataType tensorDataType
+                                                                          = DataType::FLOAT)
 {
-    hipdnn_data_sdk::data_objects::GraphT graphT;
+    hipdnn_flatbuffers_sdk::data_objects::GraphT graphT;
 
     const bool wantStats = sdpaAttrs.generate_stats.has_value() && sdpaAttrs.generate_stats.value();
 
@@ -113,7 +113,7 @@ hipdnn_data_sdk::data_objects::GraphT buildAndDeserializeSdpaGraph(hipdnnHandle_
         return graphT;
     }
 
-    auto graphFb = hipdnn_data_sdk::data_objects::GetGraph(serializedData.data());
+    auto graphFb = hipdnn_flatbuffers_sdk::data_objects::GetGraph(serializedData.data());
     if(graphFb == nullptr)
     {
         ADD_FAILURE() << "GetGraph returned null";
@@ -207,9 +207,9 @@ TEST_F(IntegrationSdpaFwdDescriptorLowering, SdpaFwdGraphRoundTrip)
               HIPDNN_STATUS_SUCCESS);
 
     // -- Deserialize into GraphT --
-    auto graphFb = hipdnn_data_sdk::data_objects::GetGraph(serializedData.data());
+    auto graphFb = hipdnn_flatbuffers_sdk::data_objects::GetGraph(serializedData.data());
     ASSERT_NE(graphFb, nullptr);
-    hipdnn_data_sdk::data_objects::GraphT graphT;
+    hipdnn_flatbuffers_sdk::data_objects::GraphT graphT;
     graphFb->UnPackTo(&graphT);
 
     // -- Verify graph-level attributes --
@@ -220,7 +220,8 @@ TEST_F(IntegrationSdpaFwdDescriptorLowering, SdpaFwdGraphRoundTrip)
     // -- Verify tensors (Q, K, V, O = 4 tensors) --
     ASSERT_EQ(graphT.tensors.size(), 4u);
 
-    std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributesT*> tensorMap;
+    std::unordered_map<int64_t, const hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT*>
+        tensorMap;
     for(const auto& t : graphT.tensors)
     {
         tensorMap[t->uid] = t.get();
@@ -326,8 +327,8 @@ TEST_F(IntegrationSdpaFwdDescriptorLowering, AutoAssignedUidsPreservedInRoundTri
                   rawDesc, serializedSize, &serializedSize, serializedData.data()),
               HIPDNN_STATUS_SUCCESS);
 
-    hipdnn_data_sdk::data_objects::GraphT graphT;
-    hipdnn_data_sdk::data_objects::GetGraph(serializedData.data())->UnPackTo(&graphT);
+    hipdnn_flatbuffers_sdk::data_objects::GraphT graphT;
+    hipdnn_flatbuffers_sdk::data_objects::GetGraph(serializedData.data())->UnPackTo(&graphT);
 
     // All tensors should have been auto-assigned unique UIDs (Q, K, V, O = 4)
     ASSERT_EQ(graphT.tensors.size(), 4u);
@@ -412,9 +413,9 @@ TEST_F(IntegrationSdpaFwdDescriptorLowering, SdpaFwdWithStatsRoundTrip)
               HIPDNN_STATUS_SUCCESS);
 
     // -- Deserialize into GraphT --
-    auto graphFb = hipdnn_data_sdk::data_objects::GetGraph(serializedData.data());
+    auto graphFb = hipdnn_flatbuffers_sdk::data_objects::GetGraph(serializedData.data());
     ASSERT_NE(graphFb, nullptr);
-    hipdnn_data_sdk::data_objects::GraphT graphT;
+    hipdnn_flatbuffers_sdk::data_objects::GraphT graphT;
     graphFb->UnPackTo(&graphT);
 
     // -- Verify tensors (Q, K, V, O, STATS = 5 tensors) --
@@ -434,7 +435,8 @@ TEST_F(IntegrationSdpaFwdDescriptorLowering, SdpaFwdWithStatsRoundTrip)
     EXPECT_TRUE(sdpa->generate_stats);
 
     // Verify inferred stats tensor shape
-    std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributesT*> tensorMap;
+    std::unordered_map<int64_t, const hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT*>
+        tensorMap;
     for(const auto& t : graphT.tensors)
     {
         tensorMap[t->uid] = t.get();

--- a/projects/hipdnn/tests/test_plugins/CMakeLists.txt
+++ b/projects/hipdnn/tests/test_plugins/CMakeLists.txt
@@ -30,7 +30,7 @@ function(add_test_plugin target_name)
 
     target_include_directories(${target_name} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-    target_link_libraries(${target_name} PUBLIC hipdnn_data_sdk hipdnn_plugin_sdk hip::host)
+    target_link_libraries(${target_name} PUBLIC hipdnn_data_sdk hipdnn_flatbuffers_sdk hipdnn_plugin_sdk hip::host)
 
     target_compile_options(${target_name} PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
 

--- a/projects/hipdnn/tests/test_plugins/TestKnobConstraintValidationPlugin.cpp
+++ b/projects/hipdnn/tests/test_plugins/TestKnobConstraintValidationPlugin.cpp
@@ -4,8 +4,8 @@
 #include "TestPluginCommon.hpp"
 #include "TestPluginEngineIdMap.hpp"
 
-#include <hipdnn_data_sdk/data_objects/knob_value_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/knob_value_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
 #include <hipdnn_plugin_sdk/KnobFactory.hpp>
 
 // NOLINTNEXTLINE
@@ -72,7 +72,8 @@ public:
             flatbuffers::FlatBufferBuilder builder;
 
             // Create knobs vector using KnobFactory
-            std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::Knob>> knobOffsets;
+            std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Knob>>
+                knobOffsets;
 
             // Knob 1: Integer knob with min/max/step constraints
             knobOffsets.push_back(hipdnn_plugin_sdk::KnobFactory::createIntKnob(
@@ -103,7 +104,7 @@ public:
                 {"alpha", "beta", "gamma"})); // valid values
 
             auto knobsVector = builder.CreateVector(knobOffsets);
-            auto newEngineDetails = hipdnn_data_sdk::data_objects::CreateEngineDetails(
+            auto newEngineDetails = hipdnn_flatbuffers_sdk::data_objects::CreateEngineDetails(
                 builder, getInstance()->getEngineId(), knobsVector);
             builder.Finish(newEngineDetails);
             auto serializedDetails = builder.Release();
@@ -137,7 +138,7 @@ public:
             hipdnn_plugin_sdk::throwIfNull(executionContext);
 
             // Deserialize engineConfig to access knob settings
-            const hipdnn_data_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(
+            const hipdnn_flatbuffers_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(
                 engineConfig->ptr, engineConfig->size);
 
             // Validate knob types
@@ -149,7 +150,7 @@ public:
                 // Match against known knobs and validate type
                 if(knobId == "constraint.int_knob")
                 {
-                    if(valueType != hipdnn_data_sdk::data_objects::KnobValue::IntValue)
+                    if(valueType != hipdnn_flatbuffers_sdk::data_objects::KnobValue::IntValue)
                     {
                         throw hipdnn_plugin_sdk::HipdnnPluginException(
                             HIPDNN_PLUGIN_STATUS_BAD_PARAM,
@@ -158,7 +159,7 @@ public:
                 }
                 else if(knobId == "constraint.float_knob")
                 {
-                    if(valueType != hipdnn_data_sdk::data_objects::KnobValue::FloatValue)
+                    if(valueType != hipdnn_flatbuffers_sdk::data_objects::KnobValue::FloatValue)
                     {
                         throw hipdnn_plugin_sdk::HipdnnPluginException(
                             HIPDNN_PLUGIN_STATUS_BAD_PARAM,
@@ -167,7 +168,7 @@ public:
                 }
                 else if(knobId == "constraint.string_knob")
                 {
-                    if(valueType != hipdnn_data_sdk::data_objects::KnobValue::StringValue)
+                    if(valueType != hipdnn_flatbuffers_sdk::data_objects::KnobValue::StringValue)
                     {
                         throw hipdnn_plugin_sdk::HipdnnPluginException(
                             HIPDNN_PLUGIN_STATUS_BAD_PARAM,

--- a/projects/hipdnn/tests/test_plugins/TestKnobsPlugin.cpp
+++ b/projects/hipdnn/tests/test_plugins/TestKnobsPlugin.cpp
@@ -4,7 +4,7 @@
 #include "TestPluginCommon.hpp"
 #include "TestPluginEngineIdMap.hpp"
 
-#include <hipdnn_data_sdk/data_objects/knob_value_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/knob_value_generated.h>
 #include <hipdnn_plugin_sdk/KnobFactory.hpp>
 
 #include <cstdint>
@@ -146,7 +146,8 @@ public:
             flatbuffers::FlatBufferBuilder builder;
 
             // Create knobs vector using KnobFactory
-            std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::Knob>> knobOffsets;
+            std::vector<flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Knob>>
+                knobOffsets;
 
             if(engineId == hipdnn_tests::plugin_constants::engineId<KnobsPlugin>())
             {
@@ -228,7 +229,7 @@ public:
                 {}));
 
             auto knobsVector = builder.CreateVector(knobOffsets);
-            auto newEngineDetails = hipdnn_data_sdk::data_objects::CreateEngineDetails(
+            auto newEngineDetails = hipdnn_flatbuffers_sdk::data_objects::CreateEngineDetails(
                 builder, engineId, knobsVector);
             builder.Finish(newEngineDetails);
             auto serializedDetails = builder.Release();

--- a/projects/hipdnn/tests/test_plugins/TestPluginCommon.hpp
+++ b/projects/hipdnn/tests/test_plugins/TestPluginCommon.hpp
@@ -7,9 +7,9 @@
 #include <iostream>
 #include <memory>
 
-#include <hipdnn_data_sdk/data_objects/engine_details_generated.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/engine_details_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_plugin_sdk/EnginePluginApi.h>
 #include <hipdnn_plugin_sdk/PluginApi.h>
 #include <hipdnn_plugin_sdk/PluginDataTypeHelpers.hpp>
@@ -302,7 +302,7 @@ public:
             }
 
             flatbuffers::FlatBufferBuilder builder;
-            auto newEngineDetails = hipdnn_data_sdk::data_objects::CreateEngineDetails(
+            auto newEngineDetails = hipdnn_flatbuffers_sdk::data_objects::CreateEngineDetails(
                 builder, getInstance()->getEngineId());
             builder.Finish(newEngineDetails);
             auto serializedDetails = builder.Release();
@@ -426,10 +426,10 @@ public:
                     "No engines available - cannot create execution context");
             }
 
-            const hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper opGraphWrapper(opGraph->ptr,
-                                                                                     opGraph->size);
-            const hipdnn_data_sdk::flatbuffer_utilities::EngineConfigWrapper engineConfigWrapper(
-                engineConfig->ptr, engineConfig->size);
+            const hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper opGraphWrapper(
+                opGraph->ptr, opGraph->size);
+            const hipdnn_flatbuffers_sdk::flatbuffer_utilities::EngineConfigWrapper
+                engineConfigWrapper(engineConfig->ptr, engineConfig->size);
 
             *executionContext = new HipdnnEnginePluginExecutionContext();
 

--- a/projects/hipdnn/tests/test_plugins/TestPluginKnobRecorder.hpp
+++ b/projects/hipdnn/tests/test_plugins/TestPluginKnobRecorder.hpp
@@ -11,7 +11,7 @@
 #include <string>
 #include <vector>
 
-#include <hipdnn_data_sdk/data_objects/engine_config_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/engine_config_generated.h>
 
 #ifdef _WIN32
 #ifndef NOMINMAX
@@ -25,8 +25,8 @@
 namespace hipdnn_tests
 {
 
-using hipdnn_data_sdk::data_objects::EngineConfigT;
-using hipdnn_data_sdk::data_objects::UnPackEngineConfig;
+using hipdnn_flatbuffers_sdk::data_objects::EngineConfigT;
+using hipdnn_flatbuffers_sdk::data_objects::UnPackEngineConfig;
 
 /// RAII wrapper for loading a test plugin and accessing its knob recording functions.
 ///


### PR DESCRIPTION
## Summary

Migrates all FlatBuffers type usage from `hipdnn_data_sdk` to `hipdnn_flatbuffers_sdk` across the plugin SDK, test SDK, all four DNN providers, and the hipDNN test plugins. This is the consumer-side adoption of the `hipdnn_flatbuffers_sdk` library introduced in #6315.

Due to C++ nominal typing, virtual interface signatures in `plugin_sdk` (e.g., `IEngine`, `IPlanBuilder`) must exactly match their overrides in providers and test mocks. Changing these signatures from `hipdnn_data_sdk::flatbuffer_utilities::IGraph&` to `hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph&` forces an atomic migration of all downstream consumers.

### Changes by component

**hipdnn plugin_sdk** (12 files)
- Virtual interfaces (`IEngine`, `IPlanBuilder`) now use `hipdnn_flatbuffers_sdk` types
- `EngineManager`, `KnobFactory`, `KnobSettingFactory`, `PluginGraphTestUtils` updated
- CMake dependency: `hipdnn_flatbuffers_sdk` added

**hipdnn test_sdk** (103 files)
- Mock implementations (`MockGraph`, `MockNode`, `MockEngineConfig`) updated to match new interfaces
- All test utilities (`FlatbufferGraphTestUtils`, `FlatbufferDatatypeMapping`, `CpuFpReference*`, `SdkFrontendTypeConversions`, CPU graph executor) migrated
- CMake dependency: `hipdnn_flatbuffers_sdk` added

**dnn-providers** (159 files)
- **miopen-provider**: `MiopenEngine`, all plan builders, plans, utils, and tests
- **hipblaslt-provider**: `HipblasltEngine`, plan builder, plan, utils, and tests
- **hip-kernel-provider**: `HipKernelEngine`, all plan builders (including new RMSnorm backward), plans, utils, and tests
- **fusilli-provider**: plugin implementation, graph import, custom ops, and tests
- **integration-tests**: GPU reference executor, verification harness
- CMake: `find_package` and `target_link_libraries` updated in all providers

**hipdnn test_plugins** (5 files)
- Test plugin implementations updated to use `hipdnn_flatbuffers_sdk` types

## Test plan
- [x] hipblaslt-provider unit tests pass (115/115)
- [x] miopen-provider unit tests pass (1023/1029, 6 pre-existing failures)
- [x] hip-kernel-provider unit tests pass (242/246, 4 pre-existing failures)
- [x] hipdnn core tests pass (9/9 suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)