### PR TITLE
[rocsparse] Fix memory leak of nnzsplit starting_ids in csrmv info

### DIFF
--- a/projects/rocsparse/library/src/CMakeLists.txt
+++ b/projects/rocsparse/library/src/CMakeLists.txt
@@ -127,6 +127,7 @@ set(rocsparse_source
   src/level2/rocsparse_csrmv_info.cpp
   src/level2/rocsparse_csrmv_adaptive_info.cpp
   src/level2/rocsparse_csrmv_lrb_info.cpp
+  src/level2/rocsparse_csrmv_nnzsplit_info.cpp
   src/level2/rocsparse_csrmv_analysis.cpp
   #
   src/level2/rocsparse_cscmv_impl.cpp

--- a/projects/rocsparse/library/src/include/rocsparse_csrmv_info.hpp
+++ b/projects/rocsparse/library/src/include/rocsparse_csrmv_info.hpp
@@ -1,6 +1,6 @@
 /*! \file */
 /* ************************************************************************
- * Copyright (C) 2025 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2025-2026 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -63,6 +63,7 @@ typedef struct _rocsparse_csrmv_info
     {
         this->adaptive.clear();
         this->lrb.clear();
+        this->nnzsplit.clear();
         this->trans        = rocsparse_operation_none;
         this->m            = 0;
         this->n            = 0;

--- a/projects/rocsparse/library/src/level2/rocsparse_csrmv_nnzsplit_info.cpp
+++ b/projects/rocsparse/library/src/level2/rocsparse_csrmv_nnzsplit_info.cpp
@@ -1,6 +1,6 @@
 /*! \file */
 /* ************************************************************************
- * Copyright (C) 2025-2026 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,19 +22,32 @@
  *
  * ************************************************************************ */
 
-#pragma once
+#include "rocsparse_control.hpp"
+#include "rocsparse_nnzsplit_info.hpp"
+#include "rocsparse_utility.hpp"
 
-typedef struct _rocsparse_nnzsplit_info
+_rocsparse_nnzsplit_info::~_rocsparse_nnzsplit_info()
 {
+    WARNING_IF_HIP_ERROR(hipDeviceSynchronize());
 
-    bool use_starting_block_ids{};
+    // starting_block_ids points into the starting_ids allocation, so only one free is needed.
+    WARNING_IF_HIP_ERROR(rocsparse_hipFree(this->starting_ids));
 
-    size_t size{};
+    this->starting_ids           = nullptr;
+    this->starting_block_ids     = nullptr;
+    this->size                   = 0;
+    this->use_starting_block_ids = false;
+}
 
-    void* starting_ids{};
-    void* starting_block_ids{};
+void _rocsparse_nnzsplit_info::clear()
+{
+    WARNING_IF_HIP_ERROR(hipDeviceSynchronize());
 
-public:
-    ~_rocsparse_nnzsplit_info();
-    void clear();
-} * rocsparse_nnzsplit_info;
+    // starting_block_ids points into the starting_ids allocation, so only one free is needed.
+    THROW_IF_HIP_ERROR(rocsparse_hipFree(this->starting_ids));
+
+    this->starting_ids           = nullptr;
+    this->starting_block_ids     = nullptr;
+    this->size                   = 0;
+    this->use_starting_block_ids = false;
+}


### PR DESCRIPTION
## What changed and why

`_rocsparse_csrmv_info::clear()` frees the `adaptive` and `lrb` sub-info device buffers but never frees `nnzsplit.starting_ids`, the device buffer allocated in `rocsparse_csrmv_template_nnzsplit.cpp`. This causes a device memory leak every time csrmv info is cleared or destroyed.

The fix adds a destructor and `clear()` method to `_rocsparse_nnzsplit_info`, matching the existing pattern used by `_rocsparse_adaptive_info` and `_rocsparse_lrb_info`, and calls `this->nnzsplit.clear()` from `_rocsparse_csrmv_info::clear()`.

`starting_block_ids` is an interior pointer into the `starting_ids` allocation (`&temp_buffer_j[requiredBlocks + 1]`), so only `starting_ids` needs to be freed.

## API changes / backward compatibility

None. This is an internal-only change; no public API is affected.

## Performance impact

This is a memory leak fix. No performance regression is expected — the only added cost is freeing a device allocation that was previously leaked.

## Testing

The existing csrmv test suite exercises the nnzsplit code path and validates functional correctness. The leak was silent (no crash or wrong result), so no new test case is added. The fix can be verified with a memory sanitizer or memstat-enabled build.