### PR TITLE
[CI] Bump TheRock pin; sync ccache preset (#4402) and manylinux image

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Setup ccache
         run: |
           ./TheRock/build_tools/setup_ccache.py \
-            --config-preset "github-oss-presubmit" \
+            --config-preset "github-oss-dev" \
             --dir "$(dirname $CCACHE_CONFIGPATH)" \
             --local-path "$CACHE_DIR/ccache"
 

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: b68757b3461145b85eabec29cea1223027a56da0 # 2026-04-01
+          ref: 2d9260c2b1c87175539a9fc45a2e9513ed36aff6 # 2026-04-16
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       id-token: write
     container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:4443d9d710b9471e8ef658d509358bd92602498e67161b9280474bce0bb0decd
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:d6ae5712a9c7e8b88281d021e907b312cd8a26295b95690baef3e8dde4805858
       options: -v /runner/config:/home/awsconfig/
     strategy:
       fail-fast: true

--- a/.github/workflows/therock-ci-nightly.yml
+++ b/.github/workflows/therock-ci-nightly.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: b68757b3461145b85eabec29cea1223027a56da0 # 2026-04-01
+          ref: 2d9260c2b1c87175539a9fc45a2e9513ed36aff6 # 2026-04-16
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: b68757b3461145b85eabec29cea1223027a56da0 # 2026-04-01
+          ref: 2d9260c2b1c87175539a9fc45a2e9513ed36aff6 # 2026-04-16
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: b68757b3461145b85eabec29cea1223027a56da0 # 2026-04-01
+          ref: 2d9260c2b1c87175539a9fc45a2e9513ed36aff6 # 2026-04-16
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: b68757b3461145b85eabec29cea1223027a56da0 # 2026-04-01
+          ref: 2d9260c2b1c87175539a9fc45a2e9513ed36aff6 # 2026-04-16
 
       - name: Configure git for long paths on Windows
         if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: b68757b3461145b85eabec29cea1223027a56da0 # 2026-04-01
+          ref: 2d9260c2b1c87175539a9fc45a2e9513ed36aff6 # 2026-04-16
 
       - name: Setting up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0


### PR DESCRIPTION
## Summary

- Pins CI’s `ROCm/TheRock` checkout to commit `2d9260c2b1c87175539a9fc45a2e9513ed36aff6`.
- Aligns Linux CI with current TheRock tooling: **ccache preset rename** and a **newer manylinux build image** (digest update).

## Motivation

**TheRock revision:** CI should build and test against the intended TheRock commit (including validation needed for related work).

**Ccache:** Upstream renamed ccache config presets ([TheRock#4402](https://github.com/ROCm/TheRock/pull/4402)): `github-oss-presubmit` → `github-oss-dev`, `github-oss-postsubmit` → `github-oss-release`. The old `--config-preset github-oss-presubmit` is no longer valid in `setup_ccache.py`, so Linux builds fail at ccache setup until workflows use `github-oss-dev`.

**Container image:** The pinned `therock_build_manylinux_x86_64` image was older than what current TheRock builds expect. The updated digest matches the image used in TheRock’s portable Linux artifact workflows and includes dependencies required by the sysdeps path (e.g. **libnl** configure needing **flex**).

## Related PRs

These PRs depend on this change for testing:

- #6361
- #6443

## Changes

- Sets TheRock `ref:` on the checkout step in: `therock-ci-linux.yml`, `therock-ci.yml`, `therock-ci-nightly.yml`, `therock-ci-windows.yml`, `therock-test-packages.yml`, `therock-test-component.yml`.
- In `therock-ci-linux.yml`: `--config-preset "github-oss-dev"` for `./TheRock/build_tools/setup_ccache.py`.
- In `therock-ci-linux.yml`: bump `therock_build_manylinux_x86_64` image digest to `sha256:d6ae5712a9c7e8b88281d021e907b312cd8a26295b95690baef3e8dde4805858`.

## Testing

- [ ] Confirm TheRock CI (Linux/Windows as applicable) passes on this PR.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
