### PR TITLE
[rocBLAS] adds trace logging to beta get_solution APIs and tensile initialize

### DIFF
--- a/projects/rocblas/library/src/blas_ex/rocblas_gemm_batched_ex.cpp
+++ b/projects/rocblas/library/src/blas_ex/rocblas_gemm_batched_ex.cpp
@@ -97,21 +97,50 @@ rocblas_status rocblas_gemm_batched_ex_get_solutions(rocblas_handle    handle,
             return validArgs;
         }
 
-        auto layer_mode = handle->layer_mode;
+        auto                    layer_mode = handle->layer_mode;
         rocblas_internal_logger logger;
         if(layer_mode & rocblas_layer_mode_log_trace)
         {
             auto trans_a_letter = rocblas_transpose_letter(trans_a);
             auto trans_b_letter = rocblas_transpose_letter(trans_b);
 
-            if(layer_mode & rocblas_layer_mode_log_trace)
-                logger.log_trace(handle, "rocblas_gemm_batched_ex_get_solutions",
-                                 trans_a, trans_b, m, n, k,
-                                 LOG_TRACE_SCALAR_VALUE(handle, alpha),
-                                 a, a_type, lda, b, b_type, ldb,
-                                 LOG_TRACE_SCALAR_VALUE(handle, beta),
-                                 c, c_type, ldc, d, d_type, ldd,
-                                 batch_count, compute_type, algo, flags, list_array, list_size);
+            auto a_type_string       = rocblas_datatype_string(a_type);
+            auto b_type_string       = rocblas_datatype_string(b_type);
+            auto c_type_string       = rocblas_datatype_string(c_type);
+            auto d_type_string       = rocblas_datatype_string(d_type);
+            auto compute_type_string = rocblas_datatype_string(compute_type);
+
+            rocblas_internal_ostream alphass, betass;
+            (void)rocblas_internal_log_trace_alpha_beta_ex(
+                compute_type, alpha, beta, alphass, betass);
+
+            logger.log_trace(handle,
+                             ROCBLAS_API_STR(rocblas_gemm_batched_ex_get_solutions),
+                             trans_a,
+                             trans_b,
+                             m,
+                             n,
+                             k,
+                             alphass.str(),
+                             a,
+                             a_type_string,
+                             lda,
+                             b,
+                             b_type_string,
+                             ldb,
+                             betass.str(),
+                             c,
+                             c_type_string,
+                             ldc,
+                             d,
+                             d_type_string,
+                             ldd,
+                             batch_count,
+                             compute_type_string,
+                             algo,
+                             rocblas_gemm_flags(flags),
+                             list_array,
+                             list_size);
         }
 
         auto stride_a = rocblas_stride(lda) * (trans_a == rocblas_operation_none ? k : m);
@@ -175,25 +204,24 @@ rocblas_status rocblas_gemm_batched_ex_get_solutions_by_type(rocblas_handle   ha
     if(!handle)
         return rocblas_status_invalid_handle;
 
-    auto layer_mode = handle->layer_mode;
+    auto                    layer_mode = handle->layer_mode;
     rocblas_internal_logger logger;
 
     if(layer_mode & rocblas_layer_mode_log_trace)
-        logger.log_trace(handle, "rocblas_gemm_batched_ex_get_solutions_by_type",
-                         input_type, output_type, compute_type,
-                         flags, list_array, list_size);
+    {
+        auto input_type_string   = rocblas_datatype_string(input_type);
+        auto output_type_string  = rocblas_datatype_string(output_type);
+        auto compute_type_string = rocblas_datatype_string(compute_type);
 
-    if(layer_mode & rocblas_layer_mode_log_bench)
-        logger.log_bench(handle, ROCBLAS_API_BENCH " -f gemm_batched_ex_get_solutions_by_type",
-                         "--input_type", rocblas_datatype_string(input_type),
-                         "--output_type", rocblas_datatype_string(output_type),
-                         "--compute_type", rocblas_datatype_string(compute_type),
-                         "--flags", flags);
-
-    if(layer_mode & rocblas_layer_mode_log_profile)
-        logger.log_profile(handle, "rocblas_gemm_batched_ex_get_solutions_by_type",
-                          "input_type", input_type, "output_type", output_type,
-                          "compute_type", compute_type, "flags", flags);
+        logger.log_trace(handle,
+                         ROCBLAS_API_STR(rocblas_gemm_batched_ex_get_solutions_by_type),
+                         input_type_string,
+                         output_type_string,
+                         compute_type_string,
+                         rocblas_gemm_flags(flags),
+                         list_array,
+                         list_size);
+    }
 
     // Create dummy GEMM problem to take advantage of problem templating
     // Most parameters are ignored, just needs to be valid for all types

--- a/projects/rocblas/library/src/blas_ex/rocblas_gemm_batched_ex.cpp
+++ b/projects/rocblas/library/src/blas_ex/rocblas_gemm_batched_ex.cpp
@@ -97,6 +97,23 @@ rocblas_status rocblas_gemm_batched_ex_get_solutions(rocblas_handle    handle,
             return validArgs;
         }
 
+        auto layer_mode = handle->layer_mode;
+        rocblas_internal_logger logger;
+        if(layer_mode & rocblas_layer_mode_log_trace)
+        {
+            auto trans_a_letter = rocblas_transpose_letter(trans_a);
+            auto trans_b_letter = rocblas_transpose_letter(trans_b);
+
+            if(layer_mode & rocblas_layer_mode_log_trace)
+                logger.log_trace(handle, "rocblas_gemm_batched_ex_get_solutions",
+                                 trans_a, trans_b, m, n, k,
+                                 LOG_TRACE_SCALAR_VALUE(handle, alpha),
+                                 a, a_type, lda, b, b_type, ldb,
+                                 LOG_TRACE_SCALAR_VALUE(handle, beta),
+                                 c, c_type, ldc, d, d_type, ldd,
+                                 batch_count, compute_type, algo, flags, list_array, list_size);
+        }
+
         auto stride_a = rocblas_stride(lda) * (trans_a == rocblas_operation_none ? k : m);
         auto stride_b = rocblas_stride(ldb) * (trans_b == rocblas_operation_none ? n : k);
         auto stride_c = rocblas_stride(ldc) * n;
@@ -155,6 +172,29 @@ rocblas_status rocblas_gemm_batched_ex_get_solutions_by_type(rocblas_handle   ha
                                                              rocblas_int*     list_size)
 {
 #ifdef BUILD_WITH_TENSILE
+    if(!handle)
+        return rocblas_status_invalid_handle;
+
+    auto layer_mode = handle->layer_mode;
+    rocblas_internal_logger logger;
+
+    if(layer_mode & rocblas_layer_mode_log_trace)
+        logger.log_trace(handle, "rocblas_gemm_batched_ex_get_solutions_by_type",
+                         input_type, output_type, compute_type,
+                         flags, list_array, list_size);
+
+    if(layer_mode & rocblas_layer_mode_log_bench)
+        logger.log_bench(handle, ROCBLAS_API_BENCH " -f gemm_batched_ex_get_solutions_by_type",
+                         "--input_type", rocblas_datatype_string(input_type),
+                         "--output_type", rocblas_datatype_string(output_type),
+                         "--compute_type", rocblas_datatype_string(compute_type),
+                         "--flags", flags);
+
+    if(layer_mode & rocblas_layer_mode_log_profile)
+        logger.log_profile(handle, "rocblas_gemm_batched_ex_get_solutions_by_type",
+                          "input_type", input_type, "output_type", output_type,
+                          "compute_type", compute_type, "flags", flags);
+
     // Create dummy GEMM problem to take advantage of problem templating
     // Most parameters are ignored, just needs to be valid for all types
     rocblas_double_complex alpha{0, 0};

--- a/projects/rocblas/library/src/blas_ex/rocblas_gemm_ex.cpp
+++ b/projects/rocblas/library/src/blas_ex/rocblas_gemm_ex.cpp
@@ -96,21 +96,49 @@ rocblas_status rocblas_gemm_ex_get_solutions(rocblas_handle    handle,
             return validArgs;
         }
 
-        auto layer_mode = handle->layer_mode;
+        auto                    layer_mode = handle->layer_mode;
         rocblas_internal_logger logger;
         if(layer_mode & rocblas_layer_mode_log_trace)
         {
             auto trans_a_letter = rocblas_transpose_letter(trans_a);
             auto trans_b_letter = rocblas_transpose_letter(trans_b);
 
-            if(layer_mode & rocblas_layer_mode_log_trace)
-                logger.log_trace(handle, "rocblas_gemm_ex_get_solutions",
-                                 trans_a, trans_b, m, n, k,
-                                 LOG_TRACE_SCALAR_VALUE(handle, alpha),
-                                 a, a_type, lda, b, b_type, ldb,
-                                 LOG_TRACE_SCALAR_VALUE(handle, beta),
-                                 c, c_type, ldc, d, d_type, ldd,
-                                 compute_type, algo, flags, list_array, list_size);
+            auto a_type_string       = rocblas_datatype_string(a_type);
+            auto b_type_string       = rocblas_datatype_string(b_type);
+            auto c_type_string       = rocblas_datatype_string(c_type);
+            auto d_type_string       = rocblas_datatype_string(d_type);
+            auto compute_type_string = rocblas_datatype_string(compute_type);
+
+            rocblas_internal_ostream alphass, betass;
+            (void)rocblas_internal_log_trace_alpha_beta_ex(
+                compute_type, alpha, beta, alphass, betass);
+
+            logger.log_trace(handle,
+                             ROCBLAS_API_STR(rocblas_gemm_ex_get_solutions),
+                             trans_a,
+                             trans_b,
+                             m,
+                             n,
+                             k,
+                             alphass.str(),
+                             a,
+                             a_type_string,
+                             lda,
+                             b,
+                             b_type_string,
+                             ldb,
+                             betass.str(),
+                             c,
+                             c_type_string,
+                             ldc,
+                             d,
+                             d_type_string,
+                             ldd,
+                             compute_type_string,
+                             algo,
+                             rocblas_gemm_flags(flags),
+                             list_array,
+                             list_size);
         }
 
         rocblas_int batch_count = 1;
@@ -174,13 +202,24 @@ rocblas_status rocblas_gemm_ex_get_solutions_by_type(rocblas_handle   handle,
     if(!handle)
         return rocblas_status_invalid_handle;
 
-    auto layer_mode = handle->layer_mode;
+    auto                    layer_mode = handle->layer_mode;
     rocblas_internal_logger logger;
 
     if(layer_mode & rocblas_layer_mode_log_trace)
-        logger.log_trace(handle, "rocblas_gemm_ex_get_solutions_by_type",
-                         input_type, output_type, compute_type,
-                         flags, list_array, list_size);
+    {
+        auto input_type_string   = rocblas_datatype_string(input_type);
+        auto output_type_string  = rocblas_datatype_string(output_type);
+        auto compute_type_string = rocblas_datatype_string(compute_type);
+
+        logger.log_trace(handle,
+                         ROCBLAS_API_STR(rocblas_gemm_ex_get_solutions_by_type),
+                         input_type_string,
+                         output_type_string,
+                         compute_type_string,
+                         rocblas_gemm_flags(flags),
+                         list_array,
+                         list_size);
+    }
 
     // Create dummy GEMM problem to take advantage of problem templating
     // Most parameters are ignored, just needs to be valid for all types

--- a/projects/rocblas/library/src/blas_ex/rocblas_gemm_ex.cpp
+++ b/projects/rocblas/library/src/blas_ex/rocblas_gemm_ex.cpp
@@ -96,6 +96,23 @@ rocblas_status rocblas_gemm_ex_get_solutions(rocblas_handle    handle,
             return validArgs;
         }
 
+        auto layer_mode = handle->layer_mode;
+        rocblas_internal_logger logger;
+        if(layer_mode & rocblas_layer_mode_log_trace)
+        {
+            auto trans_a_letter = rocblas_transpose_letter(trans_a);
+            auto trans_b_letter = rocblas_transpose_letter(trans_b);
+
+            if(layer_mode & rocblas_layer_mode_log_trace)
+                logger.log_trace(handle, "rocblas_gemm_ex_get_solutions",
+                                 trans_a, trans_b, m, n, k,
+                                 LOG_TRACE_SCALAR_VALUE(handle, alpha),
+                                 a, a_type, lda, b, b_type, ldb,
+                                 LOG_TRACE_SCALAR_VALUE(handle, beta),
+                                 c, c_type, ldc, d, d_type, ldd,
+                                 compute_type, algo, flags, list_array, list_size);
+        }
+
         rocblas_int batch_count = 1;
 
         // TODO: These strides could be 0 ( {} ) instead of 1 ( {1} ) once Tensile is fixed
@@ -154,6 +171,17 @@ rocblas_status rocblas_gemm_ex_get_solutions_by_type(rocblas_handle   handle,
                                                      rocblas_int*     list_size)
 {
 #ifdef BUILD_WITH_TENSILE
+    if(!handle)
+        return rocblas_status_invalid_handle;
+
+    auto layer_mode = handle->layer_mode;
+    rocblas_internal_logger logger;
+
+    if(layer_mode & rocblas_layer_mode_log_trace)
+        logger.log_trace(handle, "rocblas_gemm_ex_get_solutions_by_type",
+                         input_type, output_type, compute_type,
+                         flags, list_array, list_size);
+
     // Create dummy GEMM problem to take advantage of problem templating
     // Most parameters are ignored, just needs to be valid for all types
     rocblas_double_complex alpha{0, 0};

--- a/projects/rocblas/library/src/blas_ex/rocblas_gemm_strided_batched_ex.cpp
+++ b/projects/rocblas/library/src/blas_ex/rocblas_gemm_strided_batched_ex.cpp
@@ -101,23 +101,54 @@ rocblas_status rocblas_gemm_strided_batched_ex_get_solutions(rocblas_handle    h
             return validArgs;
         }
 
-        auto layer_mode = handle->layer_mode;
+        auto                    layer_mode = handle->layer_mode;
         rocblas_internal_logger logger;
         if(layer_mode & rocblas_layer_mode_log_trace)
         {
             auto trans_a_letter = rocblas_transpose_letter(trans_a);
             auto trans_b_letter = rocblas_transpose_letter(trans_b);
 
-            if(layer_mode & rocblas_layer_mode_log_trace)
-                logger.log_trace(handle, "rocblas_gemm_strided_batched_ex_get_solutions",
-                                 trans_a, trans_b, m, n, k,
-                                 LOG_TRACE_SCALAR_VALUE(handle, alpha),
-                                 a, a_type, lda, stride_a,
-                                 b, b_type, ldb, stride_b,
-                                 LOG_TRACE_SCALAR_VALUE(handle, beta),
-                                 c, c_type, ldc, stride_c,
-                                 d, d_type, ldd, stride_d,
-                                 batch_count, compute_type, algo, flags, list_array, list_size);
+            auto a_type_string       = rocblas_datatype_string(a_type);
+            auto b_type_string       = rocblas_datatype_string(b_type);
+            auto c_type_string       = rocblas_datatype_string(c_type);
+            auto d_type_string       = rocblas_datatype_string(d_type);
+            auto compute_type_string = rocblas_datatype_string(compute_type);
+
+            rocblas_internal_ostream alphass, betass;
+            (void)rocblas_internal_log_trace_alpha_beta_ex(
+                compute_type, alpha, beta, alphass, betass);
+
+            logger.log_trace(handle,
+                             ROCBLAS_API_STR(rocblas_gemm_strided_batched_ex_get_solutions),
+                             trans_a,
+                             trans_b,
+                             m,
+                             n,
+                             k,
+                             alphass.str(),
+                             a,
+                             a_type_string,
+                             lda,
+                             stride_a,
+                             b,
+                             b_type_string,
+                             ldb,
+                             stride_b,
+                             betass.str(),
+                             c,
+                             c_type_string,
+                             ldc,
+                             stride_c,
+                             d,
+                             d_type_string,
+                             ldd,
+                             stride_d,
+                             batch_count,
+                             compute_type_string,
+                             algo,
+                             rocblas_gemm_flags(flags),
+                             list_array,
+                             list_size);
         }
 
         return rocblas_gemm_ex_get_solutions_template<false>(handle,

--- a/projects/rocblas/library/src/blas_ex/rocblas_gemm_strided_batched_ex.cpp
+++ b/projects/rocblas/library/src/blas_ex/rocblas_gemm_strided_batched_ex.cpp
@@ -101,6 +101,25 @@ rocblas_status rocblas_gemm_strided_batched_ex_get_solutions(rocblas_handle    h
             return validArgs;
         }
 
+        auto layer_mode = handle->layer_mode;
+        rocblas_internal_logger logger;
+        if(layer_mode & rocblas_layer_mode_log_trace)
+        {
+            auto trans_a_letter = rocblas_transpose_letter(trans_a);
+            auto trans_b_letter = rocblas_transpose_letter(trans_b);
+
+            if(layer_mode & rocblas_layer_mode_log_trace)
+                logger.log_trace(handle, "rocblas_gemm_strided_batched_ex_get_solutions",
+                                 trans_a, trans_b, m, n, k,
+                                 LOG_TRACE_SCALAR_VALUE(handle, alpha),
+                                 a, a_type, lda, stride_a,
+                                 b, b_type, ldb, stride_b,
+                                 LOG_TRACE_SCALAR_VALUE(handle, beta),
+                                 c, c_type, ldc, stride_c,
+                                 d, d_type, ldd, stride_d,
+                                 batch_count, compute_type, algo, flags, list_array, list_size);
+        }
+
         return rocblas_gemm_ex_get_solutions_template<false>(handle,
                                                              trans_a,
                                                              trans_b,

--- a/projects/rocblas/library/src/tensile_host.cpp
+++ b/projects/rocblas/library/src/tensile_host.cpp
@@ -698,6 +698,23 @@ namespace
 
         static int determine_tensile_base_path(std::string& base_path)
         {
+            // called once from initialize so logging check here to keep clutter down
+            const char* str_layer_mode = getenv("ROCBLAS_LAYER");
+            if(str_layer_mode)
+            {
+                rocblas_layer_mode layer_mode
+                    = static_cast<rocblas_layer_mode>(strtol(str_layer_mode, 0, 0));
+
+                if(layer_mode & (rocblas_layer_mode_log_trace | rocblas_layer_mode_log_internal))
+                {
+                    char buf[256];
+                    rocblas_get_version_string(buf, 256);
+
+                    // logs trace differently to rocblas_cerr as no handle here
+                    rocblas_cerr << "rocBLAS initialize,version," << buf << std::endl;
+                }
+            }
+
             const char* env = getenv("ROCBLAS_TENSILE_LIBPATH");
             if(env)
             {
@@ -795,7 +812,7 @@ namespace
             std::string processor = rocblas_internal_get_arch_name(deviceId);
 
             static std::string base_path;
-            static int         determined_path = determine_tensile_base_path(base_path);
+            static int         determined_path{determine_tensile_base_path(base_path)};
 
             path = base_path;
             // Probe subdirectories from most-specific to least-specific so that shard


### PR DESCRIPTION
## Motivation
This pull request adds enhanced logging and tracing capabilities to several GEMM solution retrieval beta functions and the Tensile host initialization in rocBLAS. These changes improve traceability and debugging by logging function calls and environment information when appropriate layer modes are enabled.

The most important changes are:

#### Enhanced logging for GEMM solution APIs
* Added detailed trace logging to `rocblas_gemm_ex_get_solutions`, `rocblas_gemm_batched_ex_get_solutions`, and `rocblas_gemm_strided_batched_ex_get_solutions`, including all key parameters and data types, when `rocblas_layer_mode_log_trace` is enabled. 
* Added similar trace logging to the `_get_solutions_by_type` variants for both GEMM and batched GEMM APIs, logging the input/output/compute types and other parameters. 

#### Defensive programming
* Added null handle checks to the `_get_solutions_by_type` functions to prevent null pointer dereferencing. 

#### Initialization and environment logging
* During Tensile host initialization, added logging of the rocBLAS version to `rocblas_cerr` if the environment variable `ROCBLAS_LAYER` enables trace or internal logging, improving startup diagnostics. 