### PR TITLE
hipBLASLt install: use venv for TensileLite on Ubuntu

### DIFF
--- a/projects/hipblaslt/install.sh
+++ b/projects/hipblaslt/install.sh
@@ -260,7 +260,13 @@ install_packages( )
       if [[ "${build_clients}" == true ]]; then
         install_apt_packages "${client_dependencies_ubuntu[@]}"
       fi
-      pip3 install wheel
+      install_apt_packages "python3-venv" "python3-pip"
+      venv_dir="${build_dir}/venv"
+      python3 -m venv "${venv_dir}"
+      "${venv_dir}/bin/pip" install --upgrade pip wheel
+      "${venv_dir}/bin/pip" install -r "${root_path}/tensilelite/requirements.txt"
+      export PATH="${venv_dir}/bin:${PATH}"
+      export VIRTUAL_ENV="${venv_dir}"
       ;;
 
     centos|rhel|almalinux)
@@ -660,6 +666,12 @@ fi
 
 # Default cmake executable is called cmake
 cmake_executable=cmake
+
+# Activate virtualenv if it exists (created by -d on Ubuntu)
+venv_dir="${build_dir}/venv"
+if [[ -f "${venv_dir}/bin/activate" ]]; then
+  source "${venv_dir}/bin/activate"
+fi
 
 # If user provides custom ${rocm_path} path for hcc it has lesser priority,
 # but with hip-clang existing path has lesser priority to avoid use of installed clang++


### PR DESCRIPTION
When installing dependencies on Ubuntu (-d), create a Python virtual environment under the build directory, install tensilelite/requirements.txt with pip, and prepend it to PATH. Source that venv before configure so TensileLite and the build use the same dependency set instead of only installing wheel globally.

## Motivation

pip install on ubuntu needs virtualenv

## Technical Details

sub packages needed to compile hipblasLT need python packages to be installed via pip.
ubuntu does not allow pip install. it needs 'pip install' to be done inside virtual env.

## Test Plan

install.sh -n completes successfully

## Test Result

install.sh -n completes successfully

## Submission Checklist

- [X ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
