### PR TITLE
[rocSOLVER] Add 64 bit tests for eigensolvers

### DIFF
--- a/projects/rocsolver/clients/common/lapack/testing_syev_heev.cpp
+++ b/projects/rocsolver/clients/common/lapack/testing_syev_heev.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,4 +29,8 @@
 
 #define TESTING_SYEV_HEEV(...) template void testing_syev_heev<__VA_ARGS__>(Arguments&);
 
-INSTANTIATE(TESTING_SYEV_HEEV, FOREACH_MATRIX_DATA_LAYOUT, FOREACH_SCALAR_TYPE, APPLY_STAMP)
+INSTANTIATE(TESTING_SYEV_HEEV,
+            FOREACH_MATRIX_DATA_LAYOUT,
+            FOREACH_SCALAR_TYPE,
+            FOREACH_INT_TYPE,
+            APPLY_STAMP)

--- a/projects/rocsolver/clients/common/lapack/testing_syev_heev.hpp
+++ b/projects/rocsolver/clients/common/lapack/testing_syev_heev.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,20 +36,20 @@
 #include "common/misc/rocsolver_test.hpp"
 #include "common/misc/rocsolver_timer.hpp"
 
-template <bool STRIDED, typename T, typename S, typename U>
+template <bool STRIDED, typename I, typename T, typename S, typename U>
 void syev_heev_checkBadArgs(const rocblas_handle handle,
                             const rocblas_evect evect,
                             const rocblas_fill uplo,
-                            const rocblas_int n,
+                            const I n,
                             T dA,
-                            const rocblas_int lda,
+                            const I lda,
                             const rocblas_stride stA,
                             S dD,
                             const rocblas_stride stD,
                             S dE,
                             const rocblas_stride stE,
                             U dinfo,
-                            const rocblas_int bc)
+                            const I bc)
 {
     // handle
     EXPECT_ROCBLAS_STATUS(rocsolver_syev_heev(STRIDED, nullptr, evect, uplo, n, dA, lda, stA, dD,
@@ -96,7 +96,7 @@ void syev_heev_checkBadArgs(const rocblas_handle handle,
                               rocblas_status_success);
 }
 
-template <bool BATCHED, bool STRIDED, typename T>
+template <bool BATCHED, bool STRIDED, typename T, typename I>
 void testing_syev_heev_bad_arg()
 {
     using S = decltype(std::real(T{}));
@@ -105,12 +105,12 @@ void testing_syev_heev_bad_arg()
     rocblas_local_handle handle;
     rocblas_evect evect = rocblas_evect_none;
     rocblas_fill uplo = rocblas_fill_lower;
-    rocblas_int n = 1;
-    rocblas_int lda = 1;
+    I n = 1;
+    I lda = 1;
     rocblas_stride stA = 1;
     rocblas_stride stD = 1;
     rocblas_stride stE = 1;
-    rocblas_int bc = 1;
+    I bc = 1;
 
     if(BATCHED)
     {
@@ -125,8 +125,8 @@ void testing_syev_heev_bad_arg()
         CHECK_HIP_ERROR(dinfo.memcheck());
 
         // check bad arguments
-        syev_heev_checkBadArgs<STRIDED>(handle, evect, uplo, n, dA.data(), lda, stA, dD.data(), stD,
-                                        dE.data(), stE, dinfo.data(), bc);
+        syev_heev_checkBadArgs<STRIDED, I>(handle, evect, uplo, n, dA.data(), lda, stA, dD.data(),
+                                           stD, dE.data(), stE, dinfo.data(), bc);
     }
     else
     {
@@ -141,18 +141,18 @@ void testing_syev_heev_bad_arg()
         CHECK_HIP_ERROR(dinfo.memcheck());
 
         // check bad arguments
-        syev_heev_checkBadArgs<STRIDED>(handle, evect, uplo, n, dA.data(), lda, stA, dD.data(), stD,
-                                        dE.data(), stE, dinfo.data(), bc);
+        syev_heev_checkBadArgs<STRIDED, I>(handle, evect, uplo, n, dA.data(), lda, stA, dD.data(),
+                                           stD, dE.data(), stE, dinfo.data(), bc);
     }
 }
 
-template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+template <bool CPU, bool GPU, typename T, typename I, typename Td, typename Th>
 void syev_heev_initData(const rocblas_handle handle,
                         const rocblas_evect evect,
-                        const rocblas_int n,
+                        const I n,
                         Td& dA,
-                        const rocblas_int lda,
-                        const rocblas_int bc,
+                        const I lda,
+                        const I bc,
                         Th& hA,
                         std::vector<T>& A,
                         bool test = true)
@@ -162,11 +162,11 @@ void syev_heev_initData(const rocblas_handle handle,
         rocblas_init<T>(hA, true);
 
         // scale A to avoid singularities
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(I b = 0; b < bc; ++b)
         {
-            for(rocblas_int i = 0; i < n; i++)
+            for(I i = 0; i < n; i++)
             {
-                for(rocblas_int j = 0; j < n; j++)
+                for(I j = 0; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] = std::real(hA[b][i + j * lda]) + 400;
@@ -178,9 +178,9 @@ void syev_heev_initData(const rocblas_handle handle,
             // make copy of original data to test vectors if required
             if(test && evect == rocblas_evect_original)
             {
-                for(rocblas_int i = 0; i < n; i++)
+                for(I i = 0; i < n; i++)
                 {
-                    for(rocblas_int j = 0; j < n; j++)
+                    for(I j = 0; j < n; j++)
                         A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
                 }
             }
@@ -194,20 +194,20 @@ void syev_heev_initData(const rocblas_handle handle,
     }
 }
 
-template <bool STRIDED, typename T, typename Sd, typename Td, typename Id, typename Sh, typename Th, typename Ih>
+template <bool STRIDED, typename T, typename I, typename Sd, typename Td, typename Id, typename Sh, typename Th, typename Ih>
 void syev_heev_getError(const rocblas_handle handle,
                         const rocblas_evect evect,
                         const rocblas_fill uplo,
-                        const rocblas_int n,
+                        const I n,
                         Td& dA,
-                        const rocblas_int lda,
+                        const I lda,
                         const rocblas_stride stA,
                         Sd& dD,
                         const rocblas_stride stD,
                         Sd& dE,
                         const rocblas_stride stE,
                         Id& dinfo,
-                        const rocblas_int bc,
+                        const I bc,
                         Th& hA,
                         Th& hAres,
                         Sh& hD,
@@ -239,13 +239,13 @@ void syev_heev_getError(const rocblas_handle handle,
         CHECK_HIP_ERROR(hAres.transfer_from(dA));
 
     // CPU lapack
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(I b = 0; b < bc; ++b)
         cpu_syev_heev(evect, uplo, n, hA[b], lda, hD[b], work.data(), lwork, hE.data(), sizeE,
                       hinfo[b]);
 
     // Check info for non-convergence
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(I b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hinfo[b][0], hinfoRes[b][0]) << "where b = " << b;
         if(hinfo[b][0] != hinfoRes[b][0])
@@ -258,7 +258,7 @@ void syev_heev_getError(const rocblas_handle handle,
 
     double err = 0;
 
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(I b = 0; b < bc; ++b)
     {
         if(evect != rocblas_evect_original)
         {
@@ -280,7 +280,7 @@ void syev_heev_getError(const rocblas_handle handle,
                 // eigenvalues
                 T alpha;
                 T beta = 0;
-                for(int j = 0; j < n; j++)
+                for(I j = 0; j < n; j++)
                 {
                     alpha = T(1) / hDres[b][j];
                     cpu_symv_hemv(uplo, n, alpha, A.data() + b * lda * n, lda, hAres[b] + j * lda,
@@ -296,20 +296,20 @@ void syev_heev_getError(const rocblas_handle handle,
     }
 }
 
-template <bool STRIDED, typename T, typename Sd, typename Td, typename Id, typename Sh, typename Th, typename Ih>
+template <bool STRIDED, typename T, typename I, typename Sd, typename Td, typename Id, typename Sh, typename Th, typename Ih>
 void syev_heev_getPerfData(const rocblas_handle handle,
                            const rocblas_evect evect,
                            const rocblas_fill uplo,
-                           const rocblas_int n,
+                           const I n,
                            Td& dA,
-                           const rocblas_int lda,
+                           const I lda,
                            const rocblas_stride stA,
                            Sd& dD,
                            const rocblas_stride stD,
                            Sd& dE,
                            const rocblas_stride stE,
                            Id& dinfo,
-                           const rocblas_int bc,
+                           const I bc,
                            Th& hA,
                            Sh& hD,
                            Ih& hinfo,
@@ -335,7 +335,7 @@ void syev_heev_getPerfData(const rocblas_handle handle,
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(I b = 0; b < bc; ++b)
             cpu_syev_heev(evect, uplo, n, hA[b], lda, hD[b], work.data(), lwork, hE.data(), sizeE,
                           hinfo[b]);
         *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
@@ -379,7 +379,7 @@ void syev_heev_getPerfData(const rocblas_handle handle,
     *gpu_time_used = timer.get_combined();
 }
 
-template <bool BATCHED, bool STRIDED, typename T>
+template <bool BATCHED, bool STRIDED, typename T, typename I>
 void testing_syev_heev(Arguments& argus)
 {
     using S = decltype(std::real(T{}));
@@ -388,15 +388,15 @@ void testing_syev_heev(Arguments& argus)
     rocblas_local_handle handle;
     char evectC = argus.get<char>("evect");
     char uploC = argus.get<char>("uplo");
-    rocblas_int n = argus.get<rocblas_int>("n");
-    rocblas_int lda = argus.get<rocblas_int>("lda", n);
+    I n = argus.get<rocblas_int>("n");
+    I lda = argus.get<rocblas_int>("lda", n);
     rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
     rocblas_stride stD = argus.get<rocblas_stride>("strideD", n);
     rocblas_stride stE = argus.get<rocblas_stride>("strideE", n);
 
     rocblas_evect evect = char2rocblas_evect(evectC);
     rocblas_fill uplo = char2rocblas_fill(uploC);
-    rocblas_int bc = argus.batch_count;
+    I bc = argus.batch_count;
     rocblas_int hot_calls = argus.iters;
 
     if(argus.alg_mode == 1)
@@ -526,18 +526,18 @@ void testing_syev_heev(Arguments& argus)
         // check computations
         if(argus.unit_check || argus.norm_check)
         {
-            syev_heev_getError<STRIDED, T>(handle, evect, uplo, n, dA, lda, stA, dD, stD, dE, stE,
-                                           dinfo, bc, hA, hAres, hD, hDres, hinfo, hinfoRes,
-                                           &max_error);
+            syev_heev_getError<STRIDED, T, I>(handle, evect, uplo, n, dA, lda, stA, dD, stD, dE,
+                                              stE, dinfo, bc, hA, hAres, hD, hDres, hinfo, hinfoRes,
+                                              &max_error);
         }
 
         // collect performance data
         if(argus.timing && hot_calls > 0)
         {
-            syev_heev_getPerfData<STRIDED, T>(handle, evect, uplo, n, dA, lda, stA, dD, stD, dE,
-                                              stE, dinfo, bc, hA, hD, hinfo, &gpu_time_used,
-                                              &cpu_time_used, hot_calls, argus.profile,
-                                              argus.profile_kernels, argus.perf);
+            syev_heev_getPerfData<STRIDED, T, I>(handle, evect, uplo, n, dA, lda, stA, dD, stD, dE,
+                                                 stE, dinfo, bc, hA, hD, hinfo, &gpu_time_used,
+                                                 &cpu_time_used, hot_calls, argus.profile,
+                                                 argus.profile_kernels, argus.perf);
         }
     }
 
@@ -566,18 +566,18 @@ void testing_syev_heev(Arguments& argus)
         // check computations
         if(argus.unit_check || argus.norm_check)
         {
-            syev_heev_getError<STRIDED, T>(handle, evect, uplo, n, dA, lda, stA, dD, stD, dE, stE,
-                                           dinfo, bc, hA, hAres, hD, hDres, hinfo, hinfoRes,
-                                           &max_error);
+            syev_heev_getError<STRIDED, T, I>(handle, evect, uplo, n, dA, lda, stA, dD, stD, dE,
+                                              stE, dinfo, bc, hA, hAres, hD, hDres, hinfo, hinfoRes,
+                                              &max_error);
         }
 
         // collect performance data
         if(argus.timing && hot_calls > 0)
         {
-            syev_heev_getPerfData<STRIDED, T>(handle, evect, uplo, n, dA, lda, stA, dD, stD, dE,
-                                              stE, dinfo, bc, hA, hD, hinfo, &gpu_time_used,
-                                              &cpu_time_used, hot_calls, argus.profile,
-                                              argus.profile_kernels, argus.perf);
+            syev_heev_getPerfData<STRIDED, T, I>(handle, evect, uplo, n, dA, lda, stA, dD, stD, dE,
+                                                 stE, dinfo, bc, hA, hD, hinfo, &gpu_time_used,
+                                                 &cpu_time_used, hot_calls, argus.profile,
+                                                 argus.profile_kernels, argus.perf);
         }
     }
 
@@ -637,4 +637,8 @@ void testing_syev_heev(Arguments& argus)
 #define EXTERN_TESTING_SYEV_HEEV(...) \
     extern template void testing_syev_heev<__VA_ARGS__>(Arguments&);
 
-INSTANTIATE(EXTERN_TESTING_SYEV_HEEV, FOREACH_MATRIX_DATA_LAYOUT, FOREACH_SCALAR_TYPE, APPLY_STAMP)
+INSTANTIATE(EXTERN_TESTING_SYEV_HEEV,
+            FOREACH_MATRIX_DATA_LAYOUT,
+            FOREACH_SCALAR_TYPE,
+            FOREACH_INT_TYPE,
+            APPLY_STAMP)

--- a/projects/rocsolver/clients/common/lapack/testing_syevd_heevd.cpp
+++ b/projects/rocsolver/clients/common/lapack/testing_syevd_heevd.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,4 +29,8 @@
 
 #define TESTING_SYEVD_HEEVD(...) template void testing_syevd_heevd<__VA_ARGS__>(Arguments&);
 
-INSTANTIATE(TESTING_SYEVD_HEEVD, FOREACH_MATRIX_DATA_LAYOUT, FOREACH_SCALAR_TYPE, APPLY_STAMP)
+INSTANTIATE(TESTING_SYEVD_HEEVD,
+            FOREACH_MATRIX_DATA_LAYOUT,
+            FOREACH_SCALAR_TYPE,
+            FOREACH_INT_TYPE,
+            APPLY_STAMP)

--- a/projects/rocsolver/clients/common/lapack/testing_syevd_heevd.hpp
+++ b/projects/rocsolver/clients/common/lapack/testing_syevd_heevd.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,20 +37,20 @@
 #include "common/misc/rocsolver_test.hpp"
 #include "common/misc/rocsolver_timer.hpp"
 
-template <bool STRIDED, typename T, typename S, typename U>
+template <bool STRIDED, typename I, typename T, typename S, typename U>
 void syevd_heevd_checkBadArgs(const rocblas_handle handle,
                               const rocblas_evect evect,
                               const rocblas_fill uplo,
-                              const rocblas_int n,
+                              const I n,
                               T dA,
-                              const rocblas_int lda,
+                              const I lda,
                               const rocblas_stride stA,
                               S dD,
                               const rocblas_stride stD,
                               S dE,
                               const rocblas_stride stE,
                               U dinfo,
-                              const rocblas_int bc)
+                              const I bc)
 {
     // handle
     EXPECT_ROCBLAS_STATUS(rocsolver_syevd_heevd(STRIDED, nullptr, evect, uplo, n, dA, lda, stA, dD,
@@ -97,7 +97,7 @@ void syevd_heevd_checkBadArgs(const rocblas_handle handle,
                               rocblas_status_success);
 }
 
-template <bool BATCHED, bool STRIDED, typename T>
+template <bool BATCHED, bool STRIDED, typename T, typename I>
 void testing_syevd_heevd_bad_arg()
 {
     using S = decltype(std::real(T{}));
@@ -106,12 +106,12 @@ void testing_syevd_heevd_bad_arg()
     rocblas_local_handle handle;
     rocblas_evect evect = rocblas_evect_none;
     rocblas_fill uplo = rocblas_fill_lower;
-    rocblas_int n = 1;
-    rocblas_int lda = 1;
+    I n = 1;
+    I lda = 1;
     rocblas_stride stA = 1;
     rocblas_stride stD = 1;
     rocblas_stride stE = 1;
-    rocblas_int bc = 1;
+    I bc = 1;
 
     if(BATCHED)
     {
@@ -126,8 +126,8 @@ void testing_syevd_heevd_bad_arg()
         CHECK_HIP_ERROR(dinfo.memcheck());
 
         // check bad arguments
-        syevd_heevd_checkBadArgs<STRIDED>(handle, evect, uplo, n, dA.data(), lda, stA, dD.data(),
-                                          stD, dE.data(), stE, dinfo.data(), bc);
+        syevd_heevd_checkBadArgs<STRIDED, I>(handle, evect, uplo, n, dA.data(), lda, stA, dD.data(),
+                                             stD, dE.data(), stE, dinfo.data(), bc);
     }
     else
     {
@@ -142,18 +142,18 @@ void testing_syevd_heevd_bad_arg()
         CHECK_HIP_ERROR(dinfo.memcheck());
 
         // check bad arguments
-        syevd_heevd_checkBadArgs<STRIDED>(handle, evect, uplo, n, dA.data(), lda, stA, dD.data(),
-                                          stD, dE.data(), stE, dinfo.data(), bc);
+        syevd_heevd_checkBadArgs<STRIDED, I>(handle, evect, uplo, n, dA.data(), lda, stA, dD.data(),
+                                             stD, dE.data(), stE, dinfo.data(), bc);
     }
 }
 
-template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+template <bool CPU, bool GPU, typename T, typename I, typename Td, typename Th>
 void syevd_heevd_default_initData(const rocblas_handle handle,
                                   const rocblas_evect evect,
-                                  const rocblas_int n,
+                                  const I n,
                                   Td& dA,
-                                  const rocblas_int lda,
-                                  const rocblas_int bc,
+                                  const I lda,
+                                  const I bc,
                                   Th& hA,
                                   std::vector<T>& A,
                                   bool test = true)
@@ -163,11 +163,11 @@ void syevd_heevd_default_initData(const rocblas_handle handle,
         rocblas_init<T>(hA, true);
 
         // scale A to avoid singularities
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(I b = 0; b < bc; ++b)
         {
-            for(rocblas_int i = 0; i < n; i++)
+            for(I i = 0; i < n; i++)
             {
-                for(rocblas_int j = i; j < n; j++)
+                for(I j = i; j < n; j++)
                 {
                     if(i == j)
                         hA[b][i + j * lda] = std::real(hA[b][i + j * lda]) + 400;
@@ -182,9 +182,9 @@ void syevd_heevd_default_initData(const rocblas_handle handle,
             // make copy of original data to test vectors if required
             if(test && evect == rocblas_evect_original)
             {
-                for(rocblas_int i = 0; i < n; i++)
+                for(I i = 0; i < n; i++)
                 {
-                    for(rocblas_int j = 0; j < n; j++)
+                    for(I j = 0; j < n; j++)
                         A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
                 }
             }
@@ -204,13 +204,13 @@ void syevd_heevd_default_initData(const rocblas_handle handle,
 //
 // where `ulp` is the smallest floating point number such that `1 + ulp > 1`.
 //
-template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+template <bool CPU, bool GPU, typename T, typename I, typename Td, typename Th>
 void syevd_heevd_eig7_initData(const rocblas_handle handle,
                                const rocblas_evect evect,
-                               const rocblas_int n,
+                               const I n,
                                Td& dA,
-                               const rocblas_int lda,
-                               const rocblas_int bc,
+                               const I lda,
+                               const I bc,
                                Th& hA,
                                std::vector<T>& A,
                                bool test = true)
@@ -221,10 +221,10 @@ void syevd_heevd_eig7_initData(const rocblas_handle handle,
     {
         rocblas_init<T>(hA, true);
 
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(I b = 0; b < bc; ++b)
         {
             // New matrix initialization
-            using HMat = HostMatrix<T, rocblas_int>;
+            using HMat = HostMatrix<T, I>;
             using BDesc = typename HMat::BlockDescriptor;
 
             auto hAw = HMat::Wrap(hA[b], lda, n);
@@ -241,9 +241,9 @@ void syevd_heevd_eig7_initData(const rocblas_handle handle,
             // make copy of original data to test vectors if required
             if(test && evect == rocblas_evect_original)
             {
-                for(rocblas_int i = 0; i < n; i++)
+                for(I i = 0; i < n; i++)
                 {
-                    for(rocblas_int j = 0; j < n; j++)
+                    for(I j = 0; j < n; j++)
                         A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
                 }
             }
@@ -271,13 +271,13 @@ void syevd_heevd_eig7_initData(const rocblas_handle handle,
 //
 // where `n = 2m + 1`.
 //
-template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+template <bool CPU, bool GPU, typename T, typename I, typename Td, typename Th>
 void syevd_heevd_wilkinson_initData(const rocblas_handle handle,
                                     const rocblas_evect evect,
-                                    const rocblas_int n,
+                                    const I n,
                                     Td& dA,
-                                    const rocblas_int lda,
-                                    const rocblas_int bc,
+                                    const I lda,
+                                    const I bc,
                                     Th& hA,
                                     std::vector<T>& A,
                                     bool test = true)
@@ -289,10 +289,10 @@ void syevd_heevd_wilkinson_initData(const rocblas_handle handle,
         rocblas_init<T>(hA, true);
 
         // scale A to avoid singularities
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(I b = 0; b < bc; ++b)
         {
             // New matrix initialization
-            using HMat = HostMatrix<T, rocblas_int>;
+            using HMat = HostMatrix<T, I>;
             using BDesc = typename HMat::BlockDescriptor;
 
             auto hAw = HMat::Wrap(hA[b], lda, n);
@@ -303,7 +303,7 @@ void syevd_heevd_wilkinson_initData(const rocblas_handle handle,
                 auto E = HMat::Ones(n - 1, 1);
                 auto D = HMat::Zeros(n, 1);
 
-                for(rocblas_int i = 0; i < n / 2; ++i)
+                for(I i = 0; i < n / 2; ++i)
                 {
                     D[i] = m - i;
                     D[n - 1 - i] = m - i;
@@ -320,9 +320,9 @@ void syevd_heevd_wilkinson_initData(const rocblas_handle handle,
             // make copy of original data to test vectors if required
             if(test && evect == rocblas_evect_original)
             {
-                for(rocblas_int i = 0; i < n; i++)
+                for(I i = 0; i < n; i++)
                 {
-                    for(rocblas_int j = 0; j < n; j++)
+                    for(I j = 0; j < n; j++)
                         A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
                 }
             }
@@ -342,13 +342,13 @@ void syevd_heevd_wilkinson_initData(const rocblas_handle handle,
 // T = tridiag ( 2   2 ... 2   2 ... 2    2 )
 //             (   1         1         1    )
 //
-template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+template <bool CPU, bool GPU, typename T, typename I, typename Td, typename Th>
 void syevd_heevd_toeplitz_initData(const rocblas_handle handle,
                                    const rocblas_evect evect,
-                                   const rocblas_int n,
+                                   const I n,
                                    Td& dA,
-                                   const rocblas_int lda,
-                                   const rocblas_int bc,
+                                   const I lda,
+                                   const I bc,
                                    Th& hA,
                                    std::vector<T>& A,
                                    bool test = true)
@@ -360,10 +360,10 @@ void syevd_heevd_toeplitz_initData(const rocblas_handle handle,
         rocblas_init<T>(hA, true);
 
         // scale A to avoid singularities
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(I b = 0; b < bc; ++b)
         {
             // New matrix initialization
-            using HMat = HostMatrix<T, rocblas_int>;
+            using HMat = HostMatrix<T, I>;
             using BDesc = typename HMat::BlockDescriptor;
 
             auto hAw = HMat::Wrap(hA[b], lda, n);
@@ -384,9 +384,9 @@ void syevd_heevd_toeplitz_initData(const rocblas_handle handle,
             // make copy of original data to test vectors if required
             if(test && evect == rocblas_evect_original)
             {
-                for(rocblas_int i = 0; i < n; i++)
+                for(I i = 0; i < n; i++)
                 {
-                    for(rocblas_int j = 0; j < n; j++)
+                    for(I j = 0; j < n; j++)
                         A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
                 }
             }
@@ -408,13 +408,13 @@ void syevd_heevd_toeplitz_initData(const rocblas_handle handle,
 //
 // were the `i-th` off-diagonal entry is sqrt(i(n - i)), 1 <= i < n.
 //
-template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+template <bool CPU, bool GPU, typename T, typename I, typename Td, typename Th>
 void syevd_heevd_clement_initData(const rocblas_handle handle,
                                   const rocblas_evect evect,
-                                  const rocblas_int n,
+                                  const I n,
                                   Td& dA,
-                                  const rocblas_int lda,
-                                  const rocblas_int bc,
+                                  const I lda,
+                                  const I bc,
                                   Th& hA,
                                   std::vector<T>& A,
                                   bool test = true)
@@ -426,10 +426,10 @@ void syevd_heevd_clement_initData(const rocblas_handle handle,
         rocblas_init<T>(hA, true);
 
         // scale A to avoid singularities
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(I b = 0; b < bc; ++b)
         {
             // New matrix initialization
-            using HMat = HostMatrix<T, rocblas_int>;
+            using HMat = HostMatrix<T, I>;
             using BDesc = typename HMat::BlockDescriptor;
 
             auto hAw = HMat::Wrap(hA[b], lda, n);
@@ -439,7 +439,7 @@ void syevd_heevd_clement_initData(const rocblas_handle handle,
                 auto E = HMat::Ones(n - 1, 1);
                 auto D = HMat::Zeros(n, 1);
 
-                for(rocblas_int i = 1; i < n; ++i)
+                for(I i = 1; i < n; ++i)
                 {
                     E[i - 1] = std::sqrt(i * (n - i));
                 }
@@ -455,9 +455,9 @@ void syevd_heevd_clement_initData(const rocblas_handle handle,
             // make copy of original data to test vectors if required
             if(test && evect == rocblas_evect_original)
             {
-                for(rocblas_int i = 0; i < n; i++)
+                for(I i = 0; i < n; i++)
                 {
-                    for(rocblas_int j = 0; j < n; j++)
+                    for(I j = 0; j < n; j++)
                         A[b * lda * n + i + j * lda] = hA[b][i + j * lda];
                 }
             }
@@ -471,58 +471,58 @@ void syevd_heevd_clement_initData(const rocblas_handle handle,
     }
 }
 
-template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+template <bool CPU, bool GPU, typename T, typename I, typename Td, typename Th>
 void syevd_heevd_initData(const rocblas_handle handle,
                           const rocblas_evect evect,
-                          const rocblas_int n,
+                          const I n,
                           Td& dA,
-                          const rocblas_int lda,
-                          const rocblas_int bc,
+                          const I lda,
+                          const I bc,
                           Th& hA,
                           std::vector<T>& A,
                           bool test = true)
 {
     if((std::getenv("TEST_EIG7") != nullptr) || (std::getenv("SYEVD_TEST_EIG7") != nullptr))
     {
-        syevd_heevd_eig7_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
+        syevd_heevd_eig7_initData<CPU, GPU, T, I>(handle, evect, n, dA, lda, bc, hA, A, test);
     }
     else if((std::getenv("TEST_WILKINSON") != nullptr)
             || (std::getenv("SYEVD_TEST_WILKINSON") != nullptr))
     {
-        syevd_heevd_wilkinson_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
+        syevd_heevd_wilkinson_initData<CPU, GPU, T, I>(handle, evect, n, dA, lda, bc, hA, A, test);
     }
     else if((std::getenv("TEST_CLEMENT") != nullptr)
             || (std::getenv("SYEVD_TEST_CLEMENT") != nullptr))
     {
-        syevd_heevd_clement_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
+        syevd_heevd_clement_initData<CPU, GPU, T, I>(handle, evect, n, dA, lda, bc, hA, A, test);
     }
     else if((std::getenv("TEST_TOEPLITZ") != nullptr)
             || (std::getenv("SYEVD_TEST_TOEPLITZ") != nullptr))
     {
-        syevd_heevd_toeplitz_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
+        syevd_heevd_toeplitz_initData<CPU, GPU, T, I>(handle, evect, n, dA, lda, bc, hA, A, test);
     }
     else
     {
-        syevd_heevd_default_initData<CPU, GPU>(handle, evect, n, dA, lda, bc, hA, A, test);
+        syevd_heevd_default_initData<CPU, GPU, T, I>(handle, evect, n, dA, lda, bc, hA, A, test);
     }
 
     return;
 }
 
-template <bool STRIDED, typename T, typename Sd, typename Td, typename Id, typename Sh, typename Th, typename Ih>
+template <bool STRIDED, typename T, typename I, typename Sd, typename Td, typename Id, typename Sh, typename Th, typename Ih>
 void syevd_heevd_getError(const rocblas_handle handle,
                           const rocblas_evect evect,
                           const rocblas_fill uplo,
-                          const rocblas_int n,
+                          const I n,
                           Td& dA,
-                          const rocblas_int lda,
+                          const I lda,
                           const rocblas_stride stA,
                           Sd& dD,
                           const rocblas_stride stD,
                           Sd& dE,
                           const rocblas_stride stE,
                           Id& dinfo,
-                          const rocblas_int bc,
+                          const I bc,
                           Th& hA,
                           Th& hAres,
                           Sh& hD,
@@ -535,7 +535,7 @@ void syevd_heevd_getError(const rocblas_handle handle,
     constexpr bool COMPLEX = rocblas_is_complex<T>;
     using S = decltype(std::real(T{}));
 
-    using HMat = HostMatrix<T, rocblas_int>;
+    using HMat = HostMatrix<T, I>;
     using BDesc = typename HMat::BlockDescriptor;
 
     int lgn = floor(log(n - 1) / log(2)) + 1;
@@ -558,7 +558,7 @@ void syevd_heevd_getError(const rocblas_handle handle,
     std::vector<T> A(lda * n * bc);
 
     // input data initialization
-    syevd_heevd_initData<true, true, T>(handle, evect, n, dA, lda, bc, hA, A);
+    syevd_heevd_initData<true, true, T, I>(handle, evect, n, dA, lda, bc, hA, A);
 
     // execute computations
     // GPU lapack
@@ -571,13 +571,13 @@ void syevd_heevd_getError(const rocblas_handle handle,
         CHECK_HIP_ERROR(hAres.transfer_from(dA));
 
     // CPU lapack
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(I b = 0; b < bc; ++b)
         cpu_syevd_heevd(evect, uplo, n, hA[b], lda, hD[b], work.data(), lwork, hE.data(), sizeE,
                         iwork.data(), liwork, hinfo[b]);
 
     // Check info for non-convergence
     *max_err = 0;
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(I b = 0; b < bc; ++b)
     {
         EXPECT_EQ(hinfo[b][0], hinfoRes[b][0]) << "where b = " << b;
         if(hinfo[b][0] != hinfoRes[b][0])
@@ -590,7 +590,7 @@ void syevd_heevd_getError(const rocblas_handle handle,
 
     double err = 0;
 
-    for(rocblas_int b = 0; b < bc; ++b)
+    for(I b = 0; b < bc; ++b)
     {
         if(evect != rocblas_evect_original)
         {
@@ -632,20 +632,20 @@ void syevd_heevd_getError(const rocblas_handle handle,
     }
 }
 
-template <bool STRIDED, typename T, typename Sd, typename Td, typename Id, typename Sh, typename Th, typename Ih>
+template <bool STRIDED, typename T, typename I, typename Sd, typename Td, typename Id, typename Sh, typename Th, typename Ih>
 void syevd_heevd_getPerfData(const rocblas_handle handle,
                              const rocblas_evect evect,
                              const rocblas_fill uplo,
-                             const rocblas_int n,
+                             const I n,
                              Td& dA,
-                             const rocblas_int lda,
+                             const I lda,
                              const rocblas_stride stA,
                              Sd& dD,
                              const rocblas_stride stD,
                              Sd& dE,
                              const rocblas_stride stE,
                              Id& dinfo,
-                             const rocblas_int bc,
+                             const I bc,
                              Th& hA,
                              Sh& hD,
                              Ih& hinfo,
@@ -679,22 +679,22 @@ void syevd_heevd_getPerfData(const rocblas_handle handle,
 
     if(!perf)
     {
-        syevd_heevd_initData<true, false, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
+        syevd_heevd_initData<true, false, T, I>(handle, evect, n, dA, lda, bc, hA, A, 0);
 
         // cpu-lapack performance (only if not in perf mode)
         *cpu_time_used = get_time_us_no_sync();
-        for(rocblas_int b = 0; b < bc; ++b)
+        for(I b = 0; b < bc; ++b)
             cpu_syevd_heevd(evect, uplo, n, hA[b], lda, hD[b], work.data(), lwork, hE.data(), sizeE,
                             iwork.data(), liwork, hinfo[b]);
         *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
     }
 
-    syevd_heevd_initData<true, false, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
+    syevd_heevd_initData<true, false, T, I>(handle, evect, n, dA, lda, bc, hA, A, 0);
 
     // cold calls
     for(int iter = 0; iter < 2; iter++)
     {
-        syevd_heevd_initData<false, true, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
+        syevd_heevd_initData<false, true, T, I>(handle, evect, n, dA, lda, bc, hA, A, 0);
 
         CHECK_ROCBLAS_ERROR(rocsolver_syevd_heevd(STRIDED, handle, evect, uplo, n, dA.data(), lda, stA,
                                                   dD.data(), stD, dE.data(), stE, dinfo.data(), bc));
@@ -717,7 +717,7 @@ void syevd_heevd_getPerfData(const rocblas_handle handle,
 
     for(rocblas_int iter = 0; iter < hot_calls; iter++)
     {
-        syevd_heevd_initData<false, true, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
+        syevd_heevd_initData<false, true, T, I>(handle, evect, n, dA, lda, bc, hA, A, 0);
 
         timer.start(stream);
         rocsolver_syevd_heevd(STRIDED, handle, evect, uplo, n, dA.data(), lda, stA, dD.data(), stD,
@@ -727,7 +727,7 @@ void syevd_heevd_getPerfData(const rocblas_handle handle,
     *gpu_time_used = timer.get_combined();
 }
 
-template <bool BATCHED, bool STRIDED, typename T>
+template <bool BATCHED, bool STRIDED, typename T, typename I>
 void testing_syevd_heevd(Arguments& argus)
 {
     using S = decltype(std::real(T{}));
@@ -736,15 +736,15 @@ void testing_syevd_heevd(Arguments& argus)
     rocblas_local_handle handle;
     char evectC = argus.get<char>("evect");
     char uploC = argus.get<char>("uplo");
-    rocblas_int n = argus.get<rocblas_int>("n");
-    rocblas_int lda = argus.get<rocblas_int>("lda", n);
+    I n = argus.get<rocblas_int>("n");
+    I lda = argus.get<rocblas_int>("lda", n);
     rocblas_stride stA = argus.get<rocblas_stride>("strideA", lda * n);
     rocblas_stride stD = argus.get<rocblas_stride>("strideD", n);
     rocblas_stride stE = argus.get<rocblas_stride>("strideE", n);
 
     rocblas_evect evect = char2rocblas_evect(evectC);
     rocblas_fill uplo = char2rocblas_fill(uploC);
-    rocblas_int bc = argus.batch_count;
+    I bc = argus.batch_count;
     rocblas_int hot_calls = argus.iters;
 
     if(argus.alg_mode == 1)
@@ -871,18 +871,18 @@ void testing_syevd_heevd(Arguments& argus)
         // check computations
         if(argus.unit_check || argus.norm_check)
         {
-            syevd_heevd_getError<STRIDED, T>(handle, evect, uplo, n, dA, lda, stA, dD, stD, dE, stE,
-                                             dinfo, bc, hA, hAres, hD, hDres, hinfo, hinfoRes,
-                                             &max_error, &max_ortho_error);
+            syevd_heevd_getError<STRIDED, T, I>(handle, evect, uplo, n, dA, lda, stA, dD, stD, dE,
+                                                stE, dinfo, bc, hA, hAres, hD, hDres, hinfo,
+                                                hinfoRes, &max_error, &max_ortho_error);
         }
 
         // collect performance data
         if(argus.timing && hot_calls > 0)
         {
-            syevd_heevd_getPerfData<STRIDED, T>(handle, evect, uplo, n, dA, lda, stA, dD, stD, dE,
-                                                stE, dinfo, bc, hA, hD, hinfo, &gpu_time_used,
-                                                &cpu_time_used, hot_calls, argus.profile,
-                                                argus.profile_kernels, argus.perf);
+            syevd_heevd_getPerfData<STRIDED, T, I>(handle, evect, uplo, n, dA, lda, stA, dD, stD,
+                                                   dE, stE, dinfo, bc, hA, hD, hinfo,
+                                                   &gpu_time_used, &cpu_time_used, hot_calls,
+                                                   argus.profile, argus.profile_kernels, argus.perf);
         }
     }
 
@@ -911,18 +911,18 @@ void testing_syevd_heevd(Arguments& argus)
         // check computations
         if(argus.unit_check || argus.norm_check)
         {
-            syevd_heevd_getError<STRIDED, T>(handle, evect, uplo, n, dA, lda, stA, dD, stD, dE, stE,
-                                             dinfo, bc, hA, hAres, hD, hDres, hinfo, hinfoRes,
-                                             &max_error, &max_ortho_error);
+            syevd_heevd_getError<STRIDED, T, I>(handle, evect, uplo, n, dA, lda, stA, dD, stD, dE,
+                                                stE, dinfo, bc, hA, hAres, hD, hDres, hinfo,
+                                                hinfoRes, &max_error, &max_ortho_error);
         }
 
         // collect performance data
         if(argus.timing && hot_calls > 0)
         {
-            syevd_heevd_getPerfData<STRIDED, T>(handle, evect, uplo, n, dA, lda, stA, dD, stD, dE,
-                                                stE, dinfo, bc, hA, hD, hinfo, &gpu_time_used,
-                                                &cpu_time_used, hot_calls, argus.profile,
-                                                argus.profile_kernels, argus.perf);
+            syevd_heevd_getPerfData<STRIDED, T, I>(handle, evect, uplo, n, dA, lda, stA, dD, stD,
+                                                   dE, stE, dinfo, bc, hA, hD, hinfo,
+                                                   &gpu_time_used, &cpu_time_used, hot_calls,
+                                                   argus.profile, argus.profile_kernels, argus.perf);
         }
     }
 
@@ -986,4 +986,8 @@ void testing_syevd_heevd(Arguments& argus)
 #define EXTERN_TESTING_SYEVD_HEEVD(...) \
     extern template void testing_syevd_heevd<__VA_ARGS__>(Arguments&);
 
-INSTANTIATE(EXTERN_TESTING_SYEVD_HEEVD, FOREACH_MATRIX_DATA_LAYOUT, FOREACH_SCALAR_TYPE, APPLY_STAMP)
+INSTANTIATE(EXTERN_TESTING_SYEVD_HEEVD,
+            FOREACH_MATRIX_DATA_LAYOUT,
+            FOREACH_SCALAR_TYPE,
+            FOREACH_INT_TYPE,
+            APPLY_STAMP)

--- a/projects/rocsolver/clients/common/misc/rocsolver.hpp
+++ b/projects/rocsolver/clients/common/misc/rocsolver.hpp
@@ -9094,6 +9094,160 @@ inline rocblas_status rocsolver_syev_heev(bool STRIDED,
 {
     return rocsolver_zheev_batched(handle, evect, uplo, n, A, lda, D, stD, E, stE, info, bc);
 }
+
+// normal and strided_batched (int64_t)
+inline rocblas_status rocsolver_syev_heev(bool STRIDED,
+                                          rocblas_handle handle,
+                                          rocblas_evect evect,
+                                          rocblas_fill uplo,
+                                          int64_t n,
+                                          float* A,
+                                          int64_t lda,
+                                          rocblas_stride stA,
+                                          float* D,
+                                          rocblas_stride stD,
+                                          float* E,
+                                          rocblas_stride stE,
+                                          rocblas_int* info,
+                                          int64_t bc)
+{
+    return STRIDED ? rocsolver_ssyev_strided_batched_64(handle, evect, uplo, n, A, lda, stA, D, stD,
+                                                        E, stE, info, bc)
+                   : rocsolver_ssyev_64(handle, evect, uplo, n, A, lda, D, E, info);
+}
+
+inline rocblas_status rocsolver_syev_heev(bool STRIDED,
+                                          rocblas_handle handle,
+                                          rocblas_evect evect,
+                                          rocblas_fill uplo,
+                                          int64_t n,
+                                          double* A,
+                                          int64_t lda,
+                                          rocblas_stride stA,
+                                          double* D,
+                                          rocblas_stride stD,
+                                          double* E,
+                                          rocblas_stride stE,
+                                          rocblas_int* info,
+                                          int64_t bc)
+{
+    return STRIDED ? rocsolver_dsyev_strided_batched_64(handle, evect, uplo, n, A, lda, stA, D, stD,
+                                                        E, stE, info, bc)
+                   : rocsolver_dsyev_64(handle, evect, uplo, n, A, lda, D, E, info);
+}
+
+inline rocblas_status rocsolver_syev_heev(bool STRIDED,
+                                          rocblas_handle handle,
+                                          rocblas_evect evect,
+                                          rocblas_fill uplo,
+                                          int64_t n,
+                                          rocblas_float_complex* A,
+                                          int64_t lda,
+                                          rocblas_stride stA,
+                                          float* D,
+                                          rocblas_stride stD,
+                                          float* E,
+                                          rocblas_stride stE,
+                                          rocblas_int* info,
+                                          int64_t bc)
+{
+    return STRIDED ? rocsolver_cheev_strided_batched_64(handle, evect, uplo, n, A, lda, stA, D, stD,
+                                                        E, stE, info, bc)
+                   : rocsolver_cheev_64(handle, evect, uplo, n, A, lda, D, E, info);
+}
+
+inline rocblas_status rocsolver_syev_heev(bool STRIDED,
+                                          rocblas_handle handle,
+                                          rocblas_evect evect,
+                                          rocblas_fill uplo,
+                                          int64_t n,
+                                          rocblas_double_complex* A,
+                                          int64_t lda,
+                                          rocblas_stride stA,
+                                          double* D,
+                                          rocblas_stride stD,
+                                          double* E,
+                                          rocblas_stride stE,
+                                          rocblas_int* info,
+                                          int64_t bc)
+{
+    return STRIDED ? rocsolver_zheev_strided_batched_64(handle, evect, uplo, n, A, lda, stA, D, stD,
+                                                        E, stE, info, bc)
+                   : rocsolver_zheev_64(handle, evect, uplo, n, A, lda, D, E, info);
+}
+
+// batched (int64_t)
+inline rocblas_status rocsolver_syev_heev(bool STRIDED,
+                                          rocblas_handle handle,
+                                          rocblas_evect evect,
+                                          rocblas_fill uplo,
+                                          int64_t n,
+                                          float* const A[],
+                                          int64_t lda,
+                                          rocblas_stride stA,
+                                          float* D,
+                                          rocblas_stride stD,
+                                          float* E,
+                                          rocblas_stride stE,
+                                          rocblas_int* info,
+                                          int64_t bc)
+{
+    return rocsolver_ssyev_batched_64(handle, evect, uplo, n, A, lda, D, stD, E, stE, info, bc);
+}
+
+inline rocblas_status rocsolver_syev_heev(bool STRIDED,
+                                          rocblas_handle handle,
+                                          rocblas_evect evect,
+                                          rocblas_fill uplo,
+                                          int64_t n,
+                                          double* const A[],
+                                          int64_t lda,
+                                          rocblas_stride stA,
+                                          double* D,
+                                          rocblas_stride stD,
+                                          double* E,
+                                          rocblas_stride stE,
+                                          rocblas_int* info,
+                                          int64_t bc)
+{
+    return rocsolver_dsyev_batched_64(handle, evect, uplo, n, A, lda, D, stD, E, stE, info, bc);
+}
+
+inline rocblas_status rocsolver_syev_heev(bool STRIDED,
+                                          rocblas_handle handle,
+                                          rocblas_evect evect,
+                                          rocblas_fill uplo,
+                                          int64_t n,
+                                          rocblas_float_complex* const A[],
+                                          int64_t lda,
+                                          rocblas_stride stA,
+                                          float* D,
+                                          rocblas_stride stD,
+                                          float* E,
+                                          rocblas_stride stE,
+                                          rocblas_int* info,
+                                          int64_t bc)
+{
+    return rocsolver_cheev_batched_64(handle, evect, uplo, n, A, lda, D, stD, E, stE, info, bc);
+}
+
+inline rocblas_status rocsolver_syev_heev(bool STRIDED,
+                                          rocblas_handle handle,
+                                          rocblas_evect evect,
+                                          rocblas_fill uplo,
+                                          int64_t n,
+                                          rocblas_double_complex* const A[],
+                                          int64_t lda,
+                                          rocblas_stride stA,
+                                          double* D,
+                                          rocblas_stride stD,
+                                          double* E,
+                                          rocblas_stride stE,
+                                          rocblas_int* info,
+                                          int64_t bc)
+{
+    return rocsolver_zheev_batched_64(handle, evect, uplo, n, A, lda, D, stD, E, stE, info, bc);
+}
 /********************************************************/
 
 /******************** SYEVD/HEEVD ********************/
@@ -9249,6 +9403,160 @@ inline rocblas_status rocsolver_syevd_heevd(bool STRIDED,
                                             rocblas_int bc)
 {
     return rocsolver_zheevd_batched(handle, evect, uplo, n, A, lda, D, stD, E, stE, info, bc);
+}
+
+// normal and strided_batched (int64_t)
+inline rocblas_status rocsolver_syevd_heevd(bool STRIDED,
+                                            rocblas_handle handle,
+                                            rocblas_evect evect,
+                                            rocblas_fill uplo,
+                                            int64_t n,
+                                            float* A,
+                                            int64_t lda,
+                                            rocblas_stride stA,
+                                            float* D,
+                                            rocblas_stride stD,
+                                            float* E,
+                                            rocblas_stride stE,
+                                            rocblas_int* info,
+                                            int64_t bc)
+{
+    return STRIDED ? rocsolver_ssyevd_strided_batched_64(handle, evect, uplo, n, A, lda, stA, D,
+                                                         stD, E, stE, info, bc)
+                   : rocsolver_ssyevd_64(handle, evect, uplo, n, A, lda, D, E, info);
+}
+
+inline rocblas_status rocsolver_syevd_heevd(bool STRIDED,
+                                            rocblas_handle handle,
+                                            rocblas_evect evect,
+                                            rocblas_fill uplo,
+                                            int64_t n,
+                                            double* A,
+                                            int64_t lda,
+                                            rocblas_stride stA,
+                                            double* D,
+                                            rocblas_stride stD,
+                                            double* E,
+                                            rocblas_stride stE,
+                                            rocblas_int* info,
+                                            int64_t bc)
+{
+    return STRIDED ? rocsolver_dsyevd_strided_batched_64(handle, evect, uplo, n, A, lda, stA, D,
+                                                         stD, E, stE, info, bc)
+                   : rocsolver_dsyevd_64(handle, evect, uplo, n, A, lda, D, E, info);
+}
+
+inline rocblas_status rocsolver_syevd_heevd(bool STRIDED,
+                                            rocblas_handle handle,
+                                            rocblas_evect evect,
+                                            rocblas_fill uplo,
+                                            int64_t n,
+                                            rocblas_float_complex* A,
+                                            int64_t lda,
+                                            rocblas_stride stA,
+                                            float* D,
+                                            rocblas_stride stD,
+                                            float* E,
+                                            rocblas_stride stE,
+                                            rocblas_int* info,
+                                            int64_t bc)
+{
+    return STRIDED ? rocsolver_cheevd_strided_batched_64(handle, evect, uplo, n, A, lda, stA, D,
+                                                         stD, E, stE, info, bc)
+                   : rocsolver_cheevd_64(handle, evect, uplo, n, A, lda, D, E, info);
+}
+
+inline rocblas_status rocsolver_syevd_heevd(bool STRIDED,
+                                            rocblas_handle handle,
+                                            rocblas_evect evect,
+                                            rocblas_fill uplo,
+                                            int64_t n,
+                                            rocblas_double_complex* A,
+                                            int64_t lda,
+                                            rocblas_stride stA,
+                                            double* D,
+                                            rocblas_stride stD,
+                                            double* E,
+                                            rocblas_stride stE,
+                                            rocblas_int* info,
+                                            int64_t bc)
+{
+    return STRIDED ? rocsolver_zheevd_strided_batched_64(handle, evect, uplo, n, A, lda, stA, D,
+                                                         stD, E, stE, info, bc)
+                   : rocsolver_zheevd_64(handle, evect, uplo, n, A, lda, D, E, info);
+}
+
+// batched (int64_t)
+inline rocblas_status rocsolver_syevd_heevd(bool STRIDED,
+                                            rocblas_handle handle,
+                                            rocblas_evect evect,
+                                            rocblas_fill uplo,
+                                            int64_t n,
+                                            float* const A[],
+                                            int64_t lda,
+                                            rocblas_stride stA,
+                                            float* D,
+                                            rocblas_stride stD,
+                                            float* E,
+                                            rocblas_stride stE,
+                                            rocblas_int* info,
+                                            int64_t bc)
+{
+    return rocsolver_ssyevd_batched_64(handle, evect, uplo, n, A, lda, D, stD, E, stE, info, bc);
+}
+
+inline rocblas_status rocsolver_syevd_heevd(bool STRIDED,
+                                            rocblas_handle handle,
+                                            rocblas_evect evect,
+                                            rocblas_fill uplo,
+                                            int64_t n,
+                                            double* const A[],
+                                            int64_t lda,
+                                            rocblas_stride stA,
+                                            double* D,
+                                            rocblas_stride stD,
+                                            double* E,
+                                            rocblas_stride stE,
+                                            rocblas_int* info,
+                                            int64_t bc)
+{
+    return rocsolver_dsyevd_batched_64(handle, evect, uplo, n, A, lda, D, stD, E, stE, info, bc);
+}
+
+inline rocblas_status rocsolver_syevd_heevd(bool STRIDED,
+                                            rocblas_handle handle,
+                                            rocblas_evect evect,
+                                            rocblas_fill uplo,
+                                            int64_t n,
+                                            rocblas_float_complex* const A[],
+                                            int64_t lda,
+                                            rocblas_stride stA,
+                                            float* D,
+                                            rocblas_stride stD,
+                                            float* E,
+                                            rocblas_stride stE,
+                                            rocblas_int* info,
+                                            int64_t bc)
+{
+    return rocsolver_cheevd_batched_64(handle, evect, uplo, n, A, lda, D, stD, E, stE, info, bc);
+}
+
+inline rocblas_status rocsolver_syevd_heevd(bool STRIDED,
+                                            rocblas_handle handle,
+                                            rocblas_evect evect,
+                                            rocblas_fill uplo,
+                                            int64_t n,
+                                            rocblas_double_complex* const A[],
+                                            int64_t lda,
+                                            rocblas_stride stA,
+                                            double* D,
+                                            rocblas_stride stD,
+                                            double* E,
+                                            rocblas_stride stE,
+                                            rocblas_int* info,
+                                            int64_t bc)
+{
+    return rocsolver_zheevd_batched_64(handle, evect, uplo, n, A, lda, D, stD, E, stE, info, bc);
 }
 /********************************************************/
 

--- a/projects/rocsolver/clients/gtest/lapack/syev_heev_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/syev_heev_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -81,7 +81,7 @@ Arguments syev_heev_setup_arguments(syev_heev_tuple tup)
     return arg;
 }
 
-template <rocblas_int MODE>
+template <rocblas_int MODE, typename I>
 class SYEV_HEEV : public ::TestWithParam<syev_heev_tuple>
 {
 protected:
@@ -98,26 +98,42 @@ protected:
 
         if(arg.peek<rocblas_int>("n") == 0 && arg.peek<char>("evect") == 'N'
            && arg.peek<char>("uplo") == 'L')
-            testing_syev_heev_bad_arg<BATCHED, STRIDED, T>();
+            testing_syev_heev_bad_arg<BATCHED, STRIDED, T, I>();
 
         arg.batch_count = (BATCHED || STRIDED ? 3 : 1);
-        testing_syev_heev<BATCHED, STRIDED, T>(arg);
+        testing_syev_heev<BATCHED, STRIDED, T, I>(arg);
     }
 };
 
-class SYEV : public SYEV_HEEV<0>
+class SYEV : public SYEV_HEEV<0, rocblas_int>
 {
 };
 
-class HEEV : public SYEV_HEEV<0>
+class HEEV : public SYEV_HEEV<0, rocblas_int>
 {
 };
 
-class SYEV_HYBRID : public SYEV_HEEV<1>
+class SYEV_HYBRID : public SYEV_HEEV<1, rocblas_int>
 {
 };
 
-class HEEV_HYBRID : public SYEV_HEEV<1>
+class HEEV_HYBRID : public SYEV_HEEV<1, rocblas_int>
+{
+};
+
+class SYEV_64 : public SYEV_HEEV<0, int64_t>
+{
+};
+
+class HEEV_64 : public SYEV_HEEV<0, int64_t>
+{
+};
+
+class SYEV_HYBRID_64 : public SYEV_HEEV<1, int64_t>
+{
+};
+
+class HEEV_HYBRID_64 : public SYEV_HEEV<1, int64_t>
 {
 };
 
@@ -247,6 +263,132 @@ TEST_P(HEEV_HYBRID, strided_batched__double_complex)
     run_tests<false, true, rocblas_double_complex>();
 }
 
+// non-batch tests (int64_t API)
+
+TEST_P(SYEV_64, __float)
+{
+    run_tests<false, false, float>();
+}
+
+TEST_P(SYEV_64, __double)
+{
+    run_tests<false, false, double>();
+}
+
+TEST_P(HEEV_64, __float_complex)
+{
+    run_tests<false, false, rocblas_float_complex>();
+}
+
+TEST_P(HEEV_64, __double_complex)
+{
+    run_tests<false, false, rocblas_double_complex>();
+}
+
+TEST_P(SYEV_HYBRID_64, __float)
+{
+    run_tests<false, false, float>();
+}
+
+TEST_P(SYEV_HYBRID_64, __double)
+{
+    run_tests<false, false, double>();
+}
+
+TEST_P(HEEV_HYBRID_64, __float_complex)
+{
+    run_tests<false, false, rocblas_float_complex>();
+}
+
+TEST_P(HEEV_HYBRID_64, __double_complex)
+{
+    run_tests<false, false, rocblas_double_complex>();
+}
+
+// batched tests (int64_t API)
+
+TEST_P(SYEV_64, batched__float)
+{
+    run_tests<true, true, float>();
+}
+
+TEST_P(SYEV_64, batched__double)
+{
+    run_tests<true, true, double>();
+}
+
+TEST_P(HEEV_64, batched__float_complex)
+{
+    run_tests<true, true, rocblas_float_complex>();
+}
+
+TEST_P(HEEV_64, batched__double_complex)
+{
+    run_tests<true, true, rocblas_double_complex>();
+}
+
+TEST_P(SYEV_HYBRID_64, batched__float)
+{
+    run_tests<true, true, float>();
+}
+
+TEST_P(SYEV_HYBRID_64, batched__double)
+{
+    run_tests<true, true, double>();
+}
+
+TEST_P(HEEV_HYBRID_64, batched__float_complex)
+{
+    run_tests<true, true, rocblas_float_complex>();
+}
+
+TEST_P(HEEV_HYBRID_64, batched__double_complex)
+{
+    run_tests<true, true, rocblas_double_complex>();
+}
+
+// strided_batched tests (int64_t API)
+
+TEST_P(SYEV_64, strided_batched__float)
+{
+    run_tests<false, true, float>();
+}
+
+TEST_P(SYEV_64, strided_batched__double)
+{
+    run_tests<false, true, double>();
+}
+
+TEST_P(HEEV_64, strided_batched__float_complex)
+{
+    run_tests<false, true, rocblas_float_complex>();
+}
+
+TEST_P(HEEV_64, strided_batched__double_complex)
+{
+    run_tests<false, true, rocblas_double_complex>();
+}
+
+TEST_P(SYEV_HYBRID_64, strided_batched__float)
+{
+    run_tests<false, true, float>();
+}
+
+TEST_P(SYEV_HYBRID_64, strided_batched__double)
+{
+    run_tests<false, true, double>();
+}
+
+TEST_P(HEEV_HYBRID_64, strided_batched__float_complex)
+{
+    run_tests<false, true, rocblas_float_complex>();
+}
+
+TEST_P(HEEV_HYBRID_64, strided_batched__double_complex)
+{
+    run_tests<false, true, rocblas_double_complex>();
+}
+
 // daily_lapack tests normal execution with medium to large sizes
 INSTANTIATE_TEST_SUITE_P(daily_lapack, SYEV, Combine(ValuesIn(large_size_range), ValuesIn(op_range)));
 
@@ -258,6 +400,22 @@ INSTANTIATE_TEST_SUITE_P(daily_lapack,
 
 INSTANTIATE_TEST_SUITE_P(daily_lapack,
                          HEEV_HYBRID,
+                         Combine(ValuesIn(large_size_range), ValuesIn(op_range)));
+
+INSTANTIATE_TEST_SUITE_P(daily_lapack,
+                         SYEV_64,
+                         Combine(ValuesIn(large_size_range), ValuesIn(op_range)));
+
+INSTANTIATE_TEST_SUITE_P(daily_lapack,
+                         HEEV_64,
+                         Combine(ValuesIn(large_size_range), ValuesIn(op_range)));
+
+INSTANTIATE_TEST_SUITE_P(daily_lapack,
+                         SYEV_HYBRID_64,
+                         Combine(ValuesIn(large_size_range), ValuesIn(op_range)));
+
+INSTANTIATE_TEST_SUITE_P(daily_lapack,
+                         HEEV_HYBRID_64,
                          Combine(ValuesIn(large_size_range), ValuesIn(op_range)));
 
 // checkin_lapack tests normal execution with small sizes, invalid sizes,
@@ -272,4 +430,16 @@ INSTANTIATE_TEST_SUITE_P(checkin_lapack,
 
 INSTANTIATE_TEST_SUITE_P(checkin_lapack,
                          HEEV_HYBRID,
+                         Combine(ValuesIn(size_range), ValuesIn(op_range)));
+
+INSTANTIATE_TEST_SUITE_P(checkin_lapack, SYEV_64, Combine(ValuesIn(size_range), ValuesIn(op_range)));
+
+INSTANTIATE_TEST_SUITE_P(checkin_lapack, HEEV_64, Combine(ValuesIn(size_range), ValuesIn(op_range)));
+
+INSTANTIATE_TEST_SUITE_P(checkin_lapack,
+                         SYEV_HYBRID_64,
+                         Combine(ValuesIn(size_range), ValuesIn(op_range)));
+
+INSTANTIATE_TEST_SUITE_P(checkin_lapack,
+                         HEEV_HYBRID_64,
                          Combine(ValuesIn(size_range), ValuesIn(op_range)));

--- a/projects/rocsolver/clients/gtest/lapack/syevd_heevd_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/syevd_heevd_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -81,7 +81,7 @@ Arguments syevd_heevd_setup_arguments(syevd_heevd_tuple tup)
     return arg;
 }
 
-template <rocblas_int MODE>
+template <rocblas_int MODE, typename I>
 class SYEVD_HEEVD : public ::TestWithParam<syevd_heevd_tuple>
 {
 protected:
@@ -98,26 +98,42 @@ protected:
 
         if(arg.peek<rocblas_int>("n") == 0 && arg.peek<char>("evect") == 'N'
            && arg.peek<char>("uplo") == 'L')
-            testing_syevd_heevd_bad_arg<BATCHED, STRIDED, T>();
+            testing_syevd_heevd_bad_arg<BATCHED, STRIDED, T, I>();
 
         arg.batch_count = (BATCHED || STRIDED ? 3 : 1);
-        testing_syevd_heevd<BATCHED, STRIDED, T>(arg);
+        testing_syevd_heevd<BATCHED, STRIDED, T, I>(arg);
     }
 };
 
-class SYEVD : public SYEVD_HEEVD<0>
+class SYEVD : public SYEVD_HEEVD<0, rocblas_int>
 {
 };
 
-class HEEVD : public SYEVD_HEEVD<0>
+class HEEVD : public SYEVD_HEEVD<0, rocblas_int>
 {
 };
 
-class SYEVD_HYBRID : public SYEVD_HEEVD<1>
+class SYEVD_HYBRID : public SYEVD_HEEVD<1, rocblas_int>
 {
 };
 
-class HEEVD_HYBRID : public SYEVD_HEEVD<1>
+class HEEVD_HYBRID : public SYEVD_HEEVD<1, rocblas_int>
+{
+};
+
+class SYEVD_64 : public SYEVD_HEEVD<0, int64_t>
+{
+};
+
+class HEEVD_64 : public SYEVD_HEEVD<0, int64_t>
+{
+};
+
+class SYEVD_HYBRID_64 : public SYEVD_HEEVD<1, int64_t>
+{
+};
+
+class HEEVD_HYBRID_64 : public SYEVD_HEEVD<1, int64_t>
 {
 };
 
@@ -247,6 +263,132 @@ TEST_P(HEEVD_HYBRID, strided_batched__double_complex)
     run_tests<false, true, rocblas_double_complex>();
 }
 
+// non-batch tests (int64_t API)
+
+TEST_P(SYEVD_64, __float)
+{
+    run_tests<false, false, float>();
+}
+
+TEST_P(SYEVD_64, __double)
+{
+    run_tests<false, false, double>();
+}
+
+TEST_P(HEEVD_64, __float_complex)
+{
+    run_tests<false, false, rocblas_float_complex>();
+}
+
+TEST_P(HEEVD_64, __double_complex)
+{
+    run_tests<false, false, rocblas_double_complex>();
+}
+
+TEST_P(SYEVD_HYBRID_64, __float)
+{
+    run_tests<false, false, float>();
+}
+
+TEST_P(SYEVD_HYBRID_64, __double)
+{
+    run_tests<false, false, double>();
+}
+
+TEST_P(HEEVD_HYBRID_64, __float_complex)
+{
+    run_tests<false, false, rocblas_float_complex>();
+}
+
+TEST_P(HEEVD_HYBRID_64, __double_complex)
+{
+    run_tests<false, false, rocblas_double_complex>();
+}
+
+// batched tests (int64_t API)
+
+TEST_P(SYEVD_64, batched__float)
+{
+    run_tests<true, true, float>();
+}
+
+TEST_P(SYEVD_64, batched__double)
+{
+    run_tests<true, true, double>();
+}
+
+TEST_P(HEEVD_64, batched__float_complex)
+{
+    run_tests<true, true, rocblas_float_complex>();
+}
+
+TEST_P(HEEVD_64, batched__double_complex)
+{
+    run_tests<true, true, rocblas_double_complex>();
+}
+
+TEST_P(SYEVD_HYBRID_64, batched__float)
+{
+    run_tests<true, true, float>();
+}
+
+TEST_P(SYEVD_HYBRID_64, batched__double)
+{
+    run_tests<true, true, double>();
+}
+
+TEST_P(HEEVD_HYBRID_64, batched__float_complex)
+{
+    run_tests<true, true, rocblas_float_complex>();
+}
+
+TEST_P(HEEVD_HYBRID_64, batched__double_complex)
+{
+    run_tests<true, true, rocblas_double_complex>();
+}
+
+// strided_batched tests (int64_t API)
+
+TEST_P(SYEVD_64, strided_batched__float)
+{
+    run_tests<false, true, float>();
+}
+
+TEST_P(SYEVD_64, strided_batched__double)
+{
+    run_tests<false, true, double>();
+}
+
+TEST_P(HEEVD_64, strided_batched__float_complex)
+{
+    run_tests<false, true, rocblas_float_complex>();
+}
+
+TEST_P(HEEVD_64, strided_batched__double_complex)
+{
+    run_tests<false, true, rocblas_double_complex>();
+}
+
+TEST_P(SYEVD_HYBRID_64, strided_batched__float)
+{
+    run_tests<false, true, float>();
+}
+
+TEST_P(SYEVD_HYBRID_64, strided_batched__double)
+{
+    run_tests<false, true, double>();
+}
+
+TEST_P(HEEVD_HYBRID_64, strided_batched__float_complex)
+{
+    run_tests<false, true, rocblas_float_complex>();
+}
+
+TEST_P(HEEVD_HYBRID_64, strided_batched__double_complex)
+{
+    run_tests<false, true, rocblas_double_complex>();
+}
+
 // daily_lapack tests normal execution with medium to large sizes
 INSTANTIATE_TEST_SUITE_P(daily_lapack, SYEVD, Combine(ValuesIn(large_size_range), ValuesIn(op_range)));
 
@@ -258,6 +400,22 @@ INSTANTIATE_TEST_SUITE_P(daily_lapack,
 
 INSTANTIATE_TEST_SUITE_P(daily_lapack,
                          HEEVD_HYBRID,
+                         Combine(ValuesIn(large_size_range), ValuesIn(op_range)));
+
+INSTANTIATE_TEST_SUITE_P(daily_lapack,
+                         SYEVD_64,
+                         Combine(ValuesIn(large_size_range), ValuesIn(op_range)));
+
+INSTANTIATE_TEST_SUITE_P(daily_lapack,
+                         HEEVD_64,
+                         Combine(ValuesIn(large_size_range), ValuesIn(op_range)));
+
+INSTANTIATE_TEST_SUITE_P(daily_lapack,
+                         SYEVD_HYBRID_64,
+                         Combine(ValuesIn(large_size_range), ValuesIn(op_range)));
+
+INSTANTIATE_TEST_SUITE_P(daily_lapack,
+                         HEEVD_HYBRID_64,
                          Combine(ValuesIn(large_size_range), ValuesIn(op_range)));
 
 // checkin_lapack tests normal execution with small sizes, invalid sizes,
@@ -272,4 +430,16 @@ INSTANTIATE_TEST_SUITE_P(checkin_lapack,
 
 INSTANTIATE_TEST_SUITE_P(checkin_lapack,
                          HEEVD_HYBRID,
+                         Combine(ValuesIn(size_range), ValuesIn(op_range)));
+
+INSTANTIATE_TEST_SUITE_P(checkin_lapack, SYEVD_64, Combine(ValuesIn(size_range), ValuesIn(op_range)));
+
+INSTANTIATE_TEST_SUITE_P(checkin_lapack, HEEVD_64, Combine(ValuesIn(size_range), ValuesIn(op_range)));
+
+INSTANTIATE_TEST_SUITE_P(checkin_lapack,
+                         SYEVD_HYBRID_64,
+                         Combine(ValuesIn(size_range), ValuesIn(op_range)));
+
+INSTANTIATE_TEST_SUITE_P(checkin_lapack,
+                         HEEVD_HYBRID_64,
                          Combine(ValuesIn(size_range), ValuesIn(op_range)));


### PR DESCRIPTION
## Motivation

We want to test the 64 bit eigensolver routines.

## Technical Details

This PR depends on the public interface (e.g., `ssyevd_64`) for both the batched, strided batched, and regular versions of the routines.

## Test Plan

I can't test until the public interface for `syevd` and `syev` are prepared.

## Test Result

See above.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
