### PR TITLE
[hipDNN] [ALMIOPEN-1742] Adding --skip-graph-validation flag to integration tests

### DIFF
--- a/dnn-providers/integration-tests/src/harness/IntegrationGraphVerificationHarness.hpp
+++ b/dnn-providers/integration-tests/src/harness/IntegrationGraphVerificationHarness.hpp
@@ -129,6 +129,14 @@ protected:
             }
         }
 
+        // --skip-graph-validation: graph is confirmed supported, exit early with PASS
+        if(TestConfig::get().skipGraphValidation())
+        {
+            HIPDNN_PLUGIN_LOG_INFO("--skip-graph-validation: graph is supported, skipping "
+                                   "execution and validation");
+            return;
+        }
+
         // Build execution plans, engine preference set above should ensure that
         // correct engine is selected.
         auto result = graph.create_execution_plans();

--- a/dnn-providers/integration-tests/src/harness/IntegrationGraphVerificationHarness.hpp
+++ b/dnn-providers/integration-tests/src/harness/IntegrationGraphVerificationHarness.hpp
@@ -132,8 +132,6 @@ protected:
         // --skip-graph-validation: graph is confirmed supported, exit early with PASS
         if(TestConfig::get().skipGraphValidation())
         {
-            HIPDNN_PLUGIN_LOG_INFO("--skip-graph-validation: graph is supported, skipping "
-                                   "execution and validation");
             return;
         }
 

--- a/dnn-providers/integration-tests/src/harness/TestConfig.hpp
+++ b/dnn-providers/integration-tests/src/harness/TestConfig.hpp
@@ -46,6 +46,7 @@ public:
     static void initialize(std::optional<std::filesystem::path> articlePath,
                            std::optional<std::string> engineName,
                            bool failOnUnsupported = false,
+                           bool skipGraphValidation = false,
                            std::optional<std::filesystem::path> configPath = std::nullopt)
     {
         TestConfig& instance = get();
@@ -56,6 +57,7 @@ public:
         instance._articlePath = std::move(articlePath);
         instance._engineName = std::move(engineName);
         instance._failOnUnsupported = failOnUnsupported;
+        instance._skipGraphValidation = skipGraphValidation;
 
         if(configPath.has_value())
         {
@@ -81,6 +83,12 @@ public:
     {
         throwIfNotInitialized();
         return _failOnUnsupported;
+    }
+
+    bool skipGraphValidation() const
+    {
+        throwIfNotInitialized();
+        return _skipGraphValidation;
     }
 
     // Get the article (plugin .so) path. Throws if not provided.
@@ -157,6 +165,7 @@ private:
     std::optional<std::string> _engineName;
     std::optional<TestSettings> _testSettings;
     bool _failOnUnsupported = false;
+    bool _skipGraphValidation = false;
     bool _initialized = false;
 };
 

--- a/dnn-providers/integration-tests/src/integration_tests/batchnorm/IntegrationGpuBatchnormBackward.cpp
+++ b/dnn-providers/integration-tests/src/integration_tests/batchnorm/IntegrationGpuBatchnormBackward.cpp
@@ -160,9 +160,6 @@ protected:
         this->registerValidator(outputs.dscale, this->getTolerance(graphObj, outputs.dscale));
         this->registerValidator(outputs.dbias, this->getTolerance(graphObj, outputs.dbias));
 
-        // Force execution on the specific engine that claimed capability
-        graphObj.set_preferred_engine_id_ext(TestConfig::get().getEngineId());
-
         this->verifyGraph(graphObj, bnTestCase.seed);
     }
 };

--- a/dnn-providers/integration-tests/src/integration_tests/batchnorm/IntegrationGpuBatchnormForwardInference.cpp
+++ b/dnn-providers/integration-tests/src/integration_tests/batchnorm/IntegrationGpuBatchnormForwardInference.cpp
@@ -108,9 +108,6 @@ protected:
 
         this->registerValidator(outputs.y, this->getTolerance(graphObj, outputs.y));
 
-        // Force execution on the specific engine that claimed capability
-        graphObj.set_preferred_engine_id_ext(TestConfig::get().getEngineId());
-
         this->verifyGraph(graphObj, bnTestCase.seed);
     }
 };

--- a/dnn-providers/integration-tests/src/integration_tests/batchnorm/IntegrationGpuBatchnormForwardTraining.cpp
+++ b/dnn-providers/integration-tests/src/integration_tests/batchnorm/IntegrationGpuBatchnormForwardTraining.cpp
@@ -266,9 +266,6 @@ protected:
                                     this->getTolerance(graphObj, outputs.nextRunningVariance));
         }
 
-        // Force execution on the specific engine that claimed capability
-        graphObj.set_preferred_engine_id_ext(TestConfig::get().getEngineId());
-
         this->verifyGraph(graphObj, bnTestCase.seed);
     }
 };

--- a/dnn-providers/integration-tests/src/integration_tests/conv/IntegrationGpuConvBackwardData.cpp
+++ b/dnn-providers/integration-tests/src/integration_tests/conv/IntegrationGpuConvBackwardData.cpp
@@ -84,8 +84,6 @@ public:
 protected:
     void runGraphTest() override
     {
-        SKIP_IF_WINDOWS();
-
         const auto& testCase = this->GetParam();
         const auto& [layout, convTestCase] = testCase;
 

--- a/dnn-providers/integration-tests/src/integration_tests/conv/IntegrationGpuConvBackwardWeights.cpp
+++ b/dnn-providers/integration-tests/src/integration_tests/conv/IntegrationGpuConvBackwardWeights.cpp
@@ -84,8 +84,6 @@ public:
 protected:
     void runGraphTest() override
     {
-        SKIP_IF_WINDOWS();
-
         const auto& testCase = this->GetParam();
         const auto& [layout, convTestCase] = testCase;
 

--- a/dnn-providers/integration-tests/src/integration_tests/conv/IntegrationGpuConvFwdBiasActiv.cpp
+++ b/dnn-providers/integration-tests/src/integration_tests/conv/IntegrationGpuConvFwdBiasActiv.cpp
@@ -129,8 +129,6 @@ public:
 protected:
     void runGraphTest() override
     {
-        SKIP_IF_WINDOWS();
-
         const auto& testCase = this->GetParam();
         const auto& [layout, convTestCase, doBias, activTestCase] = testCase;
 

--- a/dnn-providers/integration-tests/src/main.cpp
+++ b/dnn-providers/integration-tests/src/main.cpp
@@ -98,6 +98,11 @@ int main(int argc, char** argv) noexcept
             .default_value(false)
             .implicit_value(true)
             .help("FAIL instead of SKIP when no engine supports a graph");
+        parser.add_argument("--skip-graph-validation")
+            .default_value(false)
+            .implicit_value(true)
+            .help("PASS immediately after confirming engine support, "
+                  "without executing or validating the graph");
         parser.add_argument("--tc", "--test-config")
             .help("Path to a TOML configuration file for per-test tolerance overrides.");
 
@@ -120,6 +125,7 @@ int main(int argc, char** argv) noexcept
             engineName = parser.get<std::string>("--test-engine");
         }
         auto failOnUnsupported = parser.get<bool>("--fail-on-unsupported");
+        auto skipGraphValidation = parser.get<bool>("--skip-graph-validation");
 
         std::optional<std::filesystem::path> configPath;
         if(parser.is_used("--test-config"))
@@ -166,6 +172,7 @@ int main(int argc, char** argv) noexcept
         hipdnn_integration_tests::TestConfig::initialize(std::move(articlePath),
                                                          std::move(engineName),
                                                          failOnUnsupported,
+                                                         skipGraphValidation,
                                                          std::move(configPath));
 
         // Reconstruct argc/argv for GTest from remaining (unknown) args.

--- a/dnn-providers/integration-tests/tests/TestTestConfig.cpp
+++ b/dnn-providers/integration-tests/tests/TestTestConfig.cpp
@@ -57,6 +57,11 @@ TEST(TestConfigUninitialized, FailOnUnsupportedThrowsWhenUninitialized)
     EXPECT_THROW(TestConfig::get().failOnUnsupported(), std::runtime_error);
 }
 
+TEST(TestConfigUninitialized, SkipGraphValidationThrowsWhenUninitialized)
+{
+    EXPECT_THROW(TestConfig::get().skipGraphValidation(), std::runtime_error);
+}
+
 // ---------------------------------------------------------------------------
 // Suite 2 – initialized singleton (all args provided)
 // ---------------------------------------------------------------------------
@@ -90,6 +95,11 @@ TEST_F(TestConfigInitialized, HasEngineNameReturnsTrue)
 TEST_F(TestConfigInitialized, FailOnUnsupportedReturnsTrue)
 {
     EXPECT_TRUE(TestConfig::get().failOnUnsupported());
+}
+
+TEST_F(TestConfigInitialized, SkipGraphValidationReturnsFalse)
+{
+    EXPECT_FALSE(TestConfig::get().skipGraphValidation());
 }
 
 TEST_F(TestConfigInitialized, InitializeSetsArticlePath)


### PR DESCRIPTION
## Motivation
It would be useful if the integration test suite could quick-exit if support was detected for a given graph (as indicated by the plugin asserting applicability).  Using this in conjunction with a future flag that would allow output of a support matrix would allow a user to use this tool to quickly understand which graphs a plugin / engine (or indeed all plugins and engines in total) can support.

## Technical Details
- Added `--skip-graph-validation flag` to hipdnn_integration_tests executable target.
- Added unit tests for coverage

## Test Plan
- Manually ran the integration test suite with and without the arguments
- Run all unit and integration tests

## Test Result
- [x] Manual testing succeeded
- [x] Unit and integration tests succeed

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
