### PR TITLE
Add batchnorm forward dynamic tolerance

### DIFF
--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerances.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerances.hpp
@@ -8,6 +8,7 @@
 // New operation-specific tolerance implementations should be added to their own
 // header (e.g., DynamicTolerancesBatchNorm.hpp) and included here.
 
+#include <hipdnn_test_sdk/utilities/DynamicTolerancesBatchNorm.hpp>
 #include <hipdnn_test_sdk/utilities/DynamicTolerancesCommon.hpp>
 #include <hipdnn_test_sdk/utilities/DynamicTolerancesConv.hpp>
 #include <hipdnn_test_sdk/utilities/DynamicTolerancesMatmul.hpp>

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerancesBatchNorm.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerancesBatchNorm.hpp
@@ -74,15 +74,15 @@ float calculateBatchnormTrainingTolerance(double xMin,
     const double maxAbsScale = std::max(std::abs(scaleMin), std::abs(scaleMax));
     const double maxAbsBias = std::max(std::abs(biasMin), std::abs(biasMax));
 
-    auto NHW = static_cast<uint64_t>(nElementsPerChannel);
+    auto nhw = static_cast<uint64_t>(nElementsPerChannel);
     auto epsilon = static_cast<double>(std::numeric_limits<ComputeType>::epsilon());
 
-    const double gammaNHW = computeGamma(NHW, epsilon);
+    const double gammaNHW = computeGamma(nhw, epsilon);
     validateGamma(gammaNHW);
 
     // Sum-of-squares accumulation error for variance path (same structure as RMSNorm).
     // S = sum_{i=0}^{NHW-1} x_i^2 (self-product)
-    const double sumAbsProductBound = static_cast<double>(NHW) * maxAbsX * maxAbsX;
+    const double sumAbsProductBound = static_cast<double>(nhw) * maxAbsX * maxAbsX;
 
     double accumulatedTolerance = gammaNHW * sumAbsProductBound;
 
@@ -148,10 +148,10 @@ float calculateBatchnormMeanTolerance(double xMin, double xMax, int64_t nElement
     }
 
     const double maxAbsX = std::max(std::abs(xMin), std::abs(xMax));
-    auto NHW = static_cast<uint64_t>(nElementsPerChannel);
+    auto nhw = static_cast<uint64_t>(nElementsPerChannel);
     auto epsilon = static_cast<double>(std::numeric_limits<ComputeType>::epsilon());
 
-    const double gammaNHW = computeGamma(NHW, epsilon);
+    const double gammaNHW = computeGamma(nhw, epsilon);
     validateGamma(gammaNHW);
 
     // mean = (sum x_i) / NHW
@@ -162,11 +162,11 @@ float calculateBatchnormMeanTolerance(double xMin, double xMax, int64_t nElement
 
     // Input casting (single tensor, factor 1): signalBound = NHW * maxAbsX.
     // After division by NHW, casting contribution is ~ computeEpsilon * maxAbsX.
-    double inputCastError
-        = computeInputCastingError<InputType, ComputeType>(static_cast<double>(NHW) * maxAbsX, 1);
+    const double inputCastError
+        = computeInputCastingError<InputType, ComputeType>(static_cast<double>(nhw) * maxAbsX, 1);
     if(maxAbsX > 0.0)
     {
-        tolerance += inputCastError / static_cast<double>(NHW);
+        tolerance += inputCastError / static_cast<double>(nhw);
     }
 
     // Output casting.
@@ -210,10 +210,10 @@ float calculateBatchnormInvVarianceTolerance(double xMin,
     }
 
     const double maxAbsX = std::max(std::abs(xMin), std::abs(xMax));
-    auto NHW = static_cast<uint64_t>(nElementsPerChannel);
+    auto nhw = static_cast<uint64_t>(nElementsPerChannel);
     auto epsilon = static_cast<double>(std::numeric_limits<ComputeType>::epsilon());
 
-    const double gammaNHW = computeGamma(NHW, epsilon);
+    const double gammaNHW = computeGamma(nhw, epsilon);
     validateGamma(gammaNHW);
 
     // Variance error (see plan Section 2, Stage 2):
@@ -221,7 +221,7 @@ float calculateBatchnormInvVarianceTolerance(double xMin,
     //                     + 2 * maxAbsX * deltaMean (mean^2 error)
     //                     + u * max|x|^2            (subtraction error)
     //   Simplified: ~ 3 * gamma * max|x|^2  (since deltaMean ~ gamma * maxAbsX)
-    double deltaVariance = 3.0 * gammaNHW * maxAbsX * maxAbsX;
+    const double deltaVariance = 3.0 * gammaNHW * maxAbsX * maxAbsX;
 
     // Nonlinear ops: add(epsilon_bn) + sqrt + reciprocal
     constexpr double NONLINEAR_OPS = 3.0;
@@ -241,7 +241,7 @@ float calculateBatchnormInvVarianceTolerance(double xMin,
     }
 
     // Output casting: invVar ~ sqrt(3)/maxAbsX for typical data, 1/sqrt(eps_bn) for x~0
-    double maxInvVar = maxAbsX > 0.0 ? std::sqrt(3.0) / maxAbsX : 1.0 / std::sqrt(epsilonBn);
+    const double maxInvVar = maxAbsX > 0.0 ? std::sqrt(3.0) / maxAbsX : 1.0 / std::sqrt(epsilonBn);
     tolerance += computeOutputCastingError<OutputType, ComputeType>(maxInvVar);
 
     validateToleranceRange<OutputType>(tolerance);

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerancesBatchNorm.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerancesBatchNorm.hpp
@@ -44,6 +44,7 @@ using hipdnn_data_sdk::types::half;
  * @param biasMin             Minimum value in bias tensor
  * @param biasMax             Maximum value in bias tensor
  * @param nElementsPerChannel Number of elements per channel: N * H * W (reduction dim)
+ * @param epsilonBn           Batch norm epsilon (added to variance before sqrt)
  * @return Calculated tolerance value as float
  *
  * Known Limitations:
@@ -71,13 +72,19 @@ float calculateBatchnormTrainingTolerance(double xMin,
                                           double scaleMax,
                                           double biasMin,
                                           double biasMax,
-                                          int64_t nElementsPerChannel)
+                                          int64_t nElementsPerChannel,
+                                          double epsilonBn = 1e-5)
 {
     validateComputeType<ComputeType>();
 
     if(nElementsPerChannel < 1)
     {
         throw std::invalid_argument("nElementsPerChannel must be at least 1.");
+    }
+
+    if(epsilonBn <= 0.0)
+    {
+        throw std::invalid_argument("epsilonBn must be positive.");
     }
 
     const double maxAbsX = std::max(std::abs(xMin), std::abs(xMax));
@@ -129,11 +136,10 @@ float calculateBatchnormTrainingTolerance(double xMin,
 
     // Output casting error.
     // Conservative bound: instead of assuming |xHat| ~ O(1) cancels input magnitude,
-    // use invVarEstimate from max(maxAbsX^2, eps_bn_default) to bound output magnitude.
+    // use invVarEstimate from max(maxAbsX^2, epsilonBn) to bound output magnitude.
     // This handles the case where variance is small and |xHat| >> 1.
-    constexpr double EPSILON_BN_DEFAULT = 1e-5;
-    const double varEst = std::max(maxAbsX * maxAbsX, EPSILON_BN_DEFAULT);
-    const double invVarEst = 1.0 / std::sqrt(varEst + EPSILON_BN_DEFAULT);
+    const double varEst = std::max(maxAbsX * maxAbsX, epsilonBn);
+    const double invVarEst = 1.0 / std::sqrt(varEst + epsilonBn);
     const double maxOutputMagnitude
         = (maxAbsX > 0.0 ? maxAbsScale * maxAbsX * invVarEst : 0.0) + maxAbsBias;
     propagatedTolerance += computeOutputCastingError<OutputType, ComputeType>(maxOutputMagnitude);
@@ -229,6 +235,11 @@ float calculateBatchnormInvVarianceTolerance(double xMin,
     if(nElementsPerChannel < 1)
     {
         throw std::invalid_argument("nElementsPerChannel must be at least 1.");
+    }
+
+    if(epsilonBn <= 0.0)
+    {
+        throw std::invalid_argument("epsilonBn must be positive.");
     }
 
     const double maxAbsX = std::max(std::abs(xMin), std::abs(xMax));

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerancesBatchNorm.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerancesBatchNorm.hpp
@@ -1,0 +1,252 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+
+#include <hipdnn_data_sdk/types.hpp>
+#include <hipdnn_test_sdk/utilities/DynamicTolerancesCommon.hpp>
+
+namespace hipdnn_test_sdk::utilities::batchnorm
+{
+using hipdnn_data_sdk::types::bfloat16;
+using hipdnn_data_sdk::types::half;
+
+/**
+ * @brief Calculates the expected tolerance for Batch Norm Forward Training y output.
+ *
+ * BN Training: mean = E[x], var = E[x^2] - E[x]^2, invVar = 1/sqrt(var+eps),
+ *              y = scale * (x - mean) * invVar + bias
+ *
+ * Error sources:
+ * 1. Mean accumulation (NHW additions): gamma_NHW * max|x|
+ * 2. Variance accumulation (NHW multiply-adds): gamma_NHW * max|x|^2
+ * 3. invVariance nonlinear chain (div, sqrt, reciprocal): propagated from variance
+ * 4. Normalization per-element ops (sub, 2x mul, bias add)
+ *
+ * Key insight: after normalization, |xHat| = |(x - mean)/sqrt(var)| is O(1),
+ * so the output magnitude is bounded by |scale| + |bias|. The tolerance scales
+ * with |scale| (not |x|) because normalization cancels the input magnitude.
+ *
+ * Uses the shared computeGamma() helper for the accumulation error growth factor.
+ *
+ * @tparam OutputType  Data type of y output tensor
+ * @tparam InputType   Data type of x input tensor
+ * @tparam ComputeType Data type for intermediate computation (default: float)
+ * @param xMin                Minimum value in input tensor x
+ * @param xMax                Maximum value in input tensor x
+ * @param scaleMin            Minimum value in scale tensor
+ * @param scaleMax            Maximum value in scale tensor
+ * @param biasMin             Minimum value in bias tensor
+ * @param biasMax             Maximum value in bias tensor
+ * @param nElementsPerChannel Number of elements per channel: N * H * W (reduction dim)
+ * @return Calculated tolerance value as float
+ *
+ * Known Limitations:
+ * - Black-box: does not use kernel implementation details
+ * - Conservative |xHat| ~ O(1) assumption (could be larger for outliers)
+ * - Does not account for cancellation in variance computation
+ *   (two-pass formula E[x^2] - E[x]^2 can lose precision for small variance)
+ * - Running statistics tolerance not included (deferred)
+ * - No backward pass support (only forward training)
+ */
+template <typename OutputType, typename InputType, typename ComputeType = float>
+float calculateBatchnormTrainingTolerance(double xMin,
+                                          double xMax,
+                                          double scaleMin,
+                                          double scaleMax,
+                                          double biasMin,
+                                          double biasMax,
+                                          int64_t nElementsPerChannel)
+{
+    validateComputeType<ComputeType>();
+
+    if(nElementsPerChannel < 1)
+    {
+        throw std::invalid_argument("nElementsPerChannel must be at least 1.");
+    }
+
+    const double maxAbsX = std::max(std::abs(xMin), std::abs(xMax));
+    const double maxAbsScale = std::max(std::abs(scaleMin), std::abs(scaleMax));
+    const double maxAbsBias = std::max(std::abs(biasMin), std::abs(biasMax));
+
+    auto NHW = static_cast<uint64_t>(nElementsPerChannel);
+    auto epsilon = static_cast<double>(std::numeric_limits<ComputeType>::epsilon());
+
+    const double gammaNHW = computeGamma(NHW, epsilon);
+    validateGamma(gammaNHW);
+
+    // Sum-of-squares accumulation error for variance path (same structure as RMSNorm).
+    // S = sum_{i=0}^{NHW-1} x_i^2 (self-product)
+    const double sumAbsProductBound = static_cast<double>(NHW) * maxAbsX * maxAbsX;
+
+    double accumulatedTolerance = gammaNHW * sumAbsProductBound;
+
+    // Input casting error for variance path (single tensor self-product, factor 1).
+    accumulatedTolerance += computeInputCastingError<InputType, ComputeType>(sumAbsProductBound, 1);
+
+    // Upper bound on distinct rounding ops in the normalize chain:
+    //   div(varAccum,NHW) + sqrt + recip = 3 nonlinear ops
+    //   sub(x,mean) + mul(*,invVar) + mul(*,scale) = 3 element-wise ops
+    constexpr double NONLINEAR_OPS = 3.0;
+    constexpr double ELEM_OPS = 3.0;
+
+    double propagatedTolerance = 0.0;
+
+    // When maxAbsX == 0, all inputs are zero. mean=0, var=0, invVar=1/sqrt(eps_bn),
+    // y = scale*0*invVar + bias = bias. All accumulation errors vanish.
+    if(maxAbsX > 0.0)
+    {
+        // Variance path: propagate sum-of-squares error through invVar to output.
+        // Same derivation as RMSNorm: accTol / (2*S) * maxAbsScale
+        propagatedTolerance = (accumulatedTolerance / (2.0 * sumAbsProductBound)) * maxAbsScale;
+
+        // Mean path: delta_mean ~ gamma * maxAbsX, propagated through scale*invVar.
+        // |scale * invVar * delta_mean| ~ maxAbsScale * gamma (since invVar ~ 1/maxAbsX)
+        propagatedTolerance += gammaNHW * maxAbsScale;
+
+        // Per-op rounding for nonlinear chain and element-wise normalize ops.
+        propagatedTolerance += (NONLINEAR_OPS + ELEM_OPS) * epsilon * maxAbsScale;
+    }
+    propagatedTolerance += maxAbsBias * epsilon;
+
+    // Output casting error.
+    const double maxOutputMagnitude = (maxAbsX > 0.0 ? maxAbsScale : 0.0) + maxAbsBias;
+    propagatedTolerance += computeOutputCastingError<OutputType, ComputeType>(maxOutputMagnitude);
+
+    validateToleranceRange<OutputType>(propagatedTolerance);
+
+    return static_cast<float>(propagatedTolerance);
+}
+
+/**
+ * @brief Calculates expected tolerance for saved mean output.
+ *
+ * mean[c] = (1/NHW) * sum x[n,c,h,w]
+ * Error dominated by summation of NHW terms plus division.
+ *
+ * @tparam OutputType  Data type of mean output tensor
+ * @tparam InputType   Data type of x input tensor
+ * @tparam ComputeType Data type for intermediate computation (default: float)
+ * @param xMin                Minimum value in input tensor x
+ * @param xMax                Maximum value in input tensor x
+ * @param nElementsPerChannel Number of elements per channel: N * H * W
+ * @return Calculated tolerance value as float
+ */
+template <typename OutputType, typename InputType, typename ComputeType = float>
+float calculateBatchnormMeanTolerance(double xMin, double xMax, int64_t nElementsPerChannel)
+{
+    validateComputeType<ComputeType>();
+
+    if(nElementsPerChannel < 1)
+    {
+        throw std::invalid_argument("nElementsPerChannel must be at least 1.");
+    }
+
+    const double maxAbsX = std::max(std::abs(xMin), std::abs(xMax));
+    auto NHW = static_cast<uint64_t>(nElementsPerChannel);
+    auto epsilon = static_cast<double>(std::numeric_limits<ComputeType>::epsilon());
+
+    const double gammaNHW = computeGamma(NHW, epsilon);
+    validateGamma(gammaNHW);
+
+    // mean = (sum x_i) / NHW
+    // Summation error: gamma_NHW * max|x| (Higham bound for sum of NHW terms,
+    // divided by NHW yields gamma * max|x| since gamma already absorbs the scaling).
+    // Division error: u * |mean| <= u * maxAbsX
+    double tolerance = gammaNHW * maxAbsX + epsilon * maxAbsX;
+
+    // Input casting (single tensor, factor 1): signalBound = NHW * maxAbsX.
+    // After division by NHW, casting contribution is ~ computeEpsilon * maxAbsX.
+    double inputCastError
+        = computeInputCastingError<InputType, ComputeType>(static_cast<double>(NHW) * maxAbsX, 1);
+    if(maxAbsX > 0.0)
+    {
+        tolerance += inputCastError / static_cast<double>(NHW);
+    }
+
+    // Output casting.
+    tolerance += computeOutputCastingError<OutputType, ComputeType>(maxAbsX);
+
+    validateToleranceRange<OutputType>(tolerance);
+
+    return static_cast<float>(tolerance);
+}
+
+/**
+ * @brief Calculates expected tolerance for saved invVariance output.
+ *
+ * invVar[c] = 1 / sqrt(var[c] + epsilon_bn)
+ * Error from variance accumulation propagated through the nonlinear chain.
+ *
+ * Simplification: assumes variance ~ maxAbsX^2 (worst-case for large variance).
+ * When maxAbsX = 0, falls back to invVar = 1/sqrt(epsilon_bn) with only
+ * nonlinear op errors.
+ *
+ * @tparam OutputType  Data type of invVariance output tensor
+ * @tparam InputType   Data type of x input tensor
+ * @tparam ComputeType Data type for intermediate computation (default: float)
+ * @param xMin                Minimum value in input tensor x
+ * @param xMax                Maximum value in input tensor x
+ * @param nElementsPerChannel Number of elements per channel: N * H * W
+ * @param epsilonBn           Batch norm epsilon (added to variance before sqrt)
+ * @return Calculated tolerance value as float
+ */
+template <typename OutputType, typename InputType, typename ComputeType = float>
+float calculateBatchnormInvVarianceTolerance(double xMin,
+                                             double xMax,
+                                             int64_t nElementsPerChannel,
+                                             double epsilonBn = 1e-5)
+{
+    validateComputeType<ComputeType>();
+
+    if(nElementsPerChannel < 1)
+    {
+        throw std::invalid_argument("nElementsPerChannel must be at least 1.");
+    }
+
+    const double maxAbsX = std::max(std::abs(xMin), std::abs(xMax));
+    auto NHW = static_cast<uint64_t>(nElementsPerChannel);
+    auto epsilon = static_cast<double>(std::numeric_limits<ComputeType>::epsilon());
+
+    const double gammaNHW = computeGamma(NHW, epsilon);
+    validateGamma(gammaNHW);
+
+    // Variance error (see plan Section 2, Stage 2):
+    //   |delta_variance| <= gamma * max|x|^2       (varAccum/NHW error)
+    //                     + 2 * maxAbsX * deltaMean (mean^2 error)
+    //                     + u * max|x|^2            (subtraction error)
+    //   Simplified: ~ 3 * gamma * max|x|^2  (since deltaMean ~ gamma * maxAbsX)
+    double deltaVariance = 3.0 * gammaNHW * maxAbsX * maxAbsX;
+
+    // Nonlinear ops: add(epsilon_bn) + sqrt + reciprocal
+    constexpr double NONLINEAR_OPS = 3.0;
+
+    // Propagation through 1/sqrt(var + eps_bn):
+    //   |delta_invVar| ~ deltaVariance / (2 * maxAbsX^2) + NONLINEAR_OPS * u / maxAbsX
+    //                  = 3*gamma/2 + 3u/maxAbsX
+    double tolerance = 0.0;
+    if(maxAbsX > 0.0)
+    {
+        tolerance = deltaVariance / (2.0 * maxAbsX * maxAbsX) + NONLINEAR_OPS * epsilon / maxAbsX;
+    }
+    else
+    {
+        // x ~ 0: invVar = 1/sqrt(eps_bn), tolerance from nonlinear ops only
+        tolerance = NONLINEAR_OPS * epsilon / std::sqrt(epsilonBn);
+    }
+
+    // Output casting: invVar ~ sqrt(3)/maxAbsX for typical data, 1/sqrt(eps_bn) for x~0
+    double maxInvVar = maxAbsX > 0.0 ? std::sqrt(3.0) / maxAbsX : 1.0 / std::sqrt(epsilonBn);
+    tolerance += computeOutputCastingError<OutputType, ComputeType>(maxInvVar);
+
+    validateToleranceRange<OutputType>(tolerance);
+
+    return static_cast<float>(tolerance);
+}
+
+} // namespace hipdnn_test_sdk::utilities::batchnorm

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerancesBatchNorm.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerancesBatchNorm.hpp
@@ -74,8 +74,8 @@ float calculateBatchnormTrainingTolerance(double xMin,
     const double maxAbsScale = std::max(std::abs(scaleMin), std::abs(scaleMax));
     const double maxAbsBias = std::max(std::abs(biasMin), std::abs(biasMax));
 
-    auto nhw = static_cast<uint64_t>(nElementsPerChannel);
-    auto epsilon = static_cast<double>(std::numeric_limits<ComputeType>::epsilon());
+    const auto nhw = static_cast<uint64_t>(nElementsPerChannel);
+    const auto epsilon = static_cast<double>(std::numeric_limits<ComputeType>::epsilon());
 
     const double gammaNHW = computeGamma(nhw, epsilon);
     validateGamma(gammaNHW);
@@ -148,8 +148,8 @@ float calculateBatchnormMeanTolerance(double xMin, double xMax, int64_t nElement
     }
 
     const double maxAbsX = std::max(std::abs(xMin), std::abs(xMax));
-    auto nhw = static_cast<uint64_t>(nElementsPerChannel);
-    auto epsilon = static_cast<double>(std::numeric_limits<ComputeType>::epsilon());
+    const auto nhw = static_cast<uint64_t>(nElementsPerChannel);
+    const auto epsilon = static_cast<double>(std::numeric_limits<ComputeType>::epsilon());
 
     const double gammaNHW = computeGamma(nhw, epsilon);
     validateGamma(gammaNHW);
@@ -188,7 +188,8 @@ float calculateBatchnormMeanTolerance(double xMin, double xMax, int64_t nElement
  * nonlinear op errors.
  *
  * @tparam OutputType  Data type of invVariance output tensor
- * @tparam InputType   Data type of x input tensor
+ * @tparam InputType   Data type of x input tensor (unused — invVar has no per-element
+ *                     input casting; retained for API consistency with other BN tolerances)
  * @tparam ComputeType Data type for intermediate computation (default: float)
  * @param xMin                Minimum value in input tensor x
  * @param xMax                Maximum value in input tensor x
@@ -210,8 +211,8 @@ float calculateBatchnormInvVarianceTolerance(double xMin,
     }
 
     const double maxAbsX = std::max(std::abs(xMin), std::abs(xMax));
-    auto nhw = static_cast<uint64_t>(nElementsPerChannel);
-    auto epsilon = static_cast<double>(std::numeric_limits<ComputeType>::epsilon());
+    const auto nhw = static_cast<uint64_t>(nElementsPerChannel);
+    const auto epsilon = static_cast<double>(std::numeric_limits<ComputeType>::epsilon());
 
     const double gammaNHW = computeGamma(nhw, epsilon);
     validateGamma(gammaNHW);

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerancesBatchNorm.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerancesBatchNorm.hpp
@@ -48,10 +48,20 @@ using hipdnn_data_sdk::types::half;
  *
  * Known Limitations:
  * - Black-box: does not use kernel implementation details
- * - Conservative |xHat| ~ O(1) assumption (could be larger for outliers)
- * - Does not account for cancellation in variance computation
- *   (two-pass formula E[x^2] - E[x]^2 can lose precision for small variance)
- * - Running statistics tolerance not included (deferred)
+ * - Assumes |xHat| ~ O(1) after normalization. This holds statistically (E[xHat]=0,
+ *   Var(xHat)=1), but individual elements can be large when variance is small relative
+ *   to individual deviations (x_i - mean). For near-constant data with tiny variance,
+ *   the tolerance may underestimate error on the y output.
+ * - The variance bound (3*gamma*maxAbsX^2) is an absolute bound. The two-pass formula
+ *   E[x^2] - E[x]^2 can suffer catastrophic cancellation when variance << E[x^2],
+ *   making the relative error of variance arbitrarily large. The absolute bound remains
+ *   valid and sufficient for test tolerance validation, but users should be aware that
+ *   low-variance inputs may exhibit larger relative errors in intermediate quantities.
+ * - Nonlinear op count (6 = 3 chain + 3 element-wise) for the normalize path.
+ *   The variance division and subtraction rounding (2u terms) are tracked explicitly
+ *   in the accumulated tolerance.
+ * - Running statistics tolerance not included (Bessel's M/(M-1) amplification for
+ *   running variance is deferred to Phase 2).
  * - No backward pass support (only forward training)
  */
 template <typename OutputType, typename InputType, typename ComputeType = float>
@@ -84,7 +94,10 @@ float calculateBatchnormTrainingTolerance(double xMin,
     // S = sum_{i=0}^{NHW-1} x_i^2 (self-product)
     const double sumAbsProductBound = static_cast<double>(nhw) * maxAbsX * maxAbsX;
 
-    double accumulatedTolerance = gammaNHW * sumAbsProductBound;
+    // Variance accumulation error: gamma * S (Higham bound)
+    // Plus 2u * S for division-by-NHW and subtraction (E[x^2] - mu^2) rounding ops.
+    double accumulatedTolerance
+        = gammaNHW * sumAbsProductBound + 2.0 * epsilon * sumAbsProductBound;
 
     // Input casting error for variance path (single tensor self-product, factor 1).
     accumulatedTolerance += computeInputCastingError<InputType, ComputeType>(sumAbsProductBound, 1);
@@ -115,7 +128,14 @@ float calculateBatchnormTrainingTolerance(double xMin,
     propagatedTolerance += maxAbsBias * epsilon;
 
     // Output casting error.
-    const double maxOutputMagnitude = (maxAbsX > 0.0 ? maxAbsScale : 0.0) + maxAbsBias;
+    // Conservative bound: instead of assuming |xHat| ~ O(1) cancels input magnitude,
+    // use invVarEstimate from max(maxAbsX^2, eps_bn_default) to bound output magnitude.
+    // This handles the case where variance is small and |xHat| >> 1.
+    constexpr double EPSILON_BN_DEFAULT = 1e-5;
+    const double varEst = std::max(maxAbsX * maxAbsX, EPSILON_BN_DEFAULT);
+    const double invVarEst = 1.0 / std::sqrt(varEst + EPSILON_BN_DEFAULT);
+    const double maxOutputMagnitude
+        = (maxAbsX > 0.0 ? maxAbsScale * maxAbsX * invVarEst : 0.0) + maxAbsBias;
     propagatedTolerance += computeOutputCastingError<OutputType, ComputeType>(maxOutputMagnitude);
 
     validateToleranceRange<OutputType>(propagatedTolerance);
@@ -183,9 +203,10 @@ float calculateBatchnormMeanTolerance(double xMin, double xMax, int64_t nElement
  * invVar[c] = 1 / sqrt(var[c] + epsilon_bn)
  * Error from variance accumulation propagated through the nonlinear chain.
  *
- * Simplification: assumes variance ~ maxAbsX^2 (worst-case for large variance).
- * When maxAbsX = 0, falls back to invVar = 1/sqrt(epsilon_bn) with only
- * nonlinear op errors.
+ * Uses varEstimate = max(maxAbsX^2, epsilonBn) as the variance floor, which:
+ * - Avoids the O(eps_bn^{-3/2}) blowup from the raw (var+eps)^{-3/2} amplification
+ * - Handles the small-x regime where eps_bn dominates variance naturally
+ * - Provides correct scaling for large maxAbsX (tolerance decreases as 1/maxAbsX)
  *
  * @tparam OutputType  Data type of invVariance output tensor
  * @tparam InputType   Data type of x input tensor (unused — invVar has no per-element
@@ -217,33 +238,32 @@ float calculateBatchnormInvVarianceTolerance(double xMin,
     const double gammaNHW = computeGamma(nhw, epsilon);
     validateGamma(gammaNHW);
 
-    // Variance error (see plan Section 2, Stage 2):
+    // Variance error (see plan Section 2, Stage 2, and Section 15 Corrections):
     //   |delta_variance| <= gamma * max|x|^2       (varAccum/NHW error)
     //                     + 2 * maxAbsX * deltaMean (mean^2 error)
-    //                     + u * max|x|^2            (subtraction error)
-    //   Simplified: ~ 3 * gamma * max|x|^2  (since deltaMean ~ gamma * maxAbsX)
-    const double deltaVariance = 3.0 * gammaNHW * maxAbsX * maxAbsX;
+    //                     + 2u * max|x|^2           (division + subtraction rounding)
+    //   = 3 * gamma * max|x|^2 + 2u * max|x|^2    (since deltaMean ~ gamma * maxAbsX)
+    const double deltaVariance
+        = 3.0 * gammaNHW * maxAbsX * maxAbsX + 2.0 * epsilon * maxAbsX * maxAbsX;
 
     // Nonlinear ops: add(epsilon_bn) + sqrt + reciprocal
     constexpr double NONLINEAR_OPS = 3.0;
 
-    // Propagation through 1/sqrt(var + eps_bn):
-    //   |delta_invVar| ~ deltaVariance / (2 * maxAbsX^2) + NONLINEAR_OPS * u / maxAbsX
-    //                  = 3*gamma/2 + 3u/maxAbsX
-    double tolerance = 0.0;
-    if(maxAbsX > 0.0)
-    {
-        tolerance = deltaVariance / (2.0 * maxAbsX * maxAbsX) + NONLINEAR_OPS * epsilon / maxAbsX;
-    }
-    else
-    {
-        // x ~ 0: invVar = 1/sqrt(eps_bn), tolerance from nonlinear ops only
-        tolerance = NONLINEAR_OPS * epsilon / std::sqrt(epsilonBn);
-    }
+    // Variance floor: use max(maxAbsX^2, epsilonBn) to avoid blowup when var is small.
+    // When maxAbsX > 0 but maxAbsX^2 < epsilonBn, the eps_bn term dominates (var+eps).
+    const double varEstimate = std::max(maxAbsX * maxAbsX, epsilonBn);
 
-    // Output casting: invVar ~ sqrt(3)/maxAbsX for typical data, 1/sqrt(eps_bn) for x~0
-    const double maxInvVar = maxAbsX > 0.0 ? std::sqrt(3.0) / maxAbsX : 1.0 / std::sqrt(epsilonBn);
-    tolerance += computeOutputCastingError<OutputType, ComputeType>(maxInvVar);
+    // Propagation through invVar = 1/sqrt(var + eps_bn):
+    //   d(invVar)/d(var) = -1/2 * (var + eps)^{-3/2}
+    //   |delta_invVar| <= deltaVariance / (2 * (varEstimate + epsilonBn)^{3/2})
+    //                   + NONLINEAR_OPS * u * invVarEstimate
+    const double varPlusEps = varEstimate + epsilonBn;
+    const double invVarEstimate = 1.0 / std::sqrt(varPlusEps);
+    double tolerance = deltaVariance / (2.0 * varPlusEps * std::sqrt(varPlusEps))
+                       + NONLINEAR_OPS * epsilon * invVarEstimate;
+
+    // Output casting: invVar ~ 1/sqrt(varEstimate + eps_bn)
+    tolerance += computeOutputCastingError<OutputType, ComputeType>(invVarEstimate);
 
     validateToleranceRange<OutputType>(tolerance);
 

--- a/projects/hipdnn/test_sdk/tests/CMakeLists.txt
+++ b/projects/hipdnn/test_sdk/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(
     utilities/TestCpuTypeUtilities.cpp
     utilities/TestSdkFrontendTypeConversions.cpp
     utilities/TestCpuReferencePointwise.cpp
+    utilities/TestDynamicTolerancesBatchNorm.cpp
     utilities/TestDynamicTolerancesCommon.cpp
     utilities/TestDynamicTolerancesConv.cpp
     utilities/TestDynamicTolerancesMatmul.cpp

--- a/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerancesBatchNorm.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerancesBatchNorm.cpp
@@ -875,6 +875,62 @@ TEST(TestCalculateBnInvVarTolerance, ZeroInput)
     EXPECT_LT(tol, 1.0f); // Should be a reasonable small value
 }
 
+// Asymmetric x range: maxAbsX = max(|xMin|, |xMax|)
+TEST(TestCalculateBnTrainTolerance, AsymmetricXRange)
+{
+    // xMin=-0.5, xMax=2.0 => maxAbsX=2.0 (same as symmetric [-2,2])
+    auto tolAsym = calculateBatchnormTrainingTolerance<float, float, float>(
+        -0.5, 2.0, -1.0, 1.0, 0.0, 0.0, 10);
+    auto tolSym = calculateBatchnormTrainingTolerance<float, float, float>(
+        -2.0, 2.0, -1.0, 1.0, 0.0, 0.0, 10);
+
+    // Both have same maxAbsX=2.0, so tolerance should be identical
+    EXPECT_EQ(tolAsym, tolSym);
+
+    // One-sided: xMin=0, xMax=5.0 => maxAbsX=5.0
+    auto tolOneSided = calculateBatchnormTrainingTolerance<float, float, float>(
+        0.0, 5.0, -1.0, 1.0, 0.0, 0.0, 10);
+    auto tolSymFive = calculateBatchnormTrainingTolerance<float, float, float>(
+        -5.0, 5.0, -1.0, 1.0, 0.0, 0.0, 10);
+
+    EXPECT_EQ(tolOneSided, tolSymFive);
+
+    // Mean tolerance: same behavior
+    auto meanAsym = calculateBatchnormMeanTolerance<float, float, float>(-0.5, 2.0, 10);
+    auto meanSym = calculateBatchnormMeanTolerance<float, float, float>(-2.0, 2.0, 10);
+    EXPECT_EQ(meanAsym, meanSym);
+
+    // InvVar tolerance: same behavior
+    auto invVarAsym = calculateBatchnormInvVarianceTolerance<float, float, float>(-0.5, 2.0, 10);
+    auto invVarSym = calculateBatchnormInvVarianceTolerance<float, float, float>(-2.0, 2.0, 10);
+    EXPECT_EQ(invVarAsym, invVarSym);
+}
+
+// Scale and bias both zero: y tolerance should be zero
+TEST(TestCalculateBnTrainTolerance, ZeroScaleAndBias)
+{
+    auto tol = calculateBatchnormTrainingTolerance<float, float, float>(
+        -1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 10);
+    EXPECT_EQ(tol, 0.0f);
+
+    // With half output casting: maxOutputMagnitude = 0 + 0 = 0, so cast term also 0
+    auto tolHalf = calculateBatchnormTrainingTolerance<half, float, float>(
+        -1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 10);
+    EXPECT_EQ(tolHalf, 0.0f);
+}
+
+// Negative NHW should throw (validates the < 1 check catches negatives)
+TEST(TestCalculateBnTrainTolerance, ThrowsOnNegativeNHW)
+{
+    EXPECT_THROW((calculateBatchnormTrainingTolerance<float, float, float>(
+                     -1.0, 1.0, -1.0, 1.0, 0.0, 0.0, -1)),
+                 std::invalid_argument);
+    EXPECT_THROW((calculateBatchnormMeanTolerance<float, float, float>(-1.0, 1.0, -1)),
+                 std::invalid_argument);
+    EXPECT_THROW((calculateBatchnormInvVarianceTolerance<float, float, float>(-1.0, 1.0, -1)),
+                 std::invalid_argument);
+}
+
 // Mean and invVar also throw on singularity
 TEST(TestCalculateBnMeanTolerance, ThrowsOnSingularity)
 {

--- a/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerancesBatchNorm.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerancesBatchNorm.cpp
@@ -1,0 +1,890 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include <cmath>
+#include <gtest/gtest.h>
+#include <hipdnn_data_sdk/types.hpp>
+#include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
+#include <hipdnn_test_sdk/utilities/DynamicTolerancesBatchNorm.hpp>
+#include <hipdnn_test_sdk/utilities/DynamicTolerancesCommon.hpp>
+#include <vector>
+
+using namespace hipdnn_test_sdk::utilities::batchnorm;
+using hipdnn_data_sdk::types::bfloat16;
+using hipdnn_data_sdk::types::half;
+using hipdnn_test_sdk::utilities::computeGamma;
+
+template <typename Out, typename In, typename Comp>
+struct TypeTriple
+{
+    using OutputType = Out;
+    using InputType = In;
+    using ComputeType = Comp;
+};
+
+// =================================================================================================
+// TestCalculateBatchnormTrainingTolerance
+// =================================================================================================
+
+struct BnTrainToleranceTestCase
+{
+    double xMin;
+    double xMax;
+    double scaleMin;
+    double scaleMax;
+    double biasMin;
+    double biasMax;
+    int64_t nElementsPerChannel;
+    double expectedTolerance;
+    bool expectThrow = false;
+
+    friend std::ostream& operator<<(std::ostream& os, const BnTrainToleranceTestCase& tc)
+    {
+        os << "xMin: " << tc.xMin << ", xMax: " << tc.xMax << ", scaleMin: " << tc.scaleMin
+           << ", scaleMax: " << tc.scaleMax << ", biasMin: " << tc.biasMin
+           << ", biasMax: " << tc.biasMax << ", NHW: " << tc.nElementsPerChannel
+           << ", expectedTolerance: " << tc.expectedTolerance
+           << ", expectThrow: " << (tc.expectThrow ? "true" : "false");
+        return os;
+    }
+};
+
+template <typename T>
+std::vector<BnTrainToleranceTestCase> getBnTrainToleranceTestCases();
+
+// BN Training tolerance formula (no casting):
+//   propTol = (gamma/2 + gamma + 6u) * maxAbsScale + u * maxAbsBias
+//           = (3/2 * gamma + 6u) * maxAbsScale + u * maxAbsBias
+// With input casting (InputType=double, ComputeType=float):
+//   accTol has extra u term -> variance path becomes (gamma + u)/2
+//   total = ((gamma + u)/2 + gamma + 6u) * maxAbsScale + u * maxAbsBias
+//         = (3/2*gamma + u/2 + 6u) * maxAbsScale + u * maxAbsBias
+
+// Float / Float / Float
+template <>
+std::vector<BnTrainToleranceTestCase>
+    getBnTrainToleranceTestCases<TypeTriple<float, float, float>>()
+{
+    auto u = static_cast<double>(std::numeric_limits<float>::epsilon());
+    auto gamma = [&](int64_t c) { return computeGamma(static_cast<uint64_t>(c), u); };
+    return {// NHW = 0 => throws
+            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 0, 0.0, true},
+            // NHW=1, x=[-1,1], scale=[-1,1], no bias
+            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 1, (1.5 * gamma(1) + 6.0 * u) * 1.0},
+            // NHW=10, x=[-1,1], scale=[-1,1], no bias
+            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 10, (1.5 * gamma(10) + 6.0 * u) * 1.0},
+            // NHW=10, x=[-1000,1000], scale=[-1000,1000], no bias
+            // Tolerance scales with |scale|, not |x| (normalization cancels |x|)
+            {-1000.0, 1000.0, -1000.0, 1000.0, 0.0, 0.0, 10, (1.5 * gamma(10) + 6.0 * u) * 1000.0},
+            // NHW=3, x=[-1,1], scale=[-1,1], bias=[-0.5,0.5]
+            {-1.0, 1.0, -1.0, 1.0, -0.5, 0.5, 3, (1.5 * gamma(3) + 6.0 * u) * 1.0 + 0.5 * u}};
+}
+
+// Float / Double / Float (Input casting: inputEpsilon(double) < epsilon(float))
+// accTol = gamma * S + S * u -> variance path = (gamma + u)/2 * maxAbsScale
+template <>
+std::vector<BnTrainToleranceTestCase>
+    getBnTrainToleranceTestCases<TypeTriple<float, double, float>>()
+{
+    auto u = static_cast<double>(std::numeric_limits<float>::epsilon());
+    auto gamma = [&](int64_t c) { return computeGamma(static_cast<uint64_t>(c), u); };
+    return {
+        // NHW = 0 => throws
+        {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 0, 0.0, true},
+        // NHW=1
+        {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 1, ((gamma(1) + u) / 2.0 + gamma(1) + 6.0 * u) * 1.0},
+        // NHW=10
+        {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 10, ((gamma(10) + u) / 2.0 + gamma(10) + 6.0 * u) * 1.0},
+        // Zero input: all terms vanish
+        {0.0, 0.0, -1.0, 1.0, 0.0, 0.0, 10, 0.0}};
+}
+
+// Half / Float / Float (Output casting: outputEpsilon(half=2^-10) > epsilon(float=2^-23))
+template <>
+std::vector<BnTrainToleranceTestCase> getBnTrainToleranceTestCases<TypeTriple<half, float, float>>()
+{
+    auto u = static_cast<double>(std::numeric_limits<float>::epsilon());
+    auto uHalf = static_cast<double>(std::numeric_limits<half>::epsilon());
+    auto gamma = [&](int64_t c) { return computeGamma(static_cast<uint64_t>(c), u); };
+    return {// NHW = 0 => throws
+            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 0, 0.0, true},
+            // NHW=1: base + output cast (maxOutputMagnitude = maxAbsScale = 1)
+            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 1, (1.5 * gamma(1) + 6.0 * u) * 1.0 + 1.0 * uHalf},
+            // NHW=10
+            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 10, (1.5 * gamma(10) + 6.0 * u) * 1.0 + 1.0 * uHalf},
+            // Zero input: output cast from maxOutputMagnitude=0 vanishes
+            {0.0, 0.0, -1.0, 1.0, 0.0, 0.0, 10, 0.0}};
+}
+
+// Half / Half / Half
+template <>
+std::vector<BnTrainToleranceTestCase> getBnTrainToleranceTestCases<TypeTriple<half, half, half>>()
+{
+    auto u = static_cast<double>(std::numeric_limits<half>::epsilon());
+    auto gamma = [&](int64_t c) { return computeGamma(static_cast<uint64_t>(c), u); };
+    return {// NHW = 0 => throws
+            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 0, 0.0, true},
+            // NHW=1
+            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 1, (1.5 * gamma(1) + 6.0 * u) * 1.0},
+            // NHW=10
+            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 10, (1.5 * gamma(10) + 6.0 * u) * 1.0},
+            // Zero input
+            {0.0, 0.0, -1.0, 1.0, 0.0, 0.0, 10, 0.0}};
+}
+
+// Bfloat16 / Float / Float (Output casting: outputEpsilon(bf16=2^-7) > epsilon(float=2^-23))
+template <>
+std::vector<BnTrainToleranceTestCase>
+    getBnTrainToleranceTestCases<TypeTriple<bfloat16, float, float>>()
+{
+    auto u = static_cast<double>(std::numeric_limits<float>::epsilon());
+    auto uBf16 = static_cast<double>(std::numeric_limits<bfloat16>::epsilon());
+    auto gamma = [&](int64_t c) { return computeGamma(static_cast<uint64_t>(c), u); };
+    return {// NHW = 0 => throws
+            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 0, 0.0, true},
+            // NHW=1
+            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 1, (1.5 * gamma(1) + 6.0 * u) * 1.0 + 1.0 * uBf16},
+            // NHW=10
+            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 10, (1.5 * gamma(10) + 6.0 * u) * 1.0 + 1.0 * uBf16},
+            // Zero input
+            {0.0, 0.0, -1.0, 1.0, 0.0, 0.0, 10, 0.0}};
+}
+
+// Bfloat16 / Bfloat16 / Bfloat16
+template <>
+std::vector<BnTrainToleranceTestCase>
+    getBnTrainToleranceTestCases<TypeTriple<bfloat16, bfloat16, bfloat16>>()
+{
+    auto u = static_cast<double>(std::numeric_limits<bfloat16>::epsilon());
+    auto gamma = [&](int64_t c) { return computeGamma(static_cast<uint64_t>(c), u); };
+    return {// NHW = 0 => throws
+            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 0, 0.0, true},
+            // NHW=1
+            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 1, (1.5 * gamma(1) + 6.0 * u) * 1.0},
+            // NHW=10
+            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 10, (1.5 * gamma(10) + 6.0 * u) * 1.0},
+            // Zero input
+            {0.0, 0.0, -1.0, 1.0, 0.0, 0.0, 10, 0.0}};
+}
+
+template <typename Out, typename In, typename Comp>
+class TestCalculateBnTrainTolerance : public ::testing::TestWithParam<BnTrainToleranceTestCase>
+{
+protected:
+    void verifyTolerance()
+    {
+        const auto& params = GetParam();
+
+        if(params.expectThrow)
+        {
+            EXPECT_THROW(
+                (calculateBatchnormTrainingTolerance<Out, In, Comp>(params.xMin,
+                                                                    params.xMax,
+                                                                    params.scaleMin,
+                                                                    params.scaleMax,
+                                                                    params.biasMin,
+                                                                    params.biasMax,
+                                                                    params.nElementsPerChannel)),
+                std::invalid_argument);
+        }
+        else
+        {
+            auto tol
+                = calculateBatchnormTrainingTolerance<Out, In, Comp>(params.xMin,
+                                                                     params.xMax,
+                                                                     params.scaleMin,
+                                                                     params.scaleMax,
+                                                                     params.biasMin,
+                                                                     params.biasMax,
+                                                                     params.nElementsPerChannel);
+
+            auto expected = static_cast<float>(params.expectedTolerance);
+
+            EXPECT_NEAR(
+                tol, expected, std::max(expected * 0.01f, std::numeric_limits<float>::min()));
+        }
+    }
+};
+
+using TestCalcBnTrainTolFp32 = TestCalculateBnTrainTolerance<float, float, float>;
+TEST_P(TestCalcBnTrainTolFp32, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalcBnTrainTolFp32,
+    ::testing::ValuesIn(getBnTrainToleranceTestCases<TypeTriple<float, float, float>>()));
+
+using TestCalcBnTrainTolInputDouble = TestCalculateBnTrainTolerance<float, double, float>;
+TEST_P(TestCalcBnTrainTolInputDouble, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalcBnTrainTolInputDouble,
+    ::testing::ValuesIn(getBnTrainToleranceTestCases<TypeTriple<float, double, float>>()));
+
+using TestCalcBnTrainTolComputeFloatFp16 = TestCalculateBnTrainTolerance<half, float, float>;
+TEST_P(TestCalcBnTrainTolComputeFloatFp16, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalcBnTrainTolComputeFloatFp16,
+    ::testing::ValuesIn(getBnTrainToleranceTestCases<TypeTriple<half, float, float>>()));
+
+using TestCalcBnTrainTolFp16 = TestCalculateBnTrainTolerance<half, half, half>;
+TEST_P(TestCalcBnTrainTolFp16, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalcBnTrainTolFp16,
+    ::testing::ValuesIn(getBnTrainToleranceTestCases<TypeTriple<half, half, half>>()));
+
+using TestCalcBnTrainTolComputeFloatBfp16 = TestCalculateBnTrainTolerance<bfloat16, float, float>;
+TEST_P(TestCalcBnTrainTolComputeFloatBfp16, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalcBnTrainTolComputeFloatBfp16,
+    ::testing::ValuesIn(getBnTrainToleranceTestCases<TypeTriple<bfloat16, float, float>>()));
+
+using TestCalcBnTrainTolBfp16 = TestCalculateBnTrainTolerance<bfloat16, bfloat16, bfloat16>;
+TEST_P(TestCalcBnTrainTolBfp16, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalcBnTrainTolBfp16,
+    ::testing::ValuesIn(getBnTrainToleranceTestCases<TypeTriple<bfloat16, bfloat16, bfloat16>>()));
+
+// =================================================================================================
+// TestCalculateBatchnormMeanTolerance
+// =================================================================================================
+
+struct BnMeanToleranceTestCase
+{
+    double xMin;
+    double xMax;
+    int64_t nElementsPerChannel;
+    double expectedTolerance;
+    bool expectThrow = false;
+
+    friend std::ostream& operator<<(std::ostream& os, const BnMeanToleranceTestCase& tc)
+    {
+        os << "xMin: " << tc.xMin << ", xMax: " << tc.xMax << ", NHW: " << tc.nElementsPerChannel
+           << ", expectedTolerance: " << tc.expectedTolerance
+           << ", expectThrow: " << (tc.expectThrow ? "true" : "false");
+        return os;
+    }
+};
+
+template <typename T>
+std::vector<BnMeanToleranceTestCase> getBnMeanToleranceTestCases();
+
+// Mean tolerance formula (no casting):
+//   tolerance = (gamma + u) * maxAbsX
+// With input casting (double->float):
+//   tolerance += computeEpsilon * maxAbsX (from inputCastError / NHW)
+//   total = (gamma + 2u) * maxAbsX
+
+// Float / Float / Float
+template <>
+std::vector<BnMeanToleranceTestCase> getBnMeanToleranceTestCases<TypeTriple<float, float, float>>()
+{
+    auto u = static_cast<double>(std::numeric_limits<float>::epsilon());
+    auto gamma = [&](int64_t c) { return computeGamma(static_cast<uint64_t>(c), u); };
+    return {// NHW = 0 => throws
+            {-1.0, 1.0, 0, 0.0, true},
+            // NHW=1
+            {-1.0, 1.0, 1, (gamma(1) + u) * 1.0},
+            // NHW=10
+            {-1.0, 1.0, 10, (gamma(10) + u) * 1.0},
+            // Large x range
+            {-1000.0, 1000.0, 10, (gamma(10) + u) * 1000.0},
+            // Zero input
+            {0.0, 0.0, 10, 0.0}};
+}
+
+// Float / Double / Float
+template <>
+std::vector<BnMeanToleranceTestCase> getBnMeanToleranceTestCases<TypeTriple<float, double, float>>()
+{
+    auto u = static_cast<double>(std::numeric_limits<float>::epsilon());
+    auto gamma = [&](int64_t c) { return computeGamma(static_cast<uint64_t>(c), u); };
+    return {// NHW = 0 => throws
+            {-1.0, 1.0, 0, 0.0, true},
+            // NHW=1: input casting adds u * maxAbsX
+            {-1.0, 1.0, 1, (gamma(1) + 2.0 * u) * 1.0},
+            // NHW=10
+            {-1.0, 1.0, 10, (gamma(10) + 2.0 * u) * 1.0},
+            // Zero input
+            {0.0, 0.0, 10, 0.0}};
+}
+
+// Half / Float / Float (Output casting)
+template <>
+std::vector<BnMeanToleranceTestCase> getBnMeanToleranceTestCases<TypeTriple<half, float, float>>()
+{
+    auto u = static_cast<double>(std::numeric_limits<float>::epsilon());
+    auto uHalf = static_cast<double>(std::numeric_limits<half>::epsilon());
+    auto gamma = [&](int64_t c) { return computeGamma(static_cast<uint64_t>(c), u); };
+    return {// NHW = 0 => throws
+            {-1.0, 1.0, 0, 0.0, true},
+            // NHW=1: base + output casting (maxAbsX * uHalf)
+            {-1.0, 1.0, 1, (gamma(1) + u) * 1.0 + 1.0 * uHalf},
+            // NHW=10
+            {-1.0, 1.0, 10, (gamma(10) + u) * 1.0 + 1.0 * uHalf},
+            // Zero input
+            {0.0, 0.0, 10, 0.0}};
+}
+
+// Half / Half / Half
+template <>
+std::vector<BnMeanToleranceTestCase> getBnMeanToleranceTestCases<TypeTriple<half, half, half>>()
+{
+    auto u = static_cast<double>(std::numeric_limits<half>::epsilon());
+    auto gamma = [&](int64_t c) { return computeGamma(static_cast<uint64_t>(c), u); };
+    return {// NHW = 0 => throws
+            {-1.0, 1.0, 0, 0.0, true},
+            // NHW=1
+            {-1.0, 1.0, 1, (gamma(1) + u) * 1.0},
+            // NHW=10
+            {-1.0, 1.0, 10, (gamma(10) + u) * 1.0},
+            // Zero input
+            {0.0, 0.0, 10, 0.0}};
+}
+
+// Bfloat16 / Float / Float (Output casting)
+template <>
+std::vector<BnMeanToleranceTestCase>
+    getBnMeanToleranceTestCases<TypeTriple<bfloat16, float, float>>()
+{
+    auto u = static_cast<double>(std::numeric_limits<float>::epsilon());
+    auto uBf16 = static_cast<double>(std::numeric_limits<bfloat16>::epsilon());
+    auto gamma = [&](int64_t c) { return computeGamma(static_cast<uint64_t>(c), u); };
+    return {// NHW = 0 => throws
+            {-1.0, 1.0, 0, 0.0, true},
+            // NHW=1
+            {-1.0, 1.0, 1, (gamma(1) + u) * 1.0 + 1.0 * uBf16},
+            // NHW=10
+            {-1.0, 1.0, 10, (gamma(10) + u) * 1.0 + 1.0 * uBf16},
+            // Zero input
+            {0.0, 0.0, 10, 0.0}};
+}
+
+// Bfloat16 / Bfloat16 / Bfloat16
+template <>
+std::vector<BnMeanToleranceTestCase>
+    getBnMeanToleranceTestCases<TypeTriple<bfloat16, bfloat16, bfloat16>>()
+{
+    auto u = static_cast<double>(std::numeric_limits<bfloat16>::epsilon());
+    auto gamma = [&](int64_t c) { return computeGamma(static_cast<uint64_t>(c), u); };
+    return {// NHW = 0 => throws
+            {-1.0, 1.0, 0, 0.0, true},
+            // NHW=1
+            {-1.0, 1.0, 1, (gamma(1) + u) * 1.0},
+            // NHW=10
+            {-1.0, 1.0, 10, (gamma(10) + u) * 1.0},
+            // Zero input
+            {0.0, 0.0, 10, 0.0}};
+}
+
+template <typename Out, typename In, typename Comp>
+class TestCalculateBnMeanTolerance : public ::testing::TestWithParam<BnMeanToleranceTestCase>
+{
+protected:
+    void verifyTolerance()
+    {
+        const auto& params = GetParam();
+
+        if(params.expectThrow)
+        {
+            EXPECT_THROW((calculateBatchnormMeanTolerance<Out, In, Comp>(
+                             params.xMin, params.xMax, params.nElementsPerChannel)),
+                         std::invalid_argument);
+        }
+        else
+        {
+            auto tol = calculateBatchnormMeanTolerance<Out, In, Comp>(
+                params.xMin, params.xMax, params.nElementsPerChannel);
+
+            auto expected = static_cast<float>(params.expectedTolerance);
+
+            EXPECT_NEAR(
+                tol, expected, std::max(expected * 0.01f, std::numeric_limits<float>::min()));
+        }
+    }
+};
+
+using TestCalcBnMeanTolFp32 = TestCalculateBnMeanTolerance<float, float, float>;
+TEST_P(TestCalcBnMeanTolFp32, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalcBnMeanTolFp32,
+    ::testing::ValuesIn(getBnMeanToleranceTestCases<TypeTriple<float, float, float>>()));
+
+using TestCalcBnMeanTolInputDouble = TestCalculateBnMeanTolerance<float, double, float>;
+TEST_P(TestCalcBnMeanTolInputDouble, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalcBnMeanTolInputDouble,
+    ::testing::ValuesIn(getBnMeanToleranceTestCases<TypeTriple<float, double, float>>()));
+
+using TestCalcBnMeanTolComputeFloatFp16 = TestCalculateBnMeanTolerance<half, float, float>;
+TEST_P(TestCalcBnMeanTolComputeFloatFp16, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalcBnMeanTolComputeFloatFp16,
+    ::testing::ValuesIn(getBnMeanToleranceTestCases<TypeTriple<half, float, float>>()));
+
+using TestCalcBnMeanTolFp16 = TestCalculateBnMeanTolerance<half, half, half>;
+TEST_P(TestCalcBnMeanTolFp16, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalcBnMeanTolFp16,
+    ::testing::ValuesIn(getBnMeanToleranceTestCases<TypeTriple<half, half, half>>()));
+
+using TestCalcBnMeanTolComputeFloatBfp16 = TestCalculateBnMeanTolerance<bfloat16, float, float>;
+TEST_P(TestCalcBnMeanTolComputeFloatBfp16, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalcBnMeanTolComputeFloatBfp16,
+    ::testing::ValuesIn(getBnMeanToleranceTestCases<TypeTriple<bfloat16, float, float>>()));
+
+using TestCalcBnMeanTolBfp16 = TestCalculateBnMeanTolerance<bfloat16, bfloat16, bfloat16>;
+TEST_P(TestCalcBnMeanTolBfp16, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalcBnMeanTolBfp16,
+    ::testing::ValuesIn(getBnMeanToleranceTestCases<TypeTriple<bfloat16, bfloat16, bfloat16>>()));
+
+// =================================================================================================
+// TestCalculateBatchnormInvVarianceTolerance
+// =================================================================================================
+
+struct BnInvVarToleranceTestCase
+{
+    double xMin;
+    double xMax;
+    int64_t nElementsPerChannel;
+    double epsilonBn;
+    double expectedTolerance;
+    bool expectThrow = false;
+
+    friend std::ostream& operator<<(std::ostream& os, const BnInvVarToleranceTestCase& tc)
+    {
+        os << "xMin: " << tc.xMin << ", xMax: " << tc.xMax << ", NHW: " << tc.nElementsPerChannel
+           << ", epsilonBn: " << tc.epsilonBn << ", expectedTolerance: " << tc.expectedTolerance
+           << ", expectThrow: " << (tc.expectThrow ? "true" : "false");
+        return os;
+    }
+};
+
+template <typename T>
+std::vector<BnInvVarToleranceTestCase> getBnInvVarToleranceTestCases();
+
+// InvVar tolerance formula (no casting, maxAbsX > 0):
+//   deltaVariance = 3 * gamma * maxAbsX^2
+//   tolerance = deltaVariance / (2 * maxAbsX^2) + 3u / maxAbsX
+//             = 3*gamma/2 + 3u/maxAbsX
+// With output casting (e.g., half/float/float):
+//   + sqrt(3)/maxAbsX * uHalf
+// For x=0:
+//   tolerance = 3u / sqrt(epsilonBn)
+
+// Float / Float / Float
+template <>
+std::vector<BnInvVarToleranceTestCase>
+    getBnInvVarToleranceTestCases<TypeTriple<float, float, float>>()
+{
+    auto u = static_cast<double>(std::numeric_limits<float>::epsilon());
+    auto gamma = [&](int64_t c) { return computeGamma(static_cast<uint64_t>(c), u); };
+    return {// NHW = 0 => throws
+            {-1.0, 1.0, 0, 1e-5, 0.0, true},
+            // NHW=1, x=[-1,1]
+            {-1.0, 1.0, 1, 1e-5, 1.5 * gamma(1) + 3.0 * u},
+            // NHW=10
+            {-1.0, 1.0, 10, 1e-5, 1.5 * gamma(10) + 3.0 * u},
+            // Large x range: invVar ~ 1/maxAbsX -> tolerance terms scale down
+            {-1000.0, 1000.0, 10, 1e-5, 1.5 * gamma(10) + 3.0 * u / 1000.0},
+            // Zero input: tolerance = 3u / sqrt(eps_bn)
+            {0.0, 0.0, 10, 1e-5, 3.0 * u / std::sqrt(1e-5)}};
+}
+
+// Float / Double / Float (no output casting, no input casting for invVar)
+template <>
+std::vector<BnInvVarToleranceTestCase>
+    getBnInvVarToleranceTestCases<TypeTriple<float, double, float>>()
+{
+    auto u = static_cast<double>(std::numeric_limits<float>::epsilon());
+    auto gamma = [&](int64_t c) { return computeGamma(static_cast<uint64_t>(c), u); };
+    return {// NHW = 0 => throws
+            {-1.0, 1.0, 0, 1e-5, 0.0, true},
+            // NHW=1
+            {-1.0, 1.0, 1, 1e-5, 1.5 * gamma(1) + 3.0 * u},
+            // NHW=10
+            {-1.0, 1.0, 10, 1e-5, 1.5 * gamma(10) + 3.0 * u},
+            // Zero input
+            {0.0, 0.0, 10, 1e-5, 3.0 * u / std::sqrt(1e-5)}};
+}
+
+// Half / Float / Float (Output casting: maxInvVar = sqrt(3)/maxAbsX)
+template <>
+std::vector<BnInvVarToleranceTestCase>
+    getBnInvVarToleranceTestCases<TypeTriple<half, float, float>>()
+{
+    auto u = static_cast<double>(std::numeric_limits<float>::epsilon());
+    auto uHalf = static_cast<double>(std::numeric_limits<half>::epsilon());
+    auto gamma = [&](int64_t c) { return computeGamma(static_cast<uint64_t>(c), u); };
+    return {// NHW = 0 => throws
+            {-1.0, 1.0, 0, 1e-5, 0.0, true},
+            // NHW=1: base + sqrt(3) * uHalf
+            {-1.0, 1.0, 1, 1e-5, 1.5 * gamma(1) + 3.0 * u + std::sqrt(3.0) * uHalf},
+            // NHW=10
+            {-1.0, 1.0, 10, 1e-5, 1.5 * gamma(10) + 3.0 * u + std::sqrt(3.0) * uHalf},
+            // Zero input: output cast uses maxInvVar = 1/sqrt(eps_bn)
+            {0.0, 0.0, 10, 1e-5, 3.0 * u / std::sqrt(1e-5) + (1.0 / std::sqrt(1e-5)) * uHalf}};
+}
+
+// Half / Half / Half
+template <>
+std::vector<BnInvVarToleranceTestCase> getBnInvVarToleranceTestCases<TypeTriple<half, half, half>>()
+{
+    auto u = static_cast<double>(std::numeric_limits<half>::epsilon());
+    auto gamma = [&](int64_t c) { return computeGamma(static_cast<uint64_t>(c), u); };
+    return {// NHW = 0 => throws
+            {-1.0, 1.0, 0, 1e-5, 0.0, true},
+            // NHW=1
+            {-1.0, 1.0, 1, 1e-5, 1.5 * gamma(1) + 3.0 * u},
+            // NHW=10
+            {-1.0, 1.0, 10, 1e-5, 1.5 * gamma(10) + 3.0 * u},
+            // Zero input
+            {0.0, 0.0, 10, 1e-5, 3.0 * u / std::sqrt(1e-5)}};
+}
+
+// Bfloat16 / Float / Float
+template <>
+std::vector<BnInvVarToleranceTestCase>
+    getBnInvVarToleranceTestCases<TypeTriple<bfloat16, float, float>>()
+{
+    auto u = static_cast<double>(std::numeric_limits<float>::epsilon());
+    auto uBf16 = static_cast<double>(std::numeric_limits<bfloat16>::epsilon());
+    auto gamma = [&](int64_t c) { return computeGamma(static_cast<uint64_t>(c), u); };
+    return {// NHW = 0 => throws
+            {-1.0, 1.0, 0, 1e-5, 0.0, true},
+            // NHW=1
+            {-1.0, 1.0, 1, 1e-5, 1.5 * gamma(1) + 3.0 * u + std::sqrt(3.0) * uBf16},
+            // NHW=10
+            {-1.0, 1.0, 10, 1e-5, 1.5 * gamma(10) + 3.0 * u + std::sqrt(3.0) * uBf16},
+            // Zero input
+            {0.0, 0.0, 10, 1e-5, 3.0 * u / std::sqrt(1e-5) + (1.0 / std::sqrt(1e-5)) * uBf16}};
+}
+
+// Bfloat16 / Bfloat16 / Bfloat16
+template <>
+std::vector<BnInvVarToleranceTestCase>
+    getBnInvVarToleranceTestCases<TypeTriple<bfloat16, bfloat16, bfloat16>>()
+{
+    auto u = static_cast<double>(std::numeric_limits<bfloat16>::epsilon());
+    auto gamma = [&](int64_t c) { return computeGamma(static_cast<uint64_t>(c), u); };
+    return {// NHW = 0 => throws
+            {-1.0, 1.0, 0, 1e-5, 0.0, true},
+            // NHW=1
+            {-1.0, 1.0, 1, 1e-5, 1.5 * gamma(1) + 3.0 * u},
+            // NHW=10
+            {-1.0, 1.0, 10, 1e-5, 1.5 * gamma(10) + 3.0 * u},
+            // Zero input
+            {0.0, 0.0, 10, 1e-5, 3.0 * u / std::sqrt(1e-5)}};
+}
+
+template <typename Out, typename In, typename Comp>
+class TestCalculateBnInvVarTolerance : public ::testing::TestWithParam<BnInvVarToleranceTestCase>
+{
+protected:
+    void verifyTolerance()
+    {
+        const auto& params = GetParam();
+
+        if(params.expectThrow)
+        {
+            EXPECT_THROW(
+                (calculateBatchnormInvVarianceTolerance<Out, In, Comp>(
+                    params.xMin, params.xMax, params.nElementsPerChannel, params.epsilonBn)),
+                std::invalid_argument);
+        }
+        else
+        {
+            auto tol = calculateBatchnormInvVarianceTolerance<Out, In, Comp>(
+                params.xMin, params.xMax, params.nElementsPerChannel, params.epsilonBn);
+
+            auto expected = static_cast<float>(params.expectedTolerance);
+
+            EXPECT_NEAR(
+                tol, expected, std::max(expected * 0.01f, std::numeric_limits<float>::min()));
+        }
+    }
+};
+
+using TestCalcBnInvVarTolFp32 = TestCalculateBnInvVarTolerance<float, float, float>;
+TEST_P(TestCalcBnInvVarTolFp32, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalcBnInvVarTolFp32,
+    ::testing::ValuesIn(getBnInvVarToleranceTestCases<TypeTriple<float, float, float>>()));
+
+using TestCalcBnInvVarTolInputDouble = TestCalculateBnInvVarTolerance<float, double, float>;
+TEST_P(TestCalcBnInvVarTolInputDouble, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalcBnInvVarTolInputDouble,
+    ::testing::ValuesIn(getBnInvVarToleranceTestCases<TypeTriple<float, double, float>>()));
+
+using TestCalcBnInvVarTolComputeFloatFp16 = TestCalculateBnInvVarTolerance<half, float, float>;
+TEST_P(TestCalcBnInvVarTolComputeFloatFp16, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalcBnInvVarTolComputeFloatFp16,
+    ::testing::ValuesIn(getBnInvVarToleranceTestCases<TypeTriple<half, float, float>>()));
+
+using TestCalcBnInvVarTolFp16 = TestCalculateBnInvVarTolerance<half, half, half>;
+TEST_P(TestCalcBnInvVarTolFp16, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalcBnInvVarTolFp16,
+    ::testing::ValuesIn(getBnInvVarToleranceTestCases<TypeTriple<half, half, half>>()));
+
+using TestCalcBnInvVarTolComputeFloatBfp16 = TestCalculateBnInvVarTolerance<bfloat16, float, float>;
+TEST_P(TestCalcBnInvVarTolComputeFloatBfp16, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalcBnInvVarTolComputeFloatBfp16,
+    ::testing::ValuesIn(getBnInvVarToleranceTestCases<TypeTriple<bfloat16, float, float>>()));
+
+using TestCalcBnInvVarTolBfp16 = TestCalculateBnInvVarTolerance<bfloat16, bfloat16, bfloat16>;
+TEST_P(TestCalcBnInvVarTolBfp16, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalcBnInvVarTolBfp16,
+    ::testing::ValuesIn(getBnInvVarToleranceTestCases<TypeTriple<bfloat16, bfloat16, bfloat16>>()));
+
+// =================================================================================================
+// Standalone Tests
+// =================================================================================================
+
+// Test that calculateBatchnormTrainingTolerance catches simulated wrong outputs
+TEST(TestCalculateBnTrainTolerance, DetectsFailure)
+{
+    // NHW=100 (shape [1,1,10,10]), x=[-1,1], scale=[-1,1]
+    const std::vector<int64_t> dims = {1, 1, 10, 10};
+    const std::vector<int64_t> strides = {100, 100, 10, 1};
+
+    auto baseline = hipdnn_data_sdk::utilities::createTensor<float>(dims, strides);
+    auto actualPassing = hipdnn_data_sdk::utilities::createTensor<float>(dims, strides);
+    auto actualFailing = hipdnn_data_sdk::utilities::createTensor<float>(dims, strides);
+
+    baseline->fillTensorWithValue(1.0f);
+    actualPassing->fillTensorWithValue(1.000001f); // Small error
+    actualFailing->fillTensorWithValue(1.2f); // Large error
+
+    auto tol = calculateBatchnormTrainingTolerance<float, float, float>(
+        -1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 100);
+
+    EXPECT_LT(tol, 0.01f);
+    EXPECT_GT(tol, 1e-6f);
+
+    auto validator = hipdnn_test_sdk::utilities::createAllCloseValidator(
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT, tol, 0);
+
+    bool valid = validator->allClose(*baseline, *actualPassing);
+    EXPECT_TRUE(valid);
+
+    valid = validator->allClose(*baseline, *actualFailing);
+    EXPECT_FALSE(valid);
+}
+
+// Test that tolerance throws when gamma >= 0.5
+TEST(TestCalculateBnTrainTolerance, ThrowsOnSingularity)
+{
+    // float: gamma >= 0.5 at C ~ 3e11 (same as RMSNorm)
+    EXPECT_THROW((calculateBatchnormTrainingTolerance<float, float, float>(
+                     -1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 300000000000LL)),
+                 std::overflow_error);
+
+    // bfloat16: gamma >= 0.5 at C ~ 69. Use C=100.
+    EXPECT_THROW((calculateBatchnormTrainingTolerance<bfloat16, bfloat16, bfloat16>(
+                     -1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 100)),
+                 std::overflow_error);
+
+    // half: gamma >= 0.5 at C ~ 4370. Use C=5000.
+    EXPECT_THROW((calculateBatchnormTrainingTolerance<half, half, half>(
+                     -1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 5000)),
+                 std::overflow_error);
+}
+
+// Test that tolerance throws when it exceeds OutputType max
+TEST(TestCalculateBnTrainTolerance, ThrowsOnOutputOverflow)
+{
+    // half output with very large scale: output cast term >> 65504
+    EXPECT_THROW((calculateBatchnormTrainingTolerance<half, float, float>(
+                     -1.0, 1.0, -1e8, 1e8, 0.0, 0.0, 10)),
+                 std::overflow_error);
+}
+
+// Test zero input produces correct minimal tolerance
+TEST(TestCalculateBnTrainTolerance, ZeroInput)
+{
+    // No bias: all terms vanish
+    auto tol = calculateBatchnormTrainingTolerance<float, float, float>(
+        0.0, 0.0, -1.0, 1.0, 0.0, 0.0, 10);
+    EXPECT_EQ(tol, 0.0f);
+
+    // With bias: only bias term survives
+    auto tolBias = calculateBatchnormTrainingTolerance<float, float, float>(
+        0.0, 0.0, -1.0, 1.0, -0.5, 0.5, 10);
+    EXPECT_GT(tolBias, 0.0f);
+
+    // Zero input with bf16 output casting: maxOutputMagnitude=0 -> no output cast
+    auto tolBf16 = calculateBatchnormTrainingTolerance<bfloat16, float, float>(
+        0.0, 0.0, -1.0, 1.0, 0.0, 0.0, 10);
+    EXPECT_EQ(tolBf16, 0.0f);
+
+    // Zero input with bias and half output: bias term + output cast of bias
+    auto uFloat = static_cast<double>(std::numeric_limits<float>::epsilon());
+    auto uHalf = static_cast<double>(std::numeric_limits<half>::epsilon());
+    auto tolHalfBias = calculateBatchnormTrainingTolerance<half, float, float>(
+        0.0, 0.0, -1.0, 1.0, -0.5, 0.5, 10);
+    // Expected: maxAbsBias * epsilon + maxOutputMagnitude * outputEpsilon
+    //         = 0.5 * uFloat + 0.5 * uHalf
+    auto expectedHalfBias = static_cast<float>(0.5 * uFloat + 0.5 * uHalf);
+    EXPECT_NEAR(tolHalfBias, expectedHalfBias, 1e-10f);
+}
+
+// Sanity check: tolerance scaling behavior with increasing NHW
+TEST(TestCalculateBnTrainTolerance, ToleranceScalesWithNHW)
+{
+    // FP32: tolerance should grow roughly linearly with NHW (gamma ~ NHW*u for small NHW)
+    auto tolC1 = calculateBatchnormTrainingTolerance<float, float, float>(
+        -1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 1);
+    auto tolC10 = calculateBatchnormTrainingTolerance<float, float, float>(
+        -1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 10);
+    auto tolC100 = calculateBatchnormTrainingTolerance<float, float, float>(
+        -1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 100);
+
+    EXPECT_LT(tolC1, tolC10) << "FP32: NHW=10 should have higher tolerance than NHW=1";
+    EXPECT_LT(tolC10, tolC100) << "FP32: NHW=100 should have higher tolerance than NHW=10";
+
+    auto ratioFp32 = static_cast<double>(tolC100) / static_cast<double>(tolC1);
+    EXPECT_GT(ratioFp32, 10.0) << "FP32: ratio NHW100/NHW1 should reflect ~NHW growth";
+
+    // BF16 (statistical): tolerance should grow ~ sqrt(NHW)
+    auto tolBf16C1 = calculateBatchnormTrainingTolerance<bfloat16, bfloat16, bfloat16>(
+        -1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 1);
+    auto tolBf16C10 = calculateBatchnormTrainingTolerance<bfloat16, bfloat16, bfloat16>(
+        -1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 10);
+    auto tolBf16C50 = calculateBatchnormTrainingTolerance<bfloat16, bfloat16, bfloat16>(
+        -1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 50);
+
+    EXPECT_LT(tolBf16C1, tolBf16C10) << "BF16: NHW=10 should have higher tolerance than NHW=1";
+    EXPECT_LT(tolBf16C10, tolBf16C50) << "BF16: NHW=50 should have higher tolerance than NHW=10";
+
+    auto ratioBf16 = static_cast<double>(tolBf16C10) / static_cast<double>(tolBf16C1);
+    EXPECT_GT(ratioBf16, 1.5) << "BF16: ratio NHW10/NHW1 should reflect sqrt(NHW) growth";
+}
+
+// Sanity: mean tolerance scales with NHW
+TEST(TestCalculateBnMeanTolerance, ToleranceScalesWithNHW)
+{
+    auto tol1 = calculateBatchnormMeanTolerance<float, float, float>(-1.0, 1.0, 1);
+    auto tol10 = calculateBatchnormMeanTolerance<float, float, float>(-1.0, 1.0, 10);
+    auto tol100 = calculateBatchnormMeanTolerance<float, float, float>(-1.0, 1.0, 100);
+
+    EXPECT_LT(tol1, tol10);
+    EXPECT_LT(tol10, tol100);
+}
+
+// Sanity: mean zero input
+TEST(TestCalculateBnMeanTolerance, ZeroInput)
+{
+    auto tol = calculateBatchnormMeanTolerance<float, float, float>(0.0, 0.0, 10);
+    EXPECT_EQ(tol, 0.0f);
+}
+
+// Sanity: invVar tolerance scales with NHW
+TEST(TestCalculateBnInvVarTolerance, ToleranceScalesWithNHW)
+{
+    auto tol1 = calculateBatchnormInvVarianceTolerance<float, float, float>(-1.0, 1.0, 1);
+    auto tol10 = calculateBatchnormInvVarianceTolerance<float, float, float>(-1.0, 1.0, 10);
+    auto tol100 = calculateBatchnormInvVarianceTolerance<float, float, float>(-1.0, 1.0, 100);
+
+    EXPECT_LT(tol1, tol10);
+    EXPECT_LT(tol10, tol100);
+}
+
+// Sanity: invVar zero input gives finite positive tolerance
+TEST(TestCalculateBnInvVarTolerance, ZeroInput)
+{
+    auto tol = calculateBatchnormInvVarianceTolerance<float, float, float>(0.0, 0.0, 10);
+    EXPECT_GT(tol, 0.0f);
+    EXPECT_LT(tol, 1.0f); // Should be a reasonable small value
+}
+
+// Mean and invVar also throw on singularity
+TEST(TestCalculateBnMeanTolerance, ThrowsOnSingularity)
+{
+    EXPECT_THROW((calculateBatchnormMeanTolerance<bfloat16, bfloat16, bfloat16>(-1.0, 1.0, 100)),
+                 std::overflow_error);
+}
+
+TEST(TestCalculateBnInvVarTolerance, ThrowsOnSingularity)
+{
+    EXPECT_THROW(
+        (calculateBatchnormInvVarianceTolerance<bfloat16, bfloat16, bfloat16>(-1.0, 1.0, 100)),
+        std::overflow_error);
+}

--- a/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerancesBatchNorm.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerancesBatchNorm.cpp
@@ -54,13 +54,36 @@ struct BnTrainToleranceTestCase
 template <typename T>
 std::vector<BnTrainToleranceTestCase> getBnTrainToleranceTestCases();
 
-// BN Training tolerance formula (no casting):
-//   propTol = (gamma/2 + gamma + 6u) * maxAbsScale + u * maxAbsBias
-//           = (3/2 * gamma + 6u) * maxAbsScale + u * maxAbsBias
+// BN Training tolerance formula (no casting, maxAbsX>0):
+//   accTol = (gamma + 2u) * S     (Higham + 2u for div/sub variance ops)
+//   propTol = accTol/(2*S) * scale + gamma * scale + 6u * scale + u * bias
+//           = ((gamma + 2u)/2 + gamma + 6u) * maxAbsScale + u * maxAbsBias
+//           = (3/2*gamma + u + 6u) * maxAbsScale + u * maxAbsBias
+//           = (3/2*gamma + 7u) * maxAbsScale + u * maxAbsBias
+// Output casting: maxOutputMagnitude = maxAbsScale * maxAbsX * invVarEst + maxAbsBias
+//   where invVarEst = 1/sqrt(max(maxAbsX^2, 1e-5) + 1e-5)
 // With input casting (InputType=double, ComputeType=float):
-//   accTol has extra u term -> variance path becomes (gamma + u)/2
-//   total = ((gamma + u)/2 + gamma + 6u) * maxAbsScale + u * maxAbsBias
-//         = (3/2*gamma + u/2 + 6u) * maxAbsScale + u * maxAbsBias
+//   accTol = (gamma + 2u + u) * S -> variance path = (gamma + 3u)/2
+//   total = ((gamma + 3u)/2 + gamma + 6u) * maxAbsScale + u * maxAbsBias
+//         = (3/2*gamma + 3u/2 + 6u) * maxAbsScale + u * maxAbsBias
+
+// Helper to compute output cast contribution for y tolerance
+static double yOutputCast(double maxAbsX,
+                          double maxAbsScale,
+                          double maxAbsBias,
+                          double outputEpsilon,
+                          double computeEpsilon)
+{
+    if(outputEpsilon <= computeEpsilon)
+    {
+        return 0.0;
+    }
+    constexpr double EPS_BN = 1e-5;
+    const double varEst = std::max(maxAbsX * maxAbsX, EPS_BN);
+    const double invVarEst = 1.0 / std::sqrt(varEst + EPS_BN);
+    const double maxOut = (maxAbsX > 0.0 ? maxAbsScale * maxAbsX * invVarEst : 0.0) + maxAbsBias;
+    return maxOut * outputEpsilon;
+}
 
 // Float / Float / Float
 template <>
@@ -72,48 +95,81 @@ std::vector<BnTrainToleranceTestCase>
     return {// NHW = 0 => throws
             {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 0, 0.0, true},
             // NHW=1, x=[-1,1], scale=[-1,1], no bias
-            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 1, (1.5 * gamma(1) + 6.0 * u) * 1.0},
+            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 1, (1.5 * gamma(1) + 7.0 * u) * 1.0},
             // NHW=10, x=[-1,1], scale=[-1,1], no bias
-            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 10, (1.5 * gamma(10) + 6.0 * u) * 1.0},
+            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 10, (1.5 * gamma(10) + 7.0 * u) * 1.0},
             // NHW=10, x=[-1000,1000], scale=[-1000,1000], no bias
             // Tolerance scales with |scale|, not |x| (normalization cancels |x|)
-            {-1000.0, 1000.0, -1000.0, 1000.0, 0.0, 0.0, 10, (1.5 * gamma(10) + 6.0 * u) * 1000.0},
+            {-1000.0, 1000.0, -1000.0, 1000.0, 0.0, 0.0, 10, (1.5 * gamma(10) + 7.0 * u) * 1000.0},
             // NHW=3, x=[-1,1], scale=[-1,1], bias=[-0.5,0.5]
-            {-1.0, 1.0, -1.0, 1.0, -0.5, 0.5, 3, (1.5 * gamma(3) + 6.0 * u) * 1.0 + 0.5 * u}};
+            {-1.0, 1.0, -1.0, 1.0, -0.5, 0.5, 3, (1.5 * gamma(3) + 7.0 * u) * 1.0 + 0.5 * u}};
 }
 
 // Float / Double / Float (Input casting: inputEpsilon(double) < epsilon(float))
-// accTol = gamma * S + S * u -> variance path = (gamma + u)/2 * maxAbsScale
+// accTol = (gamma + 2u) * S + u * S (input cast) = (gamma + 3u) * S
+// variance path = (gamma + 3u)/2, then + gamma (mean) + 6u (ops)
+// total = (3/2*gamma + 3u/2 + 6u) * scale
 template <>
 std::vector<BnTrainToleranceTestCase>
     getBnTrainToleranceTestCases<TypeTriple<float, double, float>>()
 {
     auto u = static_cast<double>(std::numeric_limits<float>::epsilon());
     auto gamma = [&](int64_t c) { return computeGamma(static_cast<uint64_t>(c), u); };
-    return {
-        // NHW = 0 => throws
-        {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 0, 0.0, true},
-        // NHW=1
-        {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 1, ((gamma(1) + u) / 2.0 + gamma(1) + 6.0 * u) * 1.0},
-        // NHW=10
-        {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 10, ((gamma(10) + u) / 2.0 + gamma(10) + 6.0 * u) * 1.0},
-        // Zero input: all terms vanish
-        {0.0, 0.0, -1.0, 1.0, 0.0, 0.0, 10, 0.0}};
+    return {// NHW = 0 => throws
+            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 0, 0.0, true},
+            // NHW=1
+            {-1.0,
+             1.0,
+             -1.0,
+             1.0,
+             0.0,
+             0.0,
+             1,
+             ((gamma(1) + 3.0 * u) / 2.0 + gamma(1) + 6.0 * u) * 1.0},
+            // NHW=10
+            {-1.0,
+             1.0,
+             -1.0,
+             1.0,
+             0.0,
+             0.0,
+             10,
+             ((gamma(10) + 3.0 * u) / 2.0 + gamma(10) + 6.0 * u) * 1.0},
+            // Zero input: all terms vanish
+            {0.0, 0.0, -1.0, 1.0, 0.0, 0.0, 10, 0.0}};
 }
 
 // Half / Float / Float (Output casting: outputEpsilon(half=2^-10) > epsilon(float=2^-23))
+// maxOutputMagnitude = maxAbsScale * maxAbsX * invVarEst (conservative, not assuming xHat~O(1))
 template <>
 std::vector<BnTrainToleranceTestCase> getBnTrainToleranceTestCases<TypeTriple<half, float, float>>()
 {
     auto u = static_cast<double>(std::numeric_limits<float>::epsilon());
     auto uHalf = static_cast<double>(std::numeric_limits<half>::epsilon());
     auto gamma = [&](int64_t c) { return computeGamma(static_cast<uint64_t>(c), u); };
+    auto yCast = [&](double maxAbsX, double maxAbsScale, double maxAbsBias) {
+        return yOutputCast(maxAbsX, maxAbsScale, maxAbsBias, uHalf, u);
+    };
     return {// NHW = 0 => throws
             {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 0, 0.0, true},
-            // NHW=1: base + output cast (maxOutputMagnitude = maxAbsScale = 1)
-            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 1, (1.5 * gamma(1) + 6.0 * u) * 1.0 + 1.0 * uHalf},
+            // NHW=1: base + output cast
+            {-1.0,
+             1.0,
+             -1.0,
+             1.0,
+             0.0,
+             0.0,
+             1,
+             (1.5 * gamma(1) + 7.0 * u) * 1.0 + yCast(1.0, 1.0, 0.0)},
             // NHW=10
-            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 10, (1.5 * gamma(10) + 6.0 * u) * 1.0 + 1.0 * uHalf},
+            {-1.0,
+             1.0,
+             -1.0,
+             1.0,
+             0.0,
+             0.0,
+             10,
+             (1.5 * gamma(10) + 7.0 * u) * 1.0 + yCast(1.0, 1.0, 0.0)},
             // Zero input: output cast from maxOutputMagnitude=0 vanishes
             {0.0, 0.0, -1.0, 1.0, 0.0, 0.0, 10, 0.0}};
 }
@@ -127,9 +183,9 @@ std::vector<BnTrainToleranceTestCase> getBnTrainToleranceTestCases<TypeTriple<ha
     return {// NHW = 0 => throws
             {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 0, 0.0, true},
             // NHW=1
-            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 1, (1.5 * gamma(1) + 6.0 * u) * 1.0},
+            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 1, (1.5 * gamma(1) + 7.0 * u) * 1.0},
             // NHW=10
-            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 10, (1.5 * gamma(10) + 6.0 * u) * 1.0},
+            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 10, (1.5 * gamma(10) + 7.0 * u) * 1.0},
             // Zero input
             {0.0, 0.0, -1.0, 1.0, 0.0, 0.0, 10, 0.0}};
 }
@@ -142,12 +198,29 @@ std::vector<BnTrainToleranceTestCase>
     auto u = static_cast<double>(std::numeric_limits<float>::epsilon());
     auto uBf16 = static_cast<double>(std::numeric_limits<bfloat16>::epsilon());
     auto gamma = [&](int64_t c) { return computeGamma(static_cast<uint64_t>(c), u); };
+    auto yCast = [&](double maxAbsX, double maxAbsScale, double maxAbsBias) {
+        return yOutputCast(maxAbsX, maxAbsScale, maxAbsBias, uBf16, u);
+    };
     return {// NHW = 0 => throws
             {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 0, 0.0, true},
             // NHW=1
-            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 1, (1.5 * gamma(1) + 6.0 * u) * 1.0 + 1.0 * uBf16},
+            {-1.0,
+             1.0,
+             -1.0,
+             1.0,
+             0.0,
+             0.0,
+             1,
+             (1.5 * gamma(1) + 7.0 * u) * 1.0 + yCast(1.0, 1.0, 0.0)},
             // NHW=10
-            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 10, (1.5 * gamma(10) + 6.0 * u) * 1.0 + 1.0 * uBf16},
+            {-1.0,
+             1.0,
+             -1.0,
+             1.0,
+             0.0,
+             0.0,
+             10,
+             (1.5 * gamma(10) + 7.0 * u) * 1.0 + yCast(1.0, 1.0, 0.0)},
             // Zero input
             {0.0, 0.0, -1.0, 1.0, 0.0, 0.0, 10, 0.0}};
 }
@@ -162,9 +235,9 @@ std::vector<BnTrainToleranceTestCase>
     return {// NHW = 0 => throws
             {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 0, 0.0, true},
             // NHW=1
-            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 1, (1.5 * gamma(1) + 6.0 * u) * 1.0},
+            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 1, (1.5 * gamma(1) + 7.0 * u) * 1.0},
             // NHW=10
-            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 10, (1.5 * gamma(10) + 6.0 * u) * 1.0},
+            {-1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 10, (1.5 * gamma(10) + 7.0 * u) * 1.0},
             // Zero input
             {0.0, 0.0, -1.0, 1.0, 0.0, 0.0, 10, 0.0}};
 }
@@ -512,14 +585,34 @@ struct BnInvVarToleranceTestCase
 template <typename T>
 std::vector<BnInvVarToleranceTestCase> getBnInvVarToleranceTestCases();
 
-// InvVar tolerance formula (no casting, maxAbsX > 0):
-//   deltaVariance = 3 * gamma * maxAbsX^2
-//   tolerance = deltaVariance / (2 * maxAbsX^2) + 3u / maxAbsX
-//             = 3*gamma/2 + 3u/maxAbsX
-// With output casting (e.g., half/float/float):
-//   + sqrt(3)/maxAbsX * uHalf
-// For x=0:
-//   tolerance = 3u / sqrt(epsilonBn)
+// InvVar tolerance formula (corrected, see plan Section 15):
+//   deltaVariance = (3*gamma + 2u) * maxAbsX^2
+//   varEstimate = max(maxAbsX^2, epsilonBn)
+//   varPlusEps = varEstimate + epsilonBn
+//   tolerance = deltaVariance / (2 * varPlusEps^{3/2}) + 3u / sqrt(varPlusEps)
+// With output casting: + invVarEstimate * outputEpsilon
+//   where invVarEstimate = 1/sqrt(varPlusEps)
+// For x=0: varEstimate = epsilonBn, varPlusEps = 2*epsilonBn
+
+// Helper to compute expected invVar tolerance
+static double expectedInvVarTol(double maxAbsX,
+                                double epsBn,
+                                double gamma,
+                                double u,
+                                double outputEpsilon = 0.0,
+                                double computeEpsilon = 0.0)
+{
+    const double varEst = std::max(maxAbsX * maxAbsX, epsBn);
+    const double varPlusEps = varEst + epsBn;
+    const double deltaVar = (3.0 * gamma + 2.0 * u) * maxAbsX * maxAbsX;
+    const double invVarEst = 1.0 / std::sqrt(varPlusEps);
+    double tol = deltaVar / (2.0 * varPlusEps * std::sqrt(varPlusEps)) + 3.0 * u * invVarEst;
+    if(outputEpsilon > computeEpsilon)
+    {
+        tol += invVarEst * outputEpsilon;
+    }
+    return tol;
+}
 
 // Float / Float / Float
 template <>
@@ -531,13 +624,13 @@ std::vector<BnInvVarToleranceTestCase>
     return {// NHW = 0 => throws
             {-1.0, 1.0, 0, 1e-5, 0.0, true},
             // NHW=1, x=[-1,1]
-            {-1.0, 1.0, 1, 1e-5, 1.5 * gamma(1) + 3.0 * u},
+            {-1.0, 1.0, 1, 1e-5, expectedInvVarTol(1.0, 1e-5, gamma(1), u)},
             // NHW=10
-            {-1.0, 1.0, 10, 1e-5, 1.5 * gamma(10) + 3.0 * u},
-            // Large x range: invVar ~ 1/maxAbsX -> tolerance terms scale down
-            {-1000.0, 1000.0, 10, 1e-5, 1.5 * gamma(10) + 3.0 * u / 1000.0},
-            // Zero input: tolerance = 3u / sqrt(eps_bn)
-            {0.0, 0.0, 10, 1e-5, 3.0 * u / std::sqrt(1e-5)}};
+            {-1.0, 1.0, 10, 1e-5, expectedInvVarTol(1.0, 1e-5, gamma(10), u)},
+            // Large x range: tolerance now properly scales down with maxAbsX
+            {-1000.0, 1000.0, 10, 1e-5, expectedInvVarTol(1000.0, 1e-5, gamma(10), u)},
+            // Zero input: varEstimate = epsBn, varPlusEps = 2*epsBn
+            {0.0, 0.0, 10, 1e-5, expectedInvVarTol(0.0, 1e-5, gamma(10), u)}};
 }
 
 // Float / Double / Float (no output casting, no input casting for invVar)
@@ -550,14 +643,14 @@ std::vector<BnInvVarToleranceTestCase>
     return {// NHW = 0 => throws
             {-1.0, 1.0, 0, 1e-5, 0.0, true},
             // NHW=1
-            {-1.0, 1.0, 1, 1e-5, 1.5 * gamma(1) + 3.0 * u},
+            {-1.0, 1.0, 1, 1e-5, expectedInvVarTol(1.0, 1e-5, gamma(1), u)},
             // NHW=10
-            {-1.0, 1.0, 10, 1e-5, 1.5 * gamma(10) + 3.0 * u},
+            {-1.0, 1.0, 10, 1e-5, expectedInvVarTol(1.0, 1e-5, gamma(10), u)},
             // Zero input
-            {0.0, 0.0, 10, 1e-5, 3.0 * u / std::sqrt(1e-5)}};
+            {0.0, 0.0, 10, 1e-5, expectedInvVarTol(0.0, 1e-5, gamma(10), u)}};
 }
 
-// Half / Float / Float (Output casting: maxInvVar = sqrt(3)/maxAbsX)
+// Half / Float / Float (Output casting)
 template <>
 std::vector<BnInvVarToleranceTestCase>
     getBnInvVarToleranceTestCases<TypeTriple<half, float, float>>()
@@ -567,12 +660,12 @@ std::vector<BnInvVarToleranceTestCase>
     auto gamma = [&](int64_t c) { return computeGamma(static_cast<uint64_t>(c), u); };
     return {// NHW = 0 => throws
             {-1.0, 1.0, 0, 1e-5, 0.0, true},
-            // NHW=1: base + sqrt(3) * uHalf
-            {-1.0, 1.0, 1, 1e-5, 1.5 * gamma(1) + 3.0 * u + std::sqrt(3.0) * uHalf},
+            // NHW=1
+            {-1.0, 1.0, 1, 1e-5, expectedInvVarTol(1.0, 1e-5, gamma(1), u, uHalf, u)},
             // NHW=10
-            {-1.0, 1.0, 10, 1e-5, 1.5 * gamma(10) + 3.0 * u + std::sqrt(3.0) * uHalf},
-            // Zero input: output cast uses maxInvVar = 1/sqrt(eps_bn)
-            {0.0, 0.0, 10, 1e-5, 3.0 * u / std::sqrt(1e-5) + (1.0 / std::sqrt(1e-5)) * uHalf}};
+            {-1.0, 1.0, 10, 1e-5, expectedInvVarTol(1.0, 1e-5, gamma(10), u, uHalf, u)},
+            // Zero input
+            {0.0, 0.0, 10, 1e-5, expectedInvVarTol(0.0, 1e-5, gamma(10), u, uHalf, u)}};
 }
 
 // Half / Half / Half
@@ -584,11 +677,11 @@ std::vector<BnInvVarToleranceTestCase> getBnInvVarToleranceTestCases<TypeTriple<
     return {// NHW = 0 => throws
             {-1.0, 1.0, 0, 1e-5, 0.0, true},
             // NHW=1
-            {-1.0, 1.0, 1, 1e-5, 1.5 * gamma(1) + 3.0 * u},
+            {-1.0, 1.0, 1, 1e-5, expectedInvVarTol(1.0, 1e-5, gamma(1), u)},
             // NHW=10
-            {-1.0, 1.0, 10, 1e-5, 1.5 * gamma(10) + 3.0 * u},
+            {-1.0, 1.0, 10, 1e-5, expectedInvVarTol(1.0, 1e-5, gamma(10), u)},
             // Zero input
-            {0.0, 0.0, 10, 1e-5, 3.0 * u / std::sqrt(1e-5)}};
+            {0.0, 0.0, 10, 1e-5, expectedInvVarTol(0.0, 1e-5, gamma(10), u)}};
 }
 
 // Bfloat16 / Float / Float
@@ -602,11 +695,11 @@ std::vector<BnInvVarToleranceTestCase>
     return {// NHW = 0 => throws
             {-1.0, 1.0, 0, 1e-5, 0.0, true},
             // NHW=1
-            {-1.0, 1.0, 1, 1e-5, 1.5 * gamma(1) + 3.0 * u + std::sqrt(3.0) * uBf16},
+            {-1.0, 1.0, 1, 1e-5, expectedInvVarTol(1.0, 1e-5, gamma(1), u, uBf16, u)},
             // NHW=10
-            {-1.0, 1.0, 10, 1e-5, 1.5 * gamma(10) + 3.0 * u + std::sqrt(3.0) * uBf16},
+            {-1.0, 1.0, 10, 1e-5, expectedInvVarTol(1.0, 1e-5, gamma(10), u, uBf16, u)},
             // Zero input
-            {0.0, 0.0, 10, 1e-5, 3.0 * u / std::sqrt(1e-5) + (1.0 / std::sqrt(1e-5)) * uBf16}};
+            {0.0, 0.0, 10, 1e-5, expectedInvVarTol(0.0, 1e-5, gamma(10), u, uBf16, u)}};
 }
 
 // Bfloat16 / Bfloat16 / Bfloat16
@@ -619,11 +712,11 @@ std::vector<BnInvVarToleranceTestCase>
     return {// NHW = 0 => throws
             {-1.0, 1.0, 0, 1e-5, 0.0, true},
             // NHW=1
-            {-1.0, 1.0, 1, 1e-5, 1.5 * gamma(1) + 3.0 * u},
+            {-1.0, 1.0, 1, 1e-5, expectedInvVarTol(1.0, 1e-5, gamma(1), u)},
             // NHW=10
-            {-1.0, 1.0, 10, 1e-5, 1.5 * gamma(10) + 3.0 * u},
+            {-1.0, 1.0, 10, 1e-5, expectedInvVarTol(1.0, 1e-5, gamma(10), u)},
             // Zero input
-            {0.0, 0.0, 10, 1e-5, 3.0 * u / std::sqrt(1e-5)}};
+            {0.0, 0.0, 10, 1e-5, expectedInvVarTol(0.0, 1e-5, gamma(10), u)}};
 }
 
 template <typename Out, typename In, typename Comp>
@@ -801,8 +894,9 @@ TEST(TestCalculateBnTrainTolerance, ZeroInput)
     auto tolHalfBias = calculateBatchnormTrainingTolerance<half, float, float>(
         0.0, 0.0, -1.0, 1.0, -0.5, 0.5, 10);
     // Expected: maxAbsBias * epsilon + maxOutputMagnitude * outputEpsilon
-    //         = 0.5 * uFloat + 0.5 * uHalf
-    auto expectedHalfBias = static_cast<float>(0.5 * uFloat + 0.5 * uHalf);
+    //         = 0.5 * uFloat + 0.5 * uHalf  (maxOutputMagnitude = 0 + maxAbsBias = 0.5)
+    auto expectedHalfBias
+        = static_cast<float>(0.5 * uFloat + yOutputCast(0.0, 1.0, 0.5, uHalf, uFloat));
     EXPECT_NEAR(tolHalfBias, expectedHalfBias, 1e-10f);
 }
 
@@ -929,6 +1023,45 @@ TEST(TestCalculateBnTrainTolerance, ThrowsOnNegativeNHW)
                  std::invalid_argument);
     EXPECT_THROW((calculateBatchnormInvVarianceTolerance<float, float, float>(-1.0, 1.0, -1)),
                  std::invalid_argument);
+}
+
+// InvVar: small x where eps_bn dominates variance estimate
+TEST(TestCalculateBnInvVarTolerance, SmallXEpsilonDominates)
+{
+    // maxAbsX = 0.001, eps_bn = 1e-5
+    // maxAbsX^2 = 1e-6 < eps_bn = 1e-5, so varEstimate = eps_bn
+    // varPlusEps = 2 * eps_bn = 2e-5
+    // This tests that the variance floor prevents underestimation
+    auto tol = calculateBatchnormInvVarianceTolerance<float, float, float>(-0.001, 0.001, 10, 1e-5);
+    EXPECT_GT(tol, 0.0f);
+
+    // Compare with zero-input case: should be similar magnitude since eps_bn dominates both
+    auto tolZero = calculateBatchnormInvVarianceTolerance<float, float, float>(0.0, 0.0, 10, 1e-5);
+    EXPECT_GT(tolZero, 0.0f);
+
+    // Small-x tolerance should be >= zero-input tolerance (has additional deltaVar contribution)
+    EXPECT_GE(tol, tolZero);
+
+    // InvVar tolerance should decrease as maxAbsX increases (larger var -> less amplification)
+    auto tolLargeX
+        = calculateBatchnormInvVarianceTolerance<float, float, float>(-10.0, 10.0, 10, 1e-5);
+    EXPECT_LT(tolLargeX, tol) << "Larger x should give smaller invVar tolerance";
+}
+
+// InvVar: tolerance properly scales down for large maxAbsX
+TEST(TestCalculateBnInvVarTolerance, LargeXScalesDown)
+{
+    auto tol1 = calculateBatchnormInvVarianceTolerance<float, float, float>(-1.0, 1.0, 10);
+    auto tol100 = calculateBatchnormInvVarianceTolerance<float, float, float>(-100.0, 100.0, 10);
+    auto tol1000 = calculateBatchnormInvVarianceTolerance<float, float, float>(-1000.0, 1000.0, 10);
+
+    // Tolerance should decrease as maxAbsX increases
+    EXPECT_LT(tol100, tol1) << "x=100 should give smaller invVar tolerance than x=1";
+    EXPECT_LT(tol1000, tol100) << "x=1000 should give smaller invVar tolerance than x=100";
+
+    // The ratio should reflect the 1/maxAbsX scaling in the gamma term
+    auto ratio = static_cast<double>(tol1) / static_cast<double>(tol100);
+    EXPECT_GT(ratio, 10.0) << "Tolerance ratio should reflect ~1/maxAbsX scaling";
 }
 
 // Mean and invVar also throw on singularity

--- a/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerancesBatchNorm.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerancesBatchNorm.cpp
@@ -72,15 +72,15 @@ static double yOutputCast(double maxAbsX,
                           double maxAbsScale,
                           double maxAbsBias,
                           double outputEpsilon,
-                          double computeEpsilon)
+                          double computeEpsilon,
+                          double epsBn = 1e-5)
 {
     if(outputEpsilon <= computeEpsilon)
     {
         return 0.0;
     }
-    constexpr double EPS_BN = 1e-5;
-    const double varEst = std::max(maxAbsX * maxAbsX, EPS_BN);
-    const double invVarEst = 1.0 / std::sqrt(varEst + EPS_BN);
+    const double varEst = std::max(maxAbsX * maxAbsX, epsBn);
+    const double invVarEst = 1.0 / std::sqrt(varEst + epsBn);
     const double maxOut = (maxAbsX > 0.0 ? maxAbsScale * maxAbsX * invVarEst : 0.0) + maxAbsBias;
     return maxOut * outputEpsilon;
 }
@@ -1076,4 +1076,79 @@ TEST(TestCalculateBnInvVarTolerance, ThrowsOnSingularity)
     EXPECT_THROW(
         (calculateBatchnormInvVarianceTolerance<bfloat16, bfloat16, bfloat16>(-1.0, 1.0, 100)),
         std::overflow_error);
+}
+
+// epsilonBn <= 0 should throw for both y and invVar
+TEST(TestCalculateBnTrainTolerance, ThrowsOnInvalidEpsilon)
+{
+    EXPECT_THROW((calculateBatchnormTrainingTolerance<float, float, float>(
+                     -1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 10, 0.0)),
+                 std::invalid_argument);
+    EXPECT_THROW((calculateBatchnormTrainingTolerance<float, float, float>(
+                     -1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 10, -1e-5)),
+                 std::invalid_argument);
+}
+
+TEST(TestCalculateBnInvVarTolerance, ThrowsOnInvalidEpsilon)
+{
+    EXPECT_THROW((calculateBatchnormInvVarianceTolerance<float, float, float>(-1.0, 1.0, 10, 0.0)),
+                 std::invalid_argument);
+    EXPECT_THROW(
+        (calculateBatchnormInvVarianceTolerance<float, float, float>(-1.0, 1.0, 10, -1e-5)),
+        std::invalid_argument);
+}
+
+// InvVar: tolerance changes with different epsilon values
+TEST(TestCalculateBnInvVarTolerance, NonDefaultEpsilon)
+{
+    auto u = static_cast<double>(std::numeric_limits<float>::epsilon());
+    auto gamma10 = computeGamma(10, u);
+
+    // Large epsilon (1e-3): larger variance floor -> smaller invVar -> smaller tolerance
+    auto tolLargeEps
+        = calculateBatchnormInvVarianceTolerance<float, float, float>(-1.0, 1.0, 10, 1e-3);
+    auto expectedLargeEps = expectedInvVarTol(1.0, 1e-3, gamma10, u);
+    EXPECT_NEAR(
+        tolLargeEps,
+        static_cast<float>(expectedLargeEps),
+        std::max(static_cast<float>(expectedLargeEps) * 0.01f, std::numeric_limits<float>::min()));
+
+    // Small epsilon (1e-8): varEstimate = maxAbsX^2 dominates, epsilon barely matters
+    auto tolSmallEps
+        = calculateBatchnormInvVarianceTolerance<float, float, float>(-1.0, 1.0, 10, 1e-8);
+    auto expectedSmallEps = expectedInvVarTol(1.0, 1e-8, gamma10, u);
+    EXPECT_NEAR(
+        tolSmallEps,
+        static_cast<float>(expectedSmallEps),
+        std::max(static_cast<float>(expectedSmallEps) * 0.01f, std::numeric_limits<float>::min()));
+
+    // With maxAbsX=0: epsilon dominates entirely, larger eps -> smaller tolerance
+    auto tolZeroLargeEps
+        = calculateBatchnormInvVarianceTolerance<float, float, float>(0.0, 0.0, 10, 1e-3);
+    auto tolZeroSmallEps
+        = calculateBatchnormInvVarianceTolerance<float, float, float>(0.0, 0.0, 10, 1e-8);
+    EXPECT_LT(tolZeroLargeEps, tolZeroSmallEps)
+        << "Larger eps_bn -> larger variance floor -> smaller invVar tolerance for zero input";
+}
+
+// Y tolerance: non-default epsilon affects output casting magnitude
+TEST(TestCalculateBnTrainTolerance, NonDefaultEpsilon)
+{
+    // For maxAbsX=1, scale=1, the main tolerance (3/2*gamma + 7u) is independent
+    // of eps_bn. Only the output casting magnitude changes via invVarEst.
+    auto tolDefault = calculateBatchnormTrainingTolerance<half, float, float>(
+        -1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 10, 1e-5);
+    auto tolLargeEps = calculateBatchnormTrainingTolerance<half, float, float>(
+        -1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 10, 1e-3);
+
+    // Larger eps_bn -> smaller invVarEst -> smaller maxOutputMagnitude -> smaller output cast
+    EXPECT_LT(tolLargeEps, tolDefault) << "Larger eps_bn should reduce output casting contribution";
+
+    // For float/float/float (no output casting), eps_bn has no effect
+    auto tolFp32Default = calculateBatchnormTrainingTolerance<float, float, float>(
+        -1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 10, 1e-5);
+    auto tolFp32LargeEps = calculateBatchnormTrainingTolerance<float, float, float>(
+        -1.0, 1.0, -1.0, 1.0, 0.0, 0.0, 10, 1e-3);
+    EXPECT_EQ(tolFp32Default, tolFp32LargeEps)
+        << "Without output casting, eps_bn should not affect y tolerance";
 }


### PR DESCRIPTION

The dynamic tolerance is based on a conservative, kernel-agnostic absolute-error tolerance model for BatchNorm training that is numerically stable across floating‑point precisions and degenerate cases (low variance, constant inputs).

### Assumptions
- Statistics are computed per channel over the reduction dimension $\mathrm{NHW} = N \cdot H \cdot W$. 
- Floating-point error is modeled using machine epsilon $u$ and a Higham-style summation bound $\gamma(\mathrm{NHW}, u)$. 
- No assumptions are made about data distribution, variance magnitude, or reduction order (treated as a black box). 
- All tolerances are expressed as \emph{absolute} errors to remain valid in low-variance and degenerate cases. 

### Error Model

- **_Mean:_** Summation and division error yields $|\delta \mu| \le (\gamma + u)\max|x|$
- **_Variance:_** Using a two-pass formulation, $\delta \sigma^2| \le (3\gamma + 2u)\max|x|^2$. Relative error is intentionally not bounded due to possible catastrophic cancellation.
- **_Inverse variance:_** The propagation through the normalize chain assumes variance is $O(\max|x|^2)$, which holds for well-spread data but not for near-constant inputs offset from zero. The variance floor $\max(\max|x|^2, \epsilon_{\mathrm{bn}})$ mitigates this for the standalone inverse-variance tolerance; the $y$ output tolerance remains subject to this assumption.
- **_Output (y):_** Total output error decomposes into contributions from variance path, mean path, nonlinear ops, elementwise arithmetic, and bias addition. Algebraic cancellation ensures the variance-path contribution is independent of input magnitude.

### Final Bound

Per-element output tolerance is bounded by:
$|\delta y| \le \left(\tfrac{3}{2}\gamma + 7u\right)\max|\text{scale}| + u\max|\text{bias}|$

The casting step uses a conservative magnitude estimate that is valid for NHW = 1, low-variance, and constant-input cases, and does not rely on kernel-specific behavior.

### Tests summary per category
| Category | Count | Tests |
|----------|-------|-------|
| **Formula correctness** | 75 | All parameterized cases (exact expected value match) |
| **Scaling / monotonicity** | 4 | ScalesWithNHW (y, mean, invVar), LargeXScalesDown |
| **Edge cases** | 5 | ZeroInput (y, mean, invVar), AsymmetricXRange, ZeroScaleAndBias |
| **Overflow / validation** | 5 | ThrowsOnSingularity (y, mean, invVar), ThrowsOnOutputOverflow, ThrowsOnNegativeNHW |
| **Functional / integration** | 1 | DetectsFailure |
| **Variance floor** | 1 | SmallXEpsilonDominates |