### PR TITLE
[hipBLAS] reuse device mem API as fallback

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       id-token: write
     container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:d6ae5712a9c7e8b88281d021e907b312cd8a26295b95690baef3e8dde4805858
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:4443d9d710b9471e8ef658d509358bd92602498e67161b9280474bce0bb0decd
       options: -v /runner/config:/home/awsconfig/
     strategy:
       fail-fast: true

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       id-token: write
     container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:4443d9d710b9471e8ef658d509358bd92602498e67161b9280474bce0bb0decd
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:d6ae5712a9c7e8b88281d021e907b312cd8a26295b95690baef3e8dde4805858
       options: -v /runner/config:/home/awsconfig/
     strategy:
       fail-fast: true

--- a/projects/hipblas/library/src/amd_detail/hipblas.cpp
+++ b/projects/hipblas/library/src/amd_detail/hipblas.cpp
@@ -57,7 +57,11 @@ static hipblasStatus_t hipblasDemandAlloc(rocblas_handle                   handl
                     status = hipblasConvertStatus(blas_status);
                 else
                 {
-                    status = func();
+                    blas_status = rocblas_set_device_memory_size(handle, size);
+                    if(blas_status != rocblas_status_success)
+                        status = hipblasConvertStatus(blas_status);
+                    else
+                        status = func();
                 }
             }
         }


### PR DESCRIPTION
## Motivation

This pull request updates the device memory allocation logic in the `hipblasDemandAlloc` function to fallback to use the deprecated rocblas API to set the device memory size in the handle.   When the deprecated API is removed the on demand realloc will have to cover these use cases.
