### PR TITLE
 [MIOpen] Enable GEMM solvers for dilated convolutions

### DIFF
--- a/projects/miopen/src/convolution.cpp
+++ b/projects/miopen/src/convolution.cpp
@@ -405,16 +405,20 @@ std::size_t ConvolutionDescriptor::GetWorkSpaceSize(ExecutionContext ctx,
         /// the same workspace for Run phase. That is why we shall return
         /// actually required workspace here.
         auto fallback        = FallbackPath();
-        const auto solutions = GetSolutions(ctx, problem, 1, &fallback);
+        const auto n         = GetSolutionCount(ctx, problem);
+        const auto solutions = GetSolutions(ctx, problem, n > 0 ? n : 1, &fallback);
         if(solutions.empty() || ((findMode.IsHybrid(ctx) && fallback != FallbackPath::None) &&
                                  !env::enabled(MIOPEN_DEBUG_FORCE_IMMED_MODE_FALLBACK)))
         {
             ctx.use_dynamic_solutions_only = findMode.IsDynamicHybrid(ctx);
-            break; // Fall down to Normal Find.
+            break;
         }
-        const auto id             = solver::Id{solutions.front().solution_id};
-        const auto& s             = id.GetSolver();
-        const auto workspace_size = s.GetWorkspaceSize(ctx, problem);
+        std::size_t workspace_size = 0;
+        for(const auto& sol : solutions)
+        {
+            const auto& s  = solver::Id{sol.solution_id}.GetSolver();
+            workspace_size = std::max(workspace_size, s.GetWorkspaceSize(ctx, problem));
+        }
 
         MIOPEN_LOG_I(workspace_size);
         return workspace_size;

--- a/projects/miopen/src/convolution.cpp
+++ b/projects/miopen/src/convolution.cpp
@@ -57,8 +57,7 @@ std::size_t GetWorkSpaceSizeGEMM(const miopen::ExecutionContext& ctx,
                                  const conv::ProblemDescription& problem)
 {
 #if MIOPEN_USE_GEMM
-    if(env::disabled(MIOPEN_DEBUG_CONV_GEMM) ||
-       miopen::any_of(problem.GetConv().GetConvDilations(), [](auto v) { return v > 1; }))
+    if(env::disabled(MIOPEN_DEBUG_CONV_GEMM))
         return 0;
 
     return GetMaxWorkSpaceSize(AllGemmWorkspaceSize(ctx, problem));

--- a/projects/miopen/test/gtest/unit_conv_solver_GemmBwdRest.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_GemmBwdRest.cpp
@@ -75,6 +75,8 @@ auto GetConvTestCasesFull(miopenDataType_t datatype)
     cases.emplace_back(TestCase{{1, 8, 9, 9}, {8, 8, 3, 3}, {1, 2}, {1, 1}, {1, 2}, datatype});
     // 3D dilation=2: effective kernel size 5 in each dim, pad=2 keeps spatial dims at 8
     cases.emplace_back(TestCase{{1, 8, 8, 8, 8}, {8, 8, 3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {2, 2, 2}, datatype});
+    // 3D asymmetric dilation: dilation=(1,2,3), pad=(1,2,3) keeps spatial dims at 8
+    cases.emplace_back(TestCase{{1, 8, 8, 8, 8}, {8, 8, 3, 3, 3}, {1, 2, 3}, {1, 1, 1}, {1, 2, 3}, datatype});
     // clang-format on
 
     return cases;

--- a/projects/miopen/test/gtest/unit_conv_solver_GemmBwdRest.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_GemmBwdRest.cpp
@@ -36,6 +36,8 @@ auto GetConvTestCases(miopenDataType_t datatype)
     return std::vector{
         // clang-format off
         TestCase{{1, 8, 8, 8}, {8, 8, 3, 3}, {0, 0}, {1, 1}, {1, 1}, datatype},
+        // dilation=2: effective kernel size 5, pad=2 keeps spatial dims at 8
+        TestCase{{1, 8, 8, 8}, {8, 8, 3, 3}, {2, 2}, {1, 1}, {2, 2}, datatype},
         // clang-format on
     };
 }
@@ -54,7 +56,7 @@ auto GetConvTestCasesFull(miopenDataType_t datatype)
         // clang-format off
         if(!miopen::StartsWith(name, "gfx1151"))
         {
-            // Regression test for https://github.com/ROCm/MIOpen/issues/1956            
+            // Regression test for https://github.com/ROCm/MIOpen/issues/1956
             cases.emplace_back(TestCase{{2, 64, 128, 128, 128}, {32, 64, 3, 3, 3}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1}, miopenHalf});
         }
         else
@@ -65,6 +67,15 @@ auto GetConvTestCasesFull(miopenDataType_t datatype)
         }
         // clang-format on
     }
+
+    // clang-format off
+    // dilation=3: effective kernel size 7, pad=3 keeps spatial dims at 8
+    cases.emplace_back(TestCase{{1, 8, 8, 8}, {8, 8, 3, 3}, {3, 3}, {1, 1}, {3, 3}, datatype});
+    // asymmetric dilation: different dilation per spatial dim
+    cases.emplace_back(TestCase{{1, 8, 9, 9}, {8, 8, 3, 3}, {1, 2}, {1, 1}, {1, 2}, datatype});
+    // 3D dilation=2: effective kernel size 5 in each dim, pad=2 keeps spatial dims at 8
+    cases.emplace_back(TestCase{{1, 8, 8, 8, 8}, {8, 8, 3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {2, 2, 2}, datatype});
+    // clang-format on
 
     return cases;
 }
@@ -139,3 +150,15 @@ INSTANTIATE_TEST_SUITE_P(Full,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCasesFull(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_UnitTestConvSolverGemmBwdRestBwd_BFP16,
+                         testing::Combine(testing::Values(GetTestParams()),
+                                          testing::Values(miopenConvolutionAlgoGEMM),
+                                          testing::ValuesIn(GetConvTestCasesFull(miopenBFloat16))));
+
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_UnitTestConvSolverGemmBwdRestBwd_FP32,
+                         testing::Combine(testing::Values(GetTestParams()),
+                                          testing::Values(miopenConvolutionAlgoGEMM),
+                                          testing::ValuesIn(GetConvTestCasesFull(miopenFloat))));

--- a/projects/miopen/test/gtest/unit_conv_solver_GemmFwdRest.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_GemmFwdRest.cpp
@@ -39,6 +39,8 @@ auto GetConvTestCases(miopenDataType_t datatype)
     return std::vector{
         // clang-format off
         TestCase{{1, 8, 8, 8}, {8, 8, 3, 3}, {0, 0}, {1, 1}, {1, 1}, type_x, type_w, type_y},
+        // dilation=2: effective kernel size 5, pad=2 keeps spatial dims at 8
+        TestCase{{1, 8, 8, 8}, {8, 8, 3, 3}, {2, 2}, {1, 1}, {2, 2}, type_x, type_w, type_y},
         // clang-format on
     };
 }
@@ -55,6 +57,12 @@ auto GetConvTestCasesFull(miopenDataType_t datatype)
         // clang-format off
         // Regression test for https://github.com/ROCm/MIOpen/issues/2047
         TestCase{{1, 1, 2, 1, 2}, {2, 1, 2, 1, 2}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}, type_x, type_w, type_y},
+        // dilation=3: effective kernel size 7, pad=3 keeps spatial dims at 8
+        TestCase{{1, 8, 8, 8}, {8, 8, 3, 3}, {3, 3}, {1, 1}, {3, 3}, type_x, type_w, type_y},
+        // asymmetric dilation: different dilation per spatial dim
+        TestCase{{1, 8, 9, 9}, {8, 8, 3, 3}, {1, 2}, {1, 1}, {1, 2}, type_x, type_w, type_y},
+        // 3D dilation=2: effective kernel size 5 in each dim, pad=2 keeps spatial dims at 8
+        TestCase{{1, 8, 8, 8, 8}, {8, 8, 3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {2, 2, 2}, type_x, type_w, type_y},
         // clang-format on
     };
 }

--- a/projects/miopen/test/gtest/unit_conv_solver_GemmFwdRest.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_GemmFwdRest.cpp
@@ -63,6 +63,8 @@ auto GetConvTestCasesFull(miopenDataType_t datatype)
         TestCase{{1, 8, 9, 9}, {8, 8, 3, 3}, {1, 2}, {1, 1}, {1, 2}, type_x, type_w, type_y},
         // 3D dilation=2: effective kernel size 5 in each dim, pad=2 keeps spatial dims at 8
         TestCase{{1, 8, 8, 8, 8}, {8, 8, 3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {2, 2, 2}, type_x, type_w, type_y},
+        // 3D asymmetric dilation: dilation=(1,2,3), pad=(1,2,3) keeps spatial dims at 8
+        TestCase{{1, 8, 8, 8, 8}, {8, 8, 3, 3, 3}, {1, 2, 3}, {1, 1, 1}, {1, 2, 3}, type_x, type_w, type_y},
         // clang-format on
     };
 }

--- a/projects/miopen/test/gtest/unit_conv_solver_GemmWrwUniversal.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_GemmWrwUniversal.cpp
@@ -53,6 +53,8 @@ auto GetConvTestCasesFull(miopenDataType_t datatype)
         TestCase{{1, 8, 9, 9}, {8, 8, 3, 3}, {1, 2}, {1, 1}, {1, 2}, datatype},
         // 3D dilation=2: effective kernel size 5 in each dim, pad=2 keeps spatial dims at 8
         TestCase{{1, 8, 8, 8, 8}, {8, 8, 3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {2, 2, 2}, datatype},
+        // 3D asymmetric dilation: dilation=(1,2,3), pad=(1,2,3) keeps spatial dims at 8
+        TestCase{{1, 8, 8, 8, 8}, {8, 8, 3, 3, 3}, {1, 2, 3}, {1, 1, 1}, {1, 2, 3}, datatype},
         // clang-format on
     };
 }

--- a/projects/miopen/test/gtest/unit_conv_solver_GemmWrwUniversal.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_GemmWrwUniversal.cpp
@@ -35,6 +35,24 @@ auto GetConvTestCases(miopenDataType_t datatype)
     return std::vector{
         // clang-format off
         TestCase{{1, 8, 8, 8}, {8, 8, 3, 3}, {0, 0}, {1, 1}, {1, 1}, datatype},
+        // dilation=2: effective kernel size 5, pad=2 keeps spatial dims at 8
+        TestCase{{1, 8, 8, 8}, {8, 8, 3, 3}, {2, 2}, {1, 1}, {2, 2}, datatype},
+        // clang-format on
+    };
+}
+
+auto GetConvTestCasesFull(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        // dilation=3: effective kernel size 7, pad=3 keeps spatial dims at 8
+        TestCase{{1, 8, 8, 8}, {8, 8, 3, 3}, {3, 3}, {1, 1}, {3, 3}, datatype},
+        // asymmetric dilation: different dilation per spatial dim
+        TestCase{{1, 8, 9, 9}, {8, 8, 3, 3}, {1, 2}, {1, 1}, {1, 2}, datatype},
+        // 3D dilation=2: effective kernel size 5 in each dim, pad=2 keeps spatial dims at 8
+        TestCase{{1, 8, 8, 8, 8}, {8, 8, 3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {2, 2, 2}, datatype},
         // clang-format on
     };
 }
@@ -101,3 +119,22 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          CPU_UnitTestConvSolverGemmWrwUniversalDevApplicabilityWrw_NONE,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(GetConvTestCases(miopenFloat)[0])));
+
+// Full tests
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_UnitTestConvSolverGemmWrwUniversalWrw_FP16,
+                         testing::Combine(testing::Values(GetTestParams()),
+                                          testing::Values(miopenConvolutionAlgoGEMM),
+                                          testing::ValuesIn(GetConvTestCasesFull(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_UnitTestConvSolverGemmWrwUniversalWrw_BFP16,
+                         testing::Combine(testing::Values(GetTestParams()),
+                                          testing::Values(miopenConvolutionAlgoGEMM),
+                                          testing::ValuesIn(GetConvTestCasesFull(miopenBFloat16))));
+
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_UnitTestConvSolverGemmWrwUniversalWrw_FP32,
+                         testing::Combine(testing::Values(GetTestParams()),
+                                          testing::Values(miopenConvolutionAlgoGEMM),
+                                          testing::ValuesIn(GetConvTestCasesFull(miopenFloat))));


### PR DESCRIPTION
## Motivation

GEMM-based convolution solvers (`GemmFwdRest`, `GemmBwdRest`, `GemmWrwUniversal`) were incorrectly excluded from dilated convolutions (dilation > 1) by a blanket early-exit guard in `GetWorkSpaceSizeGEMM`. This meant that for dilated inputs, the workspace calculation returned 0 regardless of whether a GEMM solver was actually applicable, causing those solvers to be silently skipped even when they were the best or only option.

Further, the immediate-mode path previously fetched only 1 solution and returned its workspace size. This caused an issue: if sol-1 (e.g., a zero-workspace solver) was returned first but sol-2 (with a non-zero workspace requirement) was the faster or only viable solver, GetWorkSpaceSize would return 0.

The consequence of which showed up in the following shape throwing a warning and picking an ` 0/UNKNOWN` solver:

```
MIOpenDriver conv -n 1 -c 1 --in_d 10 -H 11 -W 12 -k 1 --fil_d 1 -y 2 -x 5 --pad_d 0 -p 1 -q 4 --conv_stride_d 1 -u 1 -v 1 --dilation_d 2 -l 2 -j 2 --spatial_dim 3 -m conv -g 1 -F 1 -t 1
PRNG seed: 12345678
Timestamp: 2026-04-16 20:52:40 UTC; Host Name: 2ef14e67e4f0; Operating System: Linux 5.15.0-174-generic; ROCm: 7.13.60910; MIOpen Driver: 3.5.1; CPU Vendor: Intel; CPU Model: 2 x Intel(R) Xeon(R) Platinum 8480C; RAM Size: 1007 GB; GPU Model: 8 x AMD Instinct MI300X; AMDGPU Driver: 6.16.13
MIOpen(HIP): Warning [IsEnoughWorkspace] [EvaluateInvokers] Solver <GemmFwdRest>, workspace required: 52800, provided ptr: 0x7f1a0c805000 size: 11008
MIOpen Forward Conv. Algorithm: 5, Solution: 0/UNKNOWN
GPU Kernel Time Forward Conv. Elapsed: 0.012616 ms (average)
stats: name, n, c, do, ho, wo, z, y, x, k, flopCnt, bytesRead, bytesWritten, GFLOPs, GB/s, timeMs
stats: fwd-conv1x2x5u1, 1, 1, 10, 11, 12, 1, 2, 5, 1, 26400, 5320, 5280, 2, 1, 0.012616
Forward Convolution Verifies OK on GPU reference (0 < 1.5e-06)
```

## Technical Details

1. Remove the dilation guard from GetWorkSpaceSizeGEMM:
The condition miopen::any_of(problem.GetConv().GetConvDilations(), [](auto v) { return v > 1; }) was removed. This was a legacy guard added https://github.com/ROCm/MIOpen/pull/1739 for reasons unclear. Currently, GemmFwdRest/GemmBwdRest/GemmWrwUniversal impose no dilation restriction. The 1x1 solvers are unaffected because dilation is irrelevant for 1x1 kernels.

2. Fix workspace underestimation in immediate mode:
The fix fetches all n available solutions and returns the maximum workspace across all of them, consistent with how the Normal Find path already behaves via std::max({GetWorkSpaceSizeGEMM(...), GetWorkSpaceSizeDirect(...), ...}).

## Test Plan 

- Smoke: dilation=2 symmetric 2D case added to GemmFwdRest, GemmBwdRest, GemmWrwUniversal
- Full: dilation=3 symmetric 2D, asymmetric dilation {1,2}, and 3D dilation=2 {2,2,2} added to all three solvers
- GemmBwdRest: added missing Full suite instantiations for BFP16 and FP32
- GemmWrwUniversal: added GetConvTestCasesFull and Full suite instantiations for FP16, BFP16, FP32 (previously had no Full tests at all)

## Test Result

- All newly added tests pass locally.
- The previously seen issue with unknown solver is resolved:
```
MIOpenDriver conv -n 1 -c 1 --in_d 10 -H 11 -W 12 -k 1 --fil_d 1 -y 2 -x 5 --pad_d 0 -p 1 -q 4 --conv_stride_d 1 -u 1 -v 1 --dilation_d 2 -l 2 -j 2 --spatial_dim 3 -m conv -g 1 -F 1 -t 1
PRNG seed: 12345678
Timestamp: 2026-04-16 20:49:33 UTC; Host Name: 2ef14e67e4f0; Operating System: Linux 5.15.0-174-generic; ROCm: 7.13.60910; MIOpen Driver: 3.5.1; CPU Vendor: Intel; CPU Model: 2 x Intel(R) Xeon(R) Platinum 8480C; RAM Size: 1007 GB; GPU Model: 8 x AMD Instinct MI300X; AMDGPU Driver: 6.16.13
MIOpen Forward Conv. Algorithm: 1, Solution: 85/ConvDirectNaiveConvFwd
GPU Kernel Time Forward Conv. Elapsed: 0.012847 ms (average)
stats: name, n, c, do, ho, wo, z, y, x, k, flopCnt, bytesRead, bytesWritten, GFLOPs, GB/s, timeMs
stats: fwd-conv1x2x5u1, 1, 1, 10, 11, 12, 1, 2, 5, 1, 26400, 5320, 5280, 2, 1, 0.012847
Forward Convolution Verifies OK on GPU reference (0 < 1.5e-06)
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
