### PR TITLE
[hipDNN] Fix unstable user log test.

### DIFF
--- a/projects/hipdnn/backend/tests/TestUserLoggingApis.cpp
+++ b/projects/hipdnn/backend/tests/TestUserLoggingApis.cpp
@@ -467,15 +467,21 @@ TEST_F(IntegrationBackendUserLoggingApis, ConcurrentLoggingWithCallbackToggle)
     std::vector<std::thread> threads;
     threads.reserve(NUM_LOGGER_THREADS);
 
+    constexpr auto THREAD_SYNC_TIMEOUT = std::chrono::seconds(10);
+
     // Helper to wait until at least one log-generating thread has completed a full loop.
-    auto waitForIterations = [&](uint64_t snapshot) {
-        std::unique_lock<std::mutex> lock(mutex);
-        // The iteration count will need to increment by the number of threads plus one
-        // to ensure that at least one thread ran through the log generating section of code.
-        const uint64_t targetCount = snapshot + static_cast<uint64_t>(NUM_LOGGER_THREADS) + 1;
-        cvProgress.wait(lock, [&] { return iterationCount >= targetCount; });
-        return iterationCount;
-    };
+    auto waitForIterations
+        = [&](uint64_t snapshot) {
+              std::unique_lock<std::mutex> lock(mutex);
+              // The iteration count will need to increment by the number of threads plus one
+              // to ensure that at least one thread ran through the log generating section of code.
+              const uint64_t targetCount = snapshot + static_cast<uint64_t>(NUM_LOGGER_THREADS) + 1;
+              const bool completed = cvProgress.wait_for(
+                  lock, THREAD_SYNC_TIMEOUT, [&] { return iterationCount >= targetCount; });
+              EXPECT_TRUE(completed)
+                  << "Timeout waiting for log-generating threads to complete iterations";
+              return iterationCount;
+          };
 
     // Register the user callback and set log level
     registerIsolatedCallback(HIPDNN_SEV_INFO, HIPDNN_LOG_CALLBACK_ASYNC);
@@ -523,7 +529,9 @@ TEST_F(IntegrationBackendUserLoggingApis, ConcurrentLoggingWithCallbackToggle)
     // Wait for all log-generating threads to be ready, then start them
     {
         std::unique_lock<std::mutex> lock(mutex);
-        cvProgress.wait(lock, [&] { return threadsReady == NUM_LOGGER_THREADS; });
+        const bool allReady = cvProgress.wait_for(
+            lock, THREAD_SYNC_TIMEOUT, [&] { return threadsReady == NUM_LOGGER_THREADS; });
+        ASSERT_TRUE(allReady) << "Timeout waiting for log-generating threads to become ready";
         startFlag = true;
     }
     cvStart.notify_all();

--- a/projects/hipdnn/backend/tests/TestUserLoggingApis.cpp
+++ b/projects/hipdnn/backend/tests/TestUserLoggingApis.cpp
@@ -5,6 +5,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <hipdnn_data_sdk/utilities/PlatformUtils.hpp>
@@ -12,6 +13,7 @@
 #include <hipdnn_test_sdk/utilities/ScopedEnvironmentVariableSetter.hpp>
 #include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
 #include <logging/Logging.hpp>
+#include <mutex>
 #include <regex>
 #include <stdexcept>
 #include <string>
@@ -455,10 +457,25 @@ TEST_F(IntegrationBackendUserLoggingApis, ConcurrentLoggingWithCallbackToggle)
     auto recorder = IsolatedLogRecorder::withOverrideLevel(HIPDNN_SEV_INFO);
 
     constexpr int NUM_LOGGER_THREADS = 4;
-    std::atomic<bool> startFlag{false};
-    std::atomic<bool> stopFlag{false};
+    std::mutex mutex;
+    std::condition_variable cvStart; // Main -> logger threads: start/stop signals
+    std::condition_variable cvProgress; // Logger threads -> main: iteration progress
+    bool startFlag = false;
+    bool stopFlag = false;
+    uint64_t iterationCount = 0;
+    int threadsReady = 0;
     std::vector<std::thread> threads;
     threads.reserve(NUM_LOGGER_THREADS);
+
+    // Helper to wait until at least one log-generating thread has completed a full loop.
+    auto waitForIterations = [&](uint64_t snapshot) {
+        std::unique_lock<std::mutex> lock(mutex);
+        // The iternation count will need to imcrement by the number of threads plus one
+        // to ensure that at least one thread ran through the log generating section of code.
+        const uint64_t targetCount = snapshot + static_cast<uint64_t>(NUM_LOGGER_THREADS) + 1;
+        cvProgress.wait(lock, [&] { return iterationCount >= targetCount; });
+        return iterationCount;
+    };
 
     // Register the user callback and set log level
     registerIsolatedCallback(HIPDNN_SEV_INFO, HIPDNN_LOG_CALLBACK_ASYNC);
@@ -468,29 +485,53 @@ TEST_F(IntegrationBackendUserLoggingApis, ConcurrentLoggingWithCallbackToggle)
     for(int i = 0; i < NUM_LOGGER_THREADS; ++i)
     {
         threads.emplace_back([&]() {
-            while(!startFlag.load())
             {
-                std::this_thread::yield();
+                std::unique_lock<std::mutex> lock(mutex);
+                ++threadsReady;
+                cvProgress.notify_one(); // Notify main thread that this thread is ready
+                cvStart.wait(lock, [&] { return startFlag; }); // Wait for start.
             }
 
-            while(!stopFlag.load())
+            hipdnnHandle_t handle = nullptr;
+
+            while(true)
             {
-                hipdnnHandle_t handle = nullptr;
-                hipdnnCreate(&handle);
-                if(handle != nullptr)
+                if(handle == nullptr)
+                {
+                    hipdnnCreate(&handle);
+                }
+                else
                 {
                     hipdnnDestroy(handle);
+                    handle = nullptr;
                 }
-                std::this_thread::yield();
+
+                {
+                    const std::lock_guard<std::mutex> lock(mutex);
+                    ++iterationCount;
+                    if(stopFlag && handle == nullptr)
+                    {
+                        cvProgress.notify_all();
+                        break;
+                    }
+                }
+                cvProgress.notify_all();
             }
         });
     }
 
-    // Start all logger threads
-    startFlag.store(true);
+    // Wait for all log-generating threads to be ready, then start them
+    {
+        std::unique_lock<std::mutex> lock(mutex);
+        cvProgress.wait(lock, [&] { return threadsReady == NUM_LOGGER_THREADS; });
+        startFlag = true;
+    }
+    cvStart.notify_all();
 
     // Control thread behavior: toggle callback on and off
-    constexpr int NUM_CYCLES = 4;
+    constexpr int NUM_CYCLES = 8;
+    constexpr auto LOG_WAIT_TIMEOUT = std::chrono::milliseconds(500);
+
     for(int cycle = 0; cycle < NUM_CYCLES; ++cycle)
     {
         // Use async mode for even cycles, sync mode for odd cycles
@@ -500,9 +541,24 @@ TEST_F(IntegrationBackendUserLoggingApis, ConcurrentLoggingWithCallbackToggle)
         registerIsolatedCallback(HIPDNN_SEV_INFO, mode);
 
         const size_t countBefore = recorder.getRecordedLogCount();
-        std::this_thread::sleep_for(std::chrono::milliseconds(50));
-        const size_t countAfterEnabled = recorder.getRecordedLogCount();
+        uint64_t iterSnapshot;
+        {
+            const std::lock_guard<std::mutex> lock(mutex);
+            iterSnapshot = iterationCount;
+        }
+        waitForIterations(iterSnapshot);
 
+        // For async mode, wait for logs to be delivered from the queue.
+        // For sync mode, logs are immediate so no wait needed.
+        if(mode == HIPDNN_LOG_CALLBACK_ASYNC)
+        {
+            const bool logReceived = recorder.waitForLogCount(countBefore + 1, LOG_WAIT_TIMEOUT);
+            EXPECT_TRUE(logReceived)
+                << "Timed out waiting for logs (cycle " << cycle
+                << ", mode=" << (mode == HIPDNN_LOG_CALLBACK_ASYNC ? "async" : "sync") << ")";
+        }
+
+        const size_t countAfterEnabled = recorder.getRecordedLogCount();
         EXPECT_GT(countAfterEnabled, countBefore)
             << "Log count should increase when callback is registered (cycle " << cycle
             << ", mode=" << (mode == HIPDNN_LOG_CALLBACK_ASYNC ? "async" : "sync") << ")";
@@ -511,16 +567,30 @@ TEST_F(IntegrationBackendUserLoggingApis, ConcurrentLoggingWithCallbackToggle)
         registerIsolatedCallback(HIPDNN_SEV_OFF, mode);
 
         const size_t countBeforeDisabled = recorder.getRecordedLogCount();
-        std::this_thread::sleep_for(std::chrono::milliseconds(50));
-        const size_t countAfterDisabled = recorder.getRecordedLogCount();
+        uint64_t iterSnapshotDisabled;
+        {
+            const std::lock_guard<std::mutex> lock(mutex);
+            iterSnapshotDisabled = iterationCount;
+        }
+        waitForIterations(iterSnapshotDisabled);
 
+        // For async mode, a short wait for any potential logs to arrive.
+        if(mode == HIPDNN_LOG_CALLBACK_ASYNC)
+        {
+            recorder.waitForLogCount(countBeforeDisabled + 1, std::chrono::milliseconds(50));
+        }
+
+        const size_t countAfterDisabled = recorder.getRecordedLogCount();
         EXPECT_EQ(countAfterDisabled, countBeforeDisabled)
             << "Log count should NOT increase when callback is unregistered (cycle " << cycle
-            << ")";
+            << ", mode=" << (mode == HIPDNN_LOG_CALLBACK_ASYNC ? "async" : "sync") << ")";
     }
 
-    // Stop all threads
-    stopFlag.store(true);
+    // Stop all threads - logger threads will see stopFlag after destroying their handle
+    {
+        const std::lock_guard<std::mutex> lock(mutex);
+        stopFlag = true;
+    }
     for(auto& t : threads)
     {
         t.join();

--- a/projects/hipdnn/backend/tests/TestUserLoggingApis.cpp
+++ b/projects/hipdnn/backend/tests/TestUserLoggingApis.cpp
@@ -470,7 +470,7 @@ TEST_F(IntegrationBackendUserLoggingApis, ConcurrentLoggingWithCallbackToggle)
     // Helper to wait until at least one log-generating thread has completed a full loop.
     auto waitForIterations = [&](uint64_t snapshot) {
         std::unique_lock<std::mutex> lock(mutex);
-        // The iternation count will need to imcrement by the number of threads plus one
+        // The iteration count will need to increment by the number of threads plus one
         // to ensure that at least one thread ran through the log generating section of code.
         const uint64_t targetCount = snapshot + static_cast<uint64_t>(NUM_LOGGER_THREADS) + 1;
         cvProgress.wait(lock, [&] { return iterationCount >= targetCount; });

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/LogRecorder.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/LogRecorder.hpp
@@ -8,6 +8,8 @@
 #include <hipdnn_data_sdk/logging/Logger.hpp>
 
 #include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <iostream>
 #include <mutex>
 #include <sstream>
@@ -86,8 +88,11 @@ public:
             return;
         }
 
-        const std::lock_guard<std::mutex> lock(_logsMutex);
-        _recordedLogs.push_back({severity, message});
+        {
+            const std::lock_guard<std::mutex> lock(_logsMutex);
+            _recordedLogs.push_back({severity, message});
+        }
+        _cvLogRecorded.notify_all();
     }
 
     void clearLogs()
@@ -108,6 +113,19 @@ public:
         return _recordedLogs.size();
     }
 
+    /**
+     * @brief Wait until log count reaches target, with timeout
+     * @param targetCount The target log count to wait for
+     * @param timeout Maximum time to wait
+     * @return true if target reached, false if timed out
+     */
+    bool waitForLogCount(size_t targetCount, std::chrono::milliseconds timeout)
+    {
+        std::unique_lock<std::mutex> lock(_logsMutex);
+        return _cvLogRecorded.wait_for(
+            lock, timeout, [&] { return _recordedLogs.size() >= targetCount; });
+    }
+
     LogRecording(const LogRecording&) = delete;
     LogRecording& operator=(const LogRecording&) = delete;
 
@@ -116,6 +134,7 @@ private:
     ~LogRecording() = default;
 
     mutable std::mutex _logsMutex;
+    std::condition_variable _cvLogRecorded;
     std::atomic<bool> _isRecording{false};
     std::vector<RecordedLog> _recordedLogs;
 };
@@ -356,6 +375,17 @@ public:
     void clearLogs()
     {
         LogRecording::instance(_recordingId).clearLogs();
+    }
+
+    /**
+     * @brief Wait until log count reaches target, with timeout
+     * @param targetCount The target log count to wait for
+     * @param timeout Maximum time to wait
+     * @return true if target reached, false if timed out
+     */
+    bool waitForLogCount(size_t targetCount, std::chrono::milliseconds timeout)
+    {
+        return LogRecording::instance(_recordingId).waitForLogCount(targetCount, timeout);
     }
 
 protected:


### PR DESCRIPTION
## Motivation

Test was susceptible to race conditions.

## Technical Details

Replaced sleep() with signals between threads to ensure threads were run to generate the needed data for the test.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
