### PR TITLE
Add block scale dequantize CPU reference implementation

### DIFF
--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceBlockScaleDequantize.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceBlockScaleDequantize.hpp
@@ -1,0 +1,110 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cmath>
+#include <hipdnn_data_sdk/types.hpp>
+#include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_test_sdk/utilities/detail/CpuFpReferenceUtilities.hpp>
+#include <vector>
+
+namespace hipdnn_test_sdk::utilities
+{
+
+class CpuFpReferenceBlockScaleDequantize
+{
+public:
+    /// Block scale dequantize: Y[i] = X[i] * scale[block_of(i)]
+    ///
+    /// blockSize entries map to the trailing dimensions of the tensor.
+    /// For a tensor with N dims and blockSize with K entries, blockSize[i]
+    /// applies to dimension (N - K + i). scale_index[d] = x_index[d] / blockSize[i]
+    /// for blocked trailing dims, and scale_index[d] = x_index[d] for leading dims.
+    ///
+    /// @param x                Input tensor (blocked low-precision data)
+    /// @param scale            Per-block scale tensor
+    /// @param y                Output tensor (dequantized, same shape as x)
+    /// @param blockSize        Block size for each blocked dimension (from attributes)
+    /// @param isNegativeScale  If true, scale represents negative exponent: Y = X * 2^(-scale)
+    template <class XDataType, class ScaleDataType, class YDataType, class ComputeDataType = float>
+    static void dequantize(const hipdnn_data_sdk::utilities::TensorBase<XDataType>& x,
+                           const hipdnn_data_sdk::utilities::TensorBase<ScaleDataType>& scale,
+                           hipdnn_data_sdk::utilities::TensorBase<YDataType>& y,
+                           const std::vector<int32_t>& blockSize,
+                           bool isNegativeScale = false)
+    {
+        const auto& xDims = x.dims();
+        const auto& scaleDims = scale.dims();
+
+        if(xDims.empty())
+        {
+            throw std::runtime_error("BlockScaleDequantize requires non-empty tensor dimensions.");
+        }
+
+        // blockSize entries map to the trailing dimensions of the tensor.
+        std::vector<int64_t> effectiveBlockSize(xDims.size(), 1);
+        for(size_t i = 0; i < blockSize.size() && i < xDims.size(); ++i)
+        {
+            effectiveBlockSize[xDims.size() - blockSize.size() + i] = blockSize[i];
+        }
+
+        // Validate scale dimensions are consistent with data dims and block size.
+        // Scale must have the same rank as x — there is no dim-mapping for broadcast.
+        if(scaleDims.size() != xDims.size())
+        {
+            throw std::invalid_argument(
+                "BlockScaleDequantize: scale tensor rank (" + std::to_string(scaleDims.size())
+                + ") must equal input tensor rank (" + std::to_string(xDims.size()) + ").");
+        }
+
+        for(size_t d = 0; d < scaleDims.size(); ++d)
+        {
+            const auto expectedScaleDim
+                = (xDims[d] + effectiveBlockSize[d] - 1) / effectiveBlockSize[d];
+            if(scaleDims[d] != expectedScaleDim)
+            {
+                throw std::invalid_argument("BlockScaleDequantize: scale dim[" + std::to_string(d)
+                                            + "] is " + std::to_string(scaleDims[d])
+                                            + " but expected " + std::to_string(expectedScaleDim)
+                                            + " (ceil(" + std::to_string(xDims[d]) + " / "
+                                            + std::to_string(effectiveBlockSize[d]) + ")).");
+            }
+        }
+
+        auto dequantizeFunc = [&](const std::vector<int64_t>& xIndices) {
+            // Compute scale indices by dividing by block size for blocked dims.
+            // Size to scale rank — getIndex() throws if indices.size() > strides().size().
+            std::vector<int64_t> scaleIndices(scaleDims.size());
+            for(size_t d = 0; d < scaleDims.size(); ++d)
+            {
+                scaleIndices[d] = xIndices[d] / effectiveBlockSize[d];
+            }
+
+            auto xVal = static_cast<ComputeDataType>(x.getHostValue(xIndices));
+            auto scaleVal = static_cast<ComputeDataType>(scale.getHostValue(scaleIndices));
+
+            ComputeDataType yVal;
+            if(isNegativeScale)
+            {
+                // Negative scale: Y = X * 2^(-scale_value)
+                yVal = xVal * std::pow(static_cast<ComputeDataType>(2.0), -scaleVal);
+            }
+            else
+            {
+                // Normal scale: Y = X * scale
+                yVal = xVal * scaleVal;
+            }
+
+            y.setHostValue(static_cast<YDataType>(yVal), xIndices);
+        };
+
+        auto parallelFunc
+            = hipdnn_test_sdk::detail::makeParallelTensorFunctor(dequantizeFunc, xDims);
+        parallelFunc(std::thread::hardware_concurrency());
+
+        y.memory().markHostModified();
+    }
+};
+
+} // namespace hipdnn_test_sdk::utilities

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp
@@ -67,7 +67,7 @@ public:
                 return result.load(std::memory_order_relaxed);
             }
 
-            auto absDiff = static_cast<float>(fabs(implValue - refValue));
+            auto absDiff = fabs(static_cast<float>(implValue) - static_cast<float>(refValue));
             auto threshold
                 = _absoluteTolerance + _relativeTolerance * fabs(static_cast<float>(refValue));
 

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/FlatbufferDatatypeMapping.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/FlatbufferDatatypeMapping.hpp
@@ -9,6 +9,12 @@
 namespace hipdnn_test_sdk::utilities
 {
 using hipdnn_data_sdk::types::bfloat16;
+using hipdnn_data_sdk::types::fp4_e2m1;
+using hipdnn_data_sdk::types::fp6_e2m3;
+using hipdnn_data_sdk::types::fp6_e3m2;
+using hipdnn_data_sdk::types::fp8_e4m3;
+using hipdnn_data_sdk::types::fp8_e5m2;
+using hipdnn_data_sdk::types::fp8_e8m0;
 using hipdnn_data_sdk::types::half;
 }
 
@@ -40,6 +46,30 @@ constexpr auto datatypeToNative()
     {
         return bfloat16{};
     }
+    else if constexpr(DT == DataType::FP8_E4M3)
+    {
+        return fp8_e4m3{};
+    }
+    else if constexpr(DT == DataType::FP8_E5M2)
+    {
+        return fp8_e5m2{};
+    }
+    else if constexpr(DT == DataType::FP8_E8M0)
+    {
+        return fp8_e8m0{};
+    }
+    else if constexpr(DT == DataType::FP4_E2M1)
+    {
+        return fp4_e2m1{};
+    }
+    else if constexpr(DT == DataType::FP6_E2M3)
+    {
+        return fp6_e2m3{};
+    }
+    else if constexpr(DT == DataType::FP6_E3M2)
+    {
+        return fp6_e3m2{};
+    }
     else
     {
         // NOLINTNEXTLINE(misc-redundant-expression) Intentional: DT != DT is a dependent false for constexpr-if
@@ -47,7 +77,17 @@ constexpr auto datatypeToNative()
     }
 }
 
-inline std::variant<float, half, double, int32_t, bfloat16>
+inline std::variant<float,
+                    half,
+                    double,
+                    int32_t,
+                    bfloat16,
+                    fp8_e4m3,
+                    fp8_e5m2,
+                    fp8_e8m0,
+                    fp4_e2m1,
+                    fp6_e2m3,
+                    fp6_e3m2>
     datatypeToNativeVariant(hipdnn_flatbuffers_sdk::data_objects::DataType type)
 {
     using DataType = hipdnn_flatbuffers_sdk::data_objects::DataType;
@@ -68,6 +108,24 @@ inline std::variant<float, half, double, int32_t, bfloat16>
         break;
     case DataType::BFLOAT16:
         return bfloat16{};
+        break;
+    case DataType::FP8_E4M3:
+        return fp8_e4m3{};
+        break;
+    case DataType::FP8_E5M2:
+        return fp8_e5m2{};
+        break;
+    case DataType::FP8_E8M0:
+        return fp8_e8m0{};
+        break;
+    case DataType::FP4_E2M1:
+        return fp4_e2m1{};
+        break;
+    case DataType::FP6_E2M3:
+        return fp6_e2m3{};
+        break;
+    case DataType::FP6_E3M2:
+        return fp6_e3m2{};
         break;
     default:
         throw std::runtime_error("Error: Invalid type");
@@ -96,6 +154,30 @@ constexpr hipdnn_flatbuffers_sdk::data_objects::DataType nativeTypeToDataType()
     else if constexpr(std::is_same_v<T, bfloat16>)
     {
         return hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16;
+    }
+    else if constexpr(std::is_same_v<T, fp8_e4m3>)
+    {
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E4M3;
+    }
+    else if constexpr(std::is_same_v<T, fp8_e5m2>)
+    {
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E5M2;
+    }
+    else if constexpr(std::is_same_v<T, fp8_e8m0>)
+    {
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E8M0;
+    }
+    else if constexpr(std::is_same_v<T, fp4_e2m1>)
+    {
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::FP4_E2M1;
+    }
+    else if constexpr(std::is_same_v<T, fp6_e2m3>)
+    {
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::FP6_E2M3;
+    }
+    else if constexpr(std::is_same_v<T, fp6_e3m2>)
+    {
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::FP6_E3M2;
     }
     else
     {

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp
@@ -2127,28 +2127,33 @@ inline flatbuffers::FlatBufferBuilder createValidEngineDetails(int64_t engineId)
 }
 
 inline flatbuffers::FlatBufferBuilder createValidBlockScaleDequantizeGraph(
-    const std::vector<int64_t>& strides = {65536, 1024, 32, 1},
-    const std::vector<int64_t>& dims = {2, 64, 32, 32},
+    const std::vector<int64_t>& strides = {65536, 2048, 64, 1},
+    const std::vector<int64_t>& dims = {2, 32, 32, 64},
     hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType
     = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
     hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType
+    = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+    bool isNegativeScale = false,
+    hipdnn_flatbuffers_sdk::data_objects::DataType scaleDataType
+    = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+    hipdnn_flatbuffers_sdk::data_objects::DataType outputDataType
     = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT)
 {
     flatbuffers::FlatBufferBuilder builder;
     std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
-    const std::vector<int64_t> scaleDims = {2, 2, 32, 32};
-    const std::vector<int64_t> scaleStrides = {2048, 1024, 32, 1};
+    const std::vector<int64_t> scaleDims = {2, 32, 32, 2};
+    const std::vector<int64_t> scaleStrides = {2048, 64, 2, 1};
 
     tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 1, "x", inputDataType, &strides, &dims));
 
     tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 2, "scale", inputDataType, &scaleStrides, &scaleDims));
+        builder, 2, "scale", scaleDataType, &scaleStrides, &scaleDims));
 
     tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 3, "y", inputDataType, &strides, &dims));
+        builder, 3, "y", outputDataType, &strides, &dims));
 
     const std::vector<int32_t> blockSize = {32};
     auto blockSizeVector = builder.CreateVector(blockSize);
@@ -2160,8 +2165,58 @@ inline flatbuffers::FlatBufferBuilder createValidBlockScaleDequantizeGraph(
             2, // scale uid
             3, // y uid
             blockSizeVector,
-            false // is_negative_scale
-        );
+            isNegativeScale);
+
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "block_scale_dequantize",
+        computeDataType,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BlockScaleDequantizeAttributes,
+        blockScaleDequantizeAttributes.Union());
+    nodes.push_back(node);
+
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+    return builder;
+}
+
+inline flatbuffers::FlatBufferBuilder createValidBlockScaleDequantizeMxGraph(
+    hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType,
+    hipdnn_flatbuffers_sdk::data_objects::DataType scaleDataType,
+    hipdnn_flatbuffers_sdk::data_objects::DataType outputDataType,
+    hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType
+    = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    const std::vector<int64_t> dims = {1, 4};
+    const std::vector<int64_t> strides = {4, 1};
+    const std::vector<int64_t> scaleDims = {1, 2};
+    const std::vector<int64_t> scaleStrides = {2, 1};
+
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "x", inputDataType, &strides, &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 2, "scale", scaleDataType, &scaleStrides, &scaleDims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 3, "y", outputDataType, &strides, &dims));
+
+    const std::vector<int32_t> blockSize = {2};
+    auto blockSizeVector = builder.CreateVector(blockSize);
+
+    auto blockScaleDequantizeAttributes
+        = hipdnn_flatbuffers_sdk::data_objects::CreateBlockScaleDequantizeAttributes(
+            builder, 1, 2, 3, blockSizeVector, false);
 
     std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
     auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/CpuReferenceGraphExecutor.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/CpuReferenceGraphExecutor.hpp
@@ -8,6 +8,7 @@
 
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormFwdInferencePlan.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormFwdInferenceWithVarianceSignatureKey.hpp>
+#include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BlockScaleDequantizeSignatureKey.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionBwdPlan.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionFwdPlan.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionWrwPlan.hpp>
@@ -128,6 +129,8 @@ private:
             return detail::MatmulSignatureKey(node, tensorMap, computeType);
         case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::RMSNormAttributes:
             return detail::RMSNormFwdSignatureKey(node, tensorMap);
+        case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BlockScaleDequantizeAttributes:
+            return detail::BlockScaleDequantizeSignatureKey(node, tensorMap);
         case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::SdpaAttributes:
             return detail::SdpaFwdSignatureKey(node, tensorMap);
         case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::ReductionAttributes:

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BlockScaleDequantizePlan.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BlockScaleDequantizePlan.hpp
@@ -1,0 +1,158 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <functional>
+#include <optional>
+#include <variant>
+
+#include <hipdnn_data_sdk/utilities/FlatbufferUtils.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_test_sdk/utilities/CpuFpReferenceBlockScaleDequantize.hpp>
+#include <hipdnn_test_sdk/utilities/FlatbufferDatatypeMapping.hpp>
+#include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/IGraphNodePlanBuilder.hpp>
+#include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/IGraphNodePlanExecutor.hpp>
+#include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/PlanUtils.hpp>
+#include <hipdnn_test_sdk/utilities/detail/FlatbufferTensorAttributesUtils.hpp>
+
+namespace hipdnn_test_sdk::detail
+{
+
+struct BlockScaleDequantizeParams
+{
+    BlockScaleDequantizeParams(
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& xAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& scaleAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& yAttributes,
+        std::vector<int32_t> blockSize,
+        bool isNegativeScale)
+        : xTensor(unpackTensorAttributes(xAttributes))
+        , scaleTensor(unpackTensorAttributes(scaleAttributes))
+        , yTensor(unpackTensorAttributes(yAttributes))
+        , blockSize(std::move(blockSize))
+        , isNegativeScale(isNegativeScale)
+    {
+    }
+
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT xTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT scaleTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT yTensor;
+    std::vector<int32_t> blockSize;
+    bool isNegativeScale;
+};
+
+template <typename XDataType,
+          typename ScaleDataType,
+          typename OutputDataType,
+          typename ComputeDataType>
+class BlockScaleDequantizePlan : public IGraphNodePlanExecutor
+{
+public:
+    BlockScaleDequantizePlan(BlockScaleDequantizeParams&& params)
+        : _params(std::move(params))
+    {
+    }
+
+    std::vector<int64_t> getOutputTensorIds() const override
+    {
+        return {_params.yTensor.uid};
+    }
+
+    void execute(const std::unordered_map<int64_t, void*>& variantPack) override
+    {
+        auto shallowXTensor
+            = createShallowTensor<XDataType>(_params.xTensor, variantPack.at(_params.xTensor.uid));
+
+        auto shallowYTensor = createShallowTensor<OutputDataType>(
+            _params.yTensor, variantPack.at(_params.yTensor.uid));
+
+        auto shallowScaleTensor = createShallowTensor<ScaleDataType>(
+            _params.scaleTensor, variantPack.at(_params.scaleTensor.uid));
+
+        utilities::CpuFpReferenceBlockScaleDequantize::
+            dequantize<XDataType, ScaleDataType, OutputDataType, ComputeDataType>(
+                *shallowXTensor,
+                *shallowScaleTensor,
+                *shallowYTensor,
+                _params.blockSize,
+                _params.isNegativeScale);
+    }
+
+private:
+    BlockScaleDequantizeParams _params;
+};
+
+template <hipdnn_flatbuffers_sdk::data_objects::DataType XDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType ScaleDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType OutputDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum>
+class BlockScaleDequantizePlanBuilder : public IGraphNodePlanBuilder
+{
+public:
+    using XDataType = utilities::DataTypeToNative<XDataTypeEnum>;
+    using ScaleDataType = utilities::DataTypeToNative<ScaleDataTypeEnum>;
+    using OutputDataType = utilities::DataTypeToNative<OutputDataTypeEnum>;
+    using ComputeDataType = utilities::DataTypeToNative<ComputeDataTypeEnum>;
+
+    bool isApplicable(
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
+            tensorMap) const override
+    {
+        if(node.compute_data_type() != ComputeDataTypeEnum)
+        {
+            return false;
+        }
+
+        const auto* nodeAttributes = node.attributes_as_BlockScaleDequantizeAttributes();
+        if(nodeAttributes == nullptr)
+        {
+            return false;
+        }
+
+        CHECK_TENSOR_EXISTS(tensorMap, nodeAttributes->x_tensor_uid());
+        CHECK_TENSOR_EXISTS(tensorMap, nodeAttributes->y_tensor_uid());
+        CHECK_TENSOR_EXISTS(tensorMap, nodeAttributes->scale_tensor_uid());
+
+        CHECK_TENSOR_TYPE(tensorMap, nodeAttributes->x_tensor_uid(), XDataTypeEnum);
+        CHECK_TENSOR_TYPE(tensorMap, nodeAttributes->y_tensor_uid(), OutputDataTypeEnum);
+        CHECK_TENSOR_TYPE(tensorMap, nodeAttributes->scale_tensor_uid(), ScaleDataTypeEnum);
+
+        return true;
+    }
+
+    std::unique_ptr<IGraphNodePlanExecutor>
+        buildNodePlan(const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& graph,
+                      const hipdnn_flatbuffers_sdk::data_objects::Node& node) const override
+    {
+        const auto* nodeAttributes = node.attributes_as_BlockScaleDequantizeAttributes();
+        if(nodeAttributes == nullptr)
+        {
+            throw std::runtime_error(
+                "Node attributes are not of type BlockScaleDequantizeAttributes");
+        }
+
+        const auto& tensorMap = graph.getTensorMap();
+
+        std::vector<int32_t> blockSize;
+        if(nodeAttributes->block_size() != nullptr)
+        {
+            const auto* bs = nodeAttributes->block_size();
+            blockSize.assign(bs->begin(), bs->end());
+        }
+
+        BlockScaleDequantizeParams params(*tensorMap.at(nodeAttributes->x_tensor_uid()),
+                                          *tensorMap.at(nodeAttributes->scale_tensor_uid()),
+                                          *tensorMap.at(nodeAttributes->y_tensor_uid()),
+                                          std::move(blockSize),
+                                          nodeAttributes->is_negative_scale());
+
+        return std::make_unique<
+            BlockScaleDequantizePlan<XDataType, ScaleDataType, OutputDataType, ComputeDataType>>(
+            std::move(params));
+    }
+};
+} // namespace hipdnn_test_sdk::detail

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BlockScaleDequantizeSignatureKey.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BlockScaleDequantizeSignatureKey.hpp
@@ -1,0 +1,215 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <functional>
+#include <hipdnn_flatbuffers_sdk/data_objects/data_types_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+#include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BlockScaleDequantizePlan.hpp>
+#include <ostream>
+
+namespace hipdnn_test_sdk::detail
+{
+
+struct BlockScaleDequantizeSignatureKey
+{
+    const hipdnn_flatbuffers_sdk::data_objects::NodeAttributes nodeType
+        = hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BlockScaleDequantizeAttributes;
+    hipdnn_flatbuffers_sdk::data_objects::DataType xDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType scaleDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType outputDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType;
+
+    BlockScaleDequantizeSignatureKey() = default;
+    constexpr BlockScaleDequantizeSignatureKey(
+        hipdnn_flatbuffers_sdk::data_objects::DataType x,
+        hipdnn_flatbuffers_sdk::data_objects::DataType scale,
+        hipdnn_flatbuffers_sdk::data_objects::DataType output,
+        hipdnn_flatbuffers_sdk::data_objects::DataType compute)
+        : xDataType(x)
+        , scaleDataType(scale)
+        , outputDataType(output)
+        , computeDataType(compute)
+    {
+    }
+
+    BlockScaleDequantizeSignatureKey(
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
+            tensorMap)
+    {
+        const auto* nodeAttributes = node.attributes_as_BlockScaleDequantizeAttributes();
+        if(nodeAttributes == nullptr)
+        {
+            throw std::runtime_error(
+                "Node attributes could not be cast to BlockScaleDequantizeAttributes");
+        }
+
+        auto xTensorAttr = tensorMap.at(nodeAttributes->x_tensor_uid());
+        auto scaleTensorAttr = tensorMap.at(nodeAttributes->scale_tensor_uid());
+        auto yTensorAttr = tensorMap.at(nodeAttributes->y_tensor_uid());
+
+        if(xTensorAttr == nullptr || scaleTensorAttr == nullptr || yTensorAttr == nullptr)
+        {
+            throw std::runtime_error("One or more tensor attributes could not be found in the map, "
+                                     "failed to construct key");
+        }
+
+        xDataType = xTensorAttr->data_type();
+        scaleDataType = scaleTensorAttr->data_type();
+        computeDataType = node.compute_data_type();
+        outputDataType = yTensorAttr->data_type();
+    }
+
+    std::size_t operator()(const BlockScaleDequantizeSignatureKey& k) const noexcept
+    {
+        return k.hashSelf();
+    }
+
+    constexpr std::size_t hashSelf() const
+    {
+        return static_cast<std::size_t>(static_cast<int>(nodeType))
+               ^ (static_cast<std::size_t>(static_cast<int>(xDataType)) << 4)
+               ^ (static_cast<std::size_t>(static_cast<int>(scaleDataType)) << 8)
+               ^ (static_cast<std::size_t>(static_cast<int>(outputDataType)) << 12)
+               ^ (static_cast<std::size_t>(static_cast<int>(computeDataType)) << 16);
+    }
+
+    bool operator==(const BlockScaleDequantizeSignatureKey& other) const noexcept
+    {
+        return nodeType == other.nodeType && xDataType == other.xDataType
+               && scaleDataType == other.scaleDataType && outputDataType == other.outputDataType
+               && computeDataType == other.computeDataType;
+    }
+
+    static std::unordered_map<BlockScaleDequantizeSignatureKey,
+                              std::unique_ptr<IGraphNodePlanBuilder>,
+                              BlockScaleDequantizeSignatureKey>
+        getPlanBuilders()
+    {
+        std::unordered_map<BlockScaleDequantizeSignatureKey,
+                           std::unique_ptr<IGraphNodePlanBuilder>,
+                           BlockScaleDequantizeSignatureKey>
+            map;
+
+        // Float/Float/Float/Float (matches integration test defaults)
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+
+        // Half input with float scale/output/compute
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+
+        // BFloat16 input with float scale/output/compute
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+
+        // Half input with float scale, half output, float compute
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+
+        // BFloat16 input with float scale, bfloat16 output, float compute
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+
+        // FP8 E4M3 input with E8M0 scale, float output/compute (real MX dequantize)
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E4M3,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E8M0,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+
+        // FP8 E5M2 input with E8M0 scale, float output/compute (real MX dequantize)
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E5M2,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E8M0,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+
+        // FP8 E4M3 input with E8M0 scale, half output, float compute
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E4M3,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E8M0,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+
+        // FP8 E5M2 input with E8M0 scale, half output, float compute
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E5M2,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E8M0,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+
+        // FP4 E2M1 input with E8M0 scale, float output/compute (MX dequantize)
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FP4_E2M1,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E8M0,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+
+        // FP4 E2M1 input with E8M0 scale, half output, float compute
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FP4_E2M1,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E8M0,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+
+        // FP6 E2M3 input with E8M0 scale, float output/compute (MX dequantize)
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FP6_E2M3,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E8M0,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+
+        // FP6 E2M3 input with E8M0 scale, half output, float compute
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FP6_E2M3,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E8M0,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+
+        // FP6 E3M2 input with E8M0 scale, float output/compute (MX dequantize)
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FP6_E3M2,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E8M0,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+
+        // FP6 E3M2 input with E8M0 scale, half output, float compute
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FP6_E3M2,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E8M0,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+
+        return map;
+    }
+
+    template <hipdnn_flatbuffers_sdk::data_objects::DataType XDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType ScaleDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType OutputDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum>
+    static void addPlanBuilder(std::unordered_map<BlockScaleDequantizeSignatureKey,
+                                                  std::unique_ptr<IGraphNodePlanBuilder>,
+                                                  BlockScaleDequantizeSignatureKey>& map)
+    {
+        map[BlockScaleDequantizeSignatureKey(
+            XDataTypeEnum, ScaleDataTypeEnum, OutputDataTypeEnum, ComputeDataTypeEnum)]
+            = std::make_unique<BlockScaleDequantizePlanBuilder<XDataTypeEnum,
+                                                               ScaleDataTypeEnum,
+                                                               OutputDataTypeEnum,
+                                                               ComputeDataTypeEnum>>();
+    }
+};
+
+inline std::ostream& operator<<(std::ostream& os, const BlockScaleDequantizeSignatureKey& key)
+{
+    os << "BlockScaleDequantize(x=" << key.xDataType << ", scale=" << key.scaleDataType
+       << ", y=" << key.outputDataType << ", compute=" << key.computeDataType << ")";
+    return os;
+}
+
+} // namespace hipdnn_test_sdk::detail

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/PlanBuilderRegistry.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/PlanBuilderRegistry.hpp
@@ -10,6 +10,7 @@
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormFwdInferencePlan.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormFwdInferenceWithVariancePlan.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormTrainPlan.hpp>
+#include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BlockScaleDequantizePlan.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionBwdPlan.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionFwdPlan.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/LayernormFpropPlan.hpp>

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/PlanRegistrySignatureKey.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/PlanRegistrySignatureKey.hpp
@@ -11,6 +11,7 @@
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormFwdInferenceSignatureKey.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormFwdInferenceWithVarianceSignatureKey.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormTrainSignatureKey.hpp>
+#include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BlockScaleDequantizeSignatureKey.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionBwdSignatureKey.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionFwdSignatureKey.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionWrwSignatureKey.hpp>
@@ -39,6 +40,7 @@ using PlanRegistrySignatureKey = std::variant<BatchnormFwdInferenceSignatureKey,
                                               BatchnormFwdInferenceWithVarianceSignatureKey,
                                               BatchnormBwdSignatureKey,
                                               BatchnormTrainSignatureKey,
+                                              BlockScaleDequantizeSignatureKey,
                                               ConvolutionFwdSignatureKey,
                                               ConvolutionBwdSignatureKey,
                                               ConvolutionWrwSignatureKey,

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/detail/CpuFpReferenceUtilities.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/detail/CpuFpReferenceUtilities.hpp
@@ -19,12 +19,25 @@
 namespace hipdnn_test_sdk::detail
 {
 using hipdnn_data_sdk::types::bfloat16;
+using hipdnn_data_sdk::types::fp4_e2m1;
+using hipdnn_data_sdk::types::fp6_e2m3;
+using hipdnn_data_sdk::types::fp6_e3m2;
+using hipdnn_data_sdk::types::fp8_e4m3;
+using hipdnn_data_sdk::types::fp8_e5m2;
+using hipdnn_data_sdk::types::fp8_e8m0;
 using hipdnn_data_sdk::types::half;
 
-// Type trait to validate tensor types (arithmetic types + half + bfloat16)
+// Type trait to validate tensor types (arithmetic types + half + bfloat16 + fp8 types)
 template <typename T>
-constexpr bool IS_VALID_TENSOR_TYPE_V
-    = std::disjunction_v<std::is_arithmetic<T>, std::is_same<T, half>, std::is_same<T, bfloat16>>;
+constexpr bool IS_VALID_TENSOR_TYPE_V = std::disjunction_v<std::is_arithmetic<T>,
+                                                           std::is_same<T, half>,
+                                                           std::is_same<T, bfloat16>,
+                                                           std::is_same<T, fp4_e2m1>,
+                                                           std::is_same<T, fp6_e2m3>,
+                                                           std::is_same<T, fp6_e3m2>,
+                                                           std::is_same<T, fp8_e4m3>,
+                                                           std::is_same<T, fp8_e5m2>,
+                                                           std::is_same<T, fp8_e8m0>>;
 
 /**
  * @brief Safely convert between types while avoiding implicit precision loss warnings
@@ -46,6 +59,15 @@ inline TargetType safeConvert(const SourceType& value)
         // For bfloat16/half, explicitly convert through float to avoid precision warnings
         // These types lack direct constructors from double, only from float
         return static_cast<TargetType>(static_cast<float>(value));
+    }
+    else if constexpr(std::is_same_v<TargetType, fp4_e2m1> || std::is_same_v<TargetType, fp6_e2m3>
+                      || std::is_same_v<TargetType, fp6_e3m2>
+                      || std::is_same_v<TargetType, fp8_e4m3>
+                      || std::is_same_v<TargetType, fp8_e5m2>
+                      || std::is_same_v<TargetType, fp8_e8m0>)
+    {
+        // For FP8 types, convert through float
+        return TargetType(static_cast<float>(value));
     }
     else
     {

--- a/projects/hipdnn/test_sdk/tests/CMakeLists.txt
+++ b/projects/hipdnn/test_sdk/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(
     main.cpp
     utilities/TestCpuFpReferenceBatchnorm.cpp
     utilities/TestCpuFpReferenceBatchnormWithVariance.cpp
+    utilities/TestCpuFpReferenceBlockScaleDequantize.cpp
     utilities/TestCpuFpReferenceRMSNorm.cpp
     utilities/TestCpuFpReferenceSdpa.cpp
     utilities/TestCpuFpReferenceConvolution.cpp
@@ -45,6 +46,8 @@ add_executable(
     utilities/TestSeeds.cpp
     utilities/TestTensorDiff.cpp
     utilities/TestVectorLoggingUtils.cpp
+    utilities/cpu_graph_executor/TestBlockScaleDequantizePlan.cpp
+    utilities/cpu_graph_executor/TestBlockScaleDequantizeSignatureKey.cpp
     utilities/cpu_graph_executor/TestBatchnormBwdPlan.cpp
     utilities/cpu_graph_executor/TestBatchnormBwdSignatureKey.cpp
     utilities/cpu_graph_executor/TestBatchnormFwdInferencePlan.cpp

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceBlockScaleDequantize.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceBlockScaleDequantize.cpp
@@ -1,0 +1,416 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include <gtest/gtest.h>
+#include <hipdnn_data_sdk/types.hpp>
+#include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_test_sdk/utilities/CpuFpReferenceBlockScaleDequantize.hpp>
+#include <hipdnn_test_sdk/utilities/detail/CpuFpReferenceUtilities.hpp>
+
+using namespace hipdnn_test_sdk::utilities;
+using namespace hipdnn_data_sdk::utilities;
+using namespace hipdnn_data_sdk::types;
+using hipdnn_test_sdk::detail::safeTestTypeCast;
+
+template <typename T1, typename T2, typename T3>
+struct TypeTriple
+{
+    using InputType = T1;
+    using ScaleType = T2;
+    using OutputType = T3;
+};
+
+// ============================================================================
+// Typed tests over input type: float/half/bfloat16 with float scale
+// ============================================================================
+
+using TypesBlockScaleDequantize = ::testing::Types<TypeTriple<float, float, float>,
+                                                   TypeTriple<half, float, float>,
+                                                   TypeTriple<bfloat16, float, float>>;
+
+template <class T>
+class CpuFpReferenceBlockScaleDequantizeTyped : public ::testing::Test
+{
+};
+
+TYPED_TEST_SUITE(CpuFpReferenceBlockScaleDequantizeTyped, TypesBlockScaleDequantize, );
+
+TYPED_TEST(CpuFpReferenceBlockScaleDequantizeTyped, IdentityScale)
+{
+    using XType = typename TypeParam::InputType;
+    using ScaleType = typename TypeParam::ScaleType;
+    using YType = typename TypeParam::OutputType;
+
+    // X: 2x4, Scale: 2x2 (block_size=2 along dim 1)
+    Tensor<XType> xTensor({2, 4});
+    Tensor<ScaleType> scaleTensor({2, 2});
+    Tensor<YType> yTensor({2, 4});
+
+    xTensor.fillWithValue(safeTestTypeCast<XType>(3.0f));
+    scaleTensor.fillWithValue(safeTestTypeCast<ScaleType>(1.0f));
+
+    CpuFpReferenceBlockScaleDequantize::dequantize(xTensor, scaleTensor, yTensor, {2}, false);
+
+    auto tolerance = 1e-5f;
+    for(int b = 0; b < 2; ++b)
+    {
+        for(int c = 0; c < 4; ++c)
+        {
+            EXPECT_NEAR(static_cast<float>(yTensor.getHostValue(b, c)), 3.0f, tolerance);
+        }
+    }
+}
+
+TEST(TestCpuFpReferenceBlockScaleDequantizeTyped, BFloat16InBFloat16Out)
+{
+    // bfloat16 input, float scale, bfloat16 output — registered signature gap
+    Tensor<bfloat16> xTensor({1, 4});
+    Tensor<float> scaleTensor({1, 2});
+    Tensor<bfloat16> yTensor({1, 4});
+
+    xTensor.setHostValue(bfloat16(2.0f), 0, 0);
+    xTensor.setHostValue(bfloat16(4.0f), 0, 1);
+    xTensor.setHostValue(bfloat16(1.0f), 0, 2);
+    xTensor.setHostValue(bfloat16(3.0f), 0, 3);
+
+    scaleTensor.setHostValue(0.5f, 0, 0); // scales elements [0,1]
+    scaleTensor.setHostValue(2.0f, 0, 1); // scales elements [2,3]
+
+    CpuFpReferenceBlockScaleDequantize::dequantize(xTensor, scaleTensor, yTensor, {2}, false);
+
+    auto tolerance = 1e-2f; // bfloat16 has ~2 decimal digits of precision
+    EXPECT_NEAR(static_cast<float>(yTensor.getHostValue(0, 0)), 2.0f * 0.5f, tolerance);
+    EXPECT_NEAR(static_cast<float>(yTensor.getHostValue(0, 1)), 4.0f * 0.5f, tolerance);
+    EXPECT_NEAR(static_cast<float>(yTensor.getHostValue(0, 2)), 1.0f * 2.0f, tolerance);
+    EXPECT_NEAR(static_cast<float>(yTensor.getHostValue(0, 3)), 3.0f * 2.0f, tolerance);
+}
+
+TEST(TestCpuFpReferenceBlockScaleDequantizeFp32, NonTrivialScale)
+{
+    // X: 1x4, Scale: 1x2 => block_size=2 along dim 1
+    Tensor<float> xTensor({1, 4});
+    Tensor<float> scaleTensor({1, 2});
+    Tensor<float> yTensor({1, 4});
+
+    xTensor.setHostValue(1.0f, 0, 0);
+    xTensor.setHostValue(2.0f, 0, 1);
+    xTensor.setHostValue(3.0f, 0, 2);
+    xTensor.setHostValue(4.0f, 0, 3);
+
+    scaleTensor.setHostValue(2.0f, 0, 0); // scales elements [0,1]
+    scaleTensor.setHostValue(0.5f, 0, 1); // scales elements [2,3]
+
+    CpuFpReferenceBlockScaleDequantize::dequantize(xTensor, scaleTensor, yTensor, {2}, false);
+
+    auto tolerance = 1e-5f;
+    EXPECT_NEAR(yTensor.getHostValue(0, 0), 1.0f * 2.0f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 1), 2.0f * 2.0f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 2), 3.0f * 0.5f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 3), 4.0f * 0.5f, tolerance);
+}
+
+TEST(TestCpuFpReferenceBlockScaleDequantizeFp32, MultiDimBlocking)
+{
+    // X: 2x4x8, Scale: 2x4x2 => block along trailing dim, block_size=4
+    // Use distinct per-block scale values so spot-checking can detect index mapping bugs.
+    Tensor<float> xTensor({2, 4, 8});
+    Tensor<float> scaleTensor({2, 4, 2});
+    Tensor<float> yTensor({2, 4, 8});
+
+    xTensor.fillWithValue(1.0f);
+
+    // Assign distinct scale values: scale[b][r][s] covers x[b][r][s*4..(s+1)*4-1]
+    float scaleVal = 1.0f;
+    for(int b = 0; b < 2; ++b)
+    {
+        for(int r = 0; r < 4; ++r)
+        {
+            for(int s = 0; s < 2; ++s)
+            {
+                scaleTensor.setHostValue(scaleVal, b, r, s);
+                scaleVal += 1.0f;
+            }
+        }
+    }
+
+    CpuFpReferenceBlockScaleDequantize::dequantize(xTensor, scaleTensor, yTensor, {4}, false);
+
+    auto tolerance = 1e-5f;
+    // Block (0,0,0): x[0][0][0..3] => scale[0][0][0] = 1.0
+    EXPECT_NEAR(yTensor.getHostValue(0, 0, 0), 1.0f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 0, 3), 1.0f, tolerance);
+    // Block (0,0,1): x[0][0][4..7] => scale[0][0][1] = 2.0
+    EXPECT_NEAR(yTensor.getHostValue(0, 0, 4), 2.0f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 0, 7), 2.0f, tolerance);
+    // Block (0,1,0): x[0][1][0..3] => scale[0][1][0] = 3.0
+    EXPECT_NEAR(yTensor.getHostValue(0, 1, 0), 3.0f, tolerance);
+    // Block (1,3,1): x[1][3][4..7] => scale[1][3][1] = 16.0 (last block)
+    EXPECT_NEAR(yTensor.getHostValue(1, 3, 4), 16.0f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(1, 3, 7), 16.0f, tolerance);
+}
+
+TEST(TestCpuFpReferenceBlockScaleDequantizeFp32, MultiTrailingDimBlockSize)
+{
+    // X: 1x4x6, Scale: 1x2x3 => blockSize={2,2} blocks trailing two dims simultaneously
+    // dim 1: block_size=2 (4/2=2 scale entries), dim 2: block_size=2 (6/2=3 scale entries)
+    Tensor<float> xTensor({1, 4, 6});
+    Tensor<float> scaleTensor({1, 2, 3});
+    Tensor<float> yTensor({1, 4, 6});
+
+    xTensor.fillWithValue(1.0f);
+
+    // Assign distinct scale values per block so we can verify correct index mapping
+    // scale[0][s1][s2] covers x[0][s1*2..s1*2+1][s2*2..s2*2+1]
+    scaleTensor.setHostValue(1.0f, 0, 0, 0);
+    scaleTensor.setHostValue(2.0f, 0, 0, 1);
+    scaleTensor.setHostValue(3.0f, 0, 0, 2);
+    scaleTensor.setHostValue(4.0f, 0, 1, 0);
+    scaleTensor.setHostValue(5.0f, 0, 1, 1);
+    scaleTensor.setHostValue(6.0f, 0, 1, 2);
+
+    CpuFpReferenceBlockScaleDequantize::dequantize(xTensor, scaleTensor, yTensor, {2, 2}, false);
+
+    auto tolerance = 1e-5f;
+    // Block (0,0): x[0][0..1][0..1] => scale[0][0][0] = 1.0
+    EXPECT_NEAR(yTensor.getHostValue(0, 0, 0), 1.0f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 1, 1), 1.0f, tolerance);
+    // Block (0,1): x[0][0..1][2..3] => scale[0][0][1] = 2.0
+    EXPECT_NEAR(yTensor.getHostValue(0, 0, 2), 2.0f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 1, 3), 2.0f, tolerance);
+    // Block (0,2): x[0][0..1][4..5] => scale[0][0][2] = 3.0
+    EXPECT_NEAR(yTensor.getHostValue(0, 0, 4), 3.0f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 1, 5), 3.0f, tolerance);
+    // Block (1,0): x[0][2..3][0..1] => scale[0][1][0] = 4.0
+    EXPECT_NEAR(yTensor.getHostValue(0, 2, 0), 4.0f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 3, 1), 4.0f, tolerance);
+    // Block (1,2): x[0][2..3][4..5] => scale[0][1][2] = 6.0
+    EXPECT_NEAR(yTensor.getHostValue(0, 2, 4), 6.0f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 3, 5), 6.0f, tolerance);
+}
+
+TEST(TestCpuFpReferenceBlockScaleDequantizeFp32, NegativeXValues)
+{
+    // Dequantize is linear: negative x values should scale correctly
+    Tensor<float> xTensor({1, 4});
+    Tensor<float> scaleTensor({1, 2});
+    Tensor<float> yTensor({1, 4});
+
+    xTensor.setHostValue(-2.0f, 0, 0);
+    xTensor.setHostValue(-1.0f, 0, 1);
+    xTensor.setHostValue(0.0f, 0, 2);
+    xTensor.setHostValue(-4.0f, 0, 3);
+
+    scaleTensor.setHostValue(3.0f, 0, 0); // scales elements [0,1]
+    scaleTensor.setHostValue(0.5f, 0, 1); // scales elements [2,3]
+
+    CpuFpReferenceBlockScaleDequantize::dequantize(xTensor, scaleTensor, yTensor, {2}, false);
+
+    auto tolerance = 1e-5f;
+    EXPECT_NEAR(yTensor.getHostValue(0, 0), -2.0f * 3.0f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 1), -1.0f * 3.0f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 2), 0.0f * 0.5f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 3), -4.0f * 0.5f, tolerance);
+}
+
+TEST(TestCpuFpReferenceBlockScaleDequantizeFp32, IsNegativeScaleFloat)
+{
+    // With is_negative_scale=true and float scale, Y = X * 2^(-scale)
+    Tensor<float> xTensor({1, 4});
+    Tensor<float> scaleTensor({1, 2});
+    Tensor<float> yTensor({1, 4});
+
+    xTensor.setHostValue(8.0f, 0, 0);
+    xTensor.setHostValue(8.0f, 0, 1);
+    xTensor.setHostValue(16.0f, 0, 2);
+    xTensor.setHostValue(16.0f, 0, 3);
+
+    scaleTensor.setHostValue(3.0f, 0, 0); // 2^(-3) = 0.125
+    scaleTensor.setHostValue(1.0f, 0, 1); // 2^(-1) = 0.5
+
+    CpuFpReferenceBlockScaleDequantize::dequantize(xTensor, scaleTensor, yTensor, {2}, true);
+
+    auto tolerance = 1e-5f;
+    EXPECT_NEAR(yTensor.getHostValue(0, 0), 8.0f * 0.125f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 1), 8.0f * 0.125f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 2), 16.0f * 0.5f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 3), 16.0f * 0.5f, tolerance);
+}
+
+TEST(TestCpuFpReferenceBlockScaleDequantizeFp32, NormalScaleMultiplication)
+{
+    // Normal (non-negative) scale: Y = X * scale
+    Tensor<float> xTensor({1, 2});
+    Tensor<float> scaleTensor({1, 1});
+    Tensor<float> yTensor({1, 2});
+
+    xTensor.setHostValue(5.0f, 0, 0);
+    xTensor.setHostValue(10.0f, 0, 1);
+    scaleTensor.setHostValue(0.1f, 0, 0);
+
+    CpuFpReferenceBlockScaleDequantize::dequantize(xTensor, scaleTensor, yTensor, {2}, false);
+
+    auto tolerance = 1e-5f;
+    EXPECT_NEAR(yTensor.getHostValue(0, 0), 0.5f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 1), 1.0f, tolerance);
+}
+
+// ============================================================================
+// FP8 E8M0 scale: standalone scale semantics test
+// ============================================================================
+
+TEST(TestCpuFpReferenceBlockScaleDequantizeFp8, E8M0ScaleDequantize)
+{
+    // Test with fp8_e8m0 scale: scale value is 2^(biased_exp - 127)
+    // fp8_e8m0 with bits=127 => 2^0 = 1.0
+    // fp8_e8m0 with bits=128 => 2^1 = 2.0
+    Tensor<float> xTensor({1, 4});
+    Tensor<fp8_e8m0> scaleTensor({1, 2});
+    Tensor<float> yTensor({1, 4});
+
+    xTensor.setHostValue(3.0f, 0, 0);
+    xTensor.setHostValue(3.0f, 0, 1);
+    xTensor.setHostValue(5.0f, 0, 2);
+    xTensor.setHostValue(5.0f, 0, 3);
+
+    // scale[0] = 1.0 (bits=127), scale[1] = 2.0 (bits=128)
+    scaleTensor.setHostValue(fp8_e8m0::from_bits(127), 0, 0);
+    scaleTensor.setHostValue(fp8_e8m0::from_bits(128), 0, 1);
+
+    CpuFpReferenceBlockScaleDequantize::dequantize(xTensor, scaleTensor, yTensor, {2}, false);
+
+    auto tolerance = 1e-5f;
+    EXPECT_NEAR(yTensor.getHostValue(0, 0), 3.0f * 1.0f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 1), 3.0f * 1.0f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 2), 5.0f * 2.0f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 3), 5.0f * 2.0f, tolerance);
+}
+
+TEST(TestCpuFpReferenceBlockScaleDequantizeFp8, IsNegativeScaleE8M0)
+{
+    // isNegativeScale=true with fp8_e8m0: Y = X * 2^(-float(scale))
+    // float(fp8_e8m0::from_bits(127)) = 2^0 = 1.0, so 2^(-1.0) = 0.5
+    // float(fp8_e8m0::from_bits(128)) = 2^1 = 2.0, so 2^(-2.0) = 0.25
+    Tensor<float> xTensor({1, 4});
+    Tensor<fp8_e8m0> scaleTensor({1, 2});
+    Tensor<float> yTensor({1, 4});
+
+    xTensor.setHostValue(8.0f, 0, 0);
+    xTensor.setHostValue(8.0f, 0, 1);
+    xTensor.setHostValue(16.0f, 0, 2);
+    xTensor.setHostValue(16.0f, 0, 3);
+
+    scaleTensor.setHostValue(fp8_e8m0::from_bits(127), 0, 0); // float value = 1.0 => 2^(-1.0) = 0.5
+    scaleTensor.setHostValue(
+        fp8_e8m0::from_bits(128), 0, 1); // float value = 2.0 => 2^(-2.0) = 0.25
+
+    CpuFpReferenceBlockScaleDequantize::dequantize(xTensor, scaleTensor, yTensor, {2}, true);
+
+    auto tolerance = 1e-5f;
+    EXPECT_NEAR(yTensor.getHostValue(0, 0), 8.0f * 0.5f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 1), 8.0f * 0.5f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 2), 16.0f * 0.25f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 3), 16.0f * 0.25f, tolerance);
+}
+
+// ============================================================================
+// Validation error path tests
+// ============================================================================
+
+TEST(TestCpuFpReferenceBlockScaleDequantizeValidation, ScaleRankExceedsXRank)
+{
+    // Scale tensor has more dimensions than x — should throw
+    const Tensor<float> xTensor({4});
+    const Tensor<float> scaleTensor({2, 2});
+    Tensor<float> yTensor({4});
+
+    EXPECT_THROW(
+        CpuFpReferenceBlockScaleDequantize::dequantize(xTensor, scaleTensor, yTensor, {2}, false),
+        std::invalid_argument);
+}
+
+TEST(TestCpuFpReferenceBlockScaleDequantizeValidation, ScaleRankLessThanXRank)
+{
+    // Scale tensor has fewer dimensions than x — should throw (no broadcast support)
+    const Tensor<float> xTensor({2, 4});
+    const Tensor<float> scaleTensor({2});
+    Tensor<float> yTensor({2, 4});
+
+    EXPECT_THROW(
+        CpuFpReferenceBlockScaleDequantize::dequantize(xTensor, scaleTensor, yTensor, {2}, false),
+        std::invalid_argument);
+}
+
+TEST(TestCpuFpReferenceBlockScaleDequantizeValidation, ScaleDimMismatch)
+{
+    // X: 1x4 with block_size=2 expects scale dims {1, 2}, but scale is {1, 3}
+    const Tensor<float> xTensor({1, 4});
+    const Tensor<float> scaleTensor({1, 3});
+    Tensor<float> yTensor({1, 4});
+
+    EXPECT_THROW(
+        CpuFpReferenceBlockScaleDequantize::dequantize(xTensor, scaleTensor, yTensor, {2}, false),
+        std::invalid_argument);
+}
+
+TEST(TestCpuFpReferenceBlockScaleDequantizeValidation, EmptyXDimsThrows)
+{
+    const Tensor<float> xTensor({});
+    const Tensor<float> scaleTensor({});
+    Tensor<float> yTensor({});
+
+    EXPECT_THROW(
+        CpuFpReferenceBlockScaleDequantize::dequantize(xTensor, scaleTensor, yTensor, {2}, false),
+        std::runtime_error);
+}
+
+// ============================================================================
+// MX dequantize typed tests: all narrow types with fp8_e8m0 scale
+// ============================================================================
+
+using MxDequantizeTypes = ::testing::Types<TypeTriple<fp8_e4m3, fp8_e8m0, float>,
+                                           TypeTriple<fp8_e4m3, fp8_e8m0, half>,
+                                           TypeTriple<fp8_e5m2, fp8_e8m0, float>,
+                                           TypeTriple<fp8_e5m2, fp8_e8m0, half>,
+                                           TypeTriple<fp4_e2m1, fp8_e8m0, float>,
+                                           TypeTriple<fp4_e2m1, fp8_e8m0, half>,
+                                           TypeTriple<fp6_e2m3, fp8_e8m0, float>,
+                                           TypeTriple<fp6_e2m3, fp8_e8m0, half>,
+                                           TypeTriple<fp6_e3m2, fp8_e8m0, float>,
+                                           TypeTriple<fp6_e3m2, fp8_e8m0, half>>;
+
+template <class T>
+class CpuFpReferenceMxDequantize : public ::testing::Test
+{
+};
+
+TYPED_TEST_SUITE(CpuFpReferenceMxDequantize, MxDequantizeTypes, );
+
+TYPED_TEST(CpuFpReferenceMxDequantize, WithE8m0Scale)
+{
+    using XType = typename TypeParam::InputType;
+    using ScaleType = typename TypeParam::ScaleType;
+    using YType = typename TypeParam::OutputType;
+
+    // MX dequantize: narrow input, fp8_e8m0 scale, float/half output
+    // scale[0] = 1.0 (bits=127), scale[1] = 2.0 (bits=128)
+    // x: {1, 1, 2, 2}, expected y: {1, 1, 4, 4}
+    Tensor<XType> xTensor({1, 4});
+    Tensor<ScaleType> scaleTensor({1, 2});
+    Tensor<YType> yTensor({1, 4});
+
+    xTensor.setHostValue(XType(1.0f), 0, 0);
+    xTensor.setHostValue(XType(1.0f), 0, 1);
+    xTensor.setHostValue(XType(2.0f), 0, 2);
+    xTensor.setHostValue(XType(2.0f), 0, 3);
+
+    scaleTensor.setHostValue(fp8_e8m0::from_bits(127), 0, 0); // 1.0
+    scaleTensor.setHostValue(fp8_e8m0::from_bits(128), 0, 1); // 2.0
+
+    CpuFpReferenceBlockScaleDequantize::dequantize(xTensor, scaleTensor, yTensor, {2}, false);
+
+    auto tolerance = 1e-2f;
+    EXPECT_NEAR(static_cast<float>(yTensor.getHostValue(0, 0)), 1.0f * 1.0f, tolerance);
+    EXPECT_NEAR(static_cast<float>(yTensor.getHostValue(0, 1)), 1.0f * 1.0f, tolerance);
+    EXPECT_NEAR(static_cast<float>(yTensor.getHostValue(0, 2)), 2.0f * 2.0f, tolerance);
+    EXPECT_NEAR(static_cast<float>(yTensor.getHostValue(0, 3)), 2.0f * 2.0f, tolerance);
+}

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/BlockScaleDequantizeGraphUtils.hpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/BlockScaleDequantizeGraphUtils.hpp
@@ -1,0 +1,92 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_frontend/Graph.hpp>
+#include <hipdnn_frontend/Utilities.hpp>
+#include <hipdnn_frontend/attributes/BlockScaleDequantizeAttributes.hpp>
+#include <hipdnn_frontend/attributes/TensorAttributes.hpp>
+#include <hipdnn_test_sdk/constants/BlockScaleDequantizeConstants.hpp>
+#include <hipdnn_test_sdk/utilities/SdkFrontendTypeConversions.hpp>
+#include <hipdnn_test_sdk/utilities/Seeds.hpp>
+
+namespace hipdnn_sdk_test_utils
+{
+
+template <typename XType, typename ScaleType>
+struct BlockScaleDequantizeTensorBundle
+{
+    BlockScaleDequantizeTensorBundle(const std::vector<int64_t>& xDims,
+                                     const std::vector<int64_t>& scaleDims,
+                                     unsigned int seed
+                                     = hipdnn_test_sdk::utilities::getGlobalTestSeed())
+        : xTensor(xDims)
+        , scaleTensor(scaleDims)
+    {
+        xTensor.fillWithRandomValues(static_cast<XType>(0.0f), static_cast<XType>(1.0f), seed);
+        scaleTensor.fillWithRandomValues(
+            static_cast<ScaleType>(0.1f), static_cast<ScaleType>(2.0f), seed);
+    }
+
+    std::unordered_map<int64_t, void*>
+        createVariantPack(const hipdnn_frontend::graph::TensorAttributes& xTensorAttr,
+                          const hipdnn_frontend::graph::TensorAttributes& scaleTensorAttr)
+    {
+        std::unordered_map<int64_t, void*> variantPack;
+        variantPack[xTensorAttr.get_uid()] = xTensor.memory().hostData();
+        variantPack[scaleTensorAttr.get_uid()] = scaleTensor.memory().hostData();
+        return variantPack;
+    }
+
+    hipdnn_data_sdk::utilities::Tensor<XType> xTensor;
+    hipdnn_data_sdk::utilities::Tensor<ScaleType> scaleTensor;
+};
+
+template <typename XType, typename ScaleType>
+static std::tuple<std::shared_ptr<hipdnn_frontend::graph::Graph>,
+                  std::unordered_map<int64_t, void*>>
+    buildBlockScaleDequantizeGraph(BlockScaleDequantizeTensorBundle<XType, ScaleType>& tensorBundle,
+                                   hipdnn_flatbuffers_sdk::data_objects::DataType xDataType,
+                                   hipdnn_flatbuffers_sdk::data_objects::DataType scaleDataType,
+                                   hipdnn_flatbuffers_sdk::data_objects::DataType yDataType,
+                                   hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType,
+                                   const std::vector<int32_t>& blockSize)
+{
+    using namespace hipdnn_tests::constants;
+
+    auto graph = std::make_shared<hipdnn_frontend::graph::Graph>();
+    graph->set_name("BlockScaleDequantizeTest");
+    graph->set_compute_data_type(
+        hipdnn_test_sdk::utilities::sdkToFrontendDataType(computeDataType));
+
+    auto xAttr = hipdnn_frontend::graph::makeTensorAttributes(
+        "x", hipdnn_test_sdk::utilities::sdkToFrontendDataType(xDataType), tensorBundle.xTensor);
+    xAttr.set_uid(K_BSD_TENSOR_X_UID);
+    auto xTensorAttr = std::make_shared<hipdnn_frontend::graph::TensorAttributes>(std::move(xAttr));
+
+    auto scaleAttr = hipdnn_frontend::graph::makeTensorAttributes(
+        "scale",
+        hipdnn_test_sdk::utilities::sdkToFrontendDataType(scaleDataType),
+        tensorBundle.scaleTensor);
+    scaleAttr.set_uid(K_BSD_TENSOR_SCALE_UID);
+    auto scaleTensorAttr
+        = std::make_shared<hipdnn_frontend::graph::TensorAttributes>(std::move(scaleAttr));
+
+    hipdnn_frontend::graph::BlockScaleDequantizeAttributes bsdAttrs;
+    bsdAttrs.set_name("block_scale_dequantize");
+    bsdAttrs.set_block_size(blockSize);
+
+    auto yTensorAttr = graph->block_scale_dequantize(xTensorAttr, scaleTensorAttr, bsdAttrs);
+
+    yTensorAttr->set_uid(K_BSD_TENSOR_Y_UID);
+    yTensorAttr->set_data_type(hipdnn_test_sdk::utilities::sdkToFrontendDataType(yDataType));
+
+    auto variantPack = tensorBundle.createVariantPack(*xTensorAttr, *scaleTensorAttr);
+
+    return std::make_tuple(graph, variantPack);
+}
+
+} // namespace hipdnn_sdk_test_utils

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestBlockScaleDequantizePlan.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestBlockScaleDequantizePlan.cpp
@@ -1,0 +1,452 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include <gtest/gtest.h>
+
+#include <hipdnn_data_sdk/utilities/FlatbufferUtils.hpp>
+#include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_test_sdk/utilities/CpuFpReferenceBlockScaleDequantize.hpp>
+#include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
+#include <hipdnn_test_sdk/utilities/FlatbufferDatatypeMapping.hpp>
+#include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
+#include <hipdnn_test_sdk/utilities/Seeds.hpp>
+#include <hipdnn_test_sdk/utilities/cpu_graph_executor/GraphTensorBundle.hpp>
+#include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BlockScaleDequantizePlan.hpp>
+
+using namespace hipdnn_test_sdk::utilities;
+using namespace hipdnn_test_sdk::detail;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
+using namespace hipdnn_data_sdk::utilities;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
+
+TEST(TestBlockScaleDequantizePlan, ExecutePlan)
+{
+    auto builder = createValidBlockScaleDequantizeGraph();
+    const GraphWrapper graphWrapper(builder.GetBufferPointer(), builder.GetSize());
+
+    const auto& node = graphWrapper.getNode(0);
+    const auto& tensorMap = graphWrapper.getTensorMap();
+
+    // Create two tensor bundles with same data for plan vs direct comparison
+    const unsigned int seed = getGlobalTestSeed();
+    GraphTensorBundle planBundle(tensorMap);
+    GraphTensorBundle directBundle(tensorMap);
+
+    // Fill x and scale with same random data
+    planBundle.getTensor(1).fillTensorWithRandomValues(0.0f, 1.0f, seed);
+    planBundle.getTensor(2).fillTensorWithRandomValues(0.1f, 2.0f, seed);
+    directBundle.getTensor(1).fillTensorWithRandomValues(0.0f, 1.0f, seed);
+    directBundle.getTensor(2).fillTensorWithRandomValues(0.1f, 2.0f, seed);
+
+    const auto* nodeAttributes = node.attributes_as_BlockScaleDequantizeAttributes();
+    ASSERT_NE(nodeAttributes, nullptr);
+
+    std::vector<int32_t> blockSize;
+    if(nodeAttributes->block_size() != nullptr)
+    {
+        const auto* bs = nodeAttributes->block_size();
+        blockSize.assign(bs->begin(), bs->end());
+    }
+
+    // Execute via plan
+    BlockScaleDequantizeParams params(*tensorMap.at(nodeAttributes->x_tensor_uid()),
+                                      *tensorMap.at(nodeAttributes->scale_tensor_uid()),
+                                      *tensorMap.at(nodeAttributes->y_tensor_uid()),
+                                      blockSize,
+                                      nodeAttributes->is_negative_scale());
+
+    // Direct execution for reference
+    auto directXTensor
+        = createShallowTensor<float>(params.xTensor, directBundle.getTensor(1).rawHostData());
+    auto directScaleTensor
+        = createShallowTensor<float>(params.scaleTensor, directBundle.getTensor(2).rawHostData());
+    auto directYTensor
+        = createShallowTensor<float>(params.yTensor, directBundle.getTensor(3).rawHostData());
+
+    CpuFpReferenceBlockScaleDequantize::dequantize(*directXTensor,
+                                                   *directScaleTensor,
+                                                   *directYTensor,
+                                                   blockSize,
+                                                   nodeAttributes->is_negative_scale());
+
+    // Plan execution
+    auto variantPack = planBundle.toHostVariantPack();
+    BlockScaleDequantizePlan<float, float, float, float> plan(std::move(params));
+    plan.execute(variantPack);
+
+    const float tolerance = 1e-5f;
+    const CpuFpReferenceValidation<float> cpuRefOutputValidation(tolerance, tolerance);
+    EXPECT_TRUE(
+        cpuRefOutputValidation.allClose(directBundle.getTensor(3), planBundle.getTensor(3)));
+}
+
+TEST(TestBlockScaleDequantizePlan, ExecutePlanNegativeScale)
+{
+    auto builder = createValidBlockScaleDequantizeGraph(
+        {65536, 2048, 64, 1}, {2, 32, 32, 64}, DataType::FLOAT, DataType::FLOAT, true);
+    const GraphWrapper graphWrapper(builder.GetBufferPointer(), builder.GetSize());
+
+    const auto& node = graphWrapper.getNode(0);
+    const auto& tensorMap = graphWrapper.getTensorMap();
+
+    const unsigned int seed = getGlobalTestSeed();
+    GraphTensorBundle planBundle(tensorMap);
+    GraphTensorBundle directBundle(tensorMap);
+
+    planBundle.getTensor(1).fillTensorWithRandomValues(0.0f, 1.0f, seed);
+    planBundle.getTensor(2).fillTensorWithRandomValues(0.1f, 2.0f, seed);
+    directBundle.getTensor(1).fillTensorWithRandomValues(0.0f, 1.0f, seed);
+    directBundle.getTensor(2).fillTensorWithRandomValues(0.1f, 2.0f, seed);
+
+    const auto* nodeAttributes = node.attributes_as_BlockScaleDequantizeAttributes();
+    ASSERT_NE(nodeAttributes, nullptr);
+    ASSERT_TRUE(nodeAttributes->is_negative_scale());
+
+    std::vector<int32_t> blockSize;
+    if(nodeAttributes->block_size() != nullptr)
+    {
+        const auto* bs = nodeAttributes->block_size();
+        blockSize.assign(bs->begin(), bs->end());
+    }
+
+    BlockScaleDequantizeParams params(*tensorMap.at(nodeAttributes->x_tensor_uid()),
+                                      *tensorMap.at(nodeAttributes->scale_tensor_uid()),
+                                      *tensorMap.at(nodeAttributes->y_tensor_uid()),
+                                      blockSize,
+                                      nodeAttributes->is_negative_scale());
+
+    auto directXTensor
+        = createShallowTensor<float>(params.xTensor, directBundle.getTensor(1).rawHostData());
+    auto directScaleTensor
+        = createShallowTensor<float>(params.scaleTensor, directBundle.getTensor(2).rawHostData());
+    auto directYTensor
+        = createShallowTensor<float>(params.yTensor, directBundle.getTensor(3).rawHostData());
+
+    CpuFpReferenceBlockScaleDequantize::dequantize(
+        *directXTensor, *directScaleTensor, *directYTensor, blockSize, true);
+
+    auto variantPack = planBundle.toHostVariantPack();
+    BlockScaleDequantizePlan<float, float, float, float> plan(std::move(params));
+    plan.execute(variantPack);
+
+    const float tolerance = 1e-5f;
+    const CpuFpReferenceValidation<float> cpuRefOutputValidation(tolerance, tolerance);
+    EXPECT_TRUE(
+        cpuRefOutputValidation.allClose(directBundle.getTensor(3), planBundle.getTensor(3)));
+}
+
+TEST(TestBlockScaleDequantizePlanBuilder, PlanConstruction)
+{
+    auto builder = createValidBlockScaleDequantizeGraph();
+    const GraphWrapper graphWrapper(builder.GetBufferPointer(), builder.GetSize());
+
+    const BlockScaleDequantizePlanBuilder<DataType::FLOAT,
+                                          DataType::FLOAT,
+                                          DataType::FLOAT,
+                                          DataType::FLOAT>
+        patient;
+
+    auto builtPlan = patient.buildNodePlan(graphWrapper, graphWrapper.getNode(0));
+
+    const bool result
+        = dynamic_cast<BlockScaleDequantizePlan<float, float, float, float>*>(builtPlan.get())
+          != nullptr;
+    EXPECT_TRUE(result);
+}
+
+TEST(TestBlockScaleDequantizePlanBuilder, IsApplicable)
+{
+    auto builder = createValidBlockScaleDequantizeGraph();
+    const GraphWrapper graphWrapper(builder.GetBufferPointer(), builder.GetSize());
+
+    const BlockScaleDequantizePlanBuilder<DataType::FLOAT,
+                                          DataType::FLOAT,
+                                          DataType::FLOAT,
+                                          DataType::FLOAT>
+        floatPlanBuilder;
+
+    EXPECT_TRUE(
+        floatPlanBuilder.isApplicable(graphWrapper.getNode(0), graphWrapper.getTensorMap()));
+
+    const BlockScaleDequantizePlanBuilder<DataType::HALF,
+                                          DataType::FLOAT,
+                                          DataType::FLOAT,
+                                          DataType::FLOAT>
+        badTypesPlanBuilder;
+    EXPECT_FALSE(
+        badTypesPlanBuilder.isApplicable(graphWrapper.getNode(0), graphWrapper.getTensorMap()));
+
+    // MX combinations: FP8 input with E8M0 scale
+    auto mxBuilder = createValidBlockScaleDequantizeMxGraph(
+        DataType::FP8_E4M3, DataType::FP8_E8M0, DataType::FLOAT);
+    const GraphWrapper mxGraphWrapper(mxBuilder.GetBufferPointer(), mxBuilder.GetSize());
+
+    const BlockScaleDequantizePlanBuilder<DataType::FP8_E4M3,
+                                          DataType::FP8_E8M0,
+                                          DataType::FLOAT,
+                                          DataType::FLOAT>
+        e4m3FloatBuilder;
+    EXPECT_TRUE(
+        e4m3FloatBuilder.isApplicable(mxGraphWrapper.getNode(0), mxGraphWrapper.getTensorMap()));
+
+    const BlockScaleDequantizePlanBuilder<DataType::FP8_E5M2,
+                                          DataType::FP8_E8M0,
+                                          DataType::FLOAT,
+                                          DataType::FLOAT>
+        e5m2FloatBuilder;
+    EXPECT_FALSE(
+        e5m2FloatBuilder.isApplicable(mxGraphWrapper.getNode(0), mxGraphWrapper.getTensorMap()));
+}
+
+// ============================================================================
+// MX plan typed tests: all narrow types with fp8_e8m0 scale
+// ============================================================================
+
+template <DataType XDT, DataType ScaleDT, DataType OutputDT>
+struct MxPlanConfig
+{
+    static constexpr auto X_DATA_TYPE = XDT;
+    static constexpr auto SCALE_DATA_TYPE = ScaleDT;
+    static constexpr auto OUTPUT_DATA_TYPE = OutputDT;
+    using XType = DataTypeToNative<XDT>;
+    using ScaleType = DataTypeToNative<ScaleDT>;
+    using OutputType = DataTypeToNative<OutputDT>;
+};
+
+using MxPlanTypes
+    = ::testing::Types<MxPlanConfig<DataType::FP8_E4M3, DataType::FP8_E8M0, DataType::FLOAT>,
+                       MxPlanConfig<DataType::FP8_E4M3, DataType::FP8_E8M0, DataType::HALF>,
+                       MxPlanConfig<DataType::FP8_E5M2, DataType::FP8_E8M0, DataType::FLOAT>,
+                       MxPlanConfig<DataType::FP8_E5M2, DataType::FP8_E8M0, DataType::HALF>,
+                       MxPlanConfig<DataType::FP4_E2M1, DataType::FP8_E8M0, DataType::FLOAT>,
+                       MxPlanConfig<DataType::FP4_E2M1, DataType::FP8_E8M0, DataType::HALF>,
+                       MxPlanConfig<DataType::FP6_E2M3, DataType::FP8_E8M0, DataType::FLOAT>,
+                       MxPlanConfig<DataType::FP6_E2M3, DataType::FP8_E8M0, DataType::HALF>,
+                       MxPlanConfig<DataType::FP6_E3M2, DataType::FP8_E8M0, DataType::FLOAT>,
+                       MxPlanConfig<DataType::FP6_E3M2, DataType::FP8_E8M0, DataType::HALF>>;
+
+template <class T>
+class BlockScaleDequantizeMxPlan : public ::testing::Test
+{
+};
+
+TYPED_TEST_SUITE(BlockScaleDequantizeMxPlan, MxPlanTypes, );
+
+TYPED_TEST(BlockScaleDequantizeMxPlan, ExecutePlan)
+{
+    using namespace hipdnn_data_sdk::types;
+    using Config = TypeParam;
+    using XType = typename Config::XType;
+    using ScaleType = typename Config::ScaleType;
+    using OutputType = typename Config::OutputType;
+
+    auto builder = createValidBlockScaleDequantizeMxGraph(
+        Config::X_DATA_TYPE, Config::SCALE_DATA_TYPE, Config::OUTPUT_DATA_TYPE);
+    const GraphWrapper graphWrapper(builder.GetBufferPointer(), builder.GetSize());
+
+    const auto& node = graphWrapper.getNode(0);
+    const auto& tensorMap = graphWrapper.getTensorMap();
+    const auto* nodeAttributes = node.attributes_as_BlockScaleDequantizeAttributes();
+    ASSERT_NE(nodeAttributes, nullptr);
+
+    std::vector<int32_t> blockSize;
+    if(nodeAttributes->block_size() != nullptr)
+    {
+        const auto* bs = nodeAttributes->block_size();
+        blockSize.assign(bs->begin(), bs->end());
+    }
+
+    GraphTensorBundle planBundle(tensorMap);
+    GraphTensorBundle directBundle(tensorMap);
+
+    // Set x values via raw host data
+    auto* planXData = static_cast<XType*>(planBundle.getTensor(1).rawHostData());
+    planXData[0] = XType(1.0f);
+    planXData[1] = XType(1.0f);
+    planXData[2] = XType(2.0f);
+    planXData[3] = XType(2.0f);
+
+    auto* directXData = static_cast<XType*>(directBundle.getTensor(1).rawHostData());
+    directXData[0] = XType(1.0f);
+    directXData[1] = XType(1.0f);
+    directXData[2] = XType(2.0f);
+    directXData[3] = XType(2.0f);
+
+    // Set scale values (fp8_e8m0): bits=127 => 1.0, bits=128 => 2.0
+    auto* planScaleData = static_cast<ScaleType*>(planBundle.getTensor(2).rawHostData());
+    planScaleData[0] = fp8_e8m0::from_bits(127);
+    planScaleData[1] = fp8_e8m0::from_bits(128);
+
+    auto* directScaleData = static_cast<ScaleType*>(directBundle.getTensor(2).rawHostData());
+    directScaleData[0] = fp8_e8m0::from_bits(127);
+    directScaleData[1] = fp8_e8m0::from_bits(128);
+
+    BlockScaleDequantizeParams params(*tensorMap.at(nodeAttributes->x_tensor_uid()),
+                                      *tensorMap.at(nodeAttributes->scale_tensor_uid()),
+                                      *tensorMap.at(nodeAttributes->y_tensor_uid()),
+                                      blockSize,
+                                      nodeAttributes->is_negative_scale());
+
+    // Direct reference execution
+    auto directXTensor
+        = createShallowTensor<XType>(params.xTensor, directBundle.getTensor(1).rawHostData());
+    auto directScaleTensor = createShallowTensor<ScaleType>(
+        params.scaleTensor, directBundle.getTensor(2).rawHostData());
+    auto directYTensor
+        = createShallowTensor<OutputType>(params.yTensor, directBundle.getTensor(3).rawHostData());
+
+    CpuFpReferenceBlockScaleDequantize::dequantize(
+        *directXTensor, *directScaleTensor, *directYTensor, blockSize, false);
+
+    // Plan execution
+    auto variantPack = planBundle.toHostVariantPack();
+    BlockScaleDequantizePlan<XType, ScaleType, OutputType, float> plan(std::move(params));
+    plan.execute(variantPack);
+
+    const float tolerance = 1e-2f;
+    const CpuFpReferenceValidation<OutputType> cpuRefOutputValidation(tolerance, tolerance);
+    EXPECT_TRUE(
+        cpuRefOutputValidation.allClose(directBundle.getTensor(3), planBundle.getTensor(3)));
+}
+
+// ============================================================================
+// Non-float input plan typed tests: half/bfloat16 input with float scale
+// ============================================================================
+
+using NonFloatInputPlanTypes
+    = ::testing::Types<MxPlanConfig<DataType::HALF, DataType::FLOAT, DataType::FLOAT>,
+                       MxPlanConfig<DataType::HALF, DataType::FLOAT, DataType::HALF>,
+                       MxPlanConfig<DataType::BFLOAT16, DataType::FLOAT, DataType::FLOAT>,
+                       MxPlanConfig<DataType::BFLOAT16, DataType::FLOAT, DataType::BFLOAT16>>;
+
+template <class T>
+class BlockScaleDequantizeNonFloatInputPlan : public ::testing::Test
+{
+};
+
+TYPED_TEST_SUITE(BlockScaleDequantizeNonFloatInputPlan, NonFloatInputPlanTypes, );
+
+TYPED_TEST(BlockScaleDequantizeNonFloatInputPlan, ExecutePlan)
+{
+    using namespace hipdnn_data_sdk::types;
+    using Config = TypeParam;
+    using XType = typename Config::XType;
+    using ScaleType = typename Config::ScaleType;
+    using OutputType = typename Config::OutputType;
+
+    auto builder = createValidBlockScaleDequantizeMxGraph(
+        Config::X_DATA_TYPE, Config::SCALE_DATA_TYPE, Config::OUTPUT_DATA_TYPE);
+    const GraphWrapper graphWrapper(builder.GetBufferPointer(), builder.GetSize());
+
+    const auto& node = graphWrapper.getNode(0);
+    const auto& tensorMap = graphWrapper.getTensorMap();
+    const auto* nodeAttributes = node.attributes_as_BlockScaleDequantizeAttributes();
+    ASSERT_NE(nodeAttributes, nullptr);
+
+    std::vector<int32_t> blockSize;
+    if(nodeAttributes->block_size() != nullptr)
+    {
+        const auto* bs = nodeAttributes->block_size();
+        blockSize.assign(bs->begin(), bs->end());
+    }
+
+    GraphTensorBundle planBundle(tensorMap);
+    GraphTensorBundle directBundle(tensorMap);
+
+    // Set x values
+    auto* planXData = static_cast<XType*>(planBundle.getTensor(1).rawHostData());
+    planXData[0] = XType(1.0f);
+    planXData[1] = XType(1.0f);
+    planXData[2] = XType(2.0f);
+    planXData[3] = XType(2.0f);
+
+    auto* directXData = static_cast<XType*>(directBundle.getTensor(1).rawHostData());
+    directXData[0] = XType(1.0f);
+    directXData[1] = XType(1.0f);
+    directXData[2] = XType(2.0f);
+    directXData[3] = XType(2.0f);
+
+    // Set float scale values: scale[0] = 1.5, scale[1] = 2.0
+    auto* planScaleData = static_cast<ScaleType*>(planBundle.getTensor(2).rawHostData());
+    planScaleData[0] = ScaleType(1.5f);
+    planScaleData[1] = ScaleType(2.0f);
+
+    auto* directScaleData = static_cast<ScaleType*>(directBundle.getTensor(2).rawHostData());
+    directScaleData[0] = ScaleType(1.5f);
+    directScaleData[1] = ScaleType(2.0f);
+
+    BlockScaleDequantizeParams params(*tensorMap.at(nodeAttributes->x_tensor_uid()),
+                                      *tensorMap.at(nodeAttributes->scale_tensor_uid()),
+                                      *tensorMap.at(nodeAttributes->y_tensor_uid()),
+                                      blockSize,
+                                      nodeAttributes->is_negative_scale());
+
+    auto directXTensor
+        = createShallowTensor<XType>(params.xTensor, directBundle.getTensor(1).rawHostData());
+    auto directScaleTensor = createShallowTensor<ScaleType>(
+        params.scaleTensor, directBundle.getTensor(2).rawHostData());
+    auto directYTensor
+        = createShallowTensor<OutputType>(params.yTensor, directBundle.getTensor(3).rawHostData());
+
+    CpuFpReferenceBlockScaleDequantize::dequantize(
+        *directXTensor, *directScaleTensor, *directYTensor, blockSize, false);
+
+    auto variantPack = planBundle.toHostVariantPack();
+    BlockScaleDequantizePlan<XType, ScaleType, OutputType, float> plan(std::move(params));
+    plan.execute(variantPack);
+
+    const float tolerance = 1e-2f;
+    const CpuFpReferenceValidation<OutputType> cpuRefOutputValidation(tolerance, tolerance);
+    EXPECT_TRUE(
+        cpuRefOutputValidation.allClose(directBundle.getTensor(3), planBundle.getTensor(3)));
+}
+
+// ============================================================================
+// MX IsApplicable typed tests: narrow types with fp8_e8m0 scale
+// ============================================================================
+
+template <DataType CorrectDT, DataType WrongDT>
+struct MxIsApplicableConfig
+{
+    static constexpr auto CORRECT_DATA_TYPE = CorrectDT;
+    static constexpr auto WRONG_DATA_TYPE = WrongDT;
+};
+
+using MxIsApplicableTypes
+    = ::testing::Types<MxIsApplicableConfig<DataType::FP4_E2M1, DataType::FP6_E2M3>,
+                       MxIsApplicableConfig<DataType::FP6_E2M3, DataType::FP6_E3M2>,
+                       MxIsApplicableConfig<DataType::FP6_E3M2, DataType::FP4_E2M1>>;
+
+template <class T>
+class BlockScaleDequantizeMxIsApplicable : public ::testing::Test
+{
+};
+
+TYPED_TEST_SUITE(BlockScaleDequantizeMxIsApplicable, MxIsApplicableTypes, );
+
+TYPED_TEST(BlockScaleDequantizeMxIsApplicable, MatchingTypeIsApplicable)
+{
+    using Config = TypeParam;
+
+    auto mxBuilder = createValidBlockScaleDequantizeMxGraph(
+        Config::CORRECT_DATA_TYPE, DataType::FP8_E8M0, DataType::FLOAT);
+    const GraphWrapper mxGraphWrapper(mxBuilder.GetBufferPointer(), mxBuilder.GetSize());
+
+    const BlockScaleDequantizePlanBuilder<Config::CORRECT_DATA_TYPE,
+                                          DataType::FP8_E8M0,
+                                          DataType::FLOAT,
+                                          DataType::FLOAT>
+        matchingBuilder;
+    EXPECT_TRUE(
+        matchingBuilder.isApplicable(mxGraphWrapper.getNode(0), mxGraphWrapper.getTensorMap()));
+
+    const BlockScaleDequantizePlanBuilder<Config::WRONG_DATA_TYPE,
+                                          DataType::FP8_E8M0,
+                                          DataType::FLOAT,
+                                          DataType::FLOAT>
+        wrongTypeBuilder;
+    EXPECT_FALSE(
+        wrongTypeBuilder.isApplicable(mxGraphWrapper.getNode(0), mxGraphWrapper.getTensorMap()));
+}

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestBlockScaleDequantizeSignatureKey.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestBlockScaleDequantizeSignatureKey.cpp
@@ -1,0 +1,103 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include <gtest/gtest.h>
+#include <unordered_map>
+#include <unordered_set>
+
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
+#include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BlockScaleDequantizeSignatureKey.hpp>
+
+using namespace hipdnn_test_sdk::utilities;
+using namespace hipdnn_test_sdk::detail;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
+using namespace hipdnn_data_sdk::utilities;
+
+TEST(TestBlockScaleDequantizeSignatureKey, EqualityOperator)
+{
+    const BlockScaleDequantizeSignatureKey key1{
+        DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT};
+    const BlockScaleDequantizeSignatureKey key2{
+        DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT};
+    EXPECT_TRUE(key1 == key2);
+
+    const BlockScaleDequantizeSignatureKey key3{
+        DataType::HALF, DataType::FLOAT, DataType::HALF, DataType::FLOAT};
+    const BlockScaleDequantizeSignatureKey key4{
+        DataType::HALF, DataType::FLOAT, DataType::HALF, DataType::FLOAT};
+    EXPECT_TRUE(key3 == key4);
+
+    const BlockScaleDequantizeSignatureKey key5{
+        DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT};
+    const BlockScaleDequantizeSignatureKey key6{
+        DataType::HALF, DataType::FLOAT, DataType::HALF, DataType::FLOAT};
+    EXPECT_FALSE(key5 == key6);
+
+    const BlockScaleDequantizeSignatureKey key7{
+        DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT};
+    const BlockScaleDequantizeSignatureKey key8{
+        DataType::FLOAT, DataType::HALF, DataType::FLOAT, DataType::FLOAT};
+    EXPECT_FALSE(key7 == key8);
+
+    const BlockScaleDequantizeSignatureKey key9{
+        DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT};
+    const BlockScaleDequantizeSignatureKey key10{
+        DataType::FLOAT, DataType::FLOAT, DataType::DOUBLE, DataType::FLOAT};
+    EXPECT_FALSE(key9 == key10);
+}
+
+TEST(TestBlockScaleDequantizeSignatureKey, HashFunction)
+{
+    const BlockScaleDequantizeSignatureKey key1{
+        DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT};
+    const BlockScaleDequantizeSignatureKey key2{
+        DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT};
+
+    EXPECT_EQ(key1.hashSelf(), key2.hashSelf());
+
+    const BlockScaleDequantizeSignatureKey key3{
+        DataType::HALF, DataType::FLOAT, DataType::HALF, DataType::FLOAT};
+    const BlockScaleDequantizeSignatureKey key4{
+        DataType::FLOAT, DataType::HALF, DataType::FLOAT, DataType::FLOAT};
+    const BlockScaleDequantizeSignatureKey key5{
+        DataType::FLOAT, DataType::FLOAT, DataType::HALF, DataType::FLOAT};
+    const BlockScaleDequantizeSignatureKey key6{
+        DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::HALF};
+
+    const auto hash3 = key3.hashSelf();
+    const auto hash4 = key4.hashSelf();
+    const auto hash5 = key5.hashSelf();
+    const auto hash6 = key6.hashSelf();
+
+    EXPECT_TRUE(hash3 != hash4 && hash3 != hash5 && hash4 != hash5 && hash3 != hash6
+                && hash4 != hash6 && hash5 != hash6);
+}
+
+TEST(TestBlockScaleDequantizeSignatureKey, Copy)
+{
+    const BlockScaleDequantizeSignatureKey original{
+        DataType::FLOAT, DataType::HALF, DataType::FLOAT, DataType::BFLOAT16};
+    const BlockScaleDequantizeSignatureKey copied{original};
+
+    EXPECT_TRUE(original == copied);
+    EXPECT_EQ(copied.xDataType, DataType::FLOAT);
+    EXPECT_EQ(copied.scaleDataType, DataType::HALF);
+    EXPECT_EQ(copied.outputDataType, DataType::FLOAT);
+    EXPECT_EQ(copied.computeDataType, DataType::BFLOAT16);
+}
+
+TEST(TestBlockScaleDequantizeSignatureKey, CreateFromNodeAndTensorMap)
+{
+    const BlockScaleDequantizeSignatureKey expectedKey{
+        DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT};
+
+    auto builder = createValidBlockScaleDequantizeGraph();
+    const auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        builder.GetBufferPointer(), builder.GetSize());
+
+    const BlockScaleDequantizeSignatureKey keyFromNode(graphWrap.getNode(0),
+                                                       graphWrap.getTensorMap());
+
+    EXPECT_TRUE(keyFromNode == expectedKey);
+}

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestCpuReferenceGraphExecutor.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestCpuReferenceGraphExecutor.cpp
@@ -9,10 +9,19 @@
 
 #include "BatchnormGraphUtils.hpp"
 #include "BatchnormTensorBundles.hpp"
+#include "BlockScaleDequantizeGraphUtils.hpp"
 #include "ConvolutionGraphUtils.hpp"
+#include "LayernormGraphUtils.hpp"
+#include "LayernormTensorBundles.hpp"
 #include "MatmulGraphUtils.hpp"
 #include "PointwiseGraphUtils.hpp"
 #include "PointwiseTensorBundles.hpp"
+#include "RMSNormGraphUtils.hpp"
+#include "RMSNormTensorBundles.hpp"
+#ifdef HIPDNN_ENABLE_SDPA
+#include "SdpaGraphUtils.hpp"
+#include "SdpaTensorBundles.hpp"
+#endif
 
 #include <hipdnn_data_sdk/types.hpp>
 #include <hipdnn_data_sdk/utilities/ShallowTensor.hpp>
@@ -239,6 +248,122 @@ public:
         CpuReferenceGraphExecutor().execute(
             serializedGraph.data(), serializedGraph.size(), variantPack);
     }
+
+    static void
+        runLayernormTest(hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType,
+                         hipdnn_flatbuffers_sdk::data_objects::DataType scaleBiasDataType,
+                         hipdnn_flatbuffers_sdk::data_objects::DataType meanInvVarianceDataType,
+                         hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType)
+    {
+        const unsigned int seed = getGlobalTestSeed();
+        const std::vector<int64_t> dims = {1, 3, 14, 14};
+
+        auto graph = buildLayernormFpropGraph(inputDataType,
+                                              scaleBiasDataType,
+                                              meanInvVarianceDataType,
+                                              computeDataType,
+                                              dims,
+                                              2, // normalize over last 2 dims
+                                              TensorLayout::NCHW);
+
+        auto result = graph->validate();
+        ASSERT_EQ(result.code, hipdnn_frontend::ErrorCode::OK) << result.err_msg;
+
+        auto [serializedGraph, serErr] = graph->to_binary();
+        ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
+        const GraphWrapper graphWrapper(serializedGraph.data(), serializedGraph.size());
+
+        LayernormFpropTensorBundle tensorBundle(
+            graphWrapper.getNodeWrapper(0), graphWrapper.getTensorMap(), seed);
+
+        auto variantPack = tensorBundle.toHostVariantPack();
+
+        CpuReferenceGraphExecutor().execute(
+            serializedGraph.data(), serializedGraph.size(), variantPack);
+    }
+
+    static void runRMSNormTest(hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType,
+                               hipdnn_flatbuffers_sdk::data_objects::DataType scaleDataType,
+                               hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType)
+    {
+        const unsigned int seed = getGlobalTestSeed();
+        const std::vector<int64_t> dims = {1, 3, 14, 14};
+
+        auto graph = buildRMSNormFwdGraph(
+            inputDataType, scaleDataType, computeDataType, dims, TensorLayout::NCHW);
+
+        auto result = graph->validate();
+        ASSERT_EQ(result.code, hipdnn_frontend::ErrorCode::OK) << result.err_msg;
+
+        auto [serializedGraph, serErr] = graph->to_binary();
+        ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
+        const GraphWrapper graphWrapper(serializedGraph.data(), serializedGraph.size());
+
+        RMSNormFwdTensorBundle tensorBundle(
+            graphWrapper.getNodeWrapper(0), graphWrapper.getTensorMap(), seed);
+
+        auto variantPack = tensorBundle.toHostVariantPack();
+
+        CpuReferenceGraphExecutor().execute(
+            serializedGraph.data(), serializedGraph.size(), variantPack);
+    }
+
+#ifdef HIPDNN_ENABLE_SDPA
+    template <typename InputType>
+    static void runSdpaTest(hipdnn_flatbuffers_sdk::data_objects::DataType dataType)
+    {
+        // Q/K/V: [batch=1, heads=2, seq=4, head_dim=8]
+        const std::vector<int64_t> qDims = {1, 2, 4, 8};
+        const std::vector<int64_t> kDims = {1, 2, 4, 8};
+        const std::vector<int64_t> vDims = {1, 2, 4, 8};
+
+        SdpaFwdTensorBundle<InputType> tensorBundle(qDims, kDims, vDims);
+
+        auto graphTuple = buildSdpaFwdGraph(tensorBundle, dataType);
+
+        auto& graph = std::get<0>(graphTuple);
+        auto& variantPack = std::get<1>(graphTuple);
+
+        auto result = graph->validate();
+        ASSERT_EQ(result.code, hipdnn_frontend::ErrorCode::OK) << result.err_msg;
+
+        auto [serializedGraph, serErr] = graph->to_binary();
+        ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
+
+        CpuReferenceGraphExecutor().execute(
+            serializedGraph.data(), serializedGraph.size(), variantPack);
+    }
+#endif
+
+    template <typename XType, typename ScaleType>
+    static void
+        runBlockScaleDequantizeTest(hipdnn_flatbuffers_sdk::data_objects::DataType xDataType,
+                                    hipdnn_flatbuffers_sdk::data_objects::DataType scaleDataType,
+                                    hipdnn_flatbuffers_sdk::data_objects::DataType yDataType,
+                                    hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType)
+    {
+        const std::vector<int64_t> xDims = {2, 32, 32, 64};
+        const std::vector<int32_t> blockSize = {32};
+        // scale dims: ceil(64/32) = 2 for the blocked trailing dim
+        const std::vector<int64_t> scaleDims = {2, 32, 32, 2};
+
+        BlockScaleDequantizeTensorBundle<XType, ScaleType> tensorBundle(xDims, scaleDims);
+
+        auto graphTuple = buildBlockScaleDequantizeGraph(
+            tensorBundle, xDataType, scaleDataType, yDataType, computeDataType, blockSize);
+
+        auto& graph = std::get<0>(graphTuple);
+        auto& variantPack = std::get<1>(graphTuple);
+
+        auto result = graph->validate();
+        ASSERT_EQ(result.code, hipdnn_frontend::ErrorCode::OK) << result.err_msg;
+
+        auto [serializedGraph2, serErr2] = graph->to_binary();
+        ASSERT_TRUE(serErr2.is_good()) << serErr2.get_message();
+
+        CpuReferenceGraphExecutor().execute(
+            serializedGraph2.data(), serializedGraph2.size(), variantPack);
+    }
 };
 
 TEST(TestCpuReferenceGraphExecutor, BatchnormFwdInferenceAllFloats)
@@ -386,3 +511,65 @@ TEST(TestCpuReferenceGraphExecutor, PointwiseBinaryAdd)
     CpuReferenceGraphExecutor().execute(
         serializedGraph.data(), serializedGraph.size(), variantPack);
 }
+
+TEST(TestCpuReferenceGraphExecutor, BlockScaleDequantizeAllFloats)
+{
+    TestCpuReferenceGraphExecutor::runBlockScaleDequantizeTest<float, float>(
+        DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT);
+}
+TEST(TestCpuReferenceGraphExecutor, BlockScaleDequantizeHalfInputFloatScale)
+{
+    TestCpuReferenceGraphExecutor::runBlockScaleDequantizeTest<half, float>(
+        DataType::HALF, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT);
+}
+TEST(TestCpuReferenceGraphExecutor, BlockScaleDequantizeBFloat16InputFloatScale)
+{
+    TestCpuReferenceGraphExecutor::runBlockScaleDequantizeTest<bfloat16, float>(
+        DataType::BFLOAT16, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT);
+}
+
+TEST(TestCpuReferenceGraphExecutor, LayernormAllFloats)
+{
+    TestCpuReferenceGraphExecutor::runLayernormTest(
+        DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT);
+}
+TEST(TestCpuReferenceGraphExecutor, LayernormAllHalfs)
+{
+    TestCpuReferenceGraphExecutor::runLayernormTest(
+        DataType::HALF, DataType::HALF, DataType::HALF, DataType::HALF);
+}
+TEST(TestCpuReferenceGraphExecutor, LayernormAllBFloat16)
+{
+    TestCpuReferenceGraphExecutor::runLayernormTest(
+        DataType::BFLOAT16, DataType::BFLOAT16, DataType::BFLOAT16, DataType::BFLOAT16);
+}
+
+TEST(TestCpuReferenceGraphExecutor, RMSNormAllFloats)
+{
+    TestCpuReferenceGraphExecutor::runRMSNormTest(
+        DataType::FLOAT, DataType::FLOAT, DataType::FLOAT);
+}
+TEST(TestCpuReferenceGraphExecutor, RMSNormAllHalfs)
+{
+    TestCpuReferenceGraphExecutor::runRMSNormTest(DataType::HALF, DataType::HALF, DataType::HALF);
+}
+TEST(TestCpuReferenceGraphExecutor, RMSNormAllBFloat16)
+{
+    TestCpuReferenceGraphExecutor::runRMSNormTest(
+        DataType::BFLOAT16, DataType::BFLOAT16, DataType::BFLOAT16);
+}
+
+#ifdef HIPDNN_ENABLE_SDPA
+TEST(TestCpuReferenceGraphExecutor, SdpaAllFloats)
+{
+    TestCpuReferenceGraphExecutor::runSdpaTest<float>(DataType::FLOAT);
+}
+TEST(TestCpuReferenceGraphExecutor, SdpaAllHalfs)
+{
+    TestCpuReferenceGraphExecutor::runSdpaTest<half>(DataType::HALF);
+}
+TEST(TestCpuReferenceGraphExecutor, SdpaAllBFloat16)
+{
+    TestCpuReferenceGraphExecutor::runSdpaTest<bfloat16>(DataType::BFLOAT16);
+}
+#endif


### PR DESCRIPTION
## Summary

- Adds `CpuFpReferenceBlockScaleDequantize` utility for computing the CPU reference output of block scale dequantize operations (MX types: fp4, fp6, fp8 with fp8_e8m0 scale)
- Adds `BlockScaleDequantizeSignatureKey` and `BlockScaleDequantizePlan` to the `CpuReferenceGraphExecutor` plan registry
- Extends `CpuReferenceGraphExecutor` to dispatch block scale dequantize nodes
- Adds integration test (`TestCpuReferenceGraphExecutor`) covering the full execute path, plus unit tests for the plan and signature key
- Extends `FlatbufferDatatypeMapping` with MX data types (fp8_e4m3, fp8_e5m2, fp8_e8m0, fp4_e2m1, fp6_e2m3, fp6_e3m2)
- Updates `FlatbufferGraphTestUtils` with separate `scaleDataType` and `outputDataType` parameters in `createValidBlockScaleDequantizeGraph` (addresses reviewer feedback)

## Test plan

- [x] `ninja check` in `projects/hipdnn/build` — all 9 test suites pass, 0 failures