### PR TITLE
[rocsparse][hipsparse] Expand csr2csr_compress testing to include complex tolerances

### DIFF
--- a/projects/hipsparse/clients/include/testing_csr2csr_compress.hpp
+++ b/projects/hipsparse/clients/include/testing_csr2csr_compress.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -313,7 +313,7 @@ void testing_csr2csr_compress(Arguments argus)
 {
     int                  m        = argus.M;
     int                  n        = argus.N;
-    T                    tol      = make_DataType<T>(argus.alpha);
+    T                    tol      = make_DataType<T>(argus.alpha, argus.alphai);
     hipsparseIndexBase_t idx_base = argus.baseA;
     std::string          filename = argus.filename;
 

--- a/projects/hipsparse/clients/tests/rocm/test_csr2csr_compress.yaml
+++ b/projects/hipsparse/clients/tests/rocm/test_csr2csr_compress.yaml
@@ -38,6 +38,7 @@ Tests:
   M: [10, 500, 872, 27463]
   N: [33, 242, 623, 29837]
   alpha: [0.08736, 0.33333]
+  alphai: [0.5, 1.0]
   baseA: [HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE]
 
 - name: csr2csr_compress_file
@@ -46,6 +47,7 @@ Tests:
   precision: *single_double_precisions_complex_real
   M: 1
   alpha: [0.0, 0.05, 0.25, 0.67, 0.8, 1.0]
+  alphai: [0.0, 0.7, 0.9, 1.0]
   baseA: [HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE]
   filename: [nos1,
              nos2,
@@ -61,6 +63,7 @@ Tests:
   precision: *single_only_precisions
   M: 1
   alpha: [0.0, 0.1, 0.5]
+  alphai: [0.0]
   baseA: [HIPSPARSE_INDEX_BASE_ZERO]
   filename: [rma10,
              shipsec1,

--- a/projects/hipsparse/clients/tests/test_csr2csr_compress.cpp
+++ b/projects/hipsparse/clients/tests/test_csr2csr_compress.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/projects/hipsparse/clients/tests/test_csr2csr_compress.cpp
+++ b/projects/hipsparse/clients/tests/test_csr2csr_compress.cpp
@@ -24,4 +24,4 @@
 #include "test.hpp"
 #include "testing_csr2csr_compress.hpp"
 
-TEST_ROUTINE(csr2csr_compress, conversion, arg.M, arg.N, arg.alpha, arg.baseA);
+TEST_ROUTINE(csr2csr_compress, conversion, arg.M, arg.N, arg.alpha, arg.alphai, arg.baseA);

--- a/projects/rocsparse/clients/tests/test_csr2csr_compress.cpp
+++ b/projects/rocsparse/clients/tests/test_csr2csr_compress.cpp
@@ -26,4 +26,5 @@
 
 #include "testing_csr2csr_compress.hpp"
 
-TEST_ROUTINE(csr2csr_compress, conversion, arg.M, arg.N, arg.baseA, arg.alpha, arg.matrix);
+TEST_ROUTINE(
+    csr2csr_compress, conversion, arg.M, arg.N, arg.baseA, arg.alpha, arg.alphai, arg.matrix);

--- a/projects/rocsparse/clients/tests/test_csr2csr_compress.yaml
+++ b/projects/rocsparse/clients/tests/test_csr2csr_compress.yaml
@@ -28,23 +28,23 @@ include: rocsparse_common.yaml
 Definitions:
   - &tol_range_quick
     - { alpha:   1.0,   alphai:  0.0}
-    - { alpha:   0.002, alphai:  0.0}
-    - { alpha:   0.5,   alphai:  0.0}
-    - { alpha:   1.0,   alphai:  0.0}
-    - { alpha:   3.0,   alphai:  0.0}
+    - { alpha:   0.002, alphai:  0.1}
+    - { alpha:   0.5,   alphai:  0.2}
+    - { alpha:   1.0,   alphai:  1.0}
+    - { alpha:   3.0,   alphai:  0.4}
 
   - &tol_range_checkin
     - { alpha:   0.0, alphai:  0.0}
-    - { alpha:   2.7, alphai:  0.0}
-    - { alpha:   7.1, alphai:  0.0}
-    - { alpha:   8.3, alphai:  0.0}
+    - { alpha:   2.7, alphai:  0.5}
+    - { alpha:   7.1, alphai:  0.6}
+    - { alpha:   8.3, alphai:  0.9}
 
   - &tol_range_nightly
-    - { alpha:   0.0,    alphai:  0.0}
-    - { alpha:   0.0125, alphai:  0.0}
-    - { alpha:   0.7,    alphai:  0.0}
-    - { alpha:   4.5,    alphai:  0.0}
-    - { alpha:   8.9,    alphai:  0.0}
+    - { alpha:   0.0,    alphai:  1.0}
+    - { alpha:   0.0125, alphai:  0.5}
+    - { alpha:   0.7,    alphai:  2.0}
+    - { alpha:   4.5,    alphai:  0.7}
+    - { alpha:   8.9,    alphai:  0.1}
 
 Tests:
 - name: csr2csr_compress_bad_arg


### PR DESCRIPTION
## Motivation

Previously when testing `rocsparse_Xcsr2csr_compress` or `hipsparseXcsr2csr_compress` routines we were using only zeros for the complex tolerance. This PR expands the tolerances to include complex numbers in the tolerance.
