### PR TITLE
[rocsparse] Replace hipDeviceSynchronize with hipStreamSynchronize in csric0/csrilu0 tests

### DIFF
--- a/projects/rocsparse/clients/testings/testing_csric0.cpp
+++ b/projects/rocsparse/clients/testings/testing_csric0.cpp
@@ -1,6 +1,6 @@
 /*! \file */
 /* ************************************************************************
- * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2019-2026 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -38,6 +38,9 @@ static void test_csric0_matrix(rocsparse_local_handle&    handle,
 
                                bool need_display)
 {
+    hipStream_t stream{};
+    CHECK_ROCSPARSE_ERROR(rocsparse_get_stream(handle, &stream));
+
     bool arg_unit_check = arg.unit_check;
     bool arg_timing     = arg.timing;
     int  arg_iters      = arg.iters;
@@ -117,7 +120,7 @@ static void test_csric0_matrix(rocsparse_local_handle&    handle,
         }
 
         // Sync to force updated pivots
-        CHECK_HIP_ERROR(hipDeviceSynchronize());
+        CHECK_HIP_ERROR(hipStreamSynchronize(stream));
 
         // Pointer mode device
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_device));
@@ -137,7 +140,7 @@ static void test_csric0_matrix(rocsparse_local_handle&    handle,
                                                               : rocsparse_status_success);
 
         // Sync to force updated pivots
-        CHECK_HIP_ERROR(hipDeviceSynchronize());
+        CHECK_HIP_ERROR(hipStreamSynchronize(stream));
 
         // Perform solve step
 
@@ -157,7 +160,7 @@ static void test_csric0_matrix(rocsparse_local_handle&    handle,
         }
 
         // Sync to force updated pivots
-        CHECK_HIP_ERROR(hipDeviceSynchronize());
+        CHECK_HIP_ERROR(hipStreamSynchronize(stream));
 
         // Pointer mode device
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_device));
@@ -174,7 +177,7 @@ static void test_csric0_matrix(rocsparse_local_handle&    handle,
         }
 
         // Sync to force updated pivots
-        CHECK_HIP_ERROR(hipDeviceSynchronize());
+        CHECK_HIP_ERROR(hipStreamSynchronize(stream));
 
         // Copy output to host
         CHECK_HIP_ERROR(hipMemcpy(hcsr_val_1, dcsr_val_1, sizeof(T) * nnz, hipMemcpyDeviceToHost));
@@ -510,6 +513,9 @@ void testing_csric0(const Arguments& arg)
     // Create rocsparse handle
     rocsparse_local_handle handle(arg);
 
+    hipStream_t stream{};
+    CHECK_ROCSPARSE_ERROR(rocsparse_get_stream(handle, &stream));
+
     // Create matrix descriptor
     rocsparse_local_mat_descr descr;
 
@@ -667,7 +673,7 @@ void testing_csric0(const Arguments& arg)
             }
 
             // Sync to force updated pivots
-            CHECK_HIP_ERROR(hipDeviceSynchronize());
+            CHECK_HIP_ERROR(hipStreamSynchronize(stream));
 
             // Pointer mode device
             CHECK_ROCSPARSE_ERROR(
@@ -688,7 +694,7 @@ void testing_csric0(const Arguments& arg)
                                                                   : rocsparse_status_success);
 
             // Sync to force updated pivots
-            CHECK_HIP_ERROR(hipDeviceSynchronize());
+            CHECK_HIP_ERROR(hipStreamSynchronize(stream));
 
             // Perform solve step
 
@@ -712,7 +718,7 @@ void testing_csric0(const Arguments& arg)
             }
 
             // Sync to force updated pivots
-            CHECK_HIP_ERROR(hipDeviceSynchronize());
+            CHECK_HIP_ERROR(hipStreamSynchronize(stream));
 
             // Pointer mode device
             CHECK_ROCSPARSE_ERROR(
@@ -732,7 +738,7 @@ void testing_csric0(const Arguments& arg)
                                                                : rocsparse_status_success);
 
             // Sync to force updated pivots
-            CHECK_HIP_ERROR(hipDeviceSynchronize());
+            CHECK_HIP_ERROR(hipStreamSynchronize(stream));
 
             // Copy output to host
             CHECK_HIP_ERROR(
@@ -1058,6 +1064,9 @@ void testing_csric0_extra_dense_matrix(const Arguments& arg)
     // Create rocsparse handle
     rocsparse_local_handle handle(arg);
 
+    hipStream_t stream{};
+    CHECK_ROCSPARSE_ERROR(rocsparse_get_stream(handle, &stream));
+
     // Create matrix descriptor
     rocsparse_local_mat_descr descr;
 
@@ -1149,7 +1158,7 @@ void testing_csric0_extra_dense_matrix(const Arguments& arg)
     }
 
     // Sync to force updated pivots
-    CHECK_HIP_ERROR(hipDeviceSynchronize());
+    CHECK_HIP_ERROR(hipStreamSynchronize(stream));
 
     // Pointer mode device
     CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_device));
@@ -1160,7 +1169,7 @@ void testing_csric0_extra_dense_matrix(const Arguments& arg)
                                                           : rocsparse_status_success);
 
     // Sync to force updated pivots
-    CHECK_HIP_ERROR(hipDeviceSynchronize());
+    CHECK_HIP_ERROR(hipStreamSynchronize(stream));
 
     // Perform solve step
 
@@ -1176,7 +1185,7 @@ void testing_csric0_extra_dense_matrix(const Arguments& arg)
     }
 
     // Sync to force updated pivots
-    CHECK_HIP_ERROR(hipDeviceSynchronize());
+    CHECK_HIP_ERROR(hipStreamSynchronize(stream));
 
     // Pointer mode device
     CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_device));
@@ -1187,7 +1196,7 @@ void testing_csric0_extra_dense_matrix(const Arguments& arg)
                                                        : rocsparse_status_success);
 
     // Sync to force updated pivots
-    CHECK_HIP_ERROR(hipDeviceSynchronize());
+    CHECK_HIP_ERROR(hipStreamSynchronize(stream));
 
     // Copy output to host
     CHECK_HIP_ERROR(hipMemcpy(hcsr_val_1, dcsr_val_1, sizeof(float) * nnz, hipMemcpyDeviceToHost));

--- a/projects/rocsparse/clients/testings/testing_csrilu0.cpp
+++ b/projects/rocsparse/clients/testings/testing_csrilu0.cpp
@@ -1,6 +1,6 @@
 /*! \file */
 /* ************************************************************************
- * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2019-2026 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,6 +40,9 @@ static void test_csrilu0_matrix(rocsparse_local_handle&    handle,
                                 const Arguments& arg,
                                 bool             need_display)
 {
+    hipStream_t stream{};
+    CHECK_ROCSPARSE_ERROR(rocsparse_get_stream(handle, &stream));
+
     const rocsparse_analysis_policy apol = arg.apol;
     const rocsparse_solve_policy    spol = arg.spol;
     const rocsparse_index_base      base = arg.baseA;
@@ -123,7 +126,7 @@ static void test_csrilu0_matrix(rocsparse_local_handle&    handle,
                                                                   : rocsparse_status_success);
         }
         // Sync to force updated pivots
-        CHECK_HIP_ERROR(hipDeviceSynchronize());
+        CHECK_HIP_ERROR(hipStreamSynchronize(stream));
 
         // Pointer mode device
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_device));
@@ -143,7 +146,7 @@ static void test_csrilu0_matrix(rocsparse_local_handle&    handle,
                                                               : rocsparse_status_success);
 
         // Sync to force updated pivots
-        CHECK_HIP_ERROR(hipDeviceSynchronize());
+        CHECK_HIP_ERROR(hipStreamSynchronize(stream));
 
         // Perform solve step
 
@@ -166,7 +169,7 @@ static void test_csrilu0_matrix(rocsparse_local_handle&    handle,
         }
 
         // Sync to force updated pivots
-        CHECK_HIP_ERROR(hipDeviceSynchronize());
+        CHECK_HIP_ERROR(hipStreamSynchronize(stream));
 
         // Pointer mode device
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_device));
@@ -183,7 +186,7 @@ static void test_csrilu0_matrix(rocsparse_local_handle&    handle,
             EXPECT_ROCSPARSE_STATUS(st, rocsparse_status_success);
         }
         // Sync to force updated pivots
-        CHECK_HIP_ERROR(hipDeviceSynchronize());
+        CHECK_HIP_ERROR(hipStreamSynchronize(stream));
 
         // Copy output to host
         CHECK_HIP_ERROR(hipMemcpy(hcsr_val_1, dcsr_val_1, sizeof(T) * nnz, hipMemcpyDeviceToHost));


### PR DESCRIPTION
## What changed and why

The csric0 and csrilu0 test files use `hipDeviceSynchronize()` to force updated pivots after analysis and solve steps. This synchronizes all streams on the device, which is overly broad — only the handle's stream needs to be waited on. This can mask timing issues and cause unnecessary stalls when multiple streams are in use.

This PR replaces all `hipDeviceSynchronize()` calls in `testing_csric0.cpp` and `testing_csrilu0.cpp` with `hipStreamSynchronize(stream)`, where `stream` is obtained from the rocsparse handle via `rocsparse_get_stream`.

Affected functions:
- `testing_csric0.cpp`: `test_csric0_matrix`, `testing_csric0`,  `testing_csric0_extra_dense_matrix`
- `testing_csrilu0.cpp`: `test_csrilu0_matrix`

## API changes / backward compatibility

None. This change is test-only; no library code is affected.

## Performance impact

No impact on library performance. Test execution may be marginally faster in multi-stream scenarios since only the relevant stream is synchronized.

## Testing

The change is within the test code itself. All existing csric0 and csrilu0 tests exercise these code paths and validate correctness of pivots after the synchronization points.

## Areas needing review attention

- Verify that all synchronization points in these tests are solely waiting  on work submitted to the handle's stream (no other streams involved).

## Related issues

Other test files in rocsparse may have similar `hipDeviceSynchronize()` calls that could benefit from the same treatment.