### PR TITLE
[hipDNN][SDPA] Fix STATS dtype and add missing flags to backward test graph utility

### DIFF
--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp
@@ -1957,7 +1957,12 @@ inline flatbuffers::FlatBufferBuilder
         const std::vector<int64_t> statsStrides = {qDims[1] * qDims[2], qDims[2], 1, 1};
         const auto stUid = uid++;
         tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-            builder, stUid, "stats", dataType, &statsStrides, &statsDims));
+            builder,
+            stUid,
+            "stats",
+            hipdnn_data_sdk::data_objects::DataType::FLOAT,
+            &statsStrides,
+            &statsDims));
         statsUid = flatbuffers::Optional<int64_t>(stUid);
     }
 
@@ -2183,7 +2188,12 @@ inline flatbuffers::FlatBufferBuilder
     const std::vector<int64_t> statsStrides = {qDims[1] * qDims[2], qDims[2], 1, 1};
     const auto statsUid = uid++;
     tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, statsUid, "stats", dataType, &statsStrides, &statsDims));
+        builder,
+        statsUid,
+        "stats",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &statsStrides,
+        &statsDims));
 
     // Output gradient tensors (same shapes as Q, K, V)
     const auto dqUid = uid++;

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp
@@ -2154,7 +2154,11 @@ inline flatbuffers::FlatBufferBuilder
                             const std::vector<int64_t>& oDims = {2, 8, 16, 64},
                             const std::vector<int64_t>& oStrides = {8192, 1024, 64, 1},
                             hipdnn_data_sdk::data_objects::DataType dataType
-                            = hipdnn_data_sdk::data_objects::DataType::HALF)
+                            = hipdnn_data_sdk::data_objects::DataType::HALF,
+                            bool withScale = false,
+                            bool alibiMask = false,
+                            bool paddingMask = false,
+                            bool causalMask = false)
 {
     flatbuffers::FlatBufferBuilder builder;
     std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
@@ -2208,8 +2212,49 @@ inline flatbuffers::FlatBufferBuilder
     tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
         builder, dvUid, "dv", dataType, &vStrides, &vDims));
 
+    flatbuffers::Optional<int64_t> scaleUid = flatbuffers::nullopt;
+    if(withScale)
+    {
+        const std::vector<int64_t> passByValueDims = {1};
+        const hipdnn_data_sdk::data_objects::Float32Value scaleVal(1.0f);
+        const auto sUid = uid++;
+        tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+            builder,
+            sUid,
+            "scale",
+            hipdnn_data_sdk::data_objects::DataType::FLOAT,
+            &passByValueDims,
+            &passByValueDims,
+            false,
+            hipdnn_data_sdk::data_objects::TensorValue::Float32Value,
+            builder.CreateStruct(scaleVal).Union()));
+        scaleUid = flatbuffers::Optional<int64_t>(sUid);
+    }
+
     auto sdpaBwdAttributes = hipdnn_data_sdk::data_objects::CreateSdpaBackwardAttributes(
-        builder, qUid, kUid, vUid, oUid, doUid, statsUid, dqUid, dkUid, dvUid);
+        builder,
+        qUid,
+        kUid,
+        vUid,
+        oUid,
+        doUid,
+        statsUid,
+        dqUid,
+        dkUid,
+        dvUid,
+        scaleUid,
+        flatbuffers::nullopt, // attn_mask_tensor_uid
+        flatbuffers::nullopt, // seq_len_q_tensor_uid
+        flatbuffers::nullopt, // seq_len_kv_tensor_uid
+        flatbuffers::nullopt, // seed_tensor_uid
+        flatbuffers::nullopt, // offset_tensor_uid
+        flatbuffers::nullopt, // dropout_mask_tensor_uid
+        flatbuffers::nullopt, // dropout_scale_tensor_uid
+        flatbuffers::nullopt, // dropout_scale_inv_tensor_uid
+        flatbuffers::nullopt, // dbias_tensor_uid
+        alibiMask,
+        paddingMask,
+        causalMask);
 
     std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
     nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(


### PR DESCRIPTION
The STATS/LSE tensor is always FP32 regardless of input tensor dtype (BF16/FP16), matching PyTorch and AITER behavior. The test utilities were incorrectly inheriting the input `dataType` parameter for STATS, which would create graphs with wrong dtype when testing non-FP32 inputs.

Fix both `createValidSdpaFwdGraph()` and `createValidSdpaBwdGraph()` to hardcode `DataType::FLOAT` for the STATS tensor.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
