### PR TITLE
[CI]: Bump the rock and the many linux container SHAs

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       id-token: write
     container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:d6ae5712a9c7e8b88281d021e907b312cd8a26295b95690baef3e8dde4805858
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:48492540591673fdc8d51beb89bde41e7ba13cbb528f643c0a481ba42c4058f2
       options: -v /runner/config:/home/awsconfig/
     strategy:
       fail-fast: true
@@ -43,7 +43,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 2d9260c2b1c87175539a9fc45a2e9513ed36aff6 # 2026-04-16
+          ref: b746d4d90b43df6035b163744c30c5daef209708 # 2026-04-17
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-nightly.yml
+++ b/.github/workflows/therock-ci-nightly.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 2d9260c2b1c87175539a9fc45a2e9513ed36aff6 # 2026-04-16
+          ref: b746d4d90b43df6035b163744c30c5daef209708 # 2026-04-17
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 2d9260c2b1c87175539a9fc45a2e9513ed36aff6 # 2026-04-16
+          ref: b746d4d90b43df6035b163744c30c5daef209708 # 2026-04-17
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 2d9260c2b1c87175539a9fc45a2e9513ed36aff6 # 2026-04-16
+          ref: b746d4d90b43df6035b163744c30c5daef209708 # 2026-04-17
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: 2d9260c2b1c87175539a9fc45a2e9513ed36aff6 # 2026-04-16
+          ref: b746d4d90b43df6035b163744c30c5daef209708 # 2026-04-17
 
       - name: Configure git for long paths on Windows
         if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: 2d9260c2b1c87175539a9fc45a2e9513ed36aff6 # 2026-04-16
+          ref: b746d4d90b43df6035b163744c30c5daef209708 # 2026-04-17
 
       - name: Setting up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0


### PR DESCRIPTION
## Motivation

Bump the latest rock into rocm-libraries so I can enable CI on hip-kernel-provider in a followup PR

## Technical Details

I cant 100% recall but If I didnt bump the manylinux container I hit some issues with missing pip or dvc stuff.  Bumping to this sha solved the issues I had. 

## Test Plan

Tests Pass