### PR TITLE
[hipDNN] Clone PointwiseValidation into hipdnn_flatbuffers_sdk

### DIFF
--- a/projects/hipdnn/flatbuffers_sdk/include/hipdnn_flatbuffers_sdk/utilities/PointwiseValidation.hpp
+++ b/projects/hipdnn/flatbuffers_sdk/include/hipdnn_flatbuffers_sdk/utilities/PointwiseValidation.hpp
@@ -1,0 +1,173 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <bitset>
+#include <hipdnn_flatbuffers_sdk/data_objects/pointwise_attributes_generated.h>
+
+namespace hipdnn_flatbuffers_sdk::utilities
+{
+
+// Bitset size based on the maximum PointwiseMode value + 1
+static constexpr size_t POINTWISE_MODE_COUNT
+    = static_cast<size_t>(data_objects::PointwiseMode::MAX) + 1;
+
+using PointwiseModeBitset = std::bitset<POINTWISE_MODE_COUNT>;
+
+constexpr size_t toBitPosition(data_objects::PointwiseMode mode)
+{
+    return static_cast<size_t>(mode);
+}
+
+// Get operations that have implemented functors for unary operations
+inline const PointwiseModeBitset& getImplementedUnaryModesBitset()
+{
+    static const PointwiseModeBitset s_implementedUnaryModes = []() {
+        PointwiseModeBitset bitset;
+        // Only include operations with implemented functors in ReferencePointwiseBase
+        bitset.set(toBitPosition(data_objects::PointwiseMode::RELU_FWD));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::SIGMOID_FWD));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::TANH_FWD));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::ABS));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::NEG));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::GELU_FWD));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::GELU_APPROX_TANH_FWD));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::SWISH_FWD));
+        return bitset;
+    }();
+    return s_implementedUnaryModes;
+}
+
+// Get operations that have implemented functors for binary operations
+inline const PointwiseModeBitset& getImplementedBinaryModesBitset()
+{
+    static const PointwiseModeBitset s_implementedBinaryModes = []() {
+        PointwiseModeBitset bitset;
+        // Only include operations with implemented functors in ReferencePointwiseBase
+        bitset.set(toBitPosition(data_objects::PointwiseMode::ADD));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::SUB));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::MUL));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::RELU_BWD));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::SIGMOID_BWD));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::TANH_BWD));
+        return bitset;
+    }();
+    return s_implementedBinaryModes;
+}
+
+// Get all unary operations (for frontend compatibility)
+inline const PointwiseModeBitset& getUnaryModesBitset()
+{
+    static const PointwiseModeBitset s_unaryModes = []() {
+        PointwiseModeBitset bitset;
+        bitset.set(toBitPosition(data_objects::PointwiseMode::ABS));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::CEIL));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::ELU_FWD));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::ERF));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::EXP));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::FLOOR));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::GELU_APPROX_TANH_FWD));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::GELU_FWD));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::GEN_INDEX));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::IDENTITY));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::LOG));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::LOGICAL_NOT));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::NEG));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::RECIPROCAL));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::RELU_FWD));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::RSQRT));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::SIGMOID_FWD));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::SIN));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::SOFTPLUS_FWD));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::SQRT));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::SWISH_FWD));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::TAN));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::TANH_FWD));
+        return bitset;
+    }();
+    return s_unaryModes;
+}
+
+// Get all binary operations (for frontend compatibility)
+inline const PointwiseModeBitset& getBinaryModesBitset()
+{
+    static const PointwiseModeBitset s_binaryModes = []() {
+        PointwiseModeBitset bitset;
+        bitset.set(toBitPosition(data_objects::PointwiseMode::ADD));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::ADD_SQUARE));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::CMP_EQ));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::CMP_GE));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::CMP_GT));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::CMP_LE));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::CMP_LT));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::CMP_NEQ));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::DIV));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::ELU_BWD));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::GELU_APPROX_TANH_BWD));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::GELU_BWD));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::LOGICAL_AND));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::LOGICAL_OR));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::MAX_OP));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::MIN_OP));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::MUL));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::RELU_BWD));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::SIGMOID_BWD));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::SOFTPLUS_BWD));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::SUB));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::SWISH_BWD));
+        bitset.set(toBitPosition(data_objects::PointwiseMode::TANH_BWD));
+        return bitset;
+    }();
+    return s_binaryModes;
+}
+
+// Get all ternary operations (for frontend compatibility)
+inline const PointwiseModeBitset& getTernaryModesBitset()
+{
+    static const PointwiseModeBitset s_ternaryModes = []() {
+        PointwiseModeBitset bitset;
+        bitset.set(toBitPosition(data_objects::PointwiseMode::BINARY_SELECT));
+        return bitset;
+    }();
+    return s_ternaryModes;
+}
+
+inline bool isUnaryPointwiseMode(data_objects::PointwiseMode mode)
+{
+    auto position = toBitPosition(mode);
+    return position < POINTWISE_MODE_COUNT && getUnaryModesBitset().test(position);
+}
+
+inline bool isBinaryPointwiseMode(data_objects::PointwiseMode mode)
+{
+    auto position = toBitPosition(mode);
+    return position < POINTWISE_MODE_COUNT && getBinaryModesBitset().test(position);
+}
+
+inline bool isTernaryPointwiseMode(data_objects::PointwiseMode mode)
+{
+    auto position = toBitPosition(mode);
+    return position < POINTWISE_MODE_COUNT && getTernaryModesBitset().test(position);
+}
+
+// Check if operations have implemented functors (for ReferencePointwiseBase usage)
+inline bool isImplementedUnaryPointwiseMode(data_objects::PointwiseMode mode)
+{
+    auto position = toBitPosition(mode);
+    return position < POINTWISE_MODE_COUNT && getImplementedUnaryModesBitset().test(position);
+}
+
+inline bool isImplementedBinaryPointwiseMode(data_objects::PointwiseMode mode)
+{
+    auto position = toBitPosition(mode);
+    return position < POINTWISE_MODE_COUNT && getImplementedBinaryModesBitset().test(position);
+}
+
+inline bool isImplementedTernaryPointwiseMode(data_objects::PointwiseMode /* mode */)
+{
+    // Currently no ternary operations are implemented
+    return false;
+}
+
+} // namespace hipdnn_flatbuffers_sdk::utilities

--- a/projects/hipdnn/flatbuffers_sdk/tests/CMakeLists.txt
+++ b/projects/hipdnn/flatbuffers_sdk/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(
     flatbuffer_utilities/TestKnobSettingWrapper.cpp
     flatbuffer_utilities/TestTensorAttributesWrapper.cpp
     utilities/TestJson.cpp
+    utilities/TestPointwiseValidation.cpp
 )
 
 target_compile_options(hipdnn_flatbuffers_sdk_tests PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS} ${HIPDNN_NO_RTTI_OPTIONS})

--- a/projects/hipdnn/flatbuffers_sdk/tests/utilities/TestPointwiseValidation.cpp
+++ b/projects/hipdnn/flatbuffers_sdk/tests/utilities/TestPointwiseValidation.cpp
@@ -1,0 +1,255 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <gtest/gtest.h>
+
+#include <hipdnn_flatbuffers_sdk/utilities/PointwiseValidation.hpp>
+
+using namespace hipdnn_flatbuffers_sdk::utilities;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
+
+TEST(TestPointwiseValidation, UnaryModesClassifiedCorrectly)
+{
+    // Test known unary operations
+    EXPECT_TRUE(isUnaryPointwiseMode(PointwiseMode::RELU_FWD));
+    EXPECT_TRUE(isUnaryPointwiseMode(PointwiseMode::SIGMOID_FWD));
+    EXPECT_TRUE(isUnaryPointwiseMode(PointwiseMode::TANH_FWD));
+    EXPECT_TRUE(isUnaryPointwiseMode(PointwiseMode::ABS));
+    EXPECT_TRUE(isUnaryPointwiseMode(PointwiseMode::NEG));
+    EXPECT_TRUE(isUnaryPointwiseMode(PointwiseMode::EXP));
+    EXPECT_TRUE(isUnaryPointwiseMode(PointwiseMode::LOG));
+    EXPECT_TRUE(isUnaryPointwiseMode(PointwiseMode::SQRT));
+
+    // Test that binary operations are NOT unary
+    EXPECT_FALSE(isUnaryPointwiseMode(PointwiseMode::ADD));
+    EXPECT_FALSE(isUnaryPointwiseMode(PointwiseMode::SUB));
+    EXPECT_FALSE(isUnaryPointwiseMode(PointwiseMode::MUL));
+    EXPECT_FALSE(isUnaryPointwiseMode(PointwiseMode::RELU_BWD));
+}
+
+TEST(TestPointwiseValidation, BinaryModesClassifiedCorrectly)
+{
+    // Test known binary operations
+    EXPECT_TRUE(isBinaryPointwiseMode(PointwiseMode::ADD));
+    EXPECT_TRUE(isBinaryPointwiseMode(PointwiseMode::SUB));
+    EXPECT_TRUE(isBinaryPointwiseMode(PointwiseMode::MUL));
+    EXPECT_TRUE(isBinaryPointwiseMode(PointwiseMode::DIV));
+    EXPECT_TRUE(isBinaryPointwiseMode(PointwiseMode::MAX_OP));
+    EXPECT_TRUE(isBinaryPointwiseMode(PointwiseMode::MIN_OP));
+    EXPECT_TRUE(isBinaryPointwiseMode(PointwiseMode::RELU_BWD));
+    EXPECT_TRUE(isBinaryPointwiseMode(PointwiseMode::SIGMOID_BWD));
+    EXPECT_TRUE(isBinaryPointwiseMode(PointwiseMode::TANH_BWD));
+
+    // Test that unary operations are NOT binary
+    EXPECT_FALSE(isBinaryPointwiseMode(PointwiseMode::RELU_FWD));
+    EXPECT_FALSE(isBinaryPointwiseMode(PointwiseMode::SIGMOID_FWD));
+    EXPECT_FALSE(isBinaryPointwiseMode(PointwiseMode::TANH_FWD));
+}
+
+TEST(TestPointwiseValidation, TernaryModesClassifiedCorrectly)
+{
+    // Test known ternary operations
+    EXPECT_TRUE(isTernaryPointwiseMode(PointwiseMode::BINARY_SELECT));
+
+    // Test that unary and binary operations are NOT ternary
+    EXPECT_FALSE(isTernaryPointwiseMode(PointwiseMode::RELU_FWD));
+    EXPECT_FALSE(isTernaryPointwiseMode(PointwiseMode::ADD));
+}
+
+TEST(TestPointwiseValidation, MutualExclusivityOfCategories)
+{
+    // Iterate through all pointwise modes and verify mutual exclusivity
+    for(int i = static_cast<int>(PointwiseMode::UNSET);
+        i <= static_cast<int>(PointwiseMode::TANH_FWD);
+        ++i)
+    {
+        auto mode = static_cast<PointwiseMode>(i);
+
+        const bool isUnary = isUnaryPointwiseMode(mode);
+        const bool isBinary = isBinaryPointwiseMode(mode);
+        const bool isTernary = isTernaryPointwiseMode(mode);
+
+        // Count how many categories this mode belongs to
+        const int categoryCount = (isUnary ? 1 : 0) + (isBinary ? 1 : 0) + (isTernary ? 1 : 0);
+
+        // Each mode should belong to exactly one category
+        EXPECT_LE(categoryCount, 1)
+            << "Mode " << static_cast<int>(mode) << " belongs to multiple categories";
+    }
+}
+
+TEST(TestPointwiseValidation, ImplementedUnaryModesAreSubset)
+{
+    // All implemented unary modes must be classified as unary
+    for(int i = static_cast<int>(PointwiseMode::UNSET);
+        i <= static_cast<int>(PointwiseMode::TANH_FWD);
+        ++i)
+    {
+        auto mode = static_cast<PointwiseMode>(i);
+
+        if(isImplementedUnaryPointwiseMode(mode))
+        {
+            EXPECT_TRUE(isUnaryPointwiseMode(mode))
+                << "Implemented unary mode " << static_cast<int>(mode)
+                << " should be classified as unary";
+        }
+    }
+}
+
+TEST(TestPointwiseValidation, ImplementedBinaryModesAreSubset)
+{
+    // All implemented binary modes must be classified as binary
+    for(int i = static_cast<int>(PointwiseMode::UNSET);
+        i <= static_cast<int>(PointwiseMode::TANH_FWD);
+        ++i)
+    {
+        auto mode = static_cast<PointwiseMode>(i);
+
+        if(isImplementedBinaryPointwiseMode(mode))
+        {
+            EXPECT_TRUE(isBinaryPointwiseMode(mode))
+                << "Implemented binary mode " << static_cast<int>(mode)
+                << " should be classified as binary";
+        }
+    }
+}
+
+TEST(TestPointwiseValidation, ImplementedTernaryModesAreSubset)
+{
+    // All implemented ternary modes must be classified as ternary
+    for(int i = static_cast<int>(PointwiseMode::UNSET);
+        i <= static_cast<int>(PointwiseMode::TANH_FWD);
+        ++i)
+    {
+        auto mode = static_cast<PointwiseMode>(i);
+
+        if(isImplementedTernaryPointwiseMode(mode))
+        {
+            EXPECT_TRUE(isTernaryPointwiseMode(mode))
+                << "Implemented ternary mode " << static_cast<int>(mode)
+                << " should be classified as ternary";
+        }
+    }
+}
+
+TEST(TestPointwiseValidation, KnownImplementedUnaryOperations)
+{
+    // Define which unary operations are currently implemented
+    const std::set<PointwiseMode> expectedImplementedUnary = {PointwiseMode::RELU_FWD,
+                                                              PointwiseMode::SIGMOID_FWD,
+                                                              PointwiseMode::TANH_FWD,
+                                                              PointwiseMode::ABS,
+                                                              PointwiseMode::NEG,
+                                                              PointwiseMode::GELU_FWD,
+                                                              PointwiseMode::GELU_APPROX_TANH_FWD,
+                                                              PointwiseMode::SWISH_FWD};
+
+    // Check all unary modes
+    for(size_t i = 0; i < POINTWISE_MODE_COUNT; ++i)
+    {
+        auto mode = static_cast<PointwiseMode>(i);
+
+        // Only check modes that are classified as unary
+        if(!isUnaryPointwiseMode(mode))
+        {
+            continue;
+        }
+
+        const bool isExpectedImplemented = expectedImplementedUnary.count(mode) > 0;
+        const bool isActuallyImplemented = isImplementedUnaryPointwiseMode(mode);
+
+        EXPECT_EQ(isActuallyImplemented, isExpectedImplemented)
+            << "Mode " << static_cast<int>(mode) << " implementation status mismatch";
+    }
+}
+
+TEST(TestPointwiseValidation, KnownImplementedBinaryOperations)
+{
+    // Define which binary operations are currently implemented
+    const std::set<PointwiseMode> expectedImplementedBinary = {PointwiseMode::ADD,
+                                                               PointwiseMode::SUB,
+                                                               PointwiseMode::MUL,
+                                                               PointwiseMode::RELU_BWD,
+                                                               PointwiseMode::SIGMOID_BWD,
+                                                               PointwiseMode::TANH_BWD};
+
+    // Check all binary modes
+    for(size_t i = 0; i < POINTWISE_MODE_COUNT; ++i)
+    {
+        auto mode = static_cast<PointwiseMode>(i);
+
+        // Only check modes that are classified as binary
+        if(!isBinaryPointwiseMode(mode))
+        {
+            continue;
+        }
+
+        const bool isExpectedImplemented = expectedImplementedBinary.count(mode) > 0;
+        const bool isActuallyImplemented = isImplementedBinaryPointwiseMode(mode);
+
+        EXPECT_EQ(isActuallyImplemented, isExpectedImplemented)
+            << "Mode " << static_cast<int>(mode) << " implementation status mismatch";
+    }
+}
+
+TEST(TestPointwiseValidation, BitsetConsistencyUnary)
+{
+    // Verify bitset-based helpers match individual function results
+    for(int i = static_cast<int>(PointwiseMode::UNSET);
+        i <= static_cast<int>(PointwiseMode::TANH_FWD);
+        ++i)
+    {
+        auto mode = static_cast<PointwiseMode>(i);
+
+        const bool isUnaryFromFunction = isUnaryPointwiseMode(mode);
+        const bool isImplementedFromFunction = isImplementedUnaryPointwiseMode(mode);
+
+        // If implemented, must be classified as unary
+        if(isImplementedFromFunction)
+        {
+            EXPECT_TRUE(isUnaryFromFunction) << "Mode " << static_cast<int>(mode)
+                                             << " is implemented but not classified as unary";
+        }
+    }
+}
+
+TEST(TestPointwiseValidation, BitsetConsistencyBinary)
+{
+    // Verify bitset-based helpers match individual function results
+    for(int i = static_cast<int>(PointwiseMode::UNSET);
+        i <= static_cast<int>(PointwiseMode::TANH_FWD);
+        ++i)
+    {
+        auto mode = static_cast<PointwiseMode>(i);
+
+        const bool isBinaryFromFunction = isBinaryPointwiseMode(mode);
+        const bool isImplementedFromFunction = isImplementedBinaryPointwiseMode(mode);
+
+        // If implemented, must be classified as binary
+        if(isImplementedFromFunction)
+        {
+            EXPECT_TRUE(isBinaryFromFunction) << "Mode " << static_cast<int>(mode)
+                                              << " is implemented but not classified as binary";
+        }
+    }
+}
+
+TEST(TestPointwiseValidation, AllModesAccountedFor)
+{
+    // UNSET is a special case - it should NOT be classified
+    EXPECT_FALSE(isUnaryPointwiseMode(PointwiseMode::UNSET));
+    EXPECT_FALSE(isBinaryPointwiseMode(PointwiseMode::UNSET));
+    EXPECT_FALSE(isTernaryPointwiseMode(PointwiseMode::UNSET));
+
+    // All other modes MUST be classified as unary, binary, or ternary
+    for(size_t i = 1; i < POINTWISE_MODE_COUNT; ++i) // Start from 1 to skip UNSET
+    {
+        auto mode = static_cast<PointwiseMode>(i);
+
+        const bool isClassified = isUnaryPointwiseMode(mode) || isBinaryPointwiseMode(mode)
+                                  || isTernaryPointwiseMode(mode);
+
+        EXPECT_TRUE(isClassified) << "Mode " << static_cast<int>(mode)
+                                  << " must be classified as unary, binary, or ternary";
+    }
+}


### PR DESCRIPTION
## Summary
- Clones `PointwiseValidation.hpp` from `hipdnn_data_sdk::utilities` into `hipdnn_flatbuffers_sdk::utilities` with the correct namespace and include path
- Enables downstream consumers (test_sdk pointwise utilities) to call `isUnaryPointwiseMode()`, `isImplementedUnaryPointwiseMode()`, etc. with `hipdnn_flatbuffers_sdk::data_objects::PointwiseMode` directly

## Context
The flatbuffers SDK migration (PR #6470) migrated test_sdk to use `hipdnn_flatbuffers_sdk::data_objects::PointwiseMode`, but `PointwiseValidation.hpp` only existed in `hipdnn_data_sdk`. 

## Test plan
- [x] Verify hipdnn builds with `ninja check` in `projects/hipdnn/build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)