### PR TITLE
[rocFFT] Fix Real3DEvenNode tuned-tree mismatch on optimized code paths

### DIFF
--- a/projects/rocfft/clients/tests/accuracy_test_adhoc.cpp
+++ b/projects/rocfft/clients/tests/accuracy_test_adhoc.cpp
@@ -462,6 +462,12 @@ const auto adhoc_nondefault_layout_complex_tokens = {
     "complex_forward_len_31_16_9_single_op_batch_2599_istride_144_9_1_CI_ostride_9_279_1_CI_idist_4464_odist_4464_ioffset_0_0_ooffset_0_0",
     "complex_inverse_len_23_16_8_double_op_batch_912_istride_186_8_1_CI_ostride_173_8_1_CI_idist_5888_odist_5888_ioffset_0_0_ooffset_0_0",
     "complex_forward_len_23_8_25_double_ip_batch_2056_istride_323_25_1_CI_ostride_323_25_1_CI_idist_9200_odist_9200_ioffset_0_0_ooffset_0_0",
+    // 3D complex with slowest stride padded ({B*C+1, C, 1}) to verify a
+    // fused 2D kernel pinned by a min_token solution-map entry stays correct
+    // when reused in a 3D context with non-default strides.
+    "complex_forward_len_64_32_32_single_ip_batch_2_istride_1025_32_1_CI_ostride_1025_32_1_CI_idist_65600_odist_65600_ioffset_0_0_ooffset_0_0",
+    "complex_forward_len_64_32_32_single_op_batch_2_istride_1025_32_1_CI_ostride_1025_32_1_CI_idist_65600_odist_65600_ioffset_0_0_ooffset_0_0",
+    "complex_inverse_len_64_32_32_single_op_batch_2_istride_1025_32_1_CI_ostride_1025_32_1_CI_idist_65600_odist_65600_ioffset_0_0_ooffset_0_0",
     // clang-format on
 };
 
@@ -508,7 +514,11 @@ const auto adhoc_nondefault_layout_real_tokens = {
     "real_forward_len_7_14_76_double_ip_batch_202_istride_3588_78_1_R_ostride_1794_39_1_HI_idist_150696_odist_75348_ioffset_0_0_ooffset_0_0",
     "real_forward_len_2_14_46_single_ip_batch_499_istride_2050_50_1_R_ostride_1025_25_1_HI_idist_71750_odist_35875_ioffset_0_0_ooffset_0_0",
     "real_forward_len_26_52_double_op_batch_3899_istride_240_4_R_ostride_224_7_HI_idist_15600_odist_8960_ioffset_0_0_ooffset_0_0",
+    // 3D real out-of-place with in-place-style strides; exercises the
+    // Real3DEvenNode::Build_solution stride redirect away from a
+    // REAL_2D_SINGLE_SBCC solution-map entry (fwd + inv).
     "real_forward_len_160_72_72_single_op_batch_20_istride_5328_74_1_R_ostride_2664_37_1_HI_idist_852480_odist_426240_ioffset_0_0_ooffset_0_0",
+    "real_inverse_len_160_72_72_single_op_batch_20_istride_2664_37_1_HI_ostride_5328_74_1_R_idist_426240_odist_852480_ioffset_0_0_ooffset_0_0",
     // clang-format on
 };
 

--- a/projects/rocfft/clients/tests/accuracy_test_adhoc.cpp
+++ b/projects/rocfft/clients/tests/accuracy_test_adhoc.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2021 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -508,6 +508,7 @@ const auto adhoc_nondefault_layout_real_tokens = {
     "real_forward_len_7_14_76_double_ip_batch_202_istride_3588_78_1_R_ostride_1794_39_1_HI_idist_150696_odist_75348_ioffset_0_0_ooffset_0_0",
     "real_forward_len_2_14_46_single_ip_batch_499_istride_2050_50_1_R_ostride_1025_25_1_HI_idist_71750_odist_35875_ioffset_0_0_ooffset_0_0",
     "real_forward_len_26_52_double_op_batch_3899_istride_240_4_R_ostride_224_7_HI_idist_15600_odist_8960_ioffset_0_0_ooffset_0_0",
+    "real_forward_len_160_72_72_single_op_batch_20_istride_5328_74_1_R_ostride_2664_37_1_HI_idist_852480_odist_426240_ioffset_0_0_ooffset_0_0",
     // clang-format on
 };
 

--- a/projects/rocfft/library/src/tree_node_real.cpp
+++ b/projects/rocfft/library/src/tree_node_real.cpp
@@ -959,20 +959,17 @@ void Real3DEvenNode::BuildTree_internal(SchemeTreeVec& child_scheme_trees)
 {
     Build_solution();
 
-    // The solution map's tuned tree may not match the decomposition
-    // Build_solution picks for these strides (e.g. a REAL_2D_SINGLE_SBCC
-    // entry reused with non-unit strides that force INPLACE_SBCC). In
-    // that case drop the tuned tree and fall back to the default build;
-    // ProcessNode's SanityCheck already handles the resulting kernel
-    // mismatch by retrying without solution kernels.
+    // Build_solution here is stride-conditional, but solution-map keys
+    // (min_token) ignore strides, so a tuned tree may not match the
+    // decomposition picked for the current strides (e.g. REAL_2D_SINGLE_SBCC
+    // reused with non-unit strides that force INPLACE_SBCC). Drop the
+    // mismatched tree; SanityCheck retries without solution kernels.
     if(!child_scheme_trees.empty())
     {
         size_t expectedChildren = 0;
         switch(solution)
         {
         case REAL_2D_SINGLE_SBCC:
-            // BuildTree_internal_2D_SINGLE_CC doesn't consume the tuned
-            // tree at all, so any size here is fine to drop.
             expectedChildren = 2;
             break;
         case INPLACE_SBCC:

--- a/projects/rocfft/library/src/tree_node_real.cpp
+++ b/projects/rocfft/library/src/tree_node_real.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 - 2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2021 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -958,6 +958,37 @@ void Real2DEvenNode::AssignParams_internal_TR_pair()
 void Real3DEvenNode::BuildTree_internal(SchemeTreeVec& child_scheme_trees)
 {
     Build_solution();
+
+    // The solution map's tuned tree may not match the decomposition
+    // Build_solution picks for these strides (e.g. a REAL_2D_SINGLE_SBCC
+    // entry reused with non-unit strides that force INPLACE_SBCC). In
+    // that case drop the tuned tree and fall back to the default build;
+    // ProcessNode's SanityCheck already handles the resulting kernel
+    // mismatch by retrying without solution kernels.
+    if(!child_scheme_trees.empty())
+    {
+        size_t expectedChildren = 0;
+        switch(solution)
+        {
+        case REAL_2D_SINGLE_SBCC:
+            // BuildTree_internal_2D_SINGLE_CC doesn't consume the tuned
+            // tree at all, so any size here is fine to drop.
+            expectedChildren = 2;
+            break;
+        case INPLACE_SBCC:
+        case SBCR:
+            expectedChildren = 3;
+            break;
+        case TR_PAIRS:
+            expectedChildren = 6;
+            break;
+        default:
+            break;
+        }
+
+        if(child_scheme_trees.size() != expectedChildren)
+            child_scheme_trees.clear();
+    }
 
     switch(solution)
     {


### PR DESCRIPTION
## Motivation

`rocfft_plan_create` fails for 3D real-forward transforms that use in-place-style strides out-of-place, e.g. `real_forward_len_160_72_72_..._istride_5328_74_1_R_ostride_2664_37_1_HI_...` on gfx90a. Similar configurations at other sizes already work, so this usage is valid and should be supported.

## Technical Details

In `Real3DEvenNode::BuildTree_internal`, the tuned scheme tree from the solution map can disagree with the decomposition Build_solution() picks for the current strides, causing plan creation to fail. When the tuned child-tree count doesn't match the count expected for the chosen solution, drop the tuned tree and fall back to the default build.

## Test Plan
Check correctness locally and pass full CI

## Test Result

- [x] Failing token now plans and runs:      `real_forward_len_160_72_72_single_op_batch_20_istride_5328_74_1_R_ostride_2664_37_1_HI_idist_852480_odist_426240_ioffset_0_0_ooffset_0_0`
- [x] Previously-working token still plans and runs:   `real_forward_len_256_256_256_single_op_batch_2_istride_66048_258_1_R_ostride_33024_129_1_HI_idist_16908288_odist_8454144_ioffset_0_0_ooffset_0_0`
- [x] `rocfft-test` suites pass on gfx90a

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
