### PR TITLE
[CK] Add render group to AITER and FA dockers

### DIFF
--- a/projects/composablekernel/Dockerfile.aiter
+++ b/projects/composablekernel/Dockerfile.aiter
@@ -34,6 +34,7 @@ RUN pip install pandas zmq einops ninja tabulate vcs_versioning && \
     python3 setup.py develop && \
     groupadd -g 1001 jenkins && \
     useradd -u 1001 -g 1001 -m -s /bin/bash jenkins && \
+    groupadd -f video && \
     groupadd -f render && \
     chown -R jenkins:jenkins /home/jenkins && \
     chmod -R a+rwx /home/jenkins && \

--- a/projects/composablekernel/Dockerfile.aiter
+++ b/projects/composablekernel/Dockerfile.aiter
@@ -32,6 +32,7 @@ RUN pip install pandas zmq einops ninja tabulate vcs_versioning && \
     rm -rf 3rdparty/composable_kernel/ && \
     git clone -b "$CK_AITER_BRANCH" ../ck 3rdparty/composable_kernel/ && \
     python3 setup.py develop && \
+    groupadd -f render && \
     groupadd -g 1001 jenkins && \
     useradd -u 1001 -g 1001 -m -s /bin/bash jenkins && \
     chown -R jenkins:jenkins /home/jenkins && \

--- a/projects/composablekernel/Dockerfile.aiter
+++ b/projects/composablekernel/Dockerfile.aiter
@@ -32,9 +32,9 @@ RUN pip install pandas zmq einops ninja tabulate vcs_versioning && \
     rm -rf 3rdparty/composable_kernel/ && \
     git clone -b "$CK_AITER_BRANCH" ../ck 3rdparty/composable_kernel/ && \
     python3 setup.py develop && \
-    groupadd -f render && \
     groupadd -g 1001 jenkins && \
     useradd -u 1001 -g 1001 -m -s /bin/bash jenkins && \
+    groupadd -f render && \
     chown -R jenkins:jenkins /home/jenkins && \
     chmod -R a+rwx /home/jenkins && \
     chown -R jenkins:jenkins /tmp && \

--- a/projects/composablekernel/Dockerfile.fa
+++ b/projects/composablekernel/Dockerfile.fa
@@ -34,9 +34,9 @@ RUN set -x ; \
     rm -rf csrc/composable_kernel/ && \
     git clone -b "$CK_FA_BRANCH" ../ck csrc/composable_kernel/ && git add csrc/composable_kernel && \
     MAX_JOBS=$(nproc) GPU_ARCHS="$GPU_ARCHS" /opt/venv/bin/python3 -u -m pip install --no-build-isolation -v . && \
-    groupadd -f render && \
     groupadd -g 1001 jenkins && \
     useradd -u 1001 -g 1001 -m -s /bin/bash jenkins && \
+    groupadd -f render && \
     chown -R jenkins:jenkins /home/jenkins && \
     chmod -R a+rwx /home/jenkins && \
     chown -R jenkins:jenkins /tmp && \

--- a/projects/composablekernel/Dockerfile.fa
+++ b/projects/composablekernel/Dockerfile.fa
@@ -34,6 +34,7 @@ RUN set -x ; \
     rm -rf csrc/composable_kernel/ && \
     git clone -b "$CK_FA_BRANCH" ../ck csrc/composable_kernel/ && git add csrc/composable_kernel && \
     MAX_JOBS=$(nproc) GPU_ARCHS="$GPU_ARCHS" /opt/venv/bin/python3 -u -m pip install --no-build-isolation -v . && \
+    groupadd -f render && \
     groupadd -g 1001 jenkins && \
     useradd -u 1001 -g 1001 -m -s /bin/bash jenkins && \
     chown -R jenkins:jenkins /home/jenkins && \

--- a/projects/composablekernel/Dockerfile.fa
+++ b/projects/composablekernel/Dockerfile.fa
@@ -36,6 +36,7 @@ RUN set -x ; \
     MAX_JOBS=$(nproc) GPU_ARCHS="$GPU_ARCHS" /opt/venv/bin/python3 -u -m pip install --no-build-isolation -v . && \
     groupadd -g 1001 jenkins && \
     useradd -u 1001 -g 1001 -m -s /bin/bash jenkins && \
+    groupadd -f video && \
     groupadd -f render && \
     chown -R jenkins:jenkins /home/jenkins && \
     chmod -R a+rwx /home/jenkins && \


### PR DESCRIPTION
## Motivation

The AITER and FA test dockers (`Dockerfile.aiter`, `Dockerfile.fa`) inherit from the `rocm/pytorch` base image. Recent updates to that base image dropped the `render` group from `/etc/group`, so every parallel test stage now fails on the test agents with:

```
docker: Error response from daemon: Unable to find group render:
no matching entries in group file.
```

Jenkins resolves `--group-add render` against the **container's** `/etc/group`, not the host's, so even though the test agents have render in their `/etc/group` (GID 109), the container lookup fails.

This pattern affects every recent develop build ([#673](http://micimaster.amd.com/blue/organizations/jenkins/rocm-libraries-folder%2FComposable%20Kernel/detail/develop/673), [#674](http://micimaster.amd.com/blue/organizations/jenkins/rocm-libraries-folder%2FComposable%20Kernel/detail/develop/674), [#686](http://micimaster.amd.com/blue/organizations/jenkins/rocm-libraries-folder%2FComposable%20Kernel/detail/develop/686), [#688](http://micimaster.amd.com/blue/organizations/jenkins/rocm-libraries-folder%2FComposable%20Kernel/detail/develop/688), [#699](http://micimaster.amd.com/blue/organizations/jenkins/rocm-libraries-folder%2FComposable%20Kernel/detail/develop/699), [#708](http://micimaster.amd.com/blue/organizations/jenkins/rocm-libraries-folder%2FComposable%20Kernel/detail/develop/708) — 6 days in a row), where AITER tests fail in seconds and the cascading failure aborts all downstream Build/FMHA/TILE_ENGINE stages.

## Technical Details

Add `groupadd -f render` to both `Dockerfile.aiter` and `Dockerfile.fa`, mirroring what the main `Dockerfile` already does (`Dockerfile:96`) and what `Dockerfile.pytorch` does (`Dockerfile.pytorch:4`). The `-f` flag makes it idempotent — silently succeeds if the group already exists.

This guarantees the `render` group is always present in the container, regardless of whether the base image happens to ship it.

## Test Plan
Triggering AITER CI job: 

## Test Result

## Submission Checklist

- [x] Look over the contributing guidelines at
      https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.