### PR TITLE
Add layernorm dynamic tolerance

### DIFF
--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerances.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerances.hpp
@@ -10,6 +10,7 @@
 
 #include <hipdnn_test_sdk/utilities/DynamicTolerancesCommon.hpp>
 #include <hipdnn_test_sdk/utilities/DynamicTolerancesConv.hpp>
+#include <hipdnn_test_sdk/utilities/DynamicTolerancesLayerNorm.hpp>
 #include <hipdnn_test_sdk/utilities/DynamicTolerancesMatmul.hpp>
 #include <hipdnn_test_sdk/utilities/DynamicTolerancesPointwise.hpp>
 #include <hipdnn_test_sdk/utilities/DynamicTolerancesRMSNorm.hpp>

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerancesLayerNorm.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerancesLayerNorm.hpp
@@ -23,23 +23,24 @@ using hipdnn_data_sdk::types::half;
  * normalizedDimCount dimensions using Welford's online algorithm, then normalize:
  *   y[b,i] = scale[i] * (x[b,i] - mean_b) * invStd_b + bias[i]
  *
- * Error sources:
- * 1. Mean accumulation via Welford: M incremental updates (dominant for mean output)
- * 2. M2 (variance numerator) accumulation: M multiply-adds (dominant for variance)
- * 3. Nonlinear operations: div(M2,M), sqrt, reciprocal (O(u) each)
- * 4. Output normalization: sub(x,mean), mul(invStd), mul(scale), add(bias)
+ * Two independent error paths propagate into the output y:
  *
- * The combined error is modeled using computeGamma() for the accumulation stages
- * (2M effective accumulations covering both mean and M2), then propagated through
- * the nonlinear chain using derivative analysis identical to RMSNorm.
+ * Path A (variance): M2 accumulation error → invStd error → output error.
+ *   Modeled using computeGamma(2M) for the M2 accumulation (2M effective
+ *   accumulations: M multiply-adds for M2, M incremental updates for mean
+ *   that feed the delta values).  Propagated through the nonlinear chain
+ *   (div, sqrt, reciprocal) using the same derivative analysis as RMSNorm.
+ *   Contribution: gammaVar(2M) / 2 * maxAbsScale.
  *
- * Key insight: after normalization, |xHat| = |(x - mean) * invStd| is O(1) by
- * construction (zero mean, unit variance). Therefore |y| ~ |scale| + |bias|, and
- * the tolerance scales with |scale|, not with |x|. This cancellation is the same
- * mechanism as in RMSNorm and BatchNorm.
+ * Path B (mean): mean error propagates directly into (x - mean) * invStd.
+ *   |delta_mean| ~ gamma(M) * maxAbsX from M Welford incremental updates.
+ *   Under the invStd ~ 1/maxAbsX assumption (same as Path A), the output
+ *   contribution is gamma(M) * maxAbsScale.  This path does not exist in
+ *   RMSNorm (which has no mean subtraction).
  *
- * Uses the shared computeGamma() helper for the accumulation error growth factor,
- * then propagates that error through the nonlinear chain (div, sqrt, reciprocal).
+ * Key insight: after normalization, |xHat| = |(x - mean) * invStd| is O(1)
+ * (the RMS of xHat is exactly 1).  Therefore |y| ~ |scale| + |bias|, and
+ * the tolerance scales with |scale|, not with |x|.
  *
  * @tparam OutputType  Data type of y output tensor
  * @tparam InputType   Data type of x input tensor
@@ -55,11 +56,16 @@ using hipdnn_data_sdk::types::half;
  *
  * Known Limitations:
  * - Black-box: does not use kernel implementation details
- * - Conservative bound: assumes Welford errors accumulate at worst-case rate
- * - Uses 2M effective accumulations (mean + M2) which may overestimate for
- *   Welford's algorithm whose incremental mean update is more stable than naive sum
+ * - Mean path uses invStd ~ 1/maxAbsX assumption; for data with small variance
+ *   relative to magnitude (e.g. x in [100, 100.1]), actual invStd >> 1/maxAbsX,
+ *   and the mean error contribution is underestimated
+ * - |xHat| ~ O(1) is the RMS value; individual elements can reach O(sqrt(M)),
+ *   so tail elements may exceed the tolerance (rare for random data)
  * - NONLINEAR_OPS_UPPER_BOUND=5 models worst-case op count; hardware rsqrt fusion
  *   or multiply reordering may produce fewer rounding errors in practice
+ * - GPU parallel Welford (block-wise reduction + tree merge) has different error
+ *   characteristics than the sequential reference; this tolerance is designed for
+ *   CPU-reference vs CPU-reference comparison only
  * - No backward pass support (only forward)
  * - No mean/invVariance-specific tolerance functions (training mode outputs)
  */
@@ -80,72 +86,92 @@ float calculateLayernormFpropTolerance(double xMin,
     }
 
     // Compute bounds
-    const double maxAbsX = std::max(std::abs(xMin), std::abs(xMax));
     const double maxAbsScale = std::max(std::abs(scaleMin), std::abs(scaleMax));
     const double maxAbsBias = std::max(std::abs(biasMin), std::abs(biasMax));
 
-    // Welford accumulation error.
-    // Welford's algorithm accumulates both mean and M2 over M elements.
-    // Mean: M incremental updates (sub + div + add per step)
-    // M2:   M multiply-adds (delta * delta2 + accumulate)
-    // Combined effective accumulations: 2M (accounts for both passes).
-    //
-    // The M2 accumulation has products bounded by maxAbsX^2 (delta and delta2
-    // are each bounded by the input range). This is structurally identical
-    // to RMSNorm's sum-of-squares, with the same self-product bound.
-    auto numberOfAccumulations
+    // Input range: both x and mean lie in [xMin, xMax], so Welford's
+    // delta = x - mean has |delta| <= xMax - xMin.  For constant input
+    // (range = 0), all deltas are zero and M2 = 0.
+    const double range = std::max(xMax - xMin, 0.0);
+
+    // =================================================================
+    // Path A: Variance accumulation error (M2 → invStd → y)
+    // =================================================================
+    // Welford's M2 accumulates M products delta_i * delta2_i, each
+    // bounded by range^2.  We model this as 2M effective accumulations
+    // (M for M2 multiply-adds + M for mean incremental updates that
+    // feed into the delta values).
+    auto varianceAccumulations
         = static_cast<uint64_t>(2) * static_cast<uint64_t>(normalizedElementCount);
-    const double maxProduct = maxAbsX * maxAbsX; // Welford delta products
-    const double sumAbsProductBound = static_cast<double>(numberOfAccumulations) * maxProduct;
+    const double maxProduct = range * range;
+    const double sumAbsProductBound = static_cast<double>(varianceAccumulations) * maxProduct;
 
     auto epsilon = static_cast<double>(std::numeric_limits<ComputeType>::epsilon());
 
-    // Use shared computeGamma() for the error growth factor
-    const double gamma = computeGamma(numberOfAccumulations, epsilon);
-    validateGamma(gamma);
+    // Variance path: computeGamma for 2M effective accumulations
+    const double gammaVar = computeGamma(varianceAccumulations, epsilon);
+    validateGamma(gammaVar);
 
-    double accumulatedTolerance = gamma * sumAbsProductBound;
+    double varianceAccumTolerance = gammaVar * sumAbsProductBound;
 
-    // Input casting error (if InputType precision > ComputeType precision).
+    // Input casting error for the variance path (if InputType precision > ComputeType).
     // Welford squares a single tensor (delta * delta2, both from x), so only one
     // operand is cast per product term -- factor 1, same as RMSNorm.
-    accumulatedTolerance += computeInputCastingError<InputType, ComputeType>(sumAbsProductBound, 1);
+    varianceAccumTolerance
+        += computeInputCastingError<InputType, ComputeType>(sumAbsProductBound, 1);
 
-    // Propagate accumulation error through the nonlinear chain to get output error.
+    // =================================================================
+    // Path B: Mean error propagation (delta_mean → y)
+    // =================================================================
+    // The mean error propagates into the output as:
+    //   delta_y_from_mean = -scale * delta_mean * invStd
     //
-    // The derivation follows the same logic as RMSNorm:
-    //   invStd = (M2/M + eps)^(-1/2), so d(invStd)/d(M2) = -1/(2M) * (M2/M+eps)^(-3/2)
-    //   |delta_invStd / invStd| <= accTol / (2 * M2)    [since invStd = 1/std, eps << M2/M]
-    //                            = accTol / (2 * sumAbsProductBound)  [worst-case M2 = sumAbsBound]
+    // |delta_mean| ~ gamma(M) * maxAbsX  (M incremental Welford updates,
+    //   each contributing O(u * maxAbsX) from sub + div + add).
     //
-    // After normalization:
-    //   y = scale * (x - mean) * invStd + bias
-    //   |xHat| = |(x - mean) * invStd| is O(1) by construction
-    //   |delta_y| <= maxAbsScale * accTol / (2 * sumAbsProductBound)
-    //             =  maxAbsScale * gamma / 2
+    // Using the same invStd ~ 1/maxAbsX assumption as the variance path
+    // (RMS-like bound: std ~ maxAbsX for well-spread data):
+    //   |delta_y_from_mean| ~ gamma(M) * maxAbsX * (1/maxAbsX) * maxAbsScale
+    //                       = gamma(M) * maxAbsScale
     //
-    // Additional per-op rounding (div(M2,M) + sqrt + recip + mul(x-mean,invStd) + mul(*,scale)):
-    //   |delta_y| += NONLINEAR_OPS_UPPER_BOUND * u * maxAbsScale
-    //             += maxAbsBias * epsilon
+    // Note: the ratio maxAbsX/std is data-dependent (~ 1.7 for uniform [-a,a],
+    // ~ 3.5 for uniform [0,a]).  The invStd ~ 1/maxAbsX assumption gives an
+    // O(1) ratio, which is the same modelling choice the variance path makes.
+    auto meanAccumulations = static_cast<uint64_t>(normalizedElementCount);
+    const double gammaMean = computeGamma(meanAccumulations, epsilon);
+    // gammaMean < gammaVar always (M < 2M, computeGamma is monotonic),
+    // so if gammaVar passed validateGamma, gammaMean is also valid.
+
+    // =================================================================
+    // Combined propagation
+    // =================================================================
+    // Variance path: accTol / (2 * sumAbsProductBound) * maxAbsScale = gammaVar/2 * maxAbsScale
+    //   (the sumAbsProductBound cancels in numerator and denominator)
+    // Mean path:     gammaMean * maxAbsScale
+    // Nonlinear ops: NONLINEAR_OPS_UPPER_BOUND * u * maxAbsScale
+    // Bias:          u * maxAbsBias
     constexpr double NONLINEAR_OPS_UPPER_BOUND = 5.0;
 
     double propagatedTolerance = 0.0;
 
-    // When maxAbsX == 0, all inputs are zero. M2 = 0, mean = 0, invStd = 1/sqrt(eps),
-    // y = 0*invStd*scale + bias = bias.
-    // Accumulation error is zero, the nonlinear-ops term on the xHat*scale chain vanishes,
-    // and maxOutputMagnitude reduces to maxAbsBias, leaving only the bias-related terms.
-    if(maxAbsX > 0.0)
+    // When range == 0 (constant input), all deltas are zero: M2 = 0, mean = x_const,
+    // xHat = 0, y = bias.  Both accumulation paths produce zero error, the nonlinear-ops
+    // term on the xHat*scale chain vanishes, leaving only bias-related terms.
+    if(range > 0.0)
     {
-        propagatedTolerance = (accumulatedTolerance / (2.0 * sumAbsProductBound)) * maxAbsScale;
+        // Variance path (sumAbsProductBound cancels)
+        propagatedTolerance = (varianceAccumTolerance / (2.0 * sumAbsProductBound)) * maxAbsScale;
+        // Mean path
+        propagatedTolerance += gammaMean * maxAbsScale;
+        // Nonlinear ops rounding
         propagatedTolerance += NONLINEAR_OPS_UPPER_BOUND * epsilon * maxAbsScale;
     }
     propagatedTolerance += maxAbsBias * epsilon;
 
     // Output casting error (if OutputType precision < ComputeType precision).
     // Output magnitude bound: |y| <= maxAbsScale + maxAbsBias (since |xHat| ~ O(1)).
-    // When maxAbsX == 0, the xHat*scale term is zero, so |y| <= maxAbsBias.
-    const double maxOutputMagnitude = (maxAbsX > 0.0 ? maxAbsScale : 0.0) + maxAbsBias;
+    // When range == 0, the xHat*scale term is zero, so |y| <= maxAbsBias.
+    const double maxOutputMagnitude = (range > 0.0 ? maxAbsScale : 0.0) + maxAbsBias;
     propagatedTolerance += computeOutputCastingError<OutputType, ComputeType>(maxOutputMagnitude);
 
     validateToleranceRange<OutputType>(propagatedTolerance);

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerancesLayerNorm.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerancesLayerNorm.hpp
@@ -1,0 +1,156 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+
+#include <hipdnn_data_sdk/types.hpp>
+#include <hipdnn_test_sdk/utilities/DynamicTolerancesCommon.hpp>
+
+namespace hipdnn_test_sdk::utilities::layernorm
+{
+using hipdnn_data_sdk::types::bfloat16;
+using hipdnn_data_sdk::types::half;
+
+/**
+ * @brief Calculates the expected tolerance for LayerNorm forward operations.
+ *
+ * LayerNorm: For each batch position, compute mean and variance over the last
+ * normalizedDimCount dimensions using Welford's online algorithm, then normalize:
+ *   y[b,i] = scale[i] * (x[b,i] - mean_b) * invStd_b + bias[i]
+ *
+ * Error sources:
+ * 1. Mean accumulation via Welford: M incremental updates (dominant for mean output)
+ * 2. M2 (variance numerator) accumulation: M multiply-adds (dominant for variance)
+ * 3. Nonlinear operations: div(M2,M), sqrt, reciprocal (O(u) each)
+ * 4. Output normalization: sub(x,mean), mul(invStd), mul(scale), add(bias)
+ *
+ * The combined error is modeled using computeGamma() for the accumulation stages
+ * (2M effective accumulations covering both mean and M2), then propagated through
+ * the nonlinear chain using derivative analysis identical to RMSNorm.
+ *
+ * Key insight: after normalization, |xHat| = |(x - mean) * invStd| is O(1) by
+ * construction (zero mean, unit variance). Therefore |y| ~ |scale| + |bias|, and
+ * the tolerance scales with |scale|, not with |x|. This cancellation is the same
+ * mechanism as in RMSNorm and BatchNorm.
+ *
+ * Uses the shared computeGamma() helper for the accumulation error growth factor,
+ * then propagates that error through the nonlinear chain (div, sqrt, reciprocal).
+ *
+ * @tparam OutputType  Data type of y output tensor
+ * @tparam InputType   Data type of x input tensor
+ * @tparam ComputeType Data type for intermediate computation (default: float)
+ * @param xMin                    Minimum value in input tensor x
+ * @param xMax                    Maximum value in input tensor x
+ * @param scaleMin                Minimum value in scale tensor
+ * @param scaleMax                Maximum value in scale tensor
+ * @param normalizedElementCount  M = product of normalized dimensions (reduction dim)
+ * @param biasMin                 Minimum value in bias tensor (0 if no bias)
+ * @param biasMax                 Maximum value in bias tensor (0 if no bias)
+ * @return Calculated tolerance value as float
+ *
+ * Known Limitations:
+ * - Black-box: does not use kernel implementation details
+ * - Conservative bound: assumes Welford errors accumulate at worst-case rate
+ * - Uses 2M effective accumulations (mean + M2) which may overestimate for
+ *   Welford's algorithm whose incremental mean update is more stable than naive sum
+ * - NONLINEAR_OPS_UPPER_BOUND=5 models worst-case op count; hardware rsqrt fusion
+ *   or multiply reordering may produce fewer rounding errors in practice
+ * - No backward pass support (only forward)
+ * - No mean/invVariance-specific tolerance functions (training mode outputs)
+ */
+template <typename OutputType, typename InputType, typename ComputeType = float>
+float calculateLayernormFpropTolerance(double xMin,
+                                       double xMax,
+                                       double scaleMin,
+                                       double scaleMax,
+                                       int64_t normalizedElementCount,
+                                       double biasMin = 0.0,
+                                       double biasMax = 0.0)
+{
+    validateComputeType<ComputeType>();
+
+    if(normalizedElementCount < 1)
+    {
+        throw std::invalid_argument("normalizedElementCount must be at least 1.");
+    }
+
+    // Compute bounds
+    const double maxAbsX = std::max(std::abs(xMin), std::abs(xMax));
+    const double maxAbsScale = std::max(std::abs(scaleMin), std::abs(scaleMax));
+    const double maxAbsBias = std::max(std::abs(biasMin), std::abs(biasMax));
+
+    // Welford accumulation error.
+    // Welford's algorithm accumulates both mean and M2 over M elements.
+    // Mean: M incremental updates (sub + div + add per step)
+    // M2:   M multiply-adds (delta * delta2 + accumulate)
+    // Combined effective accumulations: 2M (accounts for both passes).
+    //
+    // The M2 accumulation has products bounded by maxAbsX^2 (delta and delta2
+    // are each bounded by the input range). This is structurally identical
+    // to RMSNorm's sum-of-squares, with the same self-product bound.
+    auto numberOfAccumulations
+        = static_cast<uint64_t>(2) * static_cast<uint64_t>(normalizedElementCount);
+    const double maxProduct = maxAbsX * maxAbsX; // Welford delta products
+    const double sumAbsProductBound = static_cast<double>(numberOfAccumulations) * maxProduct;
+
+    auto epsilon = static_cast<double>(std::numeric_limits<ComputeType>::epsilon());
+
+    // Use shared computeGamma() for the error growth factor
+    const double gamma = computeGamma(numberOfAccumulations, epsilon);
+    validateGamma(gamma);
+
+    double accumulatedTolerance = gamma * sumAbsProductBound;
+
+    // Input casting error (if InputType precision > ComputeType precision).
+    // Welford squares a single tensor (delta * delta2, both from x), so only one
+    // operand is cast per product term -- factor 1, same as RMSNorm.
+    accumulatedTolerance += computeInputCastingError<InputType, ComputeType>(sumAbsProductBound, 1);
+
+    // Propagate accumulation error through the nonlinear chain to get output error.
+    //
+    // The derivation follows the same logic as RMSNorm:
+    //   invStd = (M2/M + eps)^(-1/2), so d(invStd)/d(M2) = -1/(2M) * (M2/M+eps)^(-3/2)
+    //   |delta_invStd / invStd| <= accTol / (2 * M2)    [since invStd = 1/std, eps << M2/M]
+    //                            = accTol / (2 * sumAbsProductBound)  [worst-case M2 = sumAbsBound]
+    //
+    // After normalization:
+    //   y = scale * (x - mean) * invStd + bias
+    //   |xHat| = |(x - mean) * invStd| is O(1) by construction
+    //   |delta_y| <= maxAbsScale * accTol / (2 * sumAbsProductBound)
+    //             =  maxAbsScale * gamma / 2
+    //
+    // Additional per-op rounding (div(M2,M) + sqrt + recip + mul(x-mean,invStd) + mul(*,scale)):
+    //   |delta_y| += NONLINEAR_OPS_UPPER_BOUND * u * maxAbsScale
+    //             += maxAbsBias * epsilon
+    constexpr double NONLINEAR_OPS_UPPER_BOUND = 5.0;
+
+    double propagatedTolerance = 0.0;
+
+    // When maxAbsX == 0, all inputs are zero. M2 = 0, mean = 0, invStd = 1/sqrt(eps),
+    // y = 0*invStd*scale + bias = bias.
+    // Accumulation error is zero, the nonlinear-ops term on the xHat*scale chain vanishes,
+    // and maxOutputMagnitude reduces to maxAbsBias, leaving only the bias-related terms.
+    if(maxAbsX > 0.0)
+    {
+        propagatedTolerance = (accumulatedTolerance / (2.0 * sumAbsProductBound)) * maxAbsScale;
+        propagatedTolerance += NONLINEAR_OPS_UPPER_BOUND * epsilon * maxAbsScale;
+    }
+    propagatedTolerance += maxAbsBias * epsilon;
+
+    // Output casting error (if OutputType precision < ComputeType precision).
+    // Output magnitude bound: |y| <= maxAbsScale + maxAbsBias (since |xHat| ~ O(1)).
+    // When maxAbsX == 0, the xHat*scale term is zero, so |y| <= maxAbsBias.
+    const double maxOutputMagnitude = (maxAbsX > 0.0 ? maxAbsScale : 0.0) + maxAbsBias;
+    propagatedTolerance += computeOutputCastingError<OutputType, ComputeType>(maxOutputMagnitude);
+
+    validateToleranceRange<OutputType>(propagatedTolerance);
+
+    return static_cast<float>(propagatedTolerance);
+}
+
+} // namespace hipdnn_test_sdk::utilities::layernorm

--- a/projects/hipdnn/test_sdk/tests/CMakeLists.txt
+++ b/projects/hipdnn/test_sdk/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(
     utilities/TestCpuReferencePointwise.cpp
     utilities/TestDynamicTolerancesCommon.cpp
     utilities/TestDynamicTolerancesConv.cpp
+    utilities/TestDynamicTolerancesLayerNorm.cpp
     utilities/TestDynamicTolerancesMatmul.cpp
     utilities/TestDynamicTolerancesPointwise.cpp
     utilities/TestDynamicTolerancesRMSNorm.cpp

--- a/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerancesLayerNorm.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerancesLayerNorm.cpp
@@ -55,11 +55,11 @@ struct LayernormFpropToleranceTestCase
 template <typename T>
 std::vector<LayernormFpropToleranceTestCase> getLayernormFpropToleranceTestCases();
 
-// LayerNorm uses 2M effective accumulations (Welford mean + M2).
-// propTol = (computeGamma(2*M, u) * 2*M * maxAbsX^2 / (2 * 2*M * maxAbsX^2)) * maxAbsScale
-//         + NONLINEAR_OPS * u * maxAbsScale
-//         + maxAbsBias * u
-//         = (gamma(2M) / 2 + 5u) * maxAbsScale + maxAbsBias * u
+// LayerNorm tolerance has two error paths:
+//   Path A (variance): gammaVar(2M)/2 * maxAbsScale  (sumAbsProductBound cancels)
+//   Path B (mean):     gammaMean(M) * maxAbsScale
+//   + NONLINEAR_OPS * u * maxAbsScale + maxAbsBias * u
+// Combined: (gammaVar(2M)/2 + gammaMean(M) + 5u) * maxAbsScale + maxAbsBias * u
 
 // Float / Float / Float
 // For FP32 at small M, computeGamma uses linear bound: nU/(1-nU)
@@ -68,15 +68,16 @@ std::vector<LayernormFpropToleranceTestCase>
     getLayernormFpropToleranceTestCases<TypeTriple<float, float, float>>()
 {
     auto u = static_cast<double>(std::numeric_limits<float>::epsilon());
-    auto gamma = [&](int64_t m) {
+    auto gammaVar = [&](int64_t m) {
         return computeGamma(static_cast<uint64_t>(2) * static_cast<uint64_t>(m), u);
     };
+    auto gammaMean = [&](int64_t m) { return computeGamma(static_cast<uint64_t>(m), u); };
     return {// normalizedElementCount = 0 => throws
             {-1.0, 1.0, -1.0, 1.0, 0, 0.0, 0.0, 0.0, true},
             // M=1, x=[-1,1], scale=[-1,1], no bias
-            {-1.0, 1.0, -1.0, 1.0, 1, 0.0, 0.0, (gamma(1) / 2.0) + 5.0 * u},
+            {-1.0, 1.0, -1.0, 1.0, 1, 0.0, 0.0, (gammaVar(1) / 2.0) + gammaMean(1) + 5.0 * u},
             // M=10, x=[-1,1], scale=[-1,1], no bias
-            {-1.0, 1.0, -1.0, 1.0, 10, 0.0, 0.0, (gamma(10) / 2.0) + 5.0 * u},
+            {-1.0, 1.0, -1.0, 1.0, 10, 0.0, 0.0, (gammaVar(10) / 2.0) + gammaMean(10) + 5.0 * u},
             // M=10, x=[-1000,1000], scale=[-1000,1000], no bias
             {-1000.0,
              1000.0,
@@ -85,29 +86,39 @@ std::vector<LayernormFpropToleranceTestCase>
              10,
              0.0,
              0.0,
-             (gamma(10) / 2.0) * 1000.0 + 5.0 * u * 1000.0},
+             ((gammaVar(10) / 2.0) + gammaMean(10) + 5.0 * u) * 1000.0},
             // M=3, x=[-1,1], scale=[-1,1], bias=[-0.5,0.5]
-            {-1.0, 1.0, -1.0, 1.0, 3, -0.5, 0.5, (gamma(3) / 2.0) + 5.0 * u + 0.5 * u}};
+            {-1.0,
+             1.0,
+             -1.0,
+             1.0,
+             3,
+             -0.5,
+             0.5,
+             (gammaVar(3) / 2.0) + gammaMean(3) + 5.0 * u + 0.5 * u}};
 }
 
 // Float / Double / Float (Input casting error: inputEpsilon(double) < epsilon(float))
-// accTol = gamma * sumAbsProductBound + sumAbsProductBound * epsilon
+// Variance path accTol = gammaVar * S + S * epsilon → (gammaVar + u)/2 after propagation
+// Mean path unaffected by input casting (absorbed by NONLINEAR_OPS)
 template <>
 std::vector<LayernormFpropToleranceTestCase>
     getLayernormFpropToleranceTestCases<TypeTriple<float, double, float>>()
 {
     auto u = static_cast<double>(std::numeric_limits<float>::epsilon());
-    auto gamma = [&](int64_t m) {
+    auto gammaVar = [&](int64_t m) {
         return computeGamma(static_cast<uint64_t>(2) * static_cast<uint64_t>(m), u);
     };
-    return {// normalizedElementCount = 0 => throws
-            {-1.0, 1.0, -1.0, 1.0, 0, 0.0, 0.0, 0.0, true},
-            // M=1
-            {-1.0, 1.0, -1.0, 1.0, 1, 0.0, 0.0, ((gamma(1) + u) / 2.0) + 5.0 * u},
-            // M=10
-            {-1.0, 1.0, -1.0, 1.0, 10, 0.0, 0.0, ((gamma(10) + u) / 2.0) + 5.0 * u},
-            // Zero input: x=0, all terms vanish
-            {0.0, 0.0, -1.0, 1.0, 10, 0.0, 0.0, 0.0}};
+    auto gammaMean = [&](int64_t m) { return computeGamma(static_cast<uint64_t>(m), u); };
+    return {
+        // normalizedElementCount = 0 => throws
+        {-1.0, 1.0, -1.0, 1.0, 0, 0.0, 0.0, 0.0, true},
+        // M=1
+        {-1.0, 1.0, -1.0, 1.0, 1, 0.0, 0.0, ((gammaVar(1) + u) / 2.0) + gammaMean(1) + 5.0 * u},
+        // M=10
+        {-1.0, 1.0, -1.0, 1.0, 10, 0.0, 0.0, ((gammaVar(10) + u) / 2.0) + gammaMean(10) + 5.0 * u},
+        // Zero input: x=0, range=0, all terms vanish
+        {0.0, 0.0, -1.0, 1.0, 10, 0.0, 0.0, 0.0}};
 }
 
 // Half / Float / Float (Output casting error: outputEpsilon(half=2^-10) > epsilon(float=2^-23))
@@ -117,36 +128,55 @@ std::vector<LayernormFpropToleranceTestCase>
 {
     auto u = static_cast<double>(std::numeric_limits<float>::epsilon());
     auto uHalf = static_cast<double>(std::numeric_limits<half>::epsilon());
-    auto gamma = [&](int64_t m) {
+    auto gammaVar = [&](int64_t m) {
         return computeGamma(static_cast<uint64_t>(2) * static_cast<uint64_t>(m), u);
     };
+    auto gammaMean = [&](int64_t m) { return computeGamma(static_cast<uint64_t>(m), u); };
     return {// normalizedElementCount = 0 => throws
             {-1.0, 1.0, -1.0, 1.0, 0, 0.0, 0.0, 0.0, true},
             // M=1
-            {-1.0, 1.0, -1.0, 1.0, 1, 0.0, 0.0, (gamma(1) / 2.0) + 5.0 * u + 1.0 * uHalf},
+            {-1.0,
+             1.0,
+             -1.0,
+             1.0,
+             1,
+             0.0,
+             0.0,
+             (gammaVar(1) / 2.0) + gammaMean(1) + 5.0 * u + 1.0 * uHalf},
             // M=10
-            {-1.0, 1.0, -1.0, 1.0, 10, 0.0, 0.0, (gamma(10) / 2.0) + 5.0 * u + 1.0 * uHalf},
-            // Zero input: output cast term from maxOutputMagnitude=0 vanishes
+            {-1.0,
+             1.0,
+             -1.0,
+             1.0,
+             10,
+             0.0,
+             0.0,
+             (gammaVar(10) / 2.0) + gammaMean(10) + 5.0 * u + 1.0 * uHalf},
+            // Zero input: range=0, output cast term from maxOutputMagnitude=0 vanishes
             {0.0, 0.0, -1.0, 1.0, 10, 0.0, 0.0, 0.0}};
 }
 
 // Half / Half / Half
 // computeGamma selects linear vs statistical based on nU threshold (0.01).
-// half epsilon = 2^-10.  2*M=2: nU=0.0039<0.01 -> linear.  2*M=20: nU=0.039>=0.01 -> statistical.
+// half epsilon = 2^-10.  Variance path: 2*M=2 -> nU=0.0039<0.01 (linear).
+//                        Mean path:     M=1   -> nU=0.002<0.01 (linear).
+// At M=10: variance 2*M=20 -> nU=0.039>=0.01 (statistical).
+//          mean     M=10   -> nU=0.020>=0.01 (statistical).
 template <>
 std::vector<LayernormFpropToleranceTestCase>
     getLayernormFpropToleranceTestCases<TypeTriple<half, half, half>>()
 {
     auto u = static_cast<double>(std::numeric_limits<half>::epsilon());
-    auto gamma = [&](int64_t m) {
+    auto gammaVar = [&](int64_t m) {
         return computeGamma(static_cast<uint64_t>(2) * static_cast<uint64_t>(m), u);
     };
+    auto gammaMean = [&](int64_t m) { return computeGamma(static_cast<uint64_t>(m), u); };
     return {// normalizedElementCount = 0 => throws
             {-1.0, 1.0, -1.0, 1.0, 0, 0.0, 0.0, 0.0, true},
-            // M=1: gamma via computeGamma (linear at this nU, 2*1=2 accum)
-            {-1.0, 1.0, -1.0, 1.0, 1, 0.0, 0.0, (gamma(1) / 2.0) + 5.0 * u},
-            // M=10: gamma via computeGamma (statistical at this nU, 2*10=20 accum)
-            {-1.0, 1.0, -1.0, 1.0, 10, 0.0, 0.0, (gamma(10) / 2.0) + 5.0 * u},
+            // M=1
+            {-1.0, 1.0, -1.0, 1.0, 1, 0.0, 0.0, (gammaVar(1) / 2.0) + gammaMean(1) + 5.0 * u},
+            // M=10
+            {-1.0, 1.0, -1.0, 1.0, 10, 0.0, 0.0, (gammaVar(10) / 2.0) + gammaMean(10) + 5.0 * u},
             // Zero input: all terms vanish
             {0.0, 0.0, -1.0, 1.0, 10, 0.0, 0.0, 0.0}};
 }
@@ -158,35 +188,52 @@ std::vector<LayernormFpropToleranceTestCase>
 {
     auto u = static_cast<double>(std::numeric_limits<float>::epsilon());
     auto uBf16 = static_cast<double>(std::numeric_limits<bfloat16>::epsilon());
-    auto gamma = [&](int64_t m) {
+    auto gammaVar = [&](int64_t m) {
         return computeGamma(static_cast<uint64_t>(2) * static_cast<uint64_t>(m), u);
     };
+    auto gammaMean = [&](int64_t m) { return computeGamma(static_cast<uint64_t>(m), u); };
     return {// normalizedElementCount = 0 => throws
             {-1.0, 1.0, -1.0, 1.0, 0, 0.0, 0.0, 0.0, true},
             // M=1
-            {-1.0, 1.0, -1.0, 1.0, 1, 0.0, 0.0, (gamma(1) / 2.0) + 5.0 * u + 1.0 * uBf16},
+            {-1.0,
+             1.0,
+             -1.0,
+             1.0,
+             1,
+             0.0,
+             0.0,
+             (gammaVar(1) / 2.0) + gammaMean(1) + 5.0 * u + 1.0 * uBf16},
             // M=10
-            {-1.0, 1.0, -1.0, 1.0, 10, 0.0, 0.0, (gamma(10) / 2.0) + 5.0 * u + 1.0 * uBf16},
-            // Zero input: output cast from maxOutputMagnitude=0 vanishes
+            {-1.0,
+             1.0,
+             -1.0,
+             1.0,
+             10,
+             0.0,
+             0.0,
+             (gammaVar(10) / 2.0) + gammaMean(10) + 5.0 * u + 1.0 * uBf16},
+            // Zero input: range=0, output cast from maxOutputMagnitude=0 vanishes
             {0.0, 0.0, -1.0, 1.0, 10, 0.0, 0.0, 0.0}};
 }
 
 // Bfloat16 / Bfloat16 / Bfloat16
-// bf16 epsilon = 2^-7.  2*M=2: nU=2*2*2^-7=0.03125>=0.01 -> statistical.
+// bf16 epsilon = 2^-7.  Variance: 2*M=2 -> nU=2*2*2^-7=0.03125>=0.01 -> statistical.
+//                       Mean:     M=1   -> nU=2*1*2^-7=0.01563>=0.01 -> statistical.
 template <>
 std::vector<LayernormFpropToleranceTestCase>
     getLayernormFpropToleranceTestCases<TypeTriple<bfloat16, bfloat16, bfloat16>>()
 {
     auto u = static_cast<double>(std::numeric_limits<bfloat16>::epsilon());
-    auto gamma = [&](int64_t m) {
+    auto gammaVar = [&](int64_t m) {
         return computeGamma(static_cast<uint64_t>(2) * static_cast<uint64_t>(m), u);
     };
+    auto gammaMean = [&](int64_t m) { return computeGamma(static_cast<uint64_t>(m), u); };
     return {// normalizedElementCount = 0 => throws
             {-1.0, 1.0, -1.0, 1.0, 0, 0.0, 0.0, 0.0, true},
             // M=1
-            {-1.0, 1.0, -1.0, 1.0, 1, 0.0, 0.0, (gamma(1) / 2.0) + 5.0 * u},
+            {-1.0, 1.0, -1.0, 1.0, 1, 0.0, 0.0, (gammaVar(1) / 2.0) + gammaMean(1) + 5.0 * u},
             // M=10
-            {-1.0, 1.0, -1.0, 1.0, 10, 0.0, 0.0, (gamma(10) / 2.0) + 5.0 * u},
+            {-1.0, 1.0, -1.0, 1.0, 10, 0.0, 0.0, (gammaVar(10) / 2.0) + gammaMean(10) + 5.0 * u},
             // Zero input: all terms vanish
             {0.0, 0.0, -1.0, 1.0, 10, 0.0, 0.0, 0.0}};
 }
@@ -374,8 +421,8 @@ TEST(TestCalculateLayernormFpropTolerance, ThrowsOnOutputOverflow)
 // Test zero input (x=0) produces a valid small tolerance
 TEST(TestCalculateLayernormFpropTolerance, ZeroInput)
 {
-    // When x=0, maxAbsX=0, sumAbsProductBound=0, accTol=0
-    // propagatedTolerance = 0 + 0 + maxAbsBias * epsilon
+    // When x=0, range=0, all accumulation and mean path terms vanish.
+    // propagatedTolerance = maxAbsBias * epsilon
     auto tol = calculateLayernormFpropTolerance<float, float, float>(0.0, 0.0, -1.0, 1.0, 10);
     EXPECT_EQ(tol, 0.0f);
 

--- a/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerancesLayerNorm.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerancesLayerNorm.cpp
@@ -1,0 +1,437 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include <cmath>
+#include <gtest/gtest.h>
+#include <hipdnn_data_sdk/types.hpp>
+#include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
+#include <hipdnn_test_sdk/utilities/DynamicTolerancesCommon.hpp>
+#include <hipdnn_test_sdk/utilities/DynamicTolerancesLayerNorm.hpp>
+#include <vector>
+
+using namespace hipdnn_test_sdk::utilities::layernorm;
+using hipdnn_data_sdk::types::bfloat16;
+using hipdnn_data_sdk::types::half;
+using hipdnn_test_sdk::utilities::computeGamma;
+
+template <typename Out, typename In, typename Comp>
+struct TypeTriple
+{
+    using OutputType = Out;
+    using InputType = In;
+    using ComputeType = Comp;
+};
+
+// =================================================================================================
+// TestCalculateLayernormFpropTolerance
+// =================================================================================================
+
+struct LayernormFpropToleranceTestCase
+{
+    double xMin;
+    double xMax;
+    double scaleMin;
+    double scaleMax;
+    int64_t normalizedElementCount;
+    double biasMin;
+    double biasMax;
+    double expectedTolerance;
+    bool expectThrow = false;
+
+    friend std::ostream& operator<<(std::ostream& os, const LayernormFpropToleranceTestCase& tc)
+    {
+        os << "xMin: " << tc.xMin << ", xMax: " << tc.xMax << ", scaleMin: " << tc.scaleMin
+           << ", scaleMax: " << tc.scaleMax
+           << ", normalizedElementCount: " << tc.normalizedElementCount
+           << ", biasMin: " << tc.biasMin << ", biasMax: " << tc.biasMax
+           << ", expectedTolerance: " << tc.expectedTolerance
+           << ", expectThrow: " << (tc.expectThrow ? "true" : "false");
+        return os;
+    }
+};
+
+template <typename T>
+std::vector<LayernormFpropToleranceTestCase> getLayernormFpropToleranceTestCases();
+
+// LayerNorm uses 2M effective accumulations (Welford mean + M2).
+// propTol = (computeGamma(2*M, u) * 2*M * maxAbsX^2 / (2 * 2*M * maxAbsX^2)) * maxAbsScale
+//         + NONLINEAR_OPS * u * maxAbsScale
+//         + maxAbsBias * u
+//         = (gamma(2M) / 2 + 5u) * maxAbsScale + maxAbsBias * u
+
+// Float / Float / Float
+// For FP32 at small M, computeGamma uses linear bound: nU/(1-nU)
+template <>
+std::vector<LayernormFpropToleranceTestCase>
+    getLayernormFpropToleranceTestCases<TypeTriple<float, float, float>>()
+{
+    auto u = static_cast<double>(std::numeric_limits<float>::epsilon());
+    auto gamma = [&](int64_t m) {
+        return computeGamma(static_cast<uint64_t>(2) * static_cast<uint64_t>(m), u);
+    };
+    return {// normalizedElementCount = 0 => throws
+            {-1.0, 1.0, -1.0, 1.0, 0, 0.0, 0.0, 0.0, true},
+            // M=1, x=[-1,1], scale=[-1,1], no bias
+            {-1.0, 1.0, -1.0, 1.0, 1, 0.0, 0.0, (gamma(1) / 2.0) + 5.0 * u},
+            // M=10, x=[-1,1], scale=[-1,1], no bias
+            {-1.0, 1.0, -1.0, 1.0, 10, 0.0, 0.0, (gamma(10) / 2.0) + 5.0 * u},
+            // M=10, x=[-1000,1000], scale=[-1000,1000], no bias
+            {-1000.0,
+             1000.0,
+             -1000.0,
+             1000.0,
+             10,
+             0.0,
+             0.0,
+             (gamma(10) / 2.0) * 1000.0 + 5.0 * u * 1000.0},
+            // M=3, x=[-1,1], scale=[-1,1], bias=[-0.5,0.5]
+            {-1.0, 1.0, -1.0, 1.0, 3, -0.5, 0.5, (gamma(3) / 2.0) + 5.0 * u + 0.5 * u}};
+}
+
+// Float / Double / Float (Input casting error: inputEpsilon(double) < epsilon(float))
+// accTol = gamma * sumAbsProductBound + sumAbsProductBound * epsilon
+template <>
+std::vector<LayernormFpropToleranceTestCase>
+    getLayernormFpropToleranceTestCases<TypeTriple<float, double, float>>()
+{
+    auto u = static_cast<double>(std::numeric_limits<float>::epsilon());
+    auto gamma = [&](int64_t m) {
+        return computeGamma(static_cast<uint64_t>(2) * static_cast<uint64_t>(m), u);
+    };
+    return {// normalizedElementCount = 0 => throws
+            {-1.0, 1.0, -1.0, 1.0, 0, 0.0, 0.0, 0.0, true},
+            // M=1
+            {-1.0, 1.0, -1.0, 1.0, 1, 0.0, 0.0, ((gamma(1) + u) / 2.0) + 5.0 * u},
+            // M=10
+            {-1.0, 1.0, -1.0, 1.0, 10, 0.0, 0.0, ((gamma(10) + u) / 2.0) + 5.0 * u},
+            // Zero input: x=0, all terms vanish
+            {0.0, 0.0, -1.0, 1.0, 10, 0.0, 0.0, 0.0}};
+}
+
+// Half / Float / Float (Output casting error: outputEpsilon(half=2^-10) > epsilon(float=2^-23))
+template <>
+std::vector<LayernormFpropToleranceTestCase>
+    getLayernormFpropToleranceTestCases<TypeTriple<half, float, float>>()
+{
+    auto u = static_cast<double>(std::numeric_limits<float>::epsilon());
+    auto uHalf = static_cast<double>(std::numeric_limits<half>::epsilon());
+    auto gamma = [&](int64_t m) {
+        return computeGamma(static_cast<uint64_t>(2) * static_cast<uint64_t>(m), u);
+    };
+    return {// normalizedElementCount = 0 => throws
+            {-1.0, 1.0, -1.0, 1.0, 0, 0.0, 0.0, 0.0, true},
+            // M=1
+            {-1.0, 1.0, -1.0, 1.0, 1, 0.0, 0.0, (gamma(1) / 2.0) + 5.0 * u + 1.0 * uHalf},
+            // M=10
+            {-1.0, 1.0, -1.0, 1.0, 10, 0.0, 0.0, (gamma(10) / 2.0) + 5.0 * u + 1.0 * uHalf},
+            // Zero input: output cast term from maxOutputMagnitude=0 vanishes
+            {0.0, 0.0, -1.0, 1.0, 10, 0.0, 0.0, 0.0}};
+}
+
+// Half / Half / Half
+// computeGamma selects linear vs statistical based on nU threshold (0.01).
+// half epsilon = 2^-10.  2*M=2: nU=0.0039<0.01 -> linear.  2*M=20: nU=0.039>=0.01 -> statistical.
+template <>
+std::vector<LayernormFpropToleranceTestCase>
+    getLayernormFpropToleranceTestCases<TypeTriple<half, half, half>>()
+{
+    auto u = static_cast<double>(std::numeric_limits<half>::epsilon());
+    auto gamma = [&](int64_t m) {
+        return computeGamma(static_cast<uint64_t>(2) * static_cast<uint64_t>(m), u);
+    };
+    return {// normalizedElementCount = 0 => throws
+            {-1.0, 1.0, -1.0, 1.0, 0, 0.0, 0.0, 0.0, true},
+            // M=1: gamma via computeGamma (linear at this nU, 2*1=2 accum)
+            {-1.0, 1.0, -1.0, 1.0, 1, 0.0, 0.0, (gamma(1) / 2.0) + 5.0 * u},
+            // M=10: gamma via computeGamma (statistical at this nU, 2*10=20 accum)
+            {-1.0, 1.0, -1.0, 1.0, 10, 0.0, 0.0, (gamma(10) / 2.0) + 5.0 * u},
+            // Zero input: all terms vanish
+            {0.0, 0.0, -1.0, 1.0, 10, 0.0, 0.0, 0.0}};
+}
+
+// Bfloat16 / Float / Float (Output casting error: outputEpsilon(bf16=2^-7) > epsilon(float=2^-23))
+template <>
+std::vector<LayernormFpropToleranceTestCase>
+    getLayernormFpropToleranceTestCases<TypeTriple<bfloat16, float, float>>()
+{
+    auto u = static_cast<double>(std::numeric_limits<float>::epsilon());
+    auto uBf16 = static_cast<double>(std::numeric_limits<bfloat16>::epsilon());
+    auto gamma = [&](int64_t m) {
+        return computeGamma(static_cast<uint64_t>(2) * static_cast<uint64_t>(m), u);
+    };
+    return {// normalizedElementCount = 0 => throws
+            {-1.0, 1.0, -1.0, 1.0, 0, 0.0, 0.0, 0.0, true},
+            // M=1
+            {-1.0, 1.0, -1.0, 1.0, 1, 0.0, 0.0, (gamma(1) / 2.0) + 5.0 * u + 1.0 * uBf16},
+            // M=10
+            {-1.0, 1.0, -1.0, 1.0, 10, 0.0, 0.0, (gamma(10) / 2.0) + 5.0 * u + 1.0 * uBf16},
+            // Zero input: output cast from maxOutputMagnitude=0 vanishes
+            {0.0, 0.0, -1.0, 1.0, 10, 0.0, 0.0, 0.0}};
+}
+
+// Bfloat16 / Bfloat16 / Bfloat16
+// bf16 epsilon = 2^-7.  2*M=2: nU=0.0156>=0.01 -> statistical.
+template <>
+std::vector<LayernormFpropToleranceTestCase>
+    getLayernormFpropToleranceTestCases<TypeTriple<bfloat16, bfloat16, bfloat16>>()
+{
+    auto u = static_cast<double>(std::numeric_limits<bfloat16>::epsilon());
+    auto gamma = [&](int64_t m) {
+        return computeGamma(static_cast<uint64_t>(2) * static_cast<uint64_t>(m), u);
+    };
+    return {// normalizedElementCount = 0 => throws
+            {-1.0, 1.0, -1.0, 1.0, 0, 0.0, 0.0, 0.0, true},
+            // M=1
+            {-1.0, 1.0, -1.0, 1.0, 1, 0.0, 0.0, (gamma(1) / 2.0) + 5.0 * u},
+            // M=10
+            {-1.0, 1.0, -1.0, 1.0, 10, 0.0, 0.0, (gamma(10) / 2.0) + 5.0 * u},
+            // Zero input: all terms vanish
+            {0.0, 0.0, -1.0, 1.0, 10, 0.0, 0.0, 0.0}};
+}
+
+template <typename Out, typename In, typename Comp>
+class TestCalculateLayernormFpropTolerance
+    : public ::testing::TestWithParam<LayernormFpropToleranceTestCase>
+{
+protected:
+    void verifyTolerance()
+    {
+        const auto& params = GetParam();
+
+        if(params.expectThrow)
+        {
+            EXPECT_THROW(
+                (calculateLayernormFpropTolerance<Out, In, Comp>(params.xMin,
+                                                                 params.xMax,
+                                                                 params.scaleMin,
+                                                                 params.scaleMax,
+                                                                 params.normalizedElementCount,
+                                                                 params.biasMin,
+                                                                 params.biasMax)),
+                std::invalid_argument);
+        }
+        else
+        {
+            auto tol
+                = calculateLayernormFpropTolerance<Out, In, Comp>(params.xMin,
+                                                                  params.xMax,
+                                                                  params.scaleMin,
+                                                                  params.scaleMax,
+                                                                  params.normalizedElementCount,
+                                                                  params.biasMin,
+                                                                  params.biasMax);
+
+            auto expected = static_cast<float>(params.expectedTolerance);
+
+            EXPECT_NEAR(
+                tol, expected, std::max(expected * 0.01f, std::numeric_limits<float>::min()));
+        }
+    }
+};
+
+using TestCalculateLayernormFpropToleranceFp32
+    = TestCalculateLayernormFpropTolerance<float, float, float>;
+TEST_P(TestCalculateLayernormFpropToleranceFp32, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalculateLayernormFpropToleranceFp32,
+    ::testing::ValuesIn(getLayernormFpropToleranceTestCases<TypeTriple<float, float, float>>()));
+
+using TestCalculateLayernormFpropToleranceInputDouble
+    = TestCalculateLayernormFpropTolerance<float, double, float>;
+TEST_P(TestCalculateLayernormFpropToleranceInputDouble, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalculateLayernormFpropToleranceInputDouble,
+    ::testing::ValuesIn(getLayernormFpropToleranceTestCases<TypeTriple<float, double, float>>()));
+
+using TestCalculateLayernormFpropToleranceComputeFloatFp16
+    = TestCalculateLayernormFpropTolerance<half, float, float>;
+TEST_P(TestCalculateLayernormFpropToleranceComputeFloatFp16, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalculateLayernormFpropToleranceComputeFloatFp16,
+    ::testing::ValuesIn(getLayernormFpropToleranceTestCases<TypeTriple<half, float, float>>()));
+
+using TestCalculateLayernormFpropToleranceFp16
+    = TestCalculateLayernormFpropTolerance<half, half, half>;
+TEST_P(TestCalculateLayernormFpropToleranceFp16, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalculateLayernormFpropToleranceFp16,
+    ::testing::ValuesIn(getLayernormFpropToleranceTestCases<TypeTriple<half, half, half>>()));
+
+using TestCalculateLayernormFpropToleranceComputeFloatBfp16
+    = TestCalculateLayernormFpropTolerance<bfloat16, float, float>;
+TEST_P(TestCalculateLayernormFpropToleranceComputeFloatBfp16, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalculateLayernormFpropToleranceComputeFloatBfp16,
+    ::testing::ValuesIn(getLayernormFpropToleranceTestCases<TypeTriple<bfloat16, float, float>>()));
+
+using TestCalculateLayernormFpropToleranceBfp16
+    = TestCalculateLayernormFpropTolerance<bfloat16, bfloat16, bfloat16>;
+TEST_P(TestCalculateLayernormFpropToleranceBfp16, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalculateLayernormFpropToleranceBfp16,
+    ::testing::ValuesIn(
+        getLayernormFpropToleranceTestCases<TypeTriple<bfloat16, bfloat16, bfloat16>>()));
+
+// Test that calculateLayernormFpropTolerance catches simulated wrong outputs
+TEST(TestCalculateLayernormFpropTolerance, DetectsFailure)
+{
+    // M=100, x=[-1,1], scale=[-1,1]
+    const std::vector<int64_t> dims = {1, 1, 10, 10};
+    const std::vector<int64_t> strides = {100, 100, 10, 1};
+
+    auto baseline = hipdnn_data_sdk::utilities::createTensor<float>(dims, strides);
+    auto actualPassing = hipdnn_data_sdk::utilities::createTensor<float>(dims, strides);
+    auto actualFailing = hipdnn_data_sdk::utilities::createTensor<float>(dims, strides);
+
+    baseline->fillTensorWithValue(1.0f);
+    actualPassing->fillTensorWithValue(1.000001f); // Small error
+    actualFailing->fillTensorWithValue(1.2f); // Large error
+
+    auto tol = calculateLayernormFpropTolerance<float, float, float>(-1.0, 1.0, -1.0, 1.0, 100);
+
+    // For FP32, M=100 (2M=200 accum): tolerance should be small
+    EXPECT_LT(tol, 0.01f);
+    EXPECT_GT(tol, 1e-6f);
+
+    auto validator = hipdnn_test_sdk::utilities::createAllCloseValidator(
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT, tol, 0);
+
+    bool valid = validator->allClose(*baseline, *actualPassing);
+    EXPECT_TRUE(valid);
+
+    valid = validator->allClose(*baseline, *actualFailing);
+    EXPECT_FALSE(valid);
+}
+
+// Test that calculateLayernormFpropTolerance throws when gamma >= 0.5
+TEST(TestCalculateLayernormFpropTolerance, ThrowsOnSingularity)
+{
+    // For float, epsilon = 2^-23 ~ 1.19e-7.
+    // computeGamma uses 2M accumulations. Statistical bound: gamma = 6*sqrt(2*2M)*u
+    // gamma >= 0.5 -> 2M >= (0.5/(6*u))^2 / 2 -> M >= (0.5/(6*u))^2 / 4
+    // M >= (0.5/(6*1.19e-7))^2/4 ~ 1.47e11. Use 1.5e11.
+    EXPECT_THROW((calculateLayernormFpropTolerance<float, float, float>(
+                     -1.0, 1.0, -1.0, 1.0, 150000000000LL)),
+                 std::overflow_error);
+
+    // For bfloat16, epsilon = 2^-7. gamma >= 0.5 at much smaller M.
+    // gamma = 6*sqrt(2*2M)*u >= 0.5 -> M >= (0.5/(6*2^-7))^2/4 ~ 17.1. Use M=50.
+    EXPECT_THROW(
+        (calculateLayernormFpropTolerance<bfloat16, bfloat16, bfloat16>(-1.0, 1.0, -1.0, 1.0, 50)),
+        std::overflow_error);
+
+    // For half, epsilon = 2^-10. gamma >= 0.5 -> M >= (0.5/(6*2^-10))^2/4 ~ 1093. Use M=2500.
+    EXPECT_THROW((calculateLayernormFpropTolerance<half, half, half>(-1.0, 1.0, -1.0, 1.0, 2500)),
+                 std::overflow_error);
+
+    // float/double/float uses float epsilon -> same threshold as float/float/float
+    EXPECT_THROW((calculateLayernormFpropTolerance<float, double, float>(
+                     -1.0, 1.0, -1.0, 1.0, 150000000000LL)),
+                 std::overflow_error);
+}
+
+// Test that calculateLayernormFpropTolerance throws when tolerance exceeds OutputType max
+TEST(TestCalculateLayernormFpropTolerance, ThrowsOnOutputOverflow)
+{
+    // OutputType = half (max approx 65504)
+    // Use very large scale to push tolerance above half max.
+    // M=10, x=[-1,1], scale=[-1e8,1e8]
+    // output cast term: maxAbsScale * uHalf = 1e8 * 2^-10 ~ 97656 >> 65504
+    EXPECT_THROW((calculateLayernormFpropTolerance<half, float, float>(-1.0, 1.0, -1e8, 1e8, 10)),
+                 std::overflow_error);
+
+    // half/half/half with very large scale
+    EXPECT_THROW((calculateLayernormFpropTolerance<half, half, half>(-1000, 1000, -1e7, 1e7, 10)),
+                 std::overflow_error);
+}
+
+// Test zero input (x=0) produces a valid small tolerance
+TEST(TestCalculateLayernormFpropTolerance, ZeroInput)
+{
+    // When x=0, maxAbsX=0, sumAbsProductBound=0, accTol=0
+    // propagatedTolerance = 0 + 0 + maxAbsBias * epsilon
+    auto tol = calculateLayernormFpropTolerance<float, float, float>(0.0, 0.0, -1.0, 1.0, 10);
+    EXPECT_EQ(tol, 0.0f);
+
+    // With bias (float)
+    auto tolBias
+        = calculateLayernormFpropTolerance<float, float, float>(0.0, 0.0, -1.0, 1.0, 10, -0.5, 0.5);
+    EXPECT_GT(tolBias, 0.0f);
+
+    // Zero input with bfloat16 output casting: outputEpsilon(bf16) > epsilon(float), but
+    // maxOutputMagnitude=0, so output cast term also vanishes
+    auto tolBf16
+        = calculateLayernormFpropTolerance<bfloat16, float, float>(0.0, 0.0, -1.0, 1.0, 10);
+    EXPECT_EQ(tolBf16, 0.0f);
+
+    // Zero input with bias and half output: bias term + output cast of bias
+    auto uFloat = static_cast<double>(std::numeric_limits<float>::epsilon());
+    auto uHalf = static_cast<double>(std::numeric_limits<half>::epsilon());
+    auto tolHalfBias
+        = calculateLayernormFpropTolerance<half, float, float>(0.0, 0.0, -1.0, 1.0, 10, -0.5, 0.5);
+    // Expected: maxAbsBias * epsilon + maxOutputMagnitude * outputEpsilon
+    //         = 0.5 * uFloat + 0.5 * uHalf
+    auto expectedHalfBias = static_cast<float>(0.5 * uFloat + 0.5 * uHalf);
+    EXPECT_NEAR(tolHalfBias, expectedHalfBias, 1e-10f);
+}
+
+// Sanity check: tolerance scaling behavior with increasing M.
+// For small M with FP32, computeGamma uses linear bound -> dominant term ~ 2M * u
+// For BF16, computeGamma uses statistical bound -> dominant term ~ sqrt(2M) * u
+TEST(TestCalculateLayernormFpropTolerance, ToleranceScalesWithM)
+{
+    // FP32: tolerance should grow roughly linearly with M (gamma/2 ~ M*u)
+    auto tolFp32M1 = calculateLayernormFpropTolerance<float, float, float>(-1.0, 1.0, -1.0, 1.0, 1);
+    auto tolFp32M10
+        = calculateLayernormFpropTolerance<float, float, float>(-1.0, 1.0, -1.0, 1.0, 10);
+    auto tolFp32M100
+        = calculateLayernormFpropTolerance<float, float, float>(-1.0, 1.0, -1.0, 1.0, 100);
+
+    EXPECT_LT(tolFp32M1, tolFp32M10) << "FP32: M=10 should have higher tolerance than M=1";
+    EXPECT_LT(tolFp32M10, tolFp32M100) << "FP32: M=100 should have higher tolerance than M=10";
+
+    // Ratio check: M=100 vs M=1 (use wide spread so gamma term dominates the constant 5u)
+    auto ratioFp32 = static_cast<double>(tolFp32M100) / static_cast<double>(tolFp32M1);
+    EXPECT_GT(ratioFp32, 10.0) << "FP32: ratio M100/M1 should reflect ~M growth";
+
+    // BF16 (statistical): tolerance should grow ~ sqrt(M)
+    // M=50 with 2*50=100 accum: gamma ~ 6*sqrt(200)*2^-7 ~ 0.663 >= 0.5, so use M=25 as upper
+    auto tolBf16M1
+        = calculateLayernormFpropTolerance<bfloat16, bfloat16, bfloat16>(-1.0, 1.0, -1.0, 1.0, 1);
+    auto tolBf16M5
+        = calculateLayernormFpropTolerance<bfloat16, bfloat16, bfloat16>(-1.0, 1.0, -1.0, 1.0, 5);
+    auto tolBf16M25
+        = calculateLayernormFpropTolerance<bfloat16, bfloat16, bfloat16>(-1.0, 1.0, -1.0, 1.0, 25);
+
+    EXPECT_LT(tolBf16M1, tolBf16M5) << "BF16: M=5 should have higher tolerance than M=1";
+    EXPECT_LT(tolBf16M5, tolBf16M25) << "BF16: M=25 should have higher tolerance than M=5";
+
+    auto ratioBf16 = static_cast<double>(tolBf16M5) / static_cast<double>(tolBf16M1);
+    EXPECT_GT(ratioBf16, 1.5) << "BF16: ratio M5/M1 should reflect sqrt(M) growth";
+}

--- a/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerancesLayerNorm.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerancesLayerNorm.cpp
@@ -172,7 +172,7 @@ std::vector<LayernormFpropToleranceTestCase>
 }
 
 // Bfloat16 / Bfloat16 / Bfloat16
-// bf16 epsilon = 2^-7.  2*M=2: nU=0.0156>=0.01 -> statistical.
+// bf16 epsilon = 2^-7.  2*M=2: nU=2*2*2^-7=0.03125>=0.01 -> statistical.
 template <>
 std::vector<LayernormFpropToleranceTestCase>
     getLayernormFpropToleranceTestCases<TypeTriple<bfloat16, bfloat16, bfloat16>>()

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestLayernormFpropPlan.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestLayernormFpropPlan.cpp
@@ -10,8 +10,8 @@
 #include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceLayernorm.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
+#include <hipdnn_test_sdk/utilities/DynamicTolerancesLayerNorm.hpp>
 #include <hipdnn_test_sdk/utilities/Seeds.hpp>
-#include <hipdnn_test_sdk/utilities/TestTolerances.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/LayernormFpropPlan.hpp>
 
 using namespace hipdnn_test_sdk::utilities;
@@ -28,9 +28,12 @@ class TestLayernormFpropPlan : public ::testing::Test
 
 TEST_F(TestLayernormFpropPlan, ExecutePlan)
 {
-    auto tolerance = layernorm::getTolerance<float>();
     const std::vector<int64_t> dims = {6, 3, 32, 32};
     const int64_t normalizedDimCount = 3;
+    // M = product of last normalizedDimCount dims = 3 * 32 * 32 = 3072
+    // Tensor init ranges from LayernormTensorBundles: x=[0,1], scale=[0,1], bias=[0,1]
+    auto tolerance = layernorm::calculateLayernormFpropTolerance<float, float, float>(
+        0.0, 1.0, 0.0, 1.0, 3072, 0.0, 1.0);
     const unsigned int seed = getGlobalTestSeed();
     auto graph = buildLayernormFpropGraph(DataType::FLOAT,
                                           DataType::FLOAT,
@@ -87,9 +90,11 @@ TEST_F(TestLayernormFpropPlan, ExecutePlan)
 
 TEST_F(TestLayernormFpropPlan, ExecutePlanOnePaddedNormalizedDimCount2)
 {
-    auto tolerance = layernorm::getTolerance<float>();
     const std::vector<int64_t> dims = {6, 3, 32, 32};
     const int64_t normalizedDimCount = 2;
+    // M = product of last 2 dims = 32 * 32 = 1024
+    auto tolerance = layernorm::calculateLayernormFpropTolerance<float, float, float>(
+        0.0, 1.0, 0.0, 1.0, 1024, 0.0, 1.0);
     const unsigned int seed = getGlobalTestSeed();
     auto graph = buildLayernormFpropGraph(DataType::FLOAT,
                                           DataType::FLOAT,
@@ -148,9 +153,11 @@ TEST_F(TestLayernormFpropPlan, ExecutePlanOnePaddedNormalizedDimCount2)
 
 TEST_F(TestLayernormFpropPlan, ExecutePlanTrainingPhase)
 {
-    auto tolerance = layernorm::getTolerance<float>();
     const std::vector<int64_t> dims = {6, 3, 32, 32};
     const int64_t normalizedDimCount = 3;
+    // M = 3 * 32 * 32 = 3072
+    auto tolerance = layernorm::calculateLayernormFpropTolerance<float, float, float>(
+        0.0, 1.0, 0.0, 1.0, 3072, 0.0, 1.0);
     const unsigned int seed = getGlobalTestSeed();
     auto graph = buildLayernormFpropGraph(DataType::FLOAT,
                                           DataType::FLOAT,

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestLayernormFpropPlan.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestLayernormFpropPlan.cpp
@@ -10,8 +10,8 @@
 #include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceLayernorm.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
-#include <hipdnn_test_sdk/utilities/DynamicTolerancesLayerNorm.hpp>
 #include <hipdnn_test_sdk/utilities/Seeds.hpp>
+#include <hipdnn_test_sdk/utilities/TestTolerances.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/LayernormFpropPlan.hpp>
 
 using namespace hipdnn_test_sdk::utilities;
@@ -28,12 +28,9 @@ class TestLayernormFpropPlan : public ::testing::Test
 
 TEST_F(TestLayernormFpropPlan, ExecutePlan)
 {
+    auto tolerance = layernorm::getTolerance<float>();
     const std::vector<int64_t> dims = {6, 3, 32, 32};
     const int64_t normalizedDimCount = 3;
-    // M = product of last normalizedDimCount dims = 3 * 32 * 32 = 3072
-    // Tensor init ranges from LayernormTensorBundles: x=[0,1], scale=[0,1], bias=[0,1]
-    auto tolerance = layernorm::calculateLayernormFpropTolerance<float, float, float>(
-        0.0, 1.0, 0.0, 1.0, 3072, 0.0, 1.0);
     const unsigned int seed = getGlobalTestSeed();
     auto graph = buildLayernormFpropGraph(DataType::FLOAT,
                                           DataType::FLOAT,
@@ -90,11 +87,9 @@ TEST_F(TestLayernormFpropPlan, ExecutePlan)
 
 TEST_F(TestLayernormFpropPlan, ExecutePlanOnePaddedNormalizedDimCount2)
 {
+    auto tolerance = layernorm::getTolerance<float>();
     const std::vector<int64_t> dims = {6, 3, 32, 32};
     const int64_t normalizedDimCount = 2;
-    // M = product of last 2 dims = 32 * 32 = 1024
-    auto tolerance = layernorm::calculateLayernormFpropTolerance<float, float, float>(
-        0.0, 1.0, 0.0, 1.0, 1024, 0.0, 1.0);
     const unsigned int seed = getGlobalTestSeed();
     auto graph = buildLayernormFpropGraph(DataType::FLOAT,
                                           DataType::FLOAT,
@@ -153,11 +148,9 @@ TEST_F(TestLayernormFpropPlan, ExecutePlanOnePaddedNormalizedDimCount2)
 
 TEST_F(TestLayernormFpropPlan, ExecutePlanTrainingPhase)
 {
+    auto tolerance = layernorm::getTolerance<float>();
     const std::vector<int64_t> dims = {6, 3, 32, 32};
     const int64_t normalizedDimCount = 3;
-    // M = 3 * 32 * 32 = 3072
-    auto tolerance = layernorm::calculateLayernormFpropTolerance<float, float, float>(
-        0.0, 1.0, 0.0, 1.0, 3072, 0.0, 1.0);
     const unsigned int seed = getGlobalTestSeed();
     auto graph = buildLayernormFpropGraph(DataType::FLOAT,
                                           DataType::FLOAT,


### PR DESCRIPTION
This PR introduces a shape and datatype aware numerical tolerance for LayerNorm forward, replacing the static constants previously used in forward validation.

### Error model
For input $x \in \mathbb{R}^M$, LayerNorm computes:

  $$y_i = \frac{x_i - \mu}{\sqrt{\sigma^2 + \varepsilon}} \cdot \text{scale}_i + \text{bias}_i$$

Two independent rounding-error paths contribute to the output:
  - Variance path: M2 accumulation error propagating through $\text{invStd} = (\sigma^2 + \varepsilon)^{-1/2}$.
  - Mean path: mean accumulation error propagating through $x_i - \mu$ (absent in RMSNorm).

After normalization, $|\hat{x}| \sim O(1)$ by construction, so the output error scales with $|\text{scale}|$ rather than $|x|$. Using Higham's error growth factor $\gamma(k,u)$ (linear bound $\frac{2ku}{1-2ku}$ when $2ku < 0.01$, statistical bound $6\sqrt{2k} u$ otherwise), the absolute output tolerance is:

  $$\text{tol} = \left(\frac{\gamma(2M,u)}{2} + \gamma(M,u) + N_{\text{nl}} u\right) \max|\text{scale}| + u\max|\text{bias}| + \delta_{\text{cast}}$$

  Where:
  - $\gamma(2M,u)$ bounds Welford variance accumulation error, using $2M$ to account for the coupled mean and M2 updates
  - $\gamma(M,u)$ bounds mean accumulation error (M incremental Welford updates)
  - $N_{\text{nl}} = 5$ conservatively covers division, square root, reciprocal, and two multiplications
  - $\delta_{\text{cast}}$ accounts for input downcast (folded into the variance path) and output downcast ($u_{\text{out}} \cdot \max|y|$) when applicable
  
### Tests

| Test | Validates |
|------|-----------|
| `DetectsFailure` | Tolerance accepts 1e-6 error, rejects 0.2 error (end-to-end with `allClose`) |
| `ThrowsOnSingularity` | `γ >= 0.5` throws for float (M=1.5e11), bf16 (M=50), half (M=2500), float/double |
| `ThrowsOnOutputOverflow` | Tolerance exceeding `max(OutputType)` throws for half output |
| `ZeroInput` | Constant zero input: tolerance = 0 (no bias) or `u*max|bias|` (with bias); output cast vanishes when `max|y|=0` |
| `ToleranceScalesWithM` | FP32: ~linear growth (ratio M100/M1 > 10); BF16: ~sqrt(M) growth (ratio M5/M1 > 1.5) |



