### PR TITLE
[hipDNN][SDPA] Implement backward workspace size reporting

### DIFF
--- a/dnn-providers/hip-kernel-provider/src/engines/asm_sdpa_engine/plans/SdpaBwdPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/asm_sdpa_engine/plans/SdpaBwdPlanBuilder.cpp
@@ -8,6 +8,30 @@
 #include <hip_kernel_provider_common/HipDeviceUtils.hpp>
 #include <hipdnn_plugin_sdk/PluginLogging.hpp>
 
+namespace
+{
+// In AITER (upstream), each workspace buffer (D buffer, dq_acc) is a separate PyTorch tensor
+// allocation. Each torch::empty() call invokes hipMalloc(), which guarantees 256-byte alignment
+// per allocation. So AITER never explicitly aligns — every buffer pointer is automatically aligned.
+//
+// In hip-kernel-provider, hipDNN provides a single contiguous workspace buffer (one hipMalloc).
+// The execute() method must carve this into sub-buffers using pointer arithmetic:
+//   D buffer    starts at: workspace + 0                     (aligned by hipMalloc)
+//   dq_acc      starts at: workspace + sizeof(D buffer)      (NOT automatically aligned)
+//
+// We round each sub-buffer size up to a 64-byte boundary (MI300X L2 cache line size) so the
+// next sub-buffer starts cache-line-aligned. This prevents false sharing between buffers and
+// ensures vector memory instructions (e.g. global_load_b128) don't span cache line boundaries.
+//
+// TODO(Task I8.9): POC hardcodes 64 bytes; production should query hipGetDeviceProperties()
+constexpr size_t K_WORKSPACE_ALIGNMENT_BYTES = 64;
+
+constexpr size_t alignUp(size_t size, size_t alignment)
+{
+    return (size + alignment - 1) & ~(alignment - 1);
+}
+} // namespace
+
 namespace asm_sdpa_engine
 {
 
@@ -160,14 +184,14 @@ size_t SdpaBwdPlanBuilder::getMaxWorkspaceSize(
     // D buffer: row-wise dot product output [B, H_q, S_q] in FP32
     // Always needed for both a16 and a32 accumulator variants
     size_t dBufferSize = batch * headsQ * seqLenQ * sizeof(float);
-    dBufferSize = (dBufferSize + 63) & ~size_t{63};
+    dBufferSize = alignUp(dBufferSize, K_WORKSPACE_ALIGNMENT_BYTES);
 
     // TODO(Task I8.2): POC assumes a32 accumulator — always allocates FP32 dq_acc buffer.
     // For a16 accumulator kernels, dQ is written directly in BF16 (no dq_acc buffer needed,
-    // no dq_convert kernel launched). Production should check accumulator type and skip
-    // dq_acc allocation for a16. See sdpa-bwd-poc-requirements_v2.md Task I8.2.
+    // no dq_convert kernel launched). Provider should check accumulator type and skip
+    // dq_acc allocation for a16.
     size_t dqAccSize = batch * headsQ * seqLenQ * headDim * sizeof(float);
-    dqAccSize = (dqAccSize + 63) & ~size_t{63};
+    dqAccSize = alignUp(dqAccSize, K_WORKSPACE_ALIGNMENT_BYTES);
 
     return dBufferSize + dqAccSize;
 }

--- a/dnn-providers/hip-kernel-provider/src/engines/asm_sdpa_engine/plans/SdpaBwdPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/asm_sdpa_engine/plans/SdpaBwdPlanBuilder.cpp
@@ -37,9 +37,9 @@ namespace asm_sdpa_engine
 
 bool SdpaBwdPlanBuilder::isApplicable(
     const HipKernelHandle& handle,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const
 {
-    using namespace hipdnn_data_sdk::data_objects;
+    using namespace hipdnn_flatbuffers_sdk::data_objects;
     // NOLINTNEXTLINE(readability-identifier-naming)
     static const char* HIP_KERNEL_LOG_PREFIX = "[SdpaBwdPlanBuilder::isApplicable] ";
 
@@ -166,10 +166,10 @@ bool SdpaBwdPlanBuilder::isApplicable(
 
 size_t SdpaBwdPlanBuilder::getMaxWorkspaceSize(
     const HipKernelHandle& /* handle */,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
     const HipKernelSettings& /* executionSettings */) const
 {
-    using namespace hipdnn_data_sdk::data_objects;
+    using namespace hipdnn_flatbuffers_sdk::data_objects;
 
     const auto& attrs = opGraph.nodeWrappers().front()->attributesAs<SdpaBackwardAttributes>();
     const auto& tensorMap = opGraph.getTensorMap();
@@ -198,8 +198,8 @@ size_t SdpaBwdPlanBuilder::getMaxWorkspaceSize(
 
 void SdpaBwdPlanBuilder::initializeExecutionSettings(
     const HipKernelHandle& /* handle */,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& /* opGraph */,
-    const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& /* engineConfig */,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& /* opGraph */,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& /* engineConfig */,
     HipKernelSettings& /* executionSettings */) const
 {
     HIPDNN_PLUGIN_LOG_ERROR("SdpaBwdPlanBuilder::initializeExecutionSettings not implemented");
@@ -207,17 +207,17 @@ void SdpaBwdPlanBuilder::initializeExecutionSettings(
 
 void SdpaBwdPlanBuilder::buildPlan(
     const HipKernelHandle& /* handle */,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& /* opGraph */,
-    const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& /* engineConfig */,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& /* opGraph */,
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& /* engineConfig */,
     HipKernelContext& /* executionContext */) const
 {
     // TODO(Task I5): Implement backward 3-kernel plan (odo -> dqdkdv -> dq_convert)
     HIPDNN_PLUGIN_LOG_ERROR("SdpaBwdPlanBuilder::buildPlan not implemented");
 }
 
-std::vector<hipdnn_data_sdk::data_objects::KnobT> SdpaBwdPlanBuilder::getCustomKnobs(
+std::vector<hipdnn_flatbuffers_sdk::data_objects::KnobT> SdpaBwdPlanBuilder::getCustomKnobs(
     const HipKernelHandle& /* handle */,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& /* opGraph */) const
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& /* opGraph */) const
 {
     return {};
 }

--- a/dnn-providers/hip-kernel-provider/src/engines/asm_sdpa_engine/plans/SdpaBwdPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/asm_sdpa_engine/plans/SdpaBwdPlanBuilder.cpp
@@ -142,12 +142,34 @@ bool SdpaBwdPlanBuilder::isApplicable(
 
 size_t SdpaBwdPlanBuilder::getMaxWorkspaceSize(
     const HipKernelHandle& /* handle */,
-    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& /* opGraph */,
+    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
     const HipKernelSettings& /* executionSettings */) const
 {
-    // TODO(Task I4): Compute actual workspace size for backward 3-kernel pipeline
-    // Backward requires workspace for D buffer and dq_acc accumulator
-    return 0;
+    using namespace hipdnn_data_sdk::data_objects;
+
+    const auto& attrs = opGraph.nodeWrappers().front()->attributesAs<SdpaBackwardAttributes>();
+    const auto& tensorMap = opGraph.getTensorMap();
+    const auto* qTensor = tensorMap.at(attrs.q_tensor_uid());
+
+    // Q tensor layout is [B, H_q, S_q, D_qk]
+    auto batch = static_cast<size_t>(qTensor->dims()->Get(0));
+    auto headsQ = static_cast<size_t>(qTensor->dims()->Get(1));
+    auto seqLenQ = static_cast<size_t>(qTensor->dims()->Get(2));
+    auto headDim = static_cast<size_t>(qTensor->dims()->Get(3));
+
+    // D buffer: row-wise dot product output [B, H_q, S_q] in FP32
+    // Always needed for both a16 and a32 accumulator variants
+    size_t dBufferSize = batch * headsQ * seqLenQ * sizeof(float);
+    dBufferSize = (dBufferSize + 63) & ~size_t{63};
+
+    // TODO(Task I8.2): POC assumes a32 accumulator — always allocates FP32 dq_acc buffer.
+    // For a16 accumulator kernels, dQ is written directly in BF16 (no dq_acc buffer needed,
+    // no dq_convert kernel launched). Production should check accumulator type and skip
+    // dq_acc allocation for a16. See sdpa-bwd-poc-requirements_v2.md Task I8.2.
+    size_t dqAccSize = batch * headsQ * seqLenQ * headDim * sizeof(float);
+    dqAccSize = (dqAccSize + 63) & ~size_t{63};
+
+    return dBufferSize + dqAccSize;
 }
 
 void SdpaBwdPlanBuilder::initializeExecutionSettings(

--- a/dnn-providers/hip-kernel-provider/src/engines/asm_sdpa_engine/plans/SdpaBwdPlanBuilder.hpp
+++ b/dnn-providers/hip-kernel-provider/src/engines/asm_sdpa_engine/plans/SdpaBwdPlanBuilder.hpp
@@ -16,28 +16,30 @@ class SdpaBwdPlanBuilder
     : public hipdnn_plugin_sdk::IPlanBuilder<HipKernelHandle, HipKernelSettings, HipKernelContext>
 {
 public:
-    bool isApplicable(const HipKernelHandle& handle,
-                      const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+    bool isApplicable(
+        const HipKernelHandle& handle,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
 
     size_t getMaxWorkspaceSize(const HipKernelHandle& handle,
-                               const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                               const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
                                const HipKernelSettings& executionSettings) const override;
 
     void initializeExecutionSettings(
         const HipKernelHandle& handle,
-        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-        const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+        const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
         HipKernelSettings& executionSettings) const override;
 
     void buildPlan(const HipKernelHandle& handle,
-                   const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
-                   const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+                   const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph,
+                   const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
                    HipKernelContext& executionContext) const override;
 
-    std::vector<hipdnn_data_sdk::data_objects::KnobT>
+    std::vector<hipdnn_flatbuffers_sdk::data_objects::KnobT>
         // NOLINTNEXTLINE(portability-template-virtual-member-function)
-        getCustomKnobs(const HipKernelHandle& handle,
-                       const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+        getCustomKnobs(
+            const HipKernelHandle& handle,
+            const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
 };
 
 } // namespace asm_sdpa_engine

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/asm_sdpa_engine/GraphTest.hpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/asm_sdpa_engine/GraphTest.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <flatbuffers/flatbuffers.h>
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 
 #include <memory>
 #include <string>
@@ -21,8 +21,9 @@ struct GraphTest
     {
     }
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graphWrapper() const
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graphWrapper() const
     {
-        return hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(buffer->data(), buffer->size());
+        return hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(buffer->data(),
+                                                                          buffer->size());
     }
 };

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/asm_sdpa_engine/TestSdpaBwdPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/asm_sdpa_engine/TestSdpaBwdPlanBuilder.cpp
@@ -3,8 +3,8 @@
 
 #include <gtest/gtest.h>
 
-#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 
 #include "GraphTest.hpp"
@@ -29,15 +29,15 @@ TEST_F(TestSdpaBwdPlanBuilder, IsApplicableReturnsFalseForNonSdpaBwdGraph)
 {
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
 
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graphWrapper(builder.GetBufferPointer(),
-                                                                     builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graphWrapper(
+        builder.GetBufferPointer(), builder.GetSize());
 
     EXPECT_FALSE(_planBuilder.isApplicable(_handle, graphWrapper));
 }
 
 auto createSdpaBwdGraph(const std::vector<int64_t>& dims = {4, 8, 256, 128},
-                        hipdnn_data_sdk::data_objects::DataType dataType
-                        = hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+                        hipdnn_flatbuffers_sdk::data_objects::DataType dataType
+                        = hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
                         bool withScale = false,
                         bool alibiMask = false,
                         bool paddingMask = false,
@@ -61,7 +61,7 @@ auto createSdpaBwdGraph(const std::vector<int64_t>& dims = {4, 8, 256, 128},
 
 TEST_F(TestSdpaBwdPlanBuilder, IsApplicableSdpaBwdVariations)
 {
-    using namespace hipdnn_data_sdk::data_objects;
+    using namespace hipdnn_flatbuffers_sdk::data_objects;
 
     if(hip_kernel_provider_common::getDeviceString(_handle.getStream()) != "gfx942")
     {
@@ -112,8 +112,8 @@ TEST_F(TestSdpaBwdPlanBuilder, BackwardWorkspaceSizeSmallUnaligned)
     // B=1, H=3, S=255, D=128 — chosen so D buffer raw size (3060) is NOT a multiple of 64,
     // exercising the alignUp() rounding: 3060 → 3072
     auto builder = createSdpaBwdGraph({1, 3, 255, 128});
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graphWrapper(builder.GetBufferPointer(),
-                                                                     builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graphWrapper(
+        builder.GetBufferPointer(), builder.GetSize());
     HipKernelSettings settings;
     size_t workspaceSize = _planBuilder.getMaxWorkspaceSize(_handle, graphWrapper, settings);
 
@@ -126,8 +126,8 @@ TEST_F(TestSdpaBwdPlanBuilder, BackwardWorkspaceSizeMedium)
 {
     // B=2, H=8, S=512, D=128
     auto builder = createSdpaBwdGraph({2, 8, 512, 128});
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graphWrapper(builder.GetBufferPointer(),
-                                                                     builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graphWrapper(
+        builder.GetBufferPointer(), builder.GetSize());
     HipKernelSettings settings;
     size_t workspaceSize = _planBuilder.getMaxWorkspaceSize(_handle, graphWrapper, settings);
 
@@ -140,8 +140,8 @@ TEST_F(TestSdpaBwdPlanBuilder, BackwardWorkspaceSizeLarge)
 {
     // B=4, H=16, S=1024, D=128
     auto builder = createSdpaBwdGraph({4, 16, 1024, 128});
-    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graphWrapper(builder.GetBufferPointer(),
-                                                                     builder.GetSize());
+    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graphWrapper(
+        builder.GetBufferPointer(), builder.GetSize());
     HipKernelSettings settings;
     size_t workspaceSize = _planBuilder.getMaxWorkspaceSize(_handle, graphWrapper, settings);
 

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/asm_sdpa_engine/TestSdpaBwdPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/asm_sdpa_engine/TestSdpaBwdPlanBuilder.cpp
@@ -107,18 +107,46 @@ TEST_F(TestSdpaBwdPlanBuilder, IsApplicableSdpaBwdVariations)
     }
 }
 
-TEST_F(TestSdpaBwdPlanBuilder, GetMaxWorkspaceSizeReturnsZero)
+TEST_F(TestSdpaBwdPlanBuilder, BackwardWorkspaceSizeSmall)
 {
-    auto builder = createSdpaBwdGraph();
-
+    // B=1, H=1, S=256, D=128
+    auto builder = createSdpaBwdGraph({1, 1, 256, 128});
     hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graphWrapper(builder.GetBufferPointer(),
                                                                      builder.GetSize());
-
     HipKernelSettings settings;
     size_t workspaceSize = _planBuilder.getMaxWorkspaceSize(_handle, graphWrapper, settings);
 
-    // Stub: returns 0 until Task I4 implements actual workspace calculation
-    EXPECT_EQ(workspaceSize, 0u);
+    // D buffer: 1*1*256*4 = 1024, aligned to 64 → 1024
+    // dq_acc:   1*1*256*128*4 = 131072, aligned to 64 → 131072
+    EXPECT_EQ(workspaceSize, 1024u + 131072u);
+}
+
+TEST_F(TestSdpaBwdPlanBuilder, BackwardWorkspaceSizeMedium)
+{
+    // B=2, H=8, S=512, D=128
+    auto builder = createSdpaBwdGraph({2, 8, 512, 128});
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graphWrapper(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
+    HipKernelSettings settings;
+    size_t workspaceSize = _planBuilder.getMaxWorkspaceSize(_handle, graphWrapper, settings);
+
+    // D buffer: 2*8*512*4 = 32768, aligned to 64 → 32768
+    // dq_acc:   2*8*512*128*4 = 4194304, aligned to 64 → 4194304
+    EXPECT_EQ(workspaceSize, 32768u + 4194304u);
+}
+
+TEST_F(TestSdpaBwdPlanBuilder, BackwardWorkspaceSizeLarge)
+{
+    // B=4, H=16, S=1024, D=128
+    auto builder = createSdpaBwdGraph({4, 16, 1024, 128});
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graphWrapper(builder.GetBufferPointer(),
+                                                                     builder.GetSize());
+    HipKernelSettings settings;
+    size_t workspaceSize = _planBuilder.getMaxWorkspaceSize(_handle, graphWrapper, settings);
+
+    // D buffer: 4*16*1024*4 = 262144, aligned to 64 → 262144
+    // dq_acc:   4*16*1024*128*4 = 33554432, aligned to 64 → 33554432
+    EXPECT_EQ(workspaceSize, 262144u + 33554432u);
 }
 
 } // namespace

--- a/dnn-providers/hip-kernel-provider/src/tests/engines/asm_sdpa_engine/TestSdpaBwdPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/src/tests/engines/asm_sdpa_engine/TestSdpaBwdPlanBuilder.cpp
@@ -107,18 +107,19 @@ TEST_F(TestSdpaBwdPlanBuilder, IsApplicableSdpaBwdVariations)
     }
 }
 
-TEST_F(TestSdpaBwdPlanBuilder, BackwardWorkspaceSizeSmall)
+TEST_F(TestSdpaBwdPlanBuilder, BackwardWorkspaceSizeSmallUnaligned)
 {
-    // B=1, H=1, S=256, D=128
-    auto builder = createSdpaBwdGraph({1, 1, 256, 128});
+    // B=1, H=3, S=255, D=128 — chosen so D buffer raw size (3060) is NOT a multiple of 64,
+    // exercising the alignUp() rounding: 3060 → 3072
+    auto builder = createSdpaBwdGraph({1, 3, 255, 128});
     hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graphWrapper(builder.GetBufferPointer(),
                                                                      builder.GetSize());
     HipKernelSettings settings;
     size_t workspaceSize = _planBuilder.getMaxWorkspaceSize(_handle, graphWrapper, settings);
 
-    // D buffer: 1*1*256*4 = 1024, aligned to 64 → 1024
-    // dq_acc:   1*1*256*128*4 = 131072, aligned to 64 → 131072
-    EXPECT_EQ(workspaceSize, 1024u + 131072u);
+    // D buffer: 1*3*255*4 = 3060, aligned to 64 → 3072  (exercises alignment rounding)
+    // dq_acc:   1*3*255*128*4 = 391680, aligned to 64 → 391680 (already aligned)
+    EXPECT_EQ(workspaceSize, 3072u + 391680u);
 }
 
 TEST_F(TestSdpaBwdPlanBuilder, BackwardWorkspaceSizeMedium)


### PR DESCRIPTION
## Motivation

Implement getMaxWorkspaceSize() for SdpaBwdPlanBuilder to compute workspace needed by the 3-kernel backward pipeline: D buffer (FP32 row-wise reduction) and dq_acc buffer (FP32 dQ accumulator), both 64-byte aligned.
## Technical Details

- **SdpaBwdPlanBuilder.cpp** — Implement `getMaxWorkspaceSize()` with D buffer + dq_acc buffer calculation
- **TestSdpaBwdPlanBuilder.cpp** — Replace stub test with 3 workspace size validation cases:
  - Small: B=1, H=3, S=255, D=128 — chosen so D buffer raw size (3060) is NOT a multiple of 64 exercising the alignUp() rounding: 3060 → 3072 to 391680 bytes
  - Medium: B=2, H=8, S=512, D=128 → 4,227,072 bytes
  - Large: B=4, H=16, S=1024, D=128 → 33,816,576 bytes
- Adapt backward plan builder and tests to the hipdnn_data_sdk → hipdnn_flatbuffers_sdk namespace rename in the SDK layer. https://github.com/ROCm/rocm-libraries/pull/6475

## Test Plan

- [ ] `hip_kernel_provider_tests --gtest_filter="*SdpaBwdPlanBuilder*"` — 5/5 pass (2 applicability + 3 workspace)

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
