### PR TITLE
[rocPRIM] Fix memory leak in test_hipgraph_basic suite

### DIFF
--- a/projects/rocprim/test/hipgraph/test_hipgraph_basic.cpp
+++ b/projects/rocprim/test/hipgraph/test_hipgraph_basic.cpp
@@ -63,7 +63,6 @@ void testStreamCapture()
 
     // Create a new graph
     hipGraph_t graph;
-    HIP_CHECK(hipGraphCreate(&graph, 0));
 
     // Note: currently, calls to hipMallocAsync do not work inside the stream capture section
     HIP_CHECK(hipMallocAsync(&d_data, sizeof(int), stream));
@@ -181,7 +180,6 @@ void testStreamCaptureWithAtomics()
 
     // Create a new graph
     hipGraph_t graph;
-    HIP_CHECK(hipGraphCreate(&graph, 0));
 
     // Note: currently, calls to hipMallocAsync do not work inside the stream capture section
     HIP_CHECK(hipMallocAsync(&d_data, sizeof(int), stream));


### PR DESCRIPTION
## Motivation

The hipgraph basic tests were calling hipGraphCreate in cases where graphs were created using stream capture. When using stream capture, the graph is created automatically by hipStreamEndCapture. As a result, the graph was being overwritten and memory was leaking.

## Technical Details

This change removes the unnecessary hipGraphCreate calls to fix the leaks.

## Test Plan

Build the test_hipgraph_basic target with `-DBUILD_ADDRESS_SANITIZER=ON`. Run the tests. Verify that there are no messages about memory leaks. The tests should still pass.

## Test Result

ASAN no longer detects any memory leaks in test_hipgraph_basic.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
