### PR TITLE
Add GitHub Action to close stale PRs

### DIFF
--- a/.github/close-stale-prs.yml
+++ b/.github/close-stale-prs.yml
@@ -22,27 +22,27 @@ jobs:
           only-pr-labels: ''
 
           # Days before marking as stale
-          days-before-stale: 30
+          days-before-stale: 25
 
           # Days before closing after being marked stale
-          days-before-close: 15
+          days-before-close: 5
 
           # Label to apply when PR becomes stale
           stale-pr-label: 'stale'
 
           # Message to post when PR becomes stale
           stale-pr-message: |
-            This pull request has been inactive for 30 days and will be marked as stale.
+            This pull request has been inactive for 25 days and will be marked as stale.
 
             If you would like to keep this PR open, please:
             - Add new commits
             - Add a comment explaining why it should remain open
 
-            This PR will be automatically closed in 15 days if no further activity occurs.
+            This PR will be automatically closed in 5 days if no further activity occurs.
 
           # Message to post when closing the PR
           close-pr-message: |
-            This pull request has been automatically closed due to inactivity (45 days with no updates).
+            This pull request has been automatically closed due to inactivity (30 days with no updates).
 
             If you'd like to continue working on this, feel free to reopen the PR or create a new one.
 

--- a/.github/close-stale-prs.yml
+++ b/.github/close-stale-prs.yml
@@ -1,0 +1,63 @@
+name: Close Stale PRs
+
+on:
+  schedule:
+    # Run daily at 00:00 UTC
+    - cron: '0 0 * * *'
+  workflow_dispatch: # Allow manual triggering
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - uses: actions/stale@v10
+        with:
+          # Only process PRs, not issues
+          only-pr-labels: ''
+
+          # Days before marking as stale
+          days-before-stale: 30
+
+          # Days before closing after being marked stale
+          days-before-close: 15
+
+          # Label to apply when PR becomes stale
+          stale-pr-label: 'stale'
+
+          # Message to post when PR becomes stale
+          stale-pr-message: |
+            This pull request has been inactive for 30 days and will be marked as stale.
+
+            If you would like to keep this PR open, please:
+            - Add new commits
+            - Add a comment explaining why it should remain open
+
+            This PR will be automatically closed in 15 days if no further activity occurs.
+
+          # Message to post when closing the PR
+          close-pr-message: |
+            This pull request has been automatically closed due to inactivity (45 days with no updates).
+
+            If you'd like to continue working on this, feel free to reopen the PR or create a new one.
+
+          # Don't process issues, only PRs
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+
+          # Exempt PRs with these labels from being marked stale
+          exempt-pr-labels: 'keep-open,in-progress,blocked'
+
+          # Remove stale label when PR has activity
+          remove-stale-when-updated: true
+
+          # Ascending order processes oldest PRs first
+          ascending: true
+
+          # Maximum number of operations per run (to avoid API rate limits)
+          operations-per-run: 100


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Close stale PRs to reduce load on CI. PRs can be reopened if needed.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Uses https://github.com/actions/stale

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Tested on test repo using 1 day values for `days-before-stale` and `days-before-close`

## Test Result

<!-- Briefly summarize test outcomes. -->

Successfully commented after `days-before-stale` days and closed after `days-before-close`

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
