### PR TITLE
Fix multi-GPU work-buffer indexing and samples cleanup in rocFFT/hipFFT

### DIFF
--- a/projects/hipfft/clients/samples/hipfft_1d_d2z.cpp
+++ b/projects/hipfft/clients/samples/hipfft_1d_d2z.cpp
@@ -92,7 +92,8 @@ int main()
     }
     std::cout << std::endl;
 
-    hipfftDestroy(plan);
+    if(hipfftDestroy(plan) != HIPFFT_SUCCESS)
+        throw std::runtime_error("hipfftDestroy failed");
 
     hip_rt = hipFree(x);
     if(hip_rt != hipSuccess)

--- a/projects/hipfft/clients/samples/hipfft_1d_d2z.cpp
+++ b/projects/hipfft/clients/samples/hipfft_1d_d2z.cpp
@@ -46,8 +46,7 @@ int main()
 
     // Create HIP device object
     double*    x;
-    hipError_t hip_rt;
-    hip_rt = hipMalloc(&x, complex_bytes);
+    hipError_t hip_rt = hipMalloc(&x, complex_bytes);
     if(hip_rt != hipSuccess)
         throw std::runtime_error("hipMalloc failed");
 
@@ -68,11 +67,11 @@ int main()
 
     // Create the plan (hipfftPlan1d internally allocates the handle)
     hipfftHandle plan{};
-    hipfftResult hipfft_rt;
-    hipfft_rt = hipfftPlan1d(&plan, // plan handle
-                             Nx, // transform length
-                             HIPFFT_D2Z, // transform type (HIPFFT_R2C for single-precision)
-                             1); // number of transforms (deprecated)
+    hipfftResult hipfft_rt
+        = hipfftPlan1d(&plan, // plan handle
+                       Nx, // transform length
+                       HIPFFT_D2Z, // transform type (HIPFFT_R2C for single-precision)
+                       1); // number of transforms (deprecated)
     if(hipfft_rt != HIPFFT_SUCCESS)
         throw std::runtime_error("hipfftPlan1d failed");
 

--- a/projects/hipfft/clients/samples/hipfft_1d_d2z.cpp
+++ b/projects/hipfft/clients/samples/hipfft_1d_d2z.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 - 2025 Advanced Micro Devices, Inc. All rights
+// Copyright (C) 2019 - 2026 Advanced Micro Devices, Inc. All rights
 // reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -51,7 +51,7 @@ int main()
     if(hip_rt != hipSuccess)
         throw std::runtime_error("hipMalloc failed");
 
-    // Inititalize the data
+    // Initialize the data
     for(size_t i = 0; i < Nx; i++)
     {
         rdata[i] = i;
@@ -66,11 +66,9 @@ int main()
     if(hip_rt != hipSuccess)
         throw std::runtime_error("hipMemcpy failed");
 
-    // Create the plan
+    // Create the plan (hipfftPlan1d internally allocates the handle)
     hipfftHandle plan{};
-    hipfftResult hipfft_rt = hipfftCreate(&plan);
-    if(hipfft_rt != HIPFFT_SUCCESS)
-        throw std::runtime_error("failed to create plan");
+    hipfftResult hipfft_rt;
     hipfft_rt = hipfftPlan1d(&plan, // plan handle
                              Nx, // transform length
                              HIPFFT_D2Z, // transform type (HIPFFT_R2C for single-precision)

--- a/projects/hipfft/clients/samples/hipfft_1d_z2z.cpp
+++ b/projects/hipfft/clients/samples/hipfft_1d_z2z.cpp
@@ -43,9 +43,8 @@ int main()
 
     // Create HIP device object and copy data to device
     // Use hipfftComplex for single-precision
-    hipError_t           hip_rt;
     hipfftDoubleComplex* x;
-    hip_rt = hipMalloc(&x, complex_bytes);
+    hipError_t           hip_rt = hipMalloc(&x, complex_bytes);
     if(hip_rt != hipSuccess)
         throw std::runtime_error("hipMalloc failed");
 
@@ -66,12 +65,11 @@ int main()
 
     // Create the plan (hipfftPlan1d internally allocates the handle)
     hipfftHandle plan{};
-    hipfftResult hipfft_rt;
-
-    hipfft_rt = hipfftPlan1d(&plan, // plan handle
-                             Nx, // transform length
-                             HIPFFT_Z2Z, // transform type (HIPFFT_C2C for single-precision)
-                             1); // number of transforms
+    hipfftResult hipfft_rt
+        = hipfftPlan1d(&plan, // plan handle
+                       Nx, // transform length
+                       HIPFFT_Z2Z, // transform type (HIPFFT_C2C for single-precision)
+                       1); // number of transforms
     if(hipfft_rt != HIPFFT_SUCCESS)
         throw std::runtime_error("hipfftPlan1d failed");
 

--- a/projects/hipfft/clients/samples/hipfft_1d_z2z.cpp
+++ b/projects/hipfft/clients/samples/hipfft_1d_z2z.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 - 2025 Advanced Micro Devices, Inc. All rights
+// Copyright (C) 2019 - 2026 Advanced Micro Devices, Inc. All rights
 // reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -49,7 +49,7 @@ int main()
     if(hip_rt != hipSuccess)
         throw std::runtime_error("hipMalloc failed");
 
-    // Inititalize the data
+    // Initialize the data
     for(size_t i = 0; i < Nx; i++)
     {
         cdata[i] = i;
@@ -64,11 +64,9 @@ int main()
     if(hip_rt != hipSuccess)
         throw std::runtime_error("hipMemcpy failed");
 
-    // Create the plan
+    // Create the plan (hipfftPlan1d internally allocates the handle)
     hipfftHandle plan{};
-    hipfftResult hipfft_rt = hipfftCreate(&plan);
-    if(hipfft_rt != HIPFFT_SUCCESS)
-        throw std::runtime_error("failed to create plan");
+    hipfftResult hipfft_rt;
 
     hipfft_rt = hipfftPlan1d(&plan, // plan handle
                              Nx, // transform length

--- a/projects/hipfft/clients/samples/hipfft_1d_z2z.cpp
+++ b/projects/hipfft/clients/samples/hipfft_1d_z2z.cpp
@@ -89,7 +89,8 @@ int main()
     }
     std::cout << std::endl;
 
-    hipfftDestroy(plan);
+    if(hipfftDestroy(plan) != HIPFFT_SUCCESS)
+        throw std::runtime_error("hipfftDestroy failed");
 
     hip_rt = hipFree(x);
     if(hip_rt != hipSuccess)

--- a/projects/hipfft/clients/samples/hipfft_2d_d2z.cpp
+++ b/projects/hipfft/clients/samples/hipfft_2d_d2z.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 - 2025 Advanced Micro Devices, Inc. All rights
+// Copyright (C) 2019 - 2026 Advanced Micro Devices, Inc. All rights
 // reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -71,17 +71,15 @@ int main()
     if(hip_rt != hipSuccess)
         throw std::runtime_error("hipMemcpy failed");
 
-    // Create plan:
+    // Create plan (hipfftPlan2d internally allocates the handle)
     hipfftHandle plan{};
-    hipfftResult hipfft_rt = hipfftCreate(&plan);
-    if(hipfft_rt != HIPFFT_SUCCESS)
-        throw std::runtime_error("failed to create plan");
+    hipfftResult hipfft_rt;
     hipfft_rt = hipfftPlan2d(&plan, // plan handle
                              Nx, // transform length
                              Ny, // transform length
                              HIPFFT_D2Z); // transform type (HIPFFT_R2C for single-precision)
     if(hipfft_rt != HIPFFT_SUCCESS)
-        throw std::runtime_error("hipfftPlandd failed");
+        throw std::runtime_error("hipfftPlan2d failed");
 
     // Execute plan:
     // hipfftExecD2Z: double precision.  hipfftExecR2C: single-precision

--- a/projects/hipfft/clients/samples/hipfft_2d_d2z.cpp
+++ b/projects/hipfft/clients/samples/hipfft_2d_d2z.cpp
@@ -61,8 +61,7 @@ int main()
     std::cout << std::endl;
 
     double*    x;
-    hipError_t hip_rt;
-    hip_rt = hipMalloc(&x, rdata.size() * sizeof(decltype(rdata)::value_type));
+    hipError_t hip_rt = hipMalloc(&x, rdata.size() * sizeof(decltype(rdata)::value_type));
     if(hip_rt != hipSuccess)
         throw std::runtime_error("hipMalloc failed");
 
@@ -73,11 +72,11 @@ int main()
 
     // Create plan (hipfftPlan2d internally allocates the handle)
     hipfftHandle plan{};
-    hipfftResult hipfft_rt;
-    hipfft_rt = hipfftPlan2d(&plan, // plan handle
-                             Nx, // transform length
-                             Ny, // transform length
-                             HIPFFT_D2Z); // transform type (HIPFFT_R2C for single-precision)
+    hipfftResult hipfft_rt
+        = hipfftPlan2d(&plan, // plan handle
+                       Nx, // transform length
+                       Ny, // transform length
+                       HIPFFT_D2Z); // transform type (HIPFFT_R2C for single-precision)
     if(hipfft_rt != HIPFFT_SUCCESS)
         throw std::runtime_error("hipfftPlan2d failed");
 

--- a/projects/hipfft/clients/samples/hipfft_2d_d2z.cpp
+++ b/projects/hipfft/clients/samples/hipfft_2d_d2z.cpp
@@ -105,7 +105,8 @@ int main()
     }
     std::cout << std::endl;
 
-    hipfftDestroy(plan);
+    if(hipfftDestroy(plan) != HIPFFT_SUCCESS)
+        throw std::runtime_error("hipfftDestroy failed");
 
     hip_rt = hipFree(x);
     if(hip_rt != hipSuccess)

--- a/projects/hipfft/clients/samples/hipfft_2d_z2z.cpp
+++ b/projects/hipfft/clients/samples/hipfft_2d_z2z.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 - 2025 Advanced Micro Devices, Inc. All rights
+// Copyright (C) 2019 - 2026 Advanced Micro Devices, Inc. All rights
 // reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -50,17 +50,17 @@ int main()
     if(hip_rt != hipSuccess)
         throw std::runtime_error("hipMalloc failed");
 
-    // Inititalize the data
-    for(size_t i = 0; i < Nx * Ny; i++)
+    // Initialize the data
+    for(size_t i = 0; i < static_cast<size_t>(Nx) * Ny; i++)
     {
         cdata[i] = i;
     }
     std::cout << "input:\n";
-    for(int i = 0; i < Nx; i++)
+    for(size_t i = 0; i < static_cast<size_t>(Nx); i++)
     {
-        for(int j = 0; j < Ny; j++)
+        for(size_t j = 0; j < static_cast<size_t>(Ny); j++)
         {
-            int pos = i * Ny + j;
+            size_t pos = i * Ny + j;
             std::cout << cdata[pos] << " ";
         }
         std::cout << "\n";
@@ -70,18 +70,16 @@ int main()
     if(hip_rt != hipSuccess)
         throw std::runtime_error("hipMemcpy failed");
 
-    // Create plan
+    // Create plan (hipfftPlan2d internally allocates the handle)
     hipfftHandle plan{};
-    hipfftResult hipfft_rt = hipfftCreate(&plan);
-    if(hipfft_rt != HIPFFT_SUCCESS)
-        throw std::runtime_error("failed to create plan");
+    hipfftResult hipfft_rt;
 
     hipfft_rt = hipfftPlan2d(&plan, // plan handle
                              Nx, // transform length
                              Ny, // transform length
                              HIPFFT_Z2Z); // transform type (HIPFFT_C2C for single-precision)
     if(hipfft_rt != HIPFFT_SUCCESS)
-        throw std::runtime_error("hipfftPlandd failed");
+        throw std::runtime_error("hipfftPlan2d failed");
 
     // Execute plan
     // hipfftExecZ2Z: double precision, hipfftExecC2C: for single-precision
@@ -93,9 +91,9 @@ int main()
     hip_rt = hipMemcpy(cdata.data(), x, complex_bytes, hipMemcpyDeviceToHost);
     if(hip_rt != hipSuccess)
         throw std::runtime_error("hipMemcpy failed");
-    for(size_t i = 0; i < Nx; i++)
+    for(size_t i = 0; i < static_cast<size_t>(Nx); i++)
     {
-        for(size_t j = 0; j < Ny; j++)
+        for(size_t j = 0; j < static_cast<size_t>(Ny); j++)
         {
             auto pos = i * Ny + j;
             std::cout << cdata[pos] << " ";

--- a/projects/hipfft/clients/samples/hipfft_2d_z2z.cpp
+++ b/projects/hipfft/clients/samples/hipfft_2d_z2z.cpp
@@ -100,7 +100,8 @@ int main()
     }
     std::cout << std::endl;
 
-    hipfftDestroy(plan);
+    if(hipfftDestroy(plan) != HIPFFT_SUCCESS)
+        throw std::runtime_error("hipfftDestroy failed");
 
     hip_rt = hipFree(x);
     if(hip_rt != hipSuccess)

--- a/projects/hipfft/clients/samples/hipfft_2d_z2z.cpp
+++ b/projects/hipfft/clients/samples/hipfft_2d_z2z.cpp
@@ -44,9 +44,8 @@ int main()
 
     // Create HIP device object and copy data to device:
     // hipfftComplex for single-precision
-    hipError_t           hip_rt;
     hipfftDoubleComplex* x;
-    hip_rt = hipMalloc(&x, complex_bytes);
+    hipError_t           hip_rt = hipMalloc(&x, complex_bytes);
     if(hip_rt != hipSuccess)
         throw std::runtime_error("hipMalloc failed");
 
@@ -72,12 +71,11 @@ int main()
 
     // Create plan (hipfftPlan2d internally allocates the handle)
     hipfftHandle plan{};
-    hipfftResult hipfft_rt;
-
-    hipfft_rt = hipfftPlan2d(&plan, // plan handle
-                             Nx, // transform length
-                             Ny, // transform length
-                             HIPFFT_Z2Z); // transform type (HIPFFT_C2C for single-precision)
+    hipfftResult hipfft_rt
+        = hipfftPlan2d(&plan, // plan handle
+                       Nx, // transform length
+                       Ny, // transform length
+                       HIPFFT_Z2Z); // transform type (HIPFFT_C2C for single-precision)
     if(hipfft_rt != HIPFFT_SUCCESS)
         throw std::runtime_error("hipfftPlan2d failed");
 

--- a/projects/hipfft/clients/samples/hipfft_3d_d2z.cpp
+++ b/projects/hipfft/clients/samples/hipfft_3d_d2z.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 - 2025 Advanced Micro Devices, Inc. All rights
+// Copyright (C) 2019 - 2026 Advanced Micro Devices, Inc. All rights
 // reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -39,7 +39,7 @@ int main()
     const size_t Ny = 5;
     const size_t Nz = 6;
 
-    std::cout << "Nx: " << Nx << "\tNy " << Ny << "\tNz " << Nz << std::endl;
+    std::cout << "Nx: " << Nx << "\tNy: " << Ny << "\tNz: " << Nz << std::endl;
 
     const size_t Nzcomplex = Nz / 2 + 1;
     const size_t rstride   = Nzcomplex * 2; // Nz for out-of-place
@@ -53,7 +53,7 @@ int main()
     if(hip_rt != hipSuccess)
         throw std::runtime_error("hipMalloc failed");
 
-    // Inititalize the data
+    // Initialize the data
     std::vector<double> rdata(Nx * Ny * rstride);
     for(size_t i = 0; i < Nx * Ny * rstride; i++)
     {
@@ -78,11 +78,9 @@ int main()
     if(hip_rt != hipSuccess)
         throw std::runtime_error("hipMemcpy failed");
 
-    // Create plan:
+    // Create plan (hipfftPlan3d internally allocates the handle)
     hipfftHandle plan{};
-    hipfftResult hipfft_rt = hipfftCreate(&plan);
-    if(hipfft_rt != HIPFFT_SUCCESS)
-        throw std::runtime_error("failed to create plan");
+    hipfftResult hipfft_rt;
     hipfft_rt = hipfftPlan3d(&plan, // plan handle
                              Nx,
                              Ny,
@@ -98,7 +96,7 @@ int main()
         throw std::runtime_error("hipfftExecD2Z failed");
 
     std::cout << "output:\n";
-    std::vector<std::complex<double>> cdata(Nx * Ny * Nz);
+    std::vector<std::complex<double>> cdata(Nx * Ny * Nzcomplex);
     hip_rt = hipMemcpy(cdata.data(), x, complex_bytes, hipMemcpyDeviceToHost);
     if(hip_rt != hipSuccess)
         throw std::runtime_error("hipMemcpy failed");

--- a/projects/hipfft/clients/samples/hipfft_3d_d2z.cpp
+++ b/projects/hipfft/clients/samples/hipfft_3d_d2z.cpp
@@ -48,8 +48,7 @@ int main()
     const size_t complex_bytes = 2 * sizeof(double) * Nx * Ny * Nzcomplex;
 
     double*    x;
-    hipError_t hip_rt;
-    hip_rt = hipMalloc(&x, real_bytes);
+    hipError_t hip_rt = hipMalloc(&x, real_bytes);
     if(hip_rt != hipSuccess)
         throw std::runtime_error("hipMalloc failed");
 
@@ -80,12 +79,12 @@ int main()
 
     // Create plan (hipfftPlan3d internally allocates the handle)
     hipfftHandle plan{};
-    hipfftResult hipfft_rt;
-    hipfft_rt = hipfftPlan3d(&plan, // plan handle
-                             Nx,
-                             Ny,
-                             Nz, // transform lengths
-                             HIPFFT_D2Z); // transform type (HIPFFT_R2C for single-precision)
+    hipfftResult hipfft_rt
+        = hipfftPlan3d(&plan, // plan handle
+                       Nx,
+                       Ny,
+                       Nz, // transform lengths
+                       HIPFFT_D2Z); // transform type (HIPFFT_R2C for single-precision)
     if(hipfft_rt != HIPFFT_SUCCESS)
         throw std::runtime_error("hipfftPlan3d failed");
 

--- a/projects/hipfft/clients/samples/hipfft_3d_d2z.cpp
+++ b/projects/hipfft/clients/samples/hipfft_3d_d2z.cpp
@@ -114,7 +114,8 @@ int main()
     }
     std::cout << std::endl;
 
-    hipfftDestroy(plan);
+    if(hipfftDestroy(plan) != HIPFFT_SUCCESS)
+        throw std::runtime_error("hipfftDestroy failed");
 
     hip_rt = hipFree(x);
     if(hip_rt != hipSuccess)

--- a/projects/hipfft/clients/samples/hipfft_3d_z2z.cpp
+++ b/projects/hipfft/clients/samples/hipfft_3d_z2z.cpp
@@ -109,7 +109,8 @@ int main()
     }
     std::cout << std::endl;
 
-    hipfftDestroy(plan);
+    if(hipfftDestroy(plan) != HIPFFT_SUCCESS)
+        throw std::runtime_error("hipfftDestroy failed");
 
     hip_rt = hipFree(x);
     if(hip_rt != hipSuccess)

--- a/projects/hipfft/clients/samples/hipfft_3d_z2z.cpp
+++ b/projects/hipfft/clients/samples/hipfft_3d_z2z.cpp
@@ -45,9 +45,8 @@ int main()
 
     // Create HIP device object and copy data to device:
     // hipfftComplex for single-precision
-    hipError_t           hip_rt;
     hipfftDoubleComplex* x;
-    hip_rt = hipMalloc(&x, complex_bytes);
+    hipError_t           hip_rt = hipMalloc(&x, complex_bytes);
     if(hip_rt != hipSuccess)
         throw std::runtime_error("hipMalloc failed");
 
@@ -76,13 +75,12 @@ int main()
 
     // Create plan (hipfftPlan3d internally allocates the handle)
     hipfftHandle plan{};
-    hipfftResult hipfft_rt;
-
-    hipfft_rt = hipfftPlan3d(&plan, // plan handle
-                             Nx, // transform length
-                             Ny, // transform length
-                             Nz, // transform length
-                             HIPFFT_Z2Z); // transform type (HIPFFT_C2C for single-precision)
+    hipfftResult hipfft_rt
+        = hipfftPlan3d(&plan, // plan handle
+                       Nx, // transform length
+                       Ny, // transform length
+                       Nz, // transform length
+                       HIPFFT_Z2Z); // transform type (HIPFFT_C2C for single-precision)
     if(hipfft_rt != HIPFFT_SUCCESS)
         throw std::runtime_error("hipfftPlan3d failed");
 

--- a/projects/hipfft/clients/samples/hipfft_3d_z2z.cpp
+++ b/projects/hipfft/clients/samples/hipfft_3d_z2z.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 - 2025 Advanced Micro Devices, Inc. All rights
+// Copyright (C) 2019 - 2026 Advanced Micro Devices, Inc. All rights
 // reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -52,17 +52,17 @@ int main()
         throw std::runtime_error("hipMalloc failed");
 
     std::cout << "Input:\n";
-    for(size_t i = 0; i < Nx * Ny * Nz; i++)
+    for(size_t i = 0; i < static_cast<size_t>(Nx) * Ny * Nz; i++)
     {
         cdata[i] = i;
     }
-    for(int i = 0; i < Nx; i++)
+    for(size_t i = 0; i < static_cast<size_t>(Nx); i++)
     {
-        for(int j = 0; j < Ny; j++)
+        for(size_t j = 0; j < static_cast<size_t>(Ny); j++)
         {
-            for(int k = 0; k < Nz; k++)
+            for(size_t k = 0; k < static_cast<size_t>(Nz); k++)
             {
-                int pos = (i * Ny + j) * Nz + k;
+                size_t pos = (i * Ny + j) * Nz + k;
                 std::cout << cdata[pos] << " ";
             }
             std::cout << "\n";
@@ -74,11 +74,9 @@ int main()
     if(hip_rt != hipSuccess)
         throw std::runtime_error("hipMemcpy failed");
 
-    // Create plan
+    // Create plan (hipfftPlan3d internally allocates the handle)
     hipfftHandle plan{};
-    hipfftResult hipfft_rt = hipfftCreate(&plan);
-    if(hipfft_rt != HIPFFT_SUCCESS)
-        throw std::runtime_error("failed to create plan");
+    hipfftResult hipfft_rt;
 
     hipfft_rt = hipfftPlan3d(&plan, // plan handle
                              Nx, // transform length
@@ -98,13 +96,13 @@ int main()
     hip_rt = hipMemcpy(cdata.data(), x, complex_bytes, hipMemcpyDeviceToHost);
     if(hip_rt != hipSuccess)
         throw std::runtime_error("hipMemcpy failed");
-    for(int i = 0; i < Nx; i++)
+    for(size_t i = 0; i < static_cast<size_t>(Nx); i++)
     {
-        for(int j = 0; j < Ny; j++)
+        for(size_t j = 0; j < static_cast<size_t>(Ny); j++)
         {
-            for(int k = 0; k < Nz; k++)
+            for(size_t k = 0; k < static_cast<size_t>(Nz); k++)
             {
-                int pos = (i * Ny + j) * Nz + k;
+                size_t pos = (i * Ny + j) * Nz + k;
                 std::cout << cdata[pos] << " ";
             }
             std::cout << "\n";

--- a/projects/hipfft/clients/samples/hipfft_callback.cpp
+++ b/projects/hipfft/clients/samples/hipfft_callback.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 - 2025 Advanced Micro Devices, Inc. All rights
+// Copyright (C) 2021 - 2026 Advanced Micro Devices, Inc. All rights
 // reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -96,11 +96,9 @@ int main()
     }
     std::cout << std::endl;
 
-    // Create the plan
+    // Create the plan (hipfftPlan1d internally allocates the handle)
     hipfftHandle plan{};
-    hipfftResult hipfft_rt = hipfftCreate(&plan);
-    if(hipfft_rt != HIPFFT_SUCCESS)
-        throw std::runtime_error("failed to create plan");
+    hipfftResult hipfft_rt;
     hipfft_rt = hipfftPlan1d(&plan, // plan handle
                              Nx, // transform length
                              HIPFFT_Z2Z, // transform type (HIPFFT_C2C for single-precision)

--- a/projects/hipfft/clients/samples/hipfft_callback.cpp
+++ b/projects/hipfft/clients/samples/hipfft_callback.cpp
@@ -66,9 +66,8 @@ int main()
 
     // Create HIP device object and copy data to device
     // Use hipfftComplex for single-precision
-    hipError_t           hip_rt;
     hipfftDoubleComplex *x, *filter_dev;
-    hip_rt = hipMalloc(&x, complex_bytes);
+    hipError_t           hip_rt = hipMalloc(&x, complex_bytes);
     if(hip_rt != hipSuccess)
         throw std::runtime_error("hipMalloc failed");
     hip_rt = hipMalloc(&filter_dev, complex_bytes);
@@ -98,11 +97,11 @@ int main()
 
     // Create the plan (hipfftPlan1d internally allocates the handle)
     hipfftHandle plan{};
-    hipfftResult hipfft_rt;
-    hipfft_rt = hipfftPlan1d(&plan, // plan handle
-                             Nx, // transform length
-                             HIPFFT_Z2Z, // transform type (HIPFFT_C2C for single-precision)
-                             1); // number of transforms
+    hipfftResult hipfft_rt
+        = hipfftPlan1d(&plan, // plan handle
+                       Nx, // transform length
+                       HIPFFT_Z2Z, // transform type (HIPFFT_C2C for single-precision)
+                       1); // number of transforms
     if(hipfft_rt != HIPFFT_SUCCESS)
         throw std::runtime_error("hipfftPlan1d failed");
 

--- a/projects/hipfft/clients/samples/hipfft_callback.cpp
+++ b/projects/hipfft/clients/samples/hipfft_callback.cpp
@@ -143,7 +143,8 @@ int main()
     }
     std::cout << std::endl;
 
-    hipfftDestroy(plan);
+    if(hipfftDestroy(plan) != HIPFFT_SUCCESS)
+        throw std::runtime_error("hipfftDestroy failed");
 
     hip_rt = hipFree(cbdata_dev);
     if(hip_rt != hipSuccess)

--- a/projects/hipfft/clients/samples/hipfft_multigpu_2d_z2z.cpp
+++ b/projects/hipfft/clients/samples/hipfft_multigpu_2d_z2z.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights
+// Copyright (C) 2025 - 2026 Advanced Micro Devices, Inc. All rights
 // reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -59,11 +59,11 @@ int main()
     if(verbose)
     {
         std::cout << "Input:\n";
-        for(int i = 0; i < Nx; i++)
+        for(size_t i = 0; i < Nx; i++)
         {
-            for(int j = 0; j < Ny; j++)
+            for(size_t j = 0; j < Ny; j++)
             {
-                int pos = i * Ny + j;
+                size_t pos = i * Ny + j;
                 std::cout << cinput[pos] << " ";
             }
             std::cout << "\n";
@@ -74,8 +74,15 @@ int main()
     // Define list of GPUs to use
     std::vector<int> gpus = {0, 1};
 
+    // Validate requested GPU ids
+    int nDevices = 0;
+    (void)hipGetDeviceCount(&nDevices);
+    for(const auto g : gpus)
+        if(g >= nDevices)
+            throw std::runtime_error("device ID greater than number of available devices");
+
     // Create the multi-gpu plan
-    hipLibXtDesc* desc; // input descriptor
+    hipLibXtDesc* desc = nullptr;
 
     hipfftHandle plan;
     if(hipfftCreate(&plan) != HIPFFT_SUCCESS)
@@ -89,7 +96,7 @@ int main()
         throw std::runtime_error("hipfftSetStream failed.");
 
     // Assign GPUs to the plan
-    hipfftResult hipfft_rt = hipfftXtSetGPUs(plan, gpus.size(), gpus.data());
+    hipfftResult hipfft_rt = hipfftXtSetGPUs(plan, static_cast<int>(gpus.size()), gpus.data());
     if(hipfft_rt != HIPFFT_SUCCESS)
         throw std::runtime_error("hipfftXtSetGPUs failed.");
 
@@ -115,7 +122,7 @@ int main()
     // Execute the plan
     hipfft_rt = hipfftXtExecDescriptor(plan, desc, desc, direction);
     if(hipfft_rt != HIPFFT_SUCCESS)
-        throw std::runtime_error("hipfftXtMemcpy failed.");
+        throw std::runtime_error("hipfftXtExecDescriptor failed.");
 
     // Print output
     if(verbose)

--- a/projects/hipfft/clients/samples/hipfft_multigpu_2d_z2z.cpp
+++ b/projects/hipfft/clients/samples/hipfft_multigpu_2d_z2z.cpp
@@ -76,10 +76,11 @@ int main()
 
     // Validate requested GPU ids
     int nDevices = 0;
-    (void)hipGetDeviceCount(&nDevices);
+    if(hipGetDeviceCount(&nDevices) != hipSuccess)
+        throw std::runtime_error("hipGetDeviceCount failed.");
     for(const auto g : gpus)
-        if(g >= nDevices)
-            throw std::runtime_error("device ID greater than number of available devices");
+        if(g < 0 || g >= nDevices)
+            throw std::runtime_error("requested GPU ID is out of range");
 
     // Create the multi-gpu plan
     hipLibXtDesc* desc = nullptr;
@@ -147,6 +148,10 @@ int main()
         }
         std::cout << std::endl;
     }
+
+    // Wait for any outstanding work on the FFT stream before tearing things down
+    if(hipStreamSynchronize(stream) != hipSuccess)
+        throw std::runtime_error("hipStreamSynchronize failed.");
 
     // Clean up
     if(hipfftXtFree(desc) != HIPFFT_SUCCESS)

--- a/projects/hipfft/clients/samples/hipfft_planmany_2d_r2c.cpp
+++ b/projects/hipfft/clients/samples/hipfft_planmany_2d_r2c.cpp
@@ -90,25 +90,23 @@ int main()
     std::cout << std::endl;
 
     hipfftHandle hipForwardPlan;
-    hipfftResult hipfft_rt;
-    hipfft_rt = hipfftPlanMany(&hipForwardPlan,
-                               rank,
-                               n,
-                               inembed,
-                               istride,
-                               idist,
-                               onembed,
-                               ostride,
-                               odist,
-                               HIPFFT_R2C, // Use HIPFFT_D2Z for double-precsion.
-                               howmany);
+    hipfftResult hipfft_rt = hipfftPlanMany(&hipForwardPlan,
+                                            rank,
+                                            n,
+                                            inembed,
+                                            istride,
+                                            idist,
+                                            onembed,
+                                            ostride,
+                                            odist,
+                                            HIPFFT_R2C, // Use HIPFFT_D2Z for double-precsion.
+                                            howmany);
     if(hipfft_rt != HIPFFT_SUCCESS)
         throw std::runtime_error("failed to create plan");
 
     hipfftReal* gpu_data;
 
-    hipError_t hip_rt;
-    hip_rt = hipMalloc((void**)&gpu_data, total_bytes);
+    hipError_t hip_rt = hipMalloc((void**)&gpu_data, total_bytes);
     if(hip_rt != hipSuccess)
         throw std::runtime_error("hipMalloc failed");
 

--- a/projects/hipfft/clients/samples/hipfft_planmany_2d_r2c.cpp
+++ b/projects/hipfft/clients/samples/hipfft_planmany_2d_r2c.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 - 2022 Advanced Micro Devices, Inc. All rights
+// Copyright (C) 2019 - 2026 Advanced Micro Devices, Inc. All rights
 // reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -99,7 +99,7 @@ int main()
                                             onembed,
                                             ostride,
                                             odist,
-                                            HIPFFT_R2C, // Use HIPFFT_D2Z for double-precsion.
+                                            HIPFFT_R2C, // Use HIPFFT_D2Z for double-precision.
                                             howmany);
     if(hipfft_rt != HIPFFT_SUCCESS)
         throw std::runtime_error("failed to create plan");
@@ -140,7 +140,8 @@ int main()
     }
     std::cout << std::endl;
 
-    hipfftDestroy(hipForwardPlan);
+    if(hipfftDestroy(hipForwardPlan) != HIPFFT_SUCCESS)
+        throw std::runtime_error("hipfftDestroy failed");
 
     hip_rt = hipFree(gpu_data);
     if(hip_rt != hipSuccess)

--- a/projects/hipfft/clients/samples/hipfft_planmany_2d_z2z.cpp
+++ b/projects/hipfft/clients/samples/hipfft_planmany_2d_z2z.cpp
@@ -93,15 +93,13 @@ int main()
     std::cout << std::endl;
 
     hipfftHandle hipPlan;
-    hipfftResult hipfft_rt;
-    hipfft_rt = hipfftPlanMany(
+    hipfftResult hipfft_rt = hipfftPlanMany(
         &hipPlan, rank, n, inembed, istride, idist, onembed, ostride, odist, HIPFFT_Z2Z, howmany);
     if(hipfft_rt != HIPFFT_SUCCESS)
         throw std::runtime_error("failed to create plan");
 
-    hipError_t           hip_rt;
     hipfftDoubleComplex* d_in_out;
-    hip_rt = hipMalloc((void**)&d_in_out, total_bytes);
+    hipError_t           hip_rt = hipMalloc((void**)&d_in_out, total_bytes);
     if(hip_rt != hipSuccess)
         throw std::runtime_error("hipMalloc failed");
     hip_rt = hipMemcpy(d_in_out, (void*)data.data(), total_bytes, hipMemcpyHostToDevice);

--- a/projects/hipfft/clients/samples/hipfft_planmany_2d_z2z.cpp
+++ b/projects/hipfft/clients/samples/hipfft_planmany_2d_z2z.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 - 2022 Advanced Micro Devices, Inc. All rights
+// Copyright (C) 2019 - 2026 Advanced Micro Devices, Inc. All rights
 // reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -132,6 +132,8 @@ int main()
         std::cout << "\n";
     }
     std::cout << std::endl;
+
+    hipfftDestroy(hipPlan);
 
     hip_rt = hipFree(d_in_out);
     if(hip_rt != hipSuccess)

--- a/projects/hipfft/clients/samples/hipfft_planmany_2d_z2z.cpp
+++ b/projects/hipfft/clients/samples/hipfft_planmany_2d_z2z.cpp
@@ -131,7 +131,8 @@ int main()
     }
     std::cout << std::endl;
 
-    hipfftDestroy(hipPlan);
+    if(hipfftDestroy(hipPlan) != HIPFFT_SUCCESS)
+        throw std::runtime_error("hipfftDestroy failed");
 
     hip_rt = hipFree(d_in_out);
     if(hip_rt != hipSuccess)

--- a/projects/hipfft/clients/samples/hipfft_setworkarea.cpp
+++ b/projects/hipfft/clients/samples/hipfft_setworkarea.cpp
@@ -126,7 +126,8 @@ int main()
     }
     std::cout << std::endl;
 
-    hipfftDestroy(plan);
+    if(hipfftDestroy(plan) != HIPFFT_SUCCESS)
+        throw std::runtime_error("hipfftDestroy failed");
 
     hip_rt = hipFree(x);
     if(hip_rt != hipSuccess)

--- a/projects/hipfft/clients/samples/hipfft_setworkarea.cpp
+++ b/projects/hipfft/clients/samples/hipfft_setworkarea.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 - 2025 Advanced Micro Devices, Inc. All rights
+// Copyright (C) 2019 - 2026 Advanced Micro Devices, Inc. All rights
 // reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -111,6 +111,8 @@ int main()
 
     // Execute plan
     hipfft_rt = hipfftExecR2C(plan, x, (hipfftComplex*)y);
+    if(hipfft_rt != HIPFFT_SUCCESS)
+        throw std::runtime_error("hipfftExecR2C failed");
 
     // Copy result back to host
     hip_rt = hipMemcpy(cdata.data(), y, complex_bytes, hipMemcpyDeviceToHost);
@@ -127,6 +129,10 @@ int main()
     hipfftDestroy(plan);
 
     hip_rt = hipFree(x);
+    if(hip_rt != hipSuccess)
+        throw std::runtime_error("hipFree failed");
+
+    hip_rt = hipFree(y);
     if(hip_rt != hipSuccess)
         throw std::runtime_error("hipFree failed");
 

--- a/projects/rocfft/clients/samples/fixed-16/fixed-16-double.cpp
+++ b/projects/rocfft/clients/samples/fixed-16/fixed-16-double.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2016 - 2022 Advanced Micro Devices, Inc. All rights reserved.
+* Copyright (C) 2016 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -57,7 +57,7 @@ int main()
         throw std::runtime_error("hipMemcpy failed.");
 
     // Create plan
-    rocfft_plan plan   = NULL;
+    rocfft_plan plan   = nullptr;
     size_t      length = N;
     if(rocfft_plan_create(&plan,
                           rocfft_placement_inplace,
@@ -66,7 +66,7 @@ int main()
                           1,
                           &length,
                           1,
-                          NULL)
+                          nullptr)
        != rocfft_status_success)
         throw std::runtime_error("rocfft_plan_create failed.");
 
@@ -88,7 +88,7 @@ int main()
     }
 
     // Execute plan
-    if(rocfft_execute(plan, (void**)&x, NULL, info) != rocfft_status_success)
+    if(rocfft_execute(plan, (void**)&x, nullptr, info) != rocfft_status_success)
         throw std::runtime_error("rocfft_execute failed.");
     if(hipDeviceSynchronize() != hipSuccess)
         throw std::runtime_error("hipDeviceSynchronize failed.");

--- a/projects/rocfft/clients/samples/fixed-16/fixed-16-float.cpp
+++ b/projects/rocfft/clients/samples/fixed-16/fixed-16-float.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2016 - 2022 Advanced Micro Devices, Inc. All rights reserved.
+* Copyright (C) 2016 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -57,7 +57,7 @@ int main()
         throw std::runtime_error("hipMemcpy failed.");
 
     // Create plan
-    rocfft_plan plan   = NULL;
+    rocfft_plan plan   = nullptr;
     size_t      length = N;
     if(rocfft_plan_create(&plan,
                           rocfft_placement_inplace,
@@ -66,7 +66,7 @@ int main()
                           1,
                           &length,
                           1,
-                          NULL)
+                          nullptr)
        != rocfft_status_success)
         throw std::runtime_error("rocfft_plan_create failed.");
 
@@ -88,7 +88,7 @@ int main()
     }
 
     // Execute plan
-    if(rocfft_execute(plan, (void**)&x, NULL, info) != rocfft_status_success)
+    if(rocfft_execute(plan, (void**)&x, nullptr, info) != rocfft_status_success)
         throw std::runtime_error("rocfft_execute failed.");
     if(hipDeviceSynchronize() != hipSuccess)
         throw std::runtime_error("hipDeviceSynchronize failed.");

--- a/projects/rocfft/clients/samples/fixed-16/fixed-16-half.cpp
+++ b/projects/rocfft/clients/samples/fixed-16/fixed-16-half.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+* Copyright (C) 2023 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -57,7 +57,7 @@ int main()
         throw std::runtime_error("hipMemcpy failed.");
 
     // Create plan
-    rocfft_plan plan   = NULL;
+    rocfft_plan plan   = nullptr;
     size_t      length = N;
     if(rocfft_plan_create(&plan,
                           rocfft_placement_inplace,
@@ -66,7 +66,7 @@ int main()
                           1,
                           &length,
                           1,
-                          NULL)
+                          nullptr)
        != rocfft_status_success)
         throw std::runtime_error("rocfft_plan_create failed.");
 
@@ -88,7 +88,7 @@ int main()
     }
 
     // Execute plan
-    if(rocfft_execute(plan, (void**)&x, NULL, info) != rocfft_status_success)
+    if(rocfft_execute(plan, (void**)&x, nullptr, info) != rocfft_status_success)
         throw std::runtime_error("rocfft_execute failed.");
     if(hipDeviceSynchronize() != hipSuccess)
         throw std::runtime_error("hipDeviceSynchronize failed.");

--- a/projects/rocfft/clients/samples/fixed-large/fixed-large-double.cpp
+++ b/projects/rocfft/clients/samples/fixed-large/fixed-large-double.cpp
@@ -85,7 +85,7 @@ int main()
 
     if(workBufferSize > 0)
     {
-        printf("size of workbuffer=%zu\n", workBufferSize);
+        std::cout << "size of workbuffer=" << workBufferSize << "\n";
         if(hipMalloc(&workBuffer, workBufferSize) != hipSuccess)
             throw std::runtime_error("hipMalloc failed.");
         if(rocfft_execution_info_set_work_buffer(info, workBuffer, workBufferSize)

--- a/projects/rocfft/clients/samples/fixed-large/fixed-large-double.cpp
+++ b/projects/rocfft/clients/samples/fixed-large/fixed-large-double.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2016 - 2022 Advanced Micro Devices, Inc. All rights reserved.
+* Copyright (C) 2016 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -85,7 +85,7 @@ int main()
 
     if(workBufferSize > 0)
     {
-        printf("size of workbuffer=%d\n", (int)workBufferSize);
+        printf("size of workbuffer=%zu\n", workBufferSize);
         if(hipMalloc(&workBuffer, workBufferSize) != hipSuccess)
             throw std::runtime_error("hipMalloc failed.");
         if(rocfft_execution_info_set_work_buffer(info, workBuffer, workBufferSize)

--- a/projects/rocfft/clients/samples/fixed-large/fixed-large-float.cpp
+++ b/projects/rocfft/clients/samples/fixed-large/fixed-large-float.cpp
@@ -85,7 +85,7 @@ int main()
 
     if(workBufferSize > 0)
     {
-        printf("size of workbuffer=%zu\n", workBufferSize);
+        std::cout << "size of workbuffer=" << workBufferSize << "\n";
         if(hipMalloc(&workBuffer, workBufferSize) != hipSuccess)
             throw std::runtime_error("hipMalloc failed.");
         if(rocfft_execution_info_set_work_buffer(info, workBuffer, workBufferSize)

--- a/projects/rocfft/clients/samples/fixed-large/fixed-large-float.cpp
+++ b/projects/rocfft/clients/samples/fixed-large/fixed-large-float.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2016 - 2022 Advanced Micro Devices, Inc. All rights reserved.
+* Copyright (C) 2016 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -85,7 +85,7 @@ int main()
 
     if(workBufferSize > 0)
     {
-        printf("size of workbuffer=%d\n", (int)workBufferSize);
+        printf("size of workbuffer=%zu\n", workBufferSize);
         if(hipMalloc(&workBuffer, workBufferSize) != hipSuccess)
             throw std::runtime_error("hipMalloc failed.");
         if(rocfft_execution_info_set_work_buffer(info, workBuffer, workBufferSize)

--- a/projects/rocfft/clients/samples/mpi/rocfft_mpi_example.cpp
+++ b/projects/rocfft/clients/samples/mpi/rocfft_mpi_example.cpp
@@ -1,6 +1,6 @@
 
 /******************************************************************************
-* Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+* Copyright (C) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -41,7 +41,7 @@ auto rocfft_status_sync(const rocfft_status fftrc, const MPI_Comm comm)
     // by getting the maximum value of the return code over all procs.
 
     // Guarantee that the enum is an unsigned int so that we can send this via MPI:
-    static_assert(std::is_same_v<std::underlying_type_t<typeof(fftrc)>, unsigned int>);
+    static_assert(std::is_same_v<std::underlying_type_t<decltype(fftrc)>, unsigned int>);
 
     auto       global_fftrc = rocfft_status_success;
     const auto mpirc        = MPI_Allreduce(&fftrc, &global_fftrc, 1, MPI_UNSIGNED, MPI_MAX, comm);
@@ -60,7 +60,7 @@ auto hip_status_sync(const hipError_t hiprc, const MPI_Comm comm)
     // by getting the maximum value of the return code over all procs.
 
     // Guarantee that the enum is an unsigned int so that we can send this via MPI:
-    static_assert(std::is_same_v<std::underlying_type_t<typeof(hiprc)>, unsigned int>);
+    static_assert(std::is_same_v<std::underlying_type_t<decltype(hiprc)>, unsigned int>);
 
     auto       global_hiprc = hipSuccess;
     const auto mpirc        = MPI_Allreduce(&hiprc, &global_hiprc, 1, MPI_UNSIGNED, MPI_MAX, comm);
@@ -259,8 +259,6 @@ int main(int argc, char** argv)
         rocfft_field_create(&outfield);
 
         rocfft_brick outbrick = nullptr;
-        outbrick_lower        = {0, outbrick_lower1, 0};
-        outbrick_upper        = {length[0], outbrick_lower1 + outbrick_length1, 1};
         rocfft_brick_create(&outbrick,
                             outbrick_lower.data(),
                             outbrick_upper.data(),
@@ -398,7 +396,7 @@ int main(int argc, char** argv)
     {
         if(rocfft_plan_description_destroy(description) != rocfft_status_success)
         {
-            std::cerr << "description descruction failed\n";
+            std::cerr << "description destruction failed\n";
         }
         else
         {

--- a/projects/rocfft/clients/samples/multi_gpu/mgpu_complex.cpp
+++ b/projects/rocfft/clients/samples/multi_gpu/mgpu_complex.cpp
@@ -318,18 +318,12 @@ int main(int argc, char* argv[])
     if(rocfft_cleanup() != rocfft_status_success)
         throw std::runtime_error("rocfft_cleanup failed.");
 
-    // Free work buffers
+    // Free work buffers and input/output buffers (indexed by brick, not device id)
     for(size_t idx = 0; idx < devices.size(); ++idx)
     {
         (void)hipSetDevice(devices[idx]);
         if(work_bufs[idx])
             (void)hipFree(work_bufs[idx]);
-    }
-
-    // Free input/output buffers (indexed by brick, not device id)
-    for(size_t idx = 0; idx < devices.size(); ++idx)
-    {
-        (void)hipSetDevice(devices[idx]);
         (void)hipFree(gpu_in[idx]);
         (void)hipFree(gpu_out[idx]);
     }

--- a/projects/rocfft/clients/samples/multi_gpu/mgpu_complex.cpp
+++ b/projects/rocfft/clients/samples/multi_gpu/mgpu_complex.cpp
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#include <algorithm>
 #include <complex>
 #include <functional>
 #include <iostream>
@@ -58,8 +59,9 @@ int main(int argc, char* argv[])
 
     int deviceCount = devices.size();
     std::cout << "Using " << deviceCount << " device(s)\n";
-    int nDevices;
-    (void)hipGetDeviceCount(&nDevices);
+    int nDevices = 0;
+    if(hipGetDeviceCount(&nDevices) != hipSuccess)
+        throw std::runtime_error("hipGetDeviceCount failed.");
 
     std::cout << "Number of available GPUs: " << nDevices << " \n";
     if(nDevices <= static_cast<int>(*std::max_element(devices.begin(), devices.end())))
@@ -217,7 +219,9 @@ int main(int argc, char* argv[])
             std::cout << "\n";
             std::cout << "\tbuffer size: " << memSize << "\n";
 
-            (void)hipSetDevice(devices[idx]);
+            hiprc = hipSetDevice(devices[idx]);
+            if(hiprc != hipSuccess)
+                throw std::runtime_error("hipSetDevice failed");
 
             if(hipMalloc(&gpu_out[idx], memSize) != hipSuccess)
                 throw std::runtime_error("hipMalloc failed");
@@ -231,7 +235,9 @@ int main(int argc, char* argv[])
     }
 
     // Create a multi-gpu plan:
-    (void)hipSetDevice(devices[0]);
+    hiprc = hipSetDevice(devices[0]);
+    if(hiprc != hipSuccess)
+        throw std::runtime_error("hipSetDevice failed");
     rocfft_plan gpu_plan = nullptr;
     fftrc                = rocfft_plan_create(&gpu_plan,
                                place,
@@ -249,7 +255,9 @@ int main(int argc, char* argv[])
     std::vector<void*>    work_bufs(devices.size(), nullptr);
     for(size_t idx = 0; idx < devices.size(); ++idx)
     {
-        (void)hipSetDevice(devices[idx]);
+        hiprc = hipSetDevice(devices[idx]);
+        if(hiprc != hipSuccess)
+            throw std::runtime_error("hipSetDevice failed");
         size_t work_buf_size = 0;
         if(rocfft_plan_get_work_buffer_size(gpu_plan, &work_buf_size) != rocfft_status_success)
             throw std::runtime_error("rocfft_plan_get_work_buffer_size failed.");
@@ -267,7 +275,9 @@ int main(int argc, char* argv[])
     }
 
     // Reset the device back to where the plan was created before execution
-    (void)hipSetDevice(devices[0]);
+    hiprc = hipSetDevice(devices[0]);
+    if(hiprc != hipSuccess)
+        throw std::runtime_error("hipSetDevice failed");
 
     // Execute plan:
     fftrc = rocfft_execute(gpu_plan, (void**)gpu_in.data(), (void**)gpu_out.data(), planinfo);
@@ -321,11 +331,14 @@ int main(int argc, char* argv[])
     // Free work buffers and input/output buffers (indexed by brick, not device id)
     for(size_t idx = 0; idx < devices.size(); ++idx)
     {
-        (void)hipSetDevice(devices[idx]);
-        if(work_bufs[idx])
-            (void)hipFree(work_bufs[idx]);
-        (void)hipFree(gpu_in[idx]);
-        (void)hipFree(gpu_out[idx]);
+        if(hipSetDevice(devices[idx]) != hipSuccess)
+            throw std::runtime_error("hipSetDevice failed");
+        if(work_bufs[idx] && hipFree(work_bufs[idx]) != hipSuccess)
+            throw std::runtime_error("hipFree failed");
+        if(hipFree(gpu_in[idx]) != hipSuccess)
+            throw std::runtime_error("hipFree failed");
+        if(hipFree(gpu_out[idx]) != hipSuccess)
+            throw std::runtime_error("hipFree failed");
     }
 
     return 0;

--- a/projects/rocfft/clients/samples/multi_gpu/mgpu_complex.cpp
+++ b/projects/rocfft/clients/samples/multi_gpu/mgpu_complex.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -244,12 +244,12 @@ int main(int argc, char* argv[])
     if(fftrc != rocfft_status_success)
         throw std::runtime_error("failed to create plan");
 
-    // Get execution information and allocate work buffer for each device
+    // Allocate a work buffer on each device used by the transform
     rocfft_execution_info planinfo = nullptr;
-    std::vector<void*>    work_bufs(nDevices);
-    for(int device = 0; device < nDevices; ++device)
+    std::vector<void*>    work_bufs(devices.size(), nullptr);
+    for(size_t idx = 0; idx < devices.size(); ++idx)
     {
-        (void)hipSetDevice(device);
+        (void)hipSetDevice(devices[idx]);
         size_t work_buf_size = 0;
         if(rocfft_plan_get_work_buffer_size(gpu_plan, &work_buf_size) != rocfft_status_success)
             throw std::runtime_error("rocfft_plan_get_work_buffer_size failed.");
@@ -258,9 +258,9 @@ int main(int argc, char* argv[])
         {
             if(!planinfo && rocfft_execution_info_create(&planinfo) != rocfft_status_success)
                 throw std::runtime_error("failed to create execution info");
-            if(hipMalloc(&work_bufs[device], work_buf_size) != hipSuccess)
+            if(hipMalloc(&work_bufs[idx], work_buf_size) != hipSuccess)
                 throw std::runtime_error("hipMalloc failed");
-            if(rocfft_execution_info_set_work_buffer(planinfo, work_bufs[device], work_buf_size)
+            if(rocfft_execution_info_set_work_buffer(planinfo, work_bufs[idx], work_buf_size)
                != rocfft_status_success)
                 throw std::runtime_error("rocfft_execution_info_set_work_buffer failed.");
         }
@@ -318,18 +318,20 @@ int main(int argc, char* argv[])
     if(rocfft_cleanup() != rocfft_status_success)
         throw std::runtime_error("rocfft_cleanup failed.");
 
-    for(int device = 0; device < nDevices; ++device)
+    // Free work buffers
+    for(size_t idx = 0; idx < devices.size(); ++idx)
     {
-        (void)hipSetDevice(device);
-        if(work_bufs[device])
-            (void)hipFree(work_bufs[device]);
+        (void)hipSetDevice(devices[idx]);
+        if(work_bufs[idx])
+            (void)hipFree(work_bufs[idx]);
     }
 
-    for(const auto device : devices)
+    // Free input/output buffers (indexed by brick, not device id)
+    for(size_t idx = 0; idx < devices.size(); ++idx)
     {
-        (void)hipSetDevice(device);
-        (void)hipFree(gpu_in[device]);
-        (void)hipFree(gpu_out[device]);
+        (void)hipSetDevice(devices[idx]);
+        (void)hipFree(gpu_in[idx]);
+        (void)hipFree(gpu_out[idx]);
     }
 
     return 0;

--- a/projects/rocfft/clients/samples/rocfft/rocfft_example_callback.cpp
+++ b/projects/rocfft/clients/samples/rocfft/rocfft_example_callback.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2021 - 2022 Advanced Micro Devices, Inc. All rights reserved.
+* Copyright (C) 2021 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -162,10 +162,12 @@ int main()
     {
         if(hipFree(work_buf) != hipSuccess)
             throw std::runtime_error("hipFree failed.");
-        if(rocfft_execution_info_destroy(info) != rocfft_status_success)
-            throw std::runtime_error("rocfft_execution_info_destroy failed.");
-        info = nullptr;
     }
+
+    // execution info is always created above; destroy it unconditionally
+    if(rocfft_execution_info_destroy(info) != rocfft_status_success)
+        throw std::runtime_error("rocfft_execution_info_destroy failed.");
+    info = nullptr;
 
     // Destroy plan
     if(rocfft_plan_destroy(plan) != rocfft_status_success)

--- a/projects/rocfft/clients/samples/rocfft/rocfft_example_complexcomplex.cpp
+++ b/projects/rocfft/clients/samples/rocfft/rocfft_example_complexcomplex.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2019 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -69,8 +69,8 @@ int main(int argc, char* argv[])
     const bool inplace = place == rocfft_placement_inplace;
 
     // Direction of transform
-    const rocfft_transform_type direction = *opt_inverse ? rocfft_transform_type_complex_forward
-                                                         : rocfft_transform_type_complex_inverse;
+    const rocfft_transform_type direction = *opt_inverse ? rocfft_transform_type_complex_inverse
+                                                         : rocfft_transform_type_complex_forward;
 
     // Set up the strides and buffer size for the input:
     std::vector<size_t> istride = {1};
@@ -112,7 +112,7 @@ int main(int argc, char* argv[])
         std::cout << " " << i;
     std::cout << "\n";
     std::cout << "input size: " << isize << "\n";
-    std::cout << "output size: " << isize << "\n";
+    std::cout << "output size: " << osize << "\n";
     std::cout << std::endl;
 
     // Set the device:
@@ -124,7 +124,7 @@ int main(int argc, char* argv[])
     if(hipMalloc(&gpu_in, isize * sizeof(hipDoubleComplex)) != hipSuccess)
         throw std::runtime_error("hipMalloc failed.");
 
-    // Inititalize the data on the device
+    // Initialize the data on the device
     initcomplex_cm(length, istride, gpu_in);
     if(hipDeviceSynchronize() != hipSuccess)
         throw std::runtime_error("hipDeviceSynchronize failed.");
@@ -225,7 +225,7 @@ int main(int argc, char* argv[])
     if(hip_status != hipSuccess)
         throw std::runtime_error("hipMemcpy failed.");
 
-    printbuffer_cm(odata, length, istride, 1, isize);
+    printbuffer_cm(odata, length, ostride, 1, osize);
 
     // Clean up: free GPU memory:
     if(hipFree(gpu_in) != hipSuccess)

--- a/projects/rocfft/clients/samples/rocfft/rocfft_example_realcomplex.cpp
+++ b/projects/rocfft/clients/samples/rocfft/rocfft_example_realcomplex.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2019 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -312,6 +312,7 @@ int main(int argc, char* argv[])
         throw std::runtime_error("rocfft_plan_destroy failed.");
     gpu_plan = nullptr;
 
-    rocfft_cleanup();
+    if(rocfft_cleanup() != rocfft_status_success)
+        throw std::runtime_error("rocfft_cleanup failed.");
     return 0;
 }

--- a/projects/rocfft/clients/samples/rocfft/rocfft_example_set_stream.cpp
+++ b/projects/rocfft/clients/samples/rocfft/rocfft_example_set_stream.cpp
@@ -38,10 +38,8 @@ int main(int argc, char* argv[])
 {
     std::cout << "rocfft example of 2 inplace transforms with 2 streams.\n" << std::endl;
 
-    size_t        length      = 8;
-    size_t        total_bytes = length * sizeof(double2);
-    hipError_t    hip_status;
-    rocfft_status fft_status;
+    size_t length      = 8;
+    size_t total_bytes = length * sizeof(double2);
 
     fft_fixture_t ffts[2];
 
@@ -69,7 +67,7 @@ int main(int argc, char* argv[])
             throw std::runtime_error("hipStreamCreate failed.");
 
         // create execution info
-        fft_status = rocfft_execution_info_create(&(it.info));
+        rocfft_status fft_status = rocfft_execution_info_create(&(it.info));
         if(fft_status != rocfft_status_success)
             throw std::runtime_error("rocfft_execution_info_create failed.");
 
@@ -103,7 +101,8 @@ int main(int argc, char* argv[])
     /// execution
     for(auto& it : ffts)
     {
-        fft_status = rocfft_execute(it.plan, (void**)&(it.gpu_buf), (void**)&(it.gpu_buf), nullptr);
+        rocfft_status fft_status
+            = rocfft_execute(it.plan, (void**)&(it.gpu_buf), (void**)&(it.gpu_buf), nullptr);
         if(fft_status != rocfft_status_success)
             throw std::runtime_error("rocfft_execute failed.");
     }
@@ -113,7 +112,8 @@ int main(int argc, char* argv[])
     {
         if(hipStreamSynchronize(it.stream) != hipSuccess)
             throw std::runtime_error("hipStreamSynchronize failed.");
-        hip_status = hipMemcpy(it.cpu_buf.data(), it.gpu_buf, total_bytes, hipMemcpyDeviceToHost);
+        hipError_t hip_status
+            = hipMemcpy(it.cpu_buf.data(), it.gpu_buf, total_bytes, hipMemcpyDeviceToHost);
         if(hip_status != hipSuccess)
             throw std::runtime_error("hipMemcpy failed.");
     }
@@ -121,7 +121,7 @@ int main(int argc, char* argv[])
     /// clean up
     for(auto& it : ffts)
     {
-        fft_status = rocfft_plan_destroy(it.plan);
+        rocfft_status fft_status = rocfft_plan_destroy(it.plan);
         if(fft_status != rocfft_status_success)
             throw std::runtime_error("rocfft_plan_destroy failed.");
 

--- a/projects/rocfft/clients/samples/rocfft/rocfft_example_set_stream.cpp
+++ b/projects/rocfft/clients/samples/rocfft/rocfft_example_set_stream.cpp
@@ -38,8 +38,8 @@ int main(int argc, char* argv[])
 {
     std::cout << "rocfft example of 2 inplace transforms with 2 streams.\n" << std::endl;
 
-    size_t length      = 8;
-    size_t total_bytes = length * sizeof(double2);
+    const size_t length      = 8;
+    const size_t total_bytes = length * sizeof(double2);
 
     fft_fixture_t ffts[2];
 


### PR DESCRIPTION
## Motivation

Fix a set of resource leaks, correctness bugs, and portability issues in the rocFFT and hipFFT client samples so they serve as reliable reference code for users.

## Technical Details

This PR plugs resource leaks (redundant hipfftCreate before hipfftPlan*d, missing hipFree/hipfftDestroy/rocfft_execution_info_destroy calls), fixes correctness issues (out-of-bounds device indexing in the multi-GPU work-buffer allocation, wrong output-size prints and error messages), and improves robustness and portability (validating requested GPU IDs, checking previously-ignored API return values, using size_t to avoid signed overflow and warnings, replacing GCC-only typeof with decltype). It also cleans up minor typos.

## Test Plan

Locally run whole samples and Run CI

## Test Result

Local testing showed all samples run correctly. CI pending.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
