### PR TITLE
[hiptensor] Add CREATE_TEST_APP_LOCAL_DEPLOY option and Windows build docs

### DIFF
--- a/projects/hiptensor/CMakeLists.txt
+++ b/projects/hiptensor/CMakeLists.txt
@@ -75,6 +75,9 @@ if(CMAKE_PROJECT_NAME STREQUAL "hiptensor")
     option(BUILD_OFFLOAD_COMPRESS "Build hiptensor with offload compression" ON)
     option(HIPTENSOR_CODE_COVERAGE "Build with code coverage flags (clang only)" OFF)
     option(HIPTENSOR_INLINE_UNARY_OPS "Inline all unary ops for best runtime performance (slower compilation)" OFF)
+    if(WIN32)
+        option(CREATE_TEST_APP_LOCAL_DEPLOY "Copy ROCm runtime DLLs next to test binaries so they take precedence over System32 (Windows only)" OFF)
+    endif()
 endif()
 
 # Setup output paths

--- a/projects/hiptensor/README.md
+++ b/projects/hiptensor/README.md
@@ -17,10 +17,10 @@ hipTensor currently supports the following AMDGPU architectures:
 
 Dependencies:
 
-* Minimum ROCm version support is 7.0.
+* Minimum ROCm version support is 7.0 (7.13 for Windows).
 * Minimum cmake version support is 3.14.
 * Minimum ROCm-cmake version support is 0.8.0.
-* Minimum Composable Kernel version support is composable_kernel 1.1.0 for ROCm 6.0.2 (or ROCm package composablekernel-dev).
+* Minimum Composable Kernel version support is composable_kernel 1.2.0 for ROCm 7.13 (or ROCm package composablekernel-dev).
 * Minimum HIP runtime version support is 4.3.0 (or ROCm package ROCm hip-runtime-amd).
 * Minimum LLVM dev package version support is 7.0 (available as ROCm package rocm-llvm-dev).
 
@@ -42,10 +42,11 @@ For more detailed information, please refer to the [hipTensor installation guide
 | HIPTENSOR_BUILD_COMPRESSED_DBG      | Enable compressed debug symbols                                          | ON                                                      |
 | HIPTENSOR_DEFAULT_STRIDES_COL_MAJOR | Set the hipTensor default data layout to column major                    | ON                                                      |
 | HIPTENSOR_INLINE_UNARY_OPS          | Inline all unary ops for best runtime performance (slower compilation)   | OFF                                                     |
+| CREATE_TEST_APP_LOCAL_DEPLOY        | Copy ROCm runtime DLLs next to test binaries so they take precedence over System32 (Windows only) | OFF                            |
 
-### Example configurations
+### Building on Linux
 
-By default, the project is configured as Release mode. Here are some of the examples for the configuration:
+By default, the project is configured as Release mode. Here are some example configurations:
 
 | Configuration                    | Command                                                                                                     |
 |----------------------------------|-------------------------------------------------------------------------------------------------------------|
@@ -54,6 +55,70 @@ By default, the project is configured as Release mode. Here are some of the exam
 | Debug build                      | `CC=/opt/rocm/bin/amdclang CXX=/opt/rocm/bin/amdclang++ cmake -B<build_dir> . -DCMAKE_BUILD_TYPE=Debug`     |
 
 After configuration, build with `cmake --build <build_dir> -- -j<nproc>`.
+
+Finally, install the built binaries with `cmake --install .`.
+
+> [!TIP]
+> Dockerfiles are available for Ubuntu 24.04 with prebuilt or source-built ROCm (using TheRock). See [docker/README.md](docker/README.md) for instructions.
+
+### Building on Windows
+
+#### Prerequisites
+
+- **Visual Studio 2026** (VS 18) or **Visual Studio 2022** — open a **"Command Prompt for VS 18"** (or "Command Prompt for VS 2022") terminal for all commands below.
+- **CMake 4.2.3+** — the version bundled with Visual Studio 2026 (msvc3) is recommended.
+- **vcpkg** — bundled with the VS command prompt. If `vcpkg --version` or `echo %VCPKG_ROOT%` returns nothing, install it following the [vcpkg getting-started guide](https://learn.microsoft.com/en-us/vcpkg/get_started/get-started).
+- **ROCm** — version 7.13 or later.
+
+#### Install ROCm (TheRock)
+
+1. If not already installed, [install ROCm from TheRock](https://github.com/ROCm/TheRock#installing-from-releases) and set the installation directory as a variable so you can reuse it in subsequent steps:
+   ```bat
+   set ROCM_PATH=C:\dist\TheRock
+   ```
+2. If you choose to [install from prebuilt tarball](https://github.com/ROCm/TheRock/blob/main/RELEASES.md#installing-from-tarballs), create the directory:
+   ```bat
+   mkdir %ROCM_PATH%
+   ```
+   Download and extract the tarball to `%ROCM_PATH%`.
+3. Set the required environment variables:
+   ```bat
+   set HIP_PATH=%ROCM_PATH%
+   set HIP_DEVICE_LIB_PATH=%ROCM_PATH%\lib\llvm\amdgcn\bitcode
+   set HIP_PLATFORM=amd
+   ```
+
+#### Configure and build hipTensor
+
+Change to the hipTensor source code directory, create a build directory and run the CMake configure command (e.g. Targeting gfx11-generic).
+
+```bat
+cd hiptensor
+mkdir build
+cd build
+
+cmake -G Ninja ^
+  -DCMAKE_INSTALL_PREFIX=%ROCM_PATH% ^
+  -DCMAKE_BUILD_TYPE=Release ^
+  -DCMAKE_CXX_COMPILER="%ROCM_PATH%/lib/llvm/bin/clang++.exe" ^
+  -DCMAKE_C_COMPILER="%ROCM_PATH%/lib/llvm/bin/clang.exe" ^
+  -DCMAKE_PREFIX_PATH="%ROCM_PATH%" ^
+  -DCMAKE_TOOLCHAIN_FILE="%VCPKG_ROOT%/scripts/buildsystems/vcpkg.cmake" ^
+  -DVCPKG_TARGET_TRIPLET=x64-windows-static ^
+  -DGPU_TARGETS=gfx11-generic ^
+  -DHIPTENSOR_BUILD_TESTS=ON ^
+  -B. ..
+```
+
+> [!NOTE]
+> If your system has a different version of ROCm installed alongside the build toolchain (for example, a system ROCm in `System32` and a development build under `%ROCM_PATH%`), add `-DCREATE_TEST_APP_LOCAL_DEPLOY=ON` to the CMake command. This copies the required ROCm runtime DLLs (`amdhip64`, `amd_comgr`, `rocm_kpack`, etc.) from `%ROCM_PATH%\bin` next to the test binaries at configure time, ensuring the correct runtime is loaded instead of the one found in `System32`.
+
+Then build and install:
+
+```bat
+cmake --build . -- -j%NUMBER_OF_PROCESSORS%
+cmake --install .
+```
 
 ## Documentation
 

--- a/projects/hiptensor/README.md
+++ b/projects/hiptensor/README.md
@@ -28,6 +28,16 @@ Optional:
 
 * doxygen (for building documentation)
 
+### Building Composable Kernel
+
+In case the Composable Kernel library isn't included in your ROCm installation, please refer to the
+[Composable Kernel installation guide](https://rocm.docs.amd.com/projects/composable_kernel/en/latest/install/Composable-Kernel-install.html)
+in order to build and install the library.
+
+> [!TIP]
+> When building Composable Kernel, add `-DHIPTENSOR_BUILD_TESTS=ON` to the cmake configure command in order to only build the
+> targets required by hipTensor and speed-up the build time.
+
 ## Build with CMake
 
 For more detailed information, please refer to the [hipTensor installation guide](https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html).

--- a/projects/hiptensor/README.md
+++ b/projects/hiptensor/README.md
@@ -58,8 +58,9 @@ After configuration, build with `cmake --build <build_dir> -- -j<nproc>`.
 
 Finally, install the built binaries with `cmake --install .`.
 
-> [!TIP]
-> Dockerfiles are available for Ubuntu 24.04 with prebuilt or source-built ROCm (using TheRock). See [docker/README.md](docker/README.md) for instructions.
+#### Docker
+
+Dockerfiles are available for Ubuntu 24.04 with prebuilt or source-built ROCm (using TheRock). See [docker/README.md](docker/README.md) for instructions.
 
 ### Building on Windows
 

--- a/projects/hiptensor/docs/install/installation.rst
+++ b/projects/hiptensor/docs/install/installation.rst
@@ -87,12 +87,12 @@ The following dependencies are required:
 
 .. <!-- spellcheck-disable -->
 
-*  `ROCm <https://github.com/ROCm/ROCm>`_ (Version 7.0 or later)
+*  `ROCm <https://github.com/ROCm/ROCm>`_ (Version 7.0 or later for Linux, Version 7.13 or later for Windows)
 *  `CMake <https://cmake.org/>`_ (Version 3.14 or later)
 *  `rocm-cmake <https://github.com/ROCm/rocm-cmake>`_ (Version 0.8.0 or later)
 *  `HIP runtime <https://github.com/ROCm/hip>`_ (Version 7.0.0 or later) (Or the ROCm hip-runtime-amd package)
 *  LLVM dev package (Version 7.0 or later) (Also available as the ROCm rocm-llvm-dev package)
-*  `composable kernel <https://github.com/ROCm/composable_kernel>`_ (hipTensor uses the amd-master branch, which is a stable and widely adopted version for development.)
+*  `composable kernel <https://github.com/ROCm/rocm-libraries/tree/develop/projects/composablekernel>`_ (hipTensor uses the amd-master branch, which is a stable and widely adopted version for development.)
 
 .. <!-- spellcheck-enable -->
 
@@ -149,8 +149,13 @@ To download hipTensor on ROCm version `x.y`, use this command:
 Replace ``x.y`` in the above command with the version of ROCm installed on your machine.
 For example, if you have ROCm 7.0 installed, then replace ``release/rocm-rel-x.y`` with ``release/rocm-rel-7.0``.
 
-Build configuration
+Building on Linux
 -------------------------------------------
+
+.. note::
+
+   The CMake options and make targets described in this section apply to all platforms.
+   For Windows-specific build instructions, see `Building on Windows`_.
 
 You can choose to build any of the following combinations:
 
@@ -187,6 +192,9 @@ Here are the available options to build the hipTensor library, with or without c
     *   -   ``HIPTENSOR_INLINE_UNARY_OPS``
         -   Inline all contraction unary ops for best runtime performance (slower compilation)
         -   ``OFF``
+    *   -   ``CREATE_TEST_APP_LOCAL_DEPLOY``
+        -   Copy ROCm runtime DLLs next to test binaries so they take precedence over System32 (Windows only)
+        -   ``OFF``
 
 Here are some example project configurations:
 
@@ -197,6 +205,11 @@ Here are some example project configurations:
    "Basic", "``CC=/opt/rocm/bin/amdclang CXX=/opt/rocm/bin/amdclang++ cmake -B<build_dir> .``"
    "Targeting gfx908", "``CC=/opt/rocm/bin/amdclang CXX=/opt/rocm/bin/amdclang++ cmake -B<build_dir> . -DGPU_TARGETS=gfx908``"
    "Debug build", "``CC=/opt/rocm/bin/amdclang CXX=/opt/rocm/bin/amdclang++ cmake -B<build_dir> . -DCMAKE_BUILD_TYPE=Debug``"
+
+.. tip::
+
+   Dockerfiles are available for Ubuntu 24.04 with prebuilt or source-built ROCm (using TheRock).
+   See `docker/README.md <https://github.com/ROCm/rocm-libraries/blob/develop/projects/hiptensor/docker/README.md>`_ for instructions.
 
 Building the library alone
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -214,6 +227,12 @@ After configuration, build the library using this command:
 .. code-block:: bash
 
    cmake --build <build_dir> -- -j<nproc>
+
+And install the built binaries into the system ROCm with:
+
+.. code-block:: bash
+
+   cmake --install .
 
 .. note::
 
@@ -493,6 +512,89 @@ The following table highlights the relationships between high-level grouped targ
 |                                   +---------------------------------------------------------------------------------+
 |                                   |``rank6_reduction_test``                                                         |
 +-----------------------------------+---------------------------------------------------------------------------------+
+
+Building on Windows
+-------------------------------------------
+
+.. note::
+
+   The CMake options (``GPU_TARGETS``, ``HIPTENSOR_BUILD_TESTS``, etc.) and make targets
+   described in `Building on Linux`_ apply equally on Windows.
+
+Prerequisites
+^^^^^^^^^^^^^
+
+*  **Visual Studio 2026** (VS 18) or **Visual Studio 2022** — open a **"Command Prompt for VS 18"** (or "Command Prompt for VS 2022") terminal for all commands below.
+*  **CMake 4.2.3 or later** — the version bundled with Visual Studio 2026 (msvc3) is recommended.
+*  **vcpkg** — bundled with the VS command prompt. If ``vcpkg --version`` or ``echo %VCPKG_ROOT%`` returns nothing, install it following the `vcpkg getting-started guide <https://learn.microsoft.com/en-us/vcpkg/get_started/get-started>`_.
+*  **ROCm** — version 7.13 or later.
+
+Installing ROCm (TheRock)
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1. If not already installed, `install ROCm from TheRock <https://github.com/ROCm/TheRock#installing-from-releases>`
+   and set the installation directory as a variable so you can reuse it in subsequent steps:
+
+   .. code-block:: bat
+
+      set ROCM_PATH=C:\dist\TheRock
+
+2. If you choose to `install from prebuilt tarball <https://github.com/ROCm/TheRock/blob/main/RELEASES.md#installing-from-tarballs>`, create the directory:
+
+   .. code-block:: bat
+
+      mkdir %ROCM_PATH%
+
+   Download the tarball from the `TheRock releases page <https://github.com/ROCm/TheRock/blob/main/RELEASES.md#installing-from-tarballs>`_
+   and extract it to ``%ROCM_PATH%``.
+
+3. Set the required environment variables:
+
+   .. code-block:: bat
+
+      set HIP_PATH=%ROCM_PATH%
+      set HIP_DEVICE_LIB_PATH=%ROCM_PATH%\lib\llvm\amdgcn\bitcode
+      set HIP_PLATFORM=amd
+
+Configure and build hipTensor
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Change to the hipTensor source directory, create a build directory, and run the CMake configure
+command (the example below targets ``gfx11-generic``):
+
+.. code-block:: bat
+
+   cd hiptensor
+   mkdir build
+   cd build
+
+   cmake -G Ninja ^
+     -DCMAKE_INSTALL_PREFIX=%ROCM_PATH% ^
+     -DCMAKE_BUILD_TYPE=Release ^
+     -DCMAKE_CXX_COMPILER="%ROCM_PATH%/lib/llvm/bin/clang++.exe" ^
+     -DCMAKE_C_COMPILER="%ROCM_PATH%/lib/llvm/bin/clang.exe" ^
+     -DCMAKE_PREFIX_PATH="%ROCM_PATH%" ^
+     -DCMAKE_TOOLCHAIN_FILE="%VCPKG_ROOT%/scripts/buildsystems/vcpkg.cmake" ^
+     -DVCPKG_TARGET_TRIPLET=x64-windows-static ^
+     -DGPU_TARGETS=gfx11-generic ^
+     -DHIPTENSOR_BUILD_TESTS=ON ^
+     -B. ..
+
+.. note::
+
+   If your system has a different version of ROCm installed alongside the build toolchain (for
+   example, a system ROCm in ``System32`` and a development build under ``%ROCM_PATH%``), add
+   ``-DCREATE_TEST_APP_LOCAL_DEPLOY=ON`` to the CMake command. This copies the required ROCm
+   runtime DLLs (``amdhip64``, ``amd_comgr``, ``rocm_kpack``, etc.) from ``%ROCM_PATH%\bin``
+   next to the test binaries at configure time, ensuring the correct runtime is loaded instead
+   of the one found in ``System32``.
+
+Then build and install:
+
+.. code-block:: bat
+
+   cmake --build . -- -j%NUMBER_OF_PROCESSORS%
+   cmake --install .
 
 Benchmarking scripts
 -------------------------------------------

--- a/projects/hiptensor/docs/install/installation.rst
+++ b/projects/hiptensor/docs/install/installation.rst
@@ -100,6 +100,10 @@ The following dependencies are required:
 
    It's best to use ROCm packages from the same release where applicable.
 
+.. note::
+
+   If building Composable Kernel from source, adding the cmake parameter ``-DHIPTENSOR_BUILD_TESTS=ON`` will speed up the build by compiling only the targets required by hipTensor.
+
 Downloading hipTensor
 -------------------------------------------
 

--- a/projects/hiptensor/test/CMakeLists.txt
+++ b/projects/hiptensor/test/CMakeLists.txt
@@ -68,10 +68,7 @@ add_custom_target(hiptensor_tests)
 # System32, which always wins over PATH. If the test binary is compiled with
 # a newer toolchain but an older runtime is loaded from System32, kernel launches
 # may crash (SEH 0xC0000005) if the code-object format is incompatible.
-# Staging the correct runtime DLLs into CMAKE_RUNTIME_OUTPUT_DIRECTORY (the application
-# directory) ensures Windows finds them before System32.
-# This runs at CMake configure time so it takes effect on every cmake invocation.
-if(WIN32)
+if(WIN32 AND CREATE_TEST_APP_LOCAL_DEPLOY)
     # hip_DIR is set by find_package(HIP) to <HIP_ROOT>/lib/cmake/hip.
     # Walk up three directory levels to reach <HIP_ROOT>, then append /bin.
     get_filename_component(_hip_cmake_dir  "${hip_DIR}"          DIRECTORY) # .../lib/cmake
@@ -84,10 +81,14 @@ if(WIN32)
 
     if(EXISTS "${_hip_bin_dir}")
         file(MAKE_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
-        file(GLOB _hip_dlls "${_hip_bin_dir}/amdhip64_7.dll")
+        file(GLOB _hip_dlls
+            "${_hip_bin_dir}/amd_comgr*.dll"   # code-object manager
+            "${_hip_bin_dir}/amdhip64*.dll"    # HIP runtime
+            "${_hip_bin_dir}/amdhiprtc*.dll"   # HIP RTC
+            "${_hip_bin_dir}/rocm_kpack*.dll"  # kernel packaging
+        )
         if(_hip_dlls)
             foreach(_dll ${_hip_dlls})
-                get_filename_component(_dll_name "${_dll}" NAME)
                 file(COPY "${_dll}" DESTINATION "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
             endforeach()
             list(LENGTH _hip_dlls _hip_dll_count)


### PR DESCRIPTION
## Motivation

Updates the documentation for hipTensor and fixes the Windows build by copying all required DLLs to local bin directory.

## Technical Details

Introduces the CREATE_TEST_APP_LOCAL_DEPLOY CMake option (default OFF, Windows only) to gate configure-time staging of ROCm runtime DLLs next to test binaries. When ON, copies amdhip64, amd_comgr, amdhiprtc, and rocm_kpack DLLs from the HIP installation's bin directory into the test output directory, ensuring they are loaded in preference to any older versions present in System32.

Expands the DLL glob from the previously hardcoded amdhip64_7.dll to cover all version variants and additional required DLLs (amd_comgr, amdhiprtc, rocm_kpack).

Documents the option in README.md and docs/install/installation.rst, including when to use it and the full Windows build prerequisites and configure command. Bump the required version for `composable_kernel` since it's the current compatible version with `hipTensor`.

## Test Plan

Build and run tests on Windows.

## Test Result

Build and tests are ok.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
