### PR TITLE
added check to report warning for ProblemType mismatch during build time

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/LibraryIO.py
+++ b/projects/hipblaslt/tensilelite/Tensile/LibraryIO.py
@@ -73,6 +73,25 @@ except ImportError:
     from yaml import SafeDumper as yamlDumper
     printWarning("CSafeDumper not installed. Fallback to SafeDumper.")
 
+# Custom YAML loader that preserves int type for 0 and 1 (doesn't auto-convert to bool)
+# This allows type validation to catch int-vs-bool mismatches in YAML files.
+class StrictTypeLoader(yamlLoader):
+    """YAML loader that does NOT auto-convert 0/1 to False/True.
+
+    Standard YAML parsers treat 0 and 1 as booleans, but we want to preserve
+    the actual type written in the YAML to catch type mismatches during validation.
+    """
+    pass
+
+# Remove the implicit bool resolver for integers
+# By default, YAML treats various forms as bool (yes/no, true/false, on/off, 0/1)
+# We remove the rule that treats plain scalars matching bool patterns as booleans
+# This forces explicit 'true'/'false' for booleans and preserves 0/1 as integers
+StrictTypeLoader.yaml_implicit_resolvers = {
+    k: [r for r in v if r[0] != 'tag:yaml.org,2002:bool']
+    for k, v in yamlLoader.yaml_implicit_resolvers.items()
+}
+
 try:
     import msgpack
     _msgpack_available = True
@@ -202,7 +221,7 @@ def read(filename, customizedLoader=False):
 def readYAML(filename):
     """Reads and returns YAML data from file."""
     with open(filename, "r") as f:
-        data = yaml.load(f, yamlLoader)
+        data = yaml.load(f, StrictTypeLoader)
     return data
 
 
@@ -374,7 +393,7 @@ def parseLibraryLogicData(
                 .format(srcFile, data["MinimumRequiredVersion"], __version__) )
 
     # unpack problemType
-    problemType = ProblemType(data["ProblemType"], printIndexAssignmentInfo)
+    problemType = ProblemType(data["ProblemType"], printIndexAssignmentInfo, srcFile=srcFile)
 
     # unpack solution
     def solutionStateToSolution(solutionState, assembler, isaInfoMap) -> Solution:

--- a/projects/hipblaslt/tensilelite/Tensile/LibraryIO.py
+++ b/projects/hipblaslt/tensilelite/Tensile/LibraryIO.py
@@ -80,6 +80,7 @@ class StrictTypeLoader(yamlLoader):
 
     Standard YAML parsers treat 0 and 1 as booleans, but we want to preserve
     the actual type written in the YAML to catch type mismatches during validation.
+    Accepts both YAML-standard (true/false) and Python-style (True/False) booleans.
     """
     pass
 
@@ -91,6 +92,15 @@ StrictTypeLoader.yaml_implicit_resolvers = {
     k: [r for r in v if r[0] != 'tag:yaml.org,2002:bool']
     for k, v in yamlLoader.yaml_implicit_resolvers.items()
 }
+
+# Add back a custom bool resolver that matches true/false/True/False but NOT 0/1
+# This regex matches: true, false, True, False (but not yes, no, on, off, 0, 1)
+import re
+StrictTypeLoader.add_implicit_resolver(
+    'tag:yaml.org,2002:bool',
+    re.compile(r'^(?:true|false|True|False)$', re.X),
+    list('tTfF')
+)
 
 try:
     import msgpack

--- a/projects/hipblaslt/tensilelite/Tensile/LibraryIO.py
+++ b/projects/hipblaslt/tensilelite/Tensile/LibraryIO.py
@@ -502,6 +502,10 @@ def parseLibraryLogicData(
         lazyLibraryLoading: bool
     ):
     """Parses the data of a library logic file."""
+    # Reset the type mismatch collector at the start to capture all type
+    # mismatches from both ProblemType and Solution constructors
+    resetTypeMismatchCollector()
+
     if isinstance(data, List):
         data = parseLibraryLogicList(data, srcFile)
 
@@ -578,7 +582,6 @@ def parseLibraryLogicData(
                          )
         return solutionObject
 
-    resetTypeMismatchCollector()
     solutions = [solutionStateToSolution(solutionState, assembler, isaInfoMap) for solutionState in data["Solutions"]]
     typeMismatches = getTypeMismatchCollector()
 

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Problem.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Problem.py
@@ -735,11 +735,17 @@ class ProblemType(Mapping):
   def FromDefaultConfig(printIndexAssignmentInfo: bool):
     return ProblemType(_defaultProblemType, printIndexAssignmentInfo)
 
-  def __init__(self, config, printIndexAssignmentInfo: bool):
+  def __init__(self, config, printIndexAssignmentInfo: bool, srcFile: str = ""):
     self.state = {}
 
     for key in _defaultProblemType:
       assignParameterWithDefault(self.state, key, config, _defaultProblemType)
+
+    # Validate parameter types against the _defaultProblemType registry.
+    # Import here to avoid circular dependency issues at module level.
+    from .Solution import validateProblemTypeParameterTypes
+    # Pass the source file for tracking
+    validateProblemTypeParameterTypes(self.state, srcFile=srcFile)
 
     # adjusting all data types
     if "DataType" in config:

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Problem.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Problem.py
@@ -741,6 +741,56 @@ def problemTypeToEnum(problemType):
   else:
       problemType["DataTypeMXSB"] = DataTypeEnum.E8
 
+# Pre-compute expected types for ProblemType parameters from _defaultProblemType.
+# Note: For _defaultProblemType, the values are defaults (not lists of allowed values),
+# so we just take type(defaultValue) directly.
+_expectedProblemTypeParamTypes = {
+    key: {type(value)} for key, value in _defaultProblemType.items()
+}
+
+
+def validateProblemTypeParameterTypes(state, srcFile=""):
+  """Validate that every ProblemType parameter has the correct Python type.
+
+  Similar to validateParameterTypes (in Solution.py), but checks ProblemType
+  parameters against the types implied by ``_defaultProblemType``.  A ``bool``
+  where ``int`` is expected (or vice versa) is the most common error.
+
+  Mismatches are collected into the module-level ``_typeMismatchCollector``
+  dict (shared with Solution validation). Call ``printTypeMismatchSummary()``
+  at the end of the build to emit a consolidated warning.
+
+  Args:
+      state: The ProblemType state dict (parameter name -> value).
+      srcFile: The YAML source file path, included in warning messages.
+  """
+  # Import collector infrastructure from Solution inside the function to avoid
+  # circular dependency (Naming → Problem → Solution → Naming).
+  # The collector is shared between Solution and ProblemType validation.
+  from Tensile.SolutionStructs.Solution import _typeMismatchCollector, _skipTypeCheck
+
+  for key, value in state.items():
+    if key not in _expectedProblemTypeParamTypes or key in _skipTypeCheck:
+      continue
+    expectedTypes = _expectedProblemTypeParamTypes[key]
+    actualType = type(value)
+    # Use type() not isinstance() so that bool and int are distinguished
+    if actualType not in expectedTypes:
+      expectedStr = " or ".join(sorted(t.__name__ for t in expectedTypes))
+      collectorKey = (key, actualType.__name__, expectedStr)
+      if collectorKey not in _typeMismatchCollector:
+        _typeMismatchCollector[collectorKey] = {
+          "count": 0,
+          "values": set(),
+          "files": set(),
+        }
+      entry = _typeMismatchCollector[collectorKey]
+      entry["count"] += 1
+      entry["values"].add(repr(value))
+      if srcFile:
+        entry["files"].add(srcFile)
+
+
 class ProblemType(Mapping):
   ########################################
 
@@ -754,10 +804,7 @@ class ProblemType(Mapping):
     for key in _defaultProblemType:
       assignParameterWithDefault(self.state, key, config, _defaultProblemType)
 
-    # Validate parameter types against the _defaultProblemType registry.
-    # Import here to avoid circular dependency issues at module level.
-    from .Solution import validateProblemTypeParameterTypes
-    # Pass the source file for tracking
+    # Validate parameter types against the _defaultProblemType registry
     validateProblemTypeParameterTypes(self.state, srcFile=srcFile)
 
     # adjusting all data types

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -42,7 +42,7 @@ from Tensile.Common.GlobalParameters import defaultSolution, \
                                             defaultInternalSupportParams
 from Tensile.Common.ValidParameters import validParameters
 from Tensile.SolutionStructs.Naming import getSolutionNameFull
-from Tensile.SolutionStructs.Problem import ProblemType
+from Tensile.SolutionStructs.Problem import ProblemType, _defaultProblemType
 from Tensile.Toolchain.Component import Assembler
 from Tensile.Components.CustomSchedule import hasCustomSchedule
 
@@ -74,16 +74,34 @@ def _getExpectedTypes(validParams):
 # Pre-compute once at import time so the per-Solution cost is a dict lookup.
 _expectedParamTypes = _getExpectedTypes(validParameters)
 
+# Pre-compute expected types for ProblemType parameters from _defaultProblemType
+# Note: For _defaultProblemType, the values are defaults (not lists of allowed values),
+# so we just take type(defaultValue) directly.
+_expectedProblemTypeParamTypes = {
+    key: {type(value)} for key, value in _defaultProblemType.items()
+}
+
 # Parameters to skip during type validation because YAML serialization
 # inherently produces a different type (e.g. [9, 0, 10] -> list) and the
 # conversion to the canonical type happens downstream in the pipeline.
-_skipTypeCheck = {"ISA"}
+# Also skip DataType* parameters as they are converted from strings/ints to DataType objects.
+_skipTypeCheck = {
+    "ISA",
+    "DataType", "DataTypeA", "DataTypeB", "DataTypeC", "DataTypeD", "DataTypeE",
+    "MacDataTypeA", "MacDataTypeB",
+    "DataTypeAmaxD", "DataTypeAmaxC", "DataTypeAmaxA", "DataTypeAmaxB",
+    "DataTypeMXSA", "DataTypeMXSB",
+    "DestDataType", "ComputeDataType",
+    "F32XdlMathOp",  # Also converted to DataType
+}
 
 
 # Module-level collector that accumulates type mismatches across all Solution
 # instances during a build.  Key is (param_name, actual_type_name,
 # expected_type_str); value is a dict with 'count', 'values' (set of unique
 # repr(value)), and 'files' (set of source file paths).
+# NOTE: Due to multiprocessing in TensileCreateLibrary, this collector won't
+# aggregate across worker processes. Warnings are printed immediately instead.
 _typeMismatchCollector = {}
 
 
@@ -139,6 +157,50 @@ def validateParameterTypes(state, srcFile=""):
         entry["files"].add(srcFile)
 
 
+def validateProblemTypeParameterTypes(state, srcFile=""):
+  """Validate that every ProblemType parameter has the correct Python type.
+
+  Similar to validateParameterTypes, but checks ProblemType parameters
+  against the types implied by ``_defaultProblemType``.  A ``bool`` where
+  ``int`` is expected (or vice versa) is the most common error.
+
+  Due to multiprocessing, warnings are printed immediately rather than
+  collected for a summary at the end.
+
+  Args:
+      state: The ProblemType state dict (parameter name -> value).
+      srcFile: The YAML source file path, included in warning messages.
+  """
+  import sys
+
+  for key, value in state.items():
+    if key not in _expectedProblemTypeParamTypes or key in _skipTypeCheck:
+      continue
+    expectedTypes = _expectedProblemTypeParamTypes[key]
+    actualType = type(value)
+    # Use type() not isinstance() so that bool and int are distinguished
+    if actualType not in expectedTypes:
+      expectedStr = " or ".join(sorted(t.__name__ for t in expectedTypes))
+      collectorKey = (key, actualType.__name__, expectedStr)
+      if collectorKey not in _typeMismatchCollector:
+        _typeMismatchCollector[collectorKey] = {
+          "count": 0,
+          "values": set(),
+          "files": set(),
+        }
+        # Print warning immediately on first occurrence
+        file_info = f" in {srcFile}" if srcFile else ""
+        print(f"\nTensile::WARNING: ProblemType parameter '{key}' has type {actualType.__name__} but expected {expectedStr}{file_info}.", file=sys.stderr)
+        print(f"                  Example value: {repr(value)}", file=sys.stderr)
+        print(f"                  This may indicate incorrect YAML formatting.", file=sys.stderr)
+        print(f"                  To fix: Use 'true'/'false' for booleans, not 0/1.\n", file=sys.stderr)
+      entry = _typeMismatchCollector[collectorKey]
+      entry["count"] += 1
+      entry["values"].add(repr(value))
+      if srcFile:
+        entry["files"].add(srcFile)
+
+
 def printTypeMismatchSummary():
   """Print a summary of all collected type mismatches to stderr.
 
@@ -146,6 +208,10 @@ def printTypeMismatchSummary():
   returns 0.  Otherwise it emits a WARNING block to stderr with one line
   per unique (parameter, actual_type) combination showing the count,
   observed values, and expected type.
+
+  NOTE: Due to multiprocessing in TensileCreateLibrary, the collector in the
+  main process may not see all mismatches from worker processes. Warnings are
+  also printed immediately during validation for this reason.
 
   Returns:
       int: The total number of individual mismatches (0 if clean).

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -42,7 +42,7 @@ from Tensile.Common.GlobalParameters import defaultSolution, \
                                             defaultInternalSupportParams
 from Tensile.Common.ValidParameters import validParameters
 from Tensile.SolutionStructs.Naming import getSolutionNameFull
-from Tensile.SolutionStructs.Problem import ProblemType, _defaultProblemType
+from Tensile.SolutionStructs.Problem import ProblemType
 from Tensile.Toolchain.Component import Assembler
 from Tensile.Components.CustomSchedule import hasCustomSchedule
 
@@ -73,13 +73,6 @@ def _getExpectedTypes(validParams):
 
 # Pre-compute once at import time so the per-Solution cost is a dict lookup.
 _expectedParamTypes = _getExpectedTypes(validParameters)
-
-# Pre-compute expected types for ProblemType parameters from _defaultProblemType
-# Note: For _defaultProblemType, the values are defaults (not lists of allowed values),
-# so we just take type(defaultValue) directly.
-_expectedProblemTypeParamTypes = {
-    key: {type(value)} for key, value in _defaultProblemType.items()
-}
 
 # Parameters to skip during type validation because YAML serialization
 # inherently produces a different type (e.g. [9, 0, 10] -> list) and the
@@ -162,43 +155,6 @@ def validateParameterTypes(state, srcFile=""):
     if key not in _expectedParamTypes or key in _skipTypeCheck:
       continue
     expectedTypes = _expectedParamTypes[key]
-    actualType = type(value)
-    # Use type() not isinstance() so that bool and int are distinguished
-    if actualType not in expectedTypes:
-      expectedStr = " or ".join(sorted(t.__name__ for t in expectedTypes))
-      collectorKey = (key, actualType.__name__, expectedStr)
-      if collectorKey not in _typeMismatchCollector:
-        _typeMismatchCollector[collectorKey] = {
-          "count": 0,
-          "values": set(),
-          "files": set(),
-        }
-      entry = _typeMismatchCollector[collectorKey]
-      entry["count"] += 1
-      entry["values"].add(repr(value))
-      if srcFile:
-        entry["files"].add(srcFile)
-
-
-def validateProblemTypeParameterTypes(state, srcFile=""):
-  """Validate that every ProblemType parameter has the correct Python type.
-
-  Similar to validateParameterTypes, but checks ProblemType parameters
-  against the types implied by ``_defaultProblemType``.  A ``bool`` where
-  ``int`` is expected (or vice versa) is the most common error.
-
-  Mismatches are collected into the module-level ``_typeMismatchCollector``
-  dict. Call ``printTypeMismatchSummary()`` at the end of the build to emit a
-  consolidated warning.
-
-  Args:
-      state: The ProblemType state dict (parameter name -> value).
-      srcFile: The YAML source file path, included in warning messages.
-  """
-  for key, value in state.items():
-    if key not in _expectedProblemTypeParamTypes or key in _skipTypeCheck:
-      continue
-    expectedTypes = _expectedProblemTypeParamTypes[key]
     actualType = type(value)
     # Use type() not isinstance() so that bool and int are distinguished
     if actualType not in expectedTypes:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_validateParameterTypes.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_validateParameterTypes.py
@@ -24,14 +24,17 @@ import pytest
 
 from Tensile.SolutionStructs.Solution import (
     validateParameterTypes,
+    validateProblemTypeParameterTypes,
     _getExpectedTypes,
     _expectedParamTypes,
+    _expectedProblemTypeParamTypes,
     _skipTypeCheck,
     _typeMismatchCollector,
     resetTypeMismatchCollector,
     printTypeMismatchSummary,
 )
 from Tensile.Common.ValidParameters import validParameters
+from Tensile.SolutionStructs.Problem import _defaultProblemType
 
 
 class TestGetExpectedTypes:
@@ -334,6 +337,129 @@ class TestPrintTypeMismatchSummary:
         printTypeMismatchSummary()
         captured = capsys.readouterr()
         assert "2 files" in captured.err
+
+
+class TestValidateProblemTypeParameterTypes:
+    """Tests for the validateProblemTypeParameterTypes function."""
+
+    def setup_method(self):
+        """Reset the collector before each test."""
+        resetTypeMismatchCollector()
+
+    # --- Passing cases (no mismatches collected) ---
+
+    def test_bool_param_with_bool_value_passes(self):
+        """TransposeA: False (bool) should not collect a mismatch."""
+        state = {"TransposeA": False}
+        validateProblemTypeParameterTypes(state)
+        assert len(_typeMismatchCollector) == 0
+
+    def test_bool_param_with_true_passes(self):
+        """TransposeA: True (bool) should not collect a mismatch."""
+        state = {"TransposeA": True}
+        validateProblemTypeParameterTypes(state)
+        assert len(_typeMismatchCollector) == 0
+
+    def test_usebeta_bool_param_with_bool_passes(self):
+        """UseBeta: True (bool) should not collect a mismatch."""
+        state = {"UseBeta": True}
+        validateProblemTypeParameterTypes(state)
+        assert len(_typeMismatchCollector) == 0
+
+    def test_int_param_with_int_value_passes(self):
+        """UseBias: 1 (int) should not collect a mismatch."""
+        state = {"UseBias": 1}
+        validateProblemTypeParameterTypes(state)
+        assert len(_typeMismatchCollector) == 0
+
+    def test_mxblock_int_param_passes(self):
+        """MXBlockA: 16 (int) should not collect a mismatch."""
+        state = {"MXBlockA": 16}
+        validateProblemTypeParameterTypes(state)
+        assert len(_typeMismatchCollector) == 0
+
+    def test_unknown_param_ignored(self):
+        """Parameters not in _defaultProblemType should be silently skipped."""
+        state = {"UnknownProblemTypeParam": "anything"}
+        validateProblemTypeParameterTypes(state)
+        assert len(_typeMismatchCollector) == 0
+
+    def test_empty_state_passes(self):
+        """Empty state should not collect any mismatches."""
+        validateProblemTypeParameterTypes({})
+        assert len(_typeMismatchCollector) == 0
+
+    # --- Failing cases (mismatches collected) ---
+
+    def test_bool_param_with_int_value_collects_mismatch(self):
+        """TransposeA: 0 (int) should collect a bool-vs-int mismatch."""
+        state = {"TransposeA": 0}
+        validateProblemTypeParameterTypes(state)
+        assert len(_typeMismatchCollector) == 1
+        key = ("TransposeA", "int", "bool")
+        assert key in _typeMismatchCollector
+
+    def test_bool_param_with_int_one_collects_mismatch(self):
+        """UseBeta: 1 (int) should collect a bool-vs-int mismatch."""
+        state = {"UseBeta": 1}
+        validateProblemTypeParameterTypes(state)
+        assert len(_typeMismatchCollector) == 1
+        key = ("UseBeta", "int", "bool")
+        assert key in _typeMismatchCollector
+
+    def test_int_param_with_bool_collects_mismatch(self):
+        """UseBias: True (bool) should collect an int-vs-bool mismatch."""
+        state = {"UseBias": True}
+        validateProblemTypeParameterTypes(state)
+        assert len(_typeMismatchCollector) == 1
+        key = ("UseBias", "bool", "int")
+        assert key in _typeMismatchCollector
+
+    def test_mxblock_with_bool_collects_mismatch(self):
+        """MXBlockA: False (bool) should collect an int-vs-bool mismatch."""
+        state = {"MXBlockA": False}
+        validateProblemTypeParameterTypes(state)
+        assert len(_typeMismatchCollector) == 1
+        key = ("MXBlockA", "bool", "int")
+        assert key in _typeMismatchCollector
+
+    def test_collector_tracks_srcfile(self):
+        """srcFile should be recorded in the collector entry."""
+        state = {"TransposeA": 0}
+        validateProblemTypeParameterTypes(state, srcFile="problem_config.yaml")
+        key = ("TransposeA", "int", "bool")
+        assert "problem_config.yaml" in _typeMismatchCollector[key]["files"]
+
+    def test_collector_tracks_values(self):
+        """Different values should be collected in the values set."""
+        validateProblemTypeParameterTypes({"TransposeA": 0})
+        validateProblemTypeParameterTypes({"TransposeA": 1})
+        key = ("TransposeA", "int", "bool")
+        assert "0" in _typeMismatchCollector[key]["values"]
+        assert "1" in _typeMismatchCollector[key]["values"]
+
+    def test_multiple_params_collect_separately(self):
+        """Different parameters should create separate collector entries."""
+        state = {"TransposeA": 0, "UseBeta": 1, "UseBias": True}
+        validateProblemTypeParameterTypes(state)
+        assert len(_typeMismatchCollector) == 3
+
+    def test_accumulates_with_solution_params(self):
+        """ProblemType and Solution mismatches should accumulate together."""
+        validateParameterTypes({"UseCustomMainLoopSchedule": False})
+        validateProblemTypeParameterTypes({"TransposeA": 0})
+        assert len(_typeMismatchCollector) == 2
+
+    def test_precomputed_problemtype_types(self):
+        """_expectedProblemTypeParamTypes should be precomputed correctly."""
+        assert "TransposeA" in _expectedProblemTypeParamTypes
+        assert _expectedProblemTypeParamTypes["TransposeA"] == {bool}
+        assert "UseBeta" in _expectedProblemTypeParamTypes
+        assert _expectedProblemTypeParamTypes["UseBeta"] == {bool}
+        assert "UseBias" in _expectedProblemTypeParamTypes
+        assert _expectedProblemTypeParamTypes["UseBias"] == {int}
+        assert "MXBlockA" in _expectedProblemTypeParamTypes
+        assert _expectedProblemTypeParamTypes["MXBlockA"] == {int}
 
     def test_output_contains_fix_message(self, capsys):
         validateParameterTypes({"UseCustomMainLoopSchedule": False})

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_validateParameterTypes.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_validateParameterTypes.py
@@ -24,17 +24,19 @@ import pytest
 
 from Tensile.SolutionStructs.Solution import (
     validateParameterTypes,
-    validateProblemTypeParameterTypes,
     _getExpectedTypes,
     _expectedParamTypes,
-    _expectedProblemTypeParamTypes,
     _skipTypeCheck,
     _typeMismatchCollector,
     resetTypeMismatchCollector,
     printTypeMismatchSummary,
 )
+from Tensile.SolutionStructs.Problem import (
+    validateProblemTypeParameterTypes,
+    _expectedProblemTypeParamTypes,
+    _defaultProblemType,
+)
 from Tensile.Common.ValidParameters import validParameters
-from Tensile.SolutionStructs.Problem import _defaultProblemType
 
 
 class TestGetExpectedTypes:


### PR DESCRIPTION
## Motivation

Currently we don't have type check for ProblemType in yaml file so sometime, with wrong type, we see compile/runtime error. Plan is to

- Raise warning for all type mismatch
- Fix our existing yaml file
- Upgrade the severity from warning to error

## Technical Details

For our boolean type/int type mention in ProblemType, we add function, which check for type mismatch at library creation time and printing warning with type mismatch like

```
Overriding PrebuiltClient=/home/dhirajp/gemm_library_work/rocm-libraries/projects/hipblaslt/tensilelite/build_tmp/tensilelite/client/tensilelite-client

Tensile::WARNING: ProblemType parameter 'TransposeA' has type int but expected bool.
                  Example value: 1
                  This may indicate incorrect YAML formatting.
                  To fix: Use 'true'/'false' for booleans, not 0/1.


Tensile::WARNING: ProblemType parameter 'TransposeB' has type int but expected bool.
                  Example value: 0
                  This may indicate incorrect YAML formatting.
                  To fix: Use 'true'/'false' for booleans, not 0/1.

```
when running `Tensile` or

```
Tensile::WARNING: ProblemType parameter 'TransposeA' has type int but expected bool in rocm-libraries/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bljk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml.
Tensile::WARNING: ProblemType parameter 'TransposeB' has type int but expected bool in rocm-libraries/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bljk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml.
Tensile::WARNING: ProblemType parameter 'TransposeA' has type int but expected bool in rocm-libraries/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml.
Tensile::WARNING: ProblemType parameter 'TransposeB' has type int but expected bool in rocm-libraries/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml.
Tensile::WARNING: ProblemType parameter 'TransposeA' has type int but expected bool in rocm-libraries/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bjlk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml.
Tensile::WARNING: ProblemType parameter 'TransposeB' has type int but expected bool in rocm-libraries/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bjlk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml.
```

when we run `./install.sh -c -a gfxXXX`

https://github.com/ROCm/rocm-libraries/commit/322275b23f24601ba7a0217d81bfc6983f9240cf

## Test Plan

N/A
## Test Result

Explained above
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
