### PR TITLE
[rocsparse] Add null/zero-size guards to memstat allocation functions

### DIFF
--- a/projects/rocsparse/library/src/common/rocsparse_memstat.cpp
+++ b/projects/rocsparse/library/src/common/rocsparse_memstat.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -243,7 +243,7 @@ private:
         }
     };
 
-    memstat(const memstat&) = delete;
+    memstat(const memstat&)            = delete;
     memstat& operator=(const memstat&) = delete;
 
     struct stat
@@ -700,6 +700,8 @@ hipError_t memstat_allocator<MODE>::free_async(void* d_, hipStream_t stream)
 
 hipError_t rocsparse_free(void* mem, memstat_mode::value_t mode, const char* tag)
 {
+    if(!mem)
+        return hipSuccess;
     hipError_t err = hipErrorInvalidValue;
     switch(mode)
     {
@@ -737,7 +739,11 @@ hipError_t rocsparse_free(void* mem, memstat_mode::value_t mode, const char* tag
 
 hipError_t rocsparse_malloc(void** mem, size_t nbytes, memstat_mode::value_t mode, const char* tag)
 {
-
+    if(nbytes == 0)
+    {
+        mem[0] = nullptr;
+        return hipSuccess;
+    }
     hipError_t err = hipErrorInvalidValue;
     switch(mode)
     {
@@ -773,6 +779,8 @@ hipError_t rocsparse_malloc(void** mem, size_t nbytes, memstat_mode::value_t mod
 hipError_t
     rocsparse_free_async(void* mem, hipStream_t stream, memstat_mode::value_t mode, const char* tag)
 {
+    if(!mem)
+        return hipSuccess;
     hipError_t err = hipErrorInvalidValue;
     switch(mode)
     {
@@ -809,7 +817,11 @@ hipError_t
 hipError_t rocsparse_malloc_async(
     void** mem, size_t nbytes, hipStream_t stream, memstat_mode::value_t mode, const char* tag)
 {
-
+    if(nbytes == 0)
+    {
+        mem[0] = nullptr;
+        return hipSuccess;
+    }
     hipError_t err = hipErrorInvalidValue;
     switch(mode)
     {

--- a/projects/rocsparse/library/src/common/rocsparse_memstat.cpp
+++ b/projects/rocsparse/library/src/common/rocsparse_memstat.cpp
@@ -243,7 +243,7 @@ private:
         }
     };
 
-    memstat(const memstat&)            = delete;
+    memstat(const memstat&) = delete;
     memstat& operator=(const memstat&) = delete;
 
     struct stat


### PR DESCRIPTION
## What changed and why

The memstat-enabled variants of `rocsparse_free`, `rocsparse_free_async`, `rocsparse_malloc`, and `rocsparse_malloc_async` in `rocsparse_memstat.cpp` lack defensive guards for null pointers and zero-size allocations.

- Calling `rocsparse_free(nullptr)` falls through to the HIP allocator and memstat bookkeeping unnecessarily.
- Calling `rocsparse_malloc(&p, 0)` issues a zero-size allocation to HIP, whose behavior is implementation-defined.

The non-memstat build path already handles these cases (e.g., the `rocsparse_hipFreeAsync` macro has a null check), but the memstat path did not, creating an inconsistency.

This PR adds early-return guards:
- `rocsparse_free` / `rocsparse_free_async`: return `hipSuccess` for `nullptr` without entering the allocator or memstat tracking.
- `rocsparse_malloc` / `rocsparse_malloc_async`: set output to `nullptr` and return `hipSuccess` for zero-size requests.

## API changes / backward compatibility

None. These are internal allocation wrappers, not part of the public API. The guards make behavior consistent with the non-memstat path.

## Performance impact

None. The guards add a single branch at function entry, avoiding unnecessary work for no-op calls.

## Testing

The existing test suite exercises these paths implicitly through normal library usage. The guards handle edge cases that previously produced undefined or unnecessary behavior. A memstat-enabled build can be used to verify correct bookkeeping.

## Areas needing review attention

- Confirm that returning `hipSuccess` without calling `memstat::remove` is correct for the null-pointer free case (it is, since a null pointer was never tracked by `memstat::add`).
- Confirm that zero-size allocations returning `nullptr` is the expected contract for all callers.