### PR TITLE
Feature flag the hip kernel provider

### DIFF
--- a/dnn-providers/hip-kernel-provider/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/CMakeLists.txt
@@ -1,6 +1,13 @@
 # Copyright © Advanced Micro Devices, Inc., or its affiliates.
 # SPDX-License-Identifier:  MIT
 
+if(NOT ENABLE_HIP_KERNEL_PROVIDER)
+    message(WARNING
+            "You must explicitly turn on hip-kernel-provider using "
+            " -DENABLE_HIP_KERNEL_PROVIDER=ON in order to build it")
+    return()
+endif()
+
 cmake_minimum_required(VERSION 3.25.2)
 add_compile_definitions(__HIP_PLATFORM_AMD__)
 

--- a/dnn-providers/hip-kernel-provider/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Copyright © Advanced Micro Devices, Inc., or its affiliates.
 # SPDX-License-Identifier:  MIT
 
-if(NOT ENABLE_HIP_KERNEL_PROVIDER)
+if(NOT HIP_KERNEL_PROVIDER_ENABLE)
     message(WARNING
             "You must explicitly turn on hip-kernel-provider using "
-            " -DENABLE_HIP_KERNEL_PROVIDER=ON in order to build it")
+            " -DHIP_KERNEL_PROVIDER_ENABLE=ON in order to build it")
     return()
 endif()
 


### PR DESCRIPTION
## Motivation

We need to feature flag the hip kernel provider so we can default it off in TheRock
