### PR TITLE
Fix all yaml for type mismatch in tensilelite

### DIFF
--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/Equality/aldebaran_Cijk_Alik_Bljk_BBS_BH_Bias_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/Equality/aldebaran_Cijk_Alik_Bljk_BBS_BH_Bias_HAH_SAV.yaml
@@ -49,8 +49,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/Equality/aldebaran_Cijk_Alik_Bljk_HHS_BH_Bias_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/Equality/aldebaran_Cijk_Alik_Bljk_HHS_BH_Bias_HAH_SAV.yaml
@@ -49,8 +49,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/Equality/aldebaran_Cijk_Alik_Bljk_SB_Bias_HA_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/Equality/aldebaran_Cijk_Alik_Bljk_SB_Bias_HA_SAV.yaml
@@ -49,8 +49,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Ailk_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Ailk_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Alik_Bjlk_BBS_BH_Bias_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Alik_Bjlk_BBS_BH_Bias_HAH_SAV.yaml
@@ -49,8 +49,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_Bias_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_Bias_HAH_SAV.yaml
@@ -49,8 +49,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Alik_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Alik_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Alik_Bjlk_SB_Bias_HA_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Alik_Bjlk_SB_Bias_HA_SAV.yaml
@@ -49,8 +49,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Alik_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Alik_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/Equality/aldebaran_Cijk_Ailk_Bljk_HHS_BH.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/Equality/aldebaran_Cijk_Ailk_Bljk_HHS_BH.yaml
@@ -50,8 +50,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/Equality/aldebaran_Cijk_Ailk_Bljk_HHS_BH_Bias_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/Equality/aldebaran_Cijk_Ailk_Bljk_HHS_BH_Bias_HAH_SAV.yaml
@@ -50,8 +50,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/Equality/aldebaran_Cijk_Ailk_Bljk_HSS_BH.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/Equality/aldebaran_Cijk_Ailk_Bljk_HSS_BH.yaml
@@ -50,8 +50,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/Equality/aldebaran_Cijk_Ailk_Bljk_HSS_BH_Bias_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/Equality/aldebaran_Cijk_Ailk_Bljk_HSS_BH_Bias_HAH_SAV.yaml
@@ -50,8 +50,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/Equality/aldebaran_Cijk_Alik_Bljk_HHS_BH.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/Equality/aldebaran_Cijk_Alik_Bljk_HHS_BH.yaml
@@ -51,8 +51,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_BSS_BH_Bias_HA_S_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_BSS_BH_Bias_HA_S_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HHS_BH_Bias_Aux_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HHS_BH_Bias_Aux_HAH_SAV.yaml
@@ -54,8 +54,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -54,8 +54,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -54,8 +54,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_HAH_SAV.yaml
@@ -54,8 +54,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HHS_BH_Bias_GG_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HHS_BH_Bias_GG_HAH_SAV.yaml
@@ -52,8 +52,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HHS_BH_GG.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HHS_BH_GG.yaml
@@ -52,8 +52,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HSS_BH_Bias_GG_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HSS_BH_Bias_GG_HAH_SAV.yaml
@@ -52,8 +52,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HSS_BH_GG.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_HSS_BH_GG.yaml
@@ -52,8 +52,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_BSS_BH_Bias_HA_S_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_BSS_BH_Bias_HA_S_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HHS_BH_Bias_Aux_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HHS_BH_Bias_Aux_HAH_SAV.yaml
@@ -54,8 +54,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -54,8 +54,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -54,8 +54,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcD_Grad_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcD_Grad_HAH_SAV.yaml
@@ -54,8 +54,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_HAH_SAV.yaml
@@ -52,8 +52,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HHS_BH_GG.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HHS_BH_GG.yaml
@@ -52,8 +52,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_HAH_SAV.yaml
@@ -52,8 +52,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HSS_BH_GG.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HSS_BH_GG.yaml
@@ -52,8 +52,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_BBS_BH_Bias_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_BBS_BH_Bias_HAH_SAV.yaml
@@ -49,8 +49,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_BSS_BH_Bias_HA_S_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_BSS_BH_Bias_HA_S_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_Bias_Aux_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_Bias_Aux_HAH_SAV.yaml
@@ -54,8 +54,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -54,8 +54,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -54,8 +54,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_HAH_SAV.yaml
@@ -54,8 +54,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_Bias_GG_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_Bias_GG_HAH_SAV.yaml
@@ -52,8 +52,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_Bias_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_Bias_HAH_SAV.yaml
@@ -49,8 +49,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_GG.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HHS_BH_GG.yaml
@@ -52,8 +52,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HSS_BH_Bias_GG_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HSS_BH_Bias_GG_HAH_SAV.yaml
@@ -52,8 +52,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HSS_BH_Bias_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HSS_BH_Bias_HAH_SAV.yaml
@@ -49,8 +49,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HSS_BH_GG.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_HSS_BH_GG.yaml
@@ -52,8 +52,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_SB_Bias_HA_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_SB_Bias_HA_SAV.yaml
@@ -49,8 +49,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_BSS_BH_Bias_HA_S_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_BSS_BH_Bias_HA_S_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HHS_BH_Bias_Aux_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HHS_BH_Bias_Aux_HAH_SAV.yaml
@@ -54,8 +54,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -54,8 +54,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -54,8 +54,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcD_Grad_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcD_Grad_HAH_SAV.yaml
@@ -54,8 +54,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HHS_BH_Bias_GG_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HHS_BH_Bias_GG_HAH_SAV.yaml
@@ -52,8 +52,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HHS_BH_GG.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HHS_BH_GG.yaml
@@ -52,8 +52,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HSS_BH_Bias_GG_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HSS_BH_Bias_GG_HAH_SAV.yaml
@@ -52,8 +52,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HSS_BH_GG.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HSS_BH_GG.yaml
@@ -52,8 +52,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bjlk_BBS_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bjlk_BBS_BH_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bjlk_F8NF8NS_BH_BiasSH_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bjlk_F8NF8NS_BH_BiasSH_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bjlk_F8NF8NS_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bjlk_F8NF8NS_BH_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bjlk_SB_Bias_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bjlk_SB_Bias_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bjlk_S_MX_B_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bjlk_S_MX_B_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_BBS_BH_Bias_Act_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_BBS_BH_Bias_Act_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_BBS_BH_Bias_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_BBS_BH_Bias_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_BBS_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_BBS_BH_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8NF8NS_BH_BiasSH_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8NF8NS_BH_BiasSH_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8NF8NS_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8NF8NS_BH_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
@@ -51,8 +51,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_custom.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_custom.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_UserArgs.yaml
@@ -51,8 +51,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_custom.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_custom.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
@@ -51,8 +51,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_UserArgs.yaml
@@ -51,8 +51,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_custom.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_custom.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_UserArgs.yaml
@@ -49,8 +49,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_SB_Bias_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_SB_Bias_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_S_MX_B_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Ailk_Bljk_S_MX_B_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bjlk_BBS_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bjlk_BBS_BH_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bjlk_SB_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bjlk_SB_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bjlk_S_MX_B_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bjlk_S_MX_B_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bjlk_S_MX_B_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bjlk_S_MX_B_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_B8F8NBS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_B8F8NBS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false
@@ -289,8 +289,8 @@
       TileAwareSelection: false
       TileB: 1
       TotalIndices: 4
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: true
       UseBias: 1
       UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_B8F8NSS_BH_SAB_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_B8F8NSS_BH_SAB_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_BBS_STA_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_BBS_STA_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_BBS_STA_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_BBS_STA_BH_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_F8B8NBS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_F8B8NBS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_F8B8NBS_BH_SAB_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_F8B8NBS_BH_SAB_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_F8B8NSS_BH_SAB_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_F8B8NSS_BH_SAB_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_F8NBS_BH_BiasSB_HAS_SABV_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_F8NBS_BH_BiasSB_HAS_SABV_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_F8NBS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_F8NBS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_F8NBS_BH_SAB_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_F8NBS_BH_SAB_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_F8NBS_STA_BH_Bias_HAS_SABV_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_F8NBS_STA_BH_Bias_HAS_SABV_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_F8NBS_STA_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_F8NBS_STA_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_F8NBS_STA_BH_SABV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_F8NBS_STA_BH_SABV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_F8NBS_STA_BH_SAB_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_F8NBS_STA_BH_SAB_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_F8NF8NS_BH_BiasSH_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_F8NF8NS_BH_BiasSH_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_F8NF8NS_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_F8NF8NS_BH_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_F8NSS_BH_BiasSHB_SAB_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_F8NSS_BH_BiasSHB_SAB_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_F8NSS_BH_SAB_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_F8NSS_BH_SAB_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_HF8N_HHS_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_HF8N_HHS_BH_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_SB_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_SB_Bias_HAS_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_S_MX_B_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/Equality/aquavanjaram_Cijk_Alik_Bljk_S_MX_B_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_F8NF8NS_BH_BiasSH_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_F8NF8NS_BH_BiasSH_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_F8NH_HHS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_F8NH_HHS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_F8NH_HSS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_F8NH_HSS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_HF8N_HHS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_HF8N_HHS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_HF8N_HSS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_HF8N_HSS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_HSS_BH_Bias_GG_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bjlk_HSS_BH_Bias_GG_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NF8NS_BH_BiasSH_HAS_SAB_SCD_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NF8NS_BH_BiasSH_HAS_SAB_SCD_SAV.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU10.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU10.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU11.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU11.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU12.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU12.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU13.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU13.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU14.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU14.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU15.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU15.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU16.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU16.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU17.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU17.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU18.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU18.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU19.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU19.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU2.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU2.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU20.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU20.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU21.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU21.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU22.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU22.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU23.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU23.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU24.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU24.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU25.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU25.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU26.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU26.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU27.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU27.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU28.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU28.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU29.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU29.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU3.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU3.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU30.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU30.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU31.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU31.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU32.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU32.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU4.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU4.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU5.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU5.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU6.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU6.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU7.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU7.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU8.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU8.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU9.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_NTA4_custom_GSU9.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU10.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU10.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU11.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU11.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU12.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU12.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU13.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU13.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU14.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU14.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU15.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU15.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU16.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU16.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU17.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU17.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU18.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU18.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU19.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU19.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU2.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU2.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU20.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU20.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU21.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU21.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU22.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU22.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU23.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU23.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU24.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU24.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU25.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU25.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU26.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU26.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU27.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU27.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU28.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU28.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU29.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU29.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU3.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU3.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU30.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU30.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU31.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU31.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU32.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU32.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU4.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU4.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU5.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU5.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU6.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU6.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU7.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU7.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU8.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU8.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU9.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_Freesize_custom_GSU9.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSUs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSUs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU10.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU10.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU11.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU11.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU12.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU12.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU13.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU13.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU14.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU14.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU15.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU15.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU16.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU16.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU17.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU17.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU18.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU18.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU19.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU19.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU2.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU2.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU20.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU20.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU21.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU21.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU22.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU22.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU23.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU23.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU24.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU24.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU25.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU25.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU26.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU26.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU27.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU27.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU28.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU28.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU29.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU29.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU3.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU3.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU30.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU30.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU31.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU31.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU32.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU32.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU4.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU4.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU5.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU5.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU6.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU6.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU7.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU7.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU8.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU8.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU9.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Freesize_custom_GSU9.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_GG_SAB_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_GG_SAB_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_freesize_custom_GSUs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_freesize_custom_GSUs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HSS_BH_GG_SAB_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HSS_BH_GG_SAB_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSU10.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSU10.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSU11.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSU11.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSU12.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSU12.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSU13.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSU13.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSU14.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSU14.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSU15.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSU15.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSU16.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSU16.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSU2.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSU2.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSU3.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSU3.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSU4.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSU4.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSU5.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSU5.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSU6.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSU6.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSU7.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSU7.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSU8.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSU8.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSU9.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_freesize_custom_GSU9.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_GG_SAB_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_GG_SAB_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HSS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HSS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HSS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HSS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HSS_BH_GG_SAB_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HSS_BH_GG_SAB_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HSS_BH_SAB_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HSS_BH_SAB_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_GG_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_GG_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_IPrefetch_custom_GSUs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_IPrefetch_custom_GSUs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU10.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU10.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU11.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU11.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU12.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU12.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU13.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU13.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU14.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU14.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU15.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU15.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU16.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU16.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU17.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU17.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU18.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU18.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU19.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU19.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU2.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU2.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU20.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU20.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU21.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU21.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU22.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU22.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU23.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU23.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU24.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU24.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU25.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU25.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU26.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU26.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU27.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU27.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU28.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU28.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU29.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU29.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU3.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU3.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU30.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU30.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU31.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU31.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU32.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU32.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU4.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU4.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU5.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU5.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU6.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU6.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU7.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU7.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU8.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU8.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU9.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSU9.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSUs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_Freesize_custom_GSUs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_GG_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_GG_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_F8NH_HHS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_F8NH_HHS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_F8NH_HSS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_F8NH_HSS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_HF8N_HHS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_HF8N_HHS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_HF8N_HSS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_HF8N_HSS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_HSS_BH_Bias_GG_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bjlk_HSS_BH_Bias_GG_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_F8NBS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_F8NBS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_F8NF8NS_BH_BiasSH_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_F8NF8NS_BH_BiasSH_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_F8NHS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_F8NHS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_F8NH_HHS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_F8NH_HHS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_F8NH_HSS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_F8NH_HSS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HF8N_HHS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HF8N_HHS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HF8N_HSS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HF8N_HSS_BH_Bias_GG_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HSS_BH_Bias_GG_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/FreeSize/aquavanjaram_Cijk_Alik_Bljk_HSS_BH_Bias_GG_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8NSS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8F8NSS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8NSS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_B8NSS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_BBS_BH_Bias_AuxB_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_BBS_BH_Bias_AuxB_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_BSS_BH_Bias_AuxS_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_BSS_BH_Bias_AuxS_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_BSS_BH_Bias_B_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_BSS_BH_Bias_B_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8NSS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8B8NSS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8NH_HF8NS_BH_Bias_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8NH_HF8NS_BH_Bias_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8NH_HSS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8NH_HSS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8NSS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_F8NSS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HF8N_HF8NS_BH_Bias_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HF8N_HF8NS_BH_Bias_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HF8N_HSS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HF8N_HSS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_AuxH_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_AuxH_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_Aux_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_Aux_HAH_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_HAH_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_GG_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_GG_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HSS_BH_Bias_AuxS_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HSS_BH_Bias_AuxS_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HSS_BH_Bias_B_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HSS_BH_Bias_B_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HSS_BH_Bias_GG_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HSS_BH_Bias_GG_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_SB_Bias_Aux_HA_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_SB_Bias_Aux_HA_SAV_UserArgs.yaml
@@ -60,8 +60,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
@@ -60,8 +60,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_SB_Bias_BiasSrcD_Grad_HA_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_SB_Bias_BiasSrcD_Grad_HA_SAV_UserArgs.yaml
@@ -60,8 +60,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8NSS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8F8NSS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8NSS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_B8NSS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_BBS_BH_Bias_AuxB_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_BBS_BH_Bias_AuxB_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_BBS_BH_Bias_BiasSrcD_GradB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_BBS_BH_Bias_BiasSrcD_GradB_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_BSS_BH_Bias_AuxS_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_BSS_BH_Bias_AuxS_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8NSS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8B8NSS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HF8NS_BH_Bias_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HF8NS_BH_Bias_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8NSS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_F8NSS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HF8NS_BH_Bias_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HF8NS_BH_Bias_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HSS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HF8N_HSS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_AuxH_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_AuxH_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_Aux_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_Aux_HAH_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcD_Grad_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcD_Grad_HAH_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_AuxS_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_AuxS_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_SB_Bias_Aux_HA_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_SB_Bias_Aux_HA_SAV_UserArgs.yaml
@@ -60,8 +60,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
@@ -60,8 +60,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_SB_Bias_BiasSrcD_Grad_HA_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Ailk_Bljk_SB_Bias_BiasSrcD_Grad_HA_SAV_UserArgs.yaml
@@ -60,8 +60,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8NSS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8F8NSS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8NSS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_B8NSS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_BBS_BH_Bias_AuxB_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_BBS_BH_Bias_AuxB_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_BSS_BH_Bias_AuxS_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_BSS_BH_Bias_AuxS_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8NSS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8B8NSS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8NH_HF8NS_BH_Bias_HAS_SAB_SCD_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8NH_HF8NS_BH_Bias_HAS_SAB_SCD_SAV.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8NH_HHS_BH_Bias_HAS_SAB_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8NH_HHS_BH_Bias_HAS_SAB_SAV.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8NH_HSS_BH_Bias_HAS_SAB_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8NH_HSS_BH_Bias_HAS_SAB_SAV.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8NSS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_F8NSS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HF8N_HF8NS_BH_Bias_HAS_SAB_SCD_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HF8N_HF8NS_BH_Bias_HAS_SAB_SCD_SAV.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HF8N_HSS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HF8N_HSS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_AuxH_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_AuxH_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_Aux_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_Aux_HAH_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_HAH_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_GG_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HHS_BH_Bias_GG_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HSS_BH_Bias_AuxS_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HSS_BH_Bias_AuxS_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HSS_BH_Bias_GG_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HSS_BH_Bias_GG_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HSS_BH_Bias_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_HSS_BH_Bias_HAH_SAV.yaml
@@ -48,8 +48,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_SB_Bias_Aux_HA_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_SB_Bias_Aux_HA_SAV_UserArgs.yaml
@@ -60,8 +60,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
@@ -60,8 +60,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_SB_Bias_BiasSrcD_Grad_HA_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bjlk_SB_Bias_BiasSrcD_Grad_HA_SAV_UserArgs.yaml
@@ -60,8 +60,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8F8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8NSS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_B8NSS_BH_BiasSB_BiasSrcB_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_BBS_STB_BH_Bias_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_BBS_STB_BH_Bias_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_BSS_BH_Bias_AuxS_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_BSS_BH_Bias_AuxS_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8B8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8NB8NS_BH_BiasSHB_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8NBS_STB_BH_Bias_SH_HA_S_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8NBS_STB_BH_Bias_SH_HA_S_SAB_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8NF8NS_BH_BiasH_AuxF8N_HAS_SAB_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8NF8NS_BH_BiasH_AuxF8N_HAS_SAB_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8NF8NS_BH_BiasH_AuxH_HAS_SAB_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8NF8NS_BH_BiasH_AuxH_HAS_SAB_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8NF8NS_BH_BiasSH_AmaxD_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8NHS_STA_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8NHS_STA_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8NHS_STB_BH_Bias_HA_S_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8NHS_STB_BH_Bias_HA_S_SAB_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8NH_HF8NS_BH_Bias_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8NH_HF8NS_BH_Bias_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8NH_HHS_BH_Bias_HAS_SAB_SAV.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8NH_HSS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8NH_HSS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8N_F8NS_BH_Bias_H_AuxH_AmaxD_HA_S_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8N_F8NS_BH_Bias_H_AuxH_AmaxD_HA_S_SAB_SCD_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HF8N_HF8NS_BH_Bias_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HF8N_HF8NS_BH_Bias_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HF8N_HHS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HF8N_HSS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HF8N_HSS_BH_Bias_HAS_SAB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_AuxH_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_AuxH_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_Aux_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_Aux_HAH_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcD_Grad_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcD_Grad_HAH_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_GG_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_GG_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_STA_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_STA_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_STB_BH_Bias_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_STB_BH_Bias_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HSS_BH_Bias_AuxS_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HSS_BH_Bias_AuxS_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HSS_BH_Bias_GG_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HSS_BH_Bias_GG_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HSS_STA_BH_Bias_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HSS_STA_BH_Bias_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HSS_STB_BH_Bias_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_HSS_STB_BH_Bias_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_SB_Bias_Aux_HA_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_SB_Bias_Aux_HA_SAV_UserArgs.yaml
@@ -60,8 +60,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
@@ -60,8 +60,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_SB_Bias_BiasSrcD_Grad_HA_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942/GridBased/aquavanjaram_Cijk_Alik_Bljk_SB_Bias_BiasSrcD_Grad_HA_SAV_UserArgs.yaml
@@ -60,8 +60,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_152cu/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_152cu/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_152cu/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_152cu/GridBased/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_152cu/GridBased/aquavanjaram_Cijk_Ailk_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_152cu/GridBased/aquavanjaram_Cijk_Ailk_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_152cu/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_152cu/GridBased/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_152cu/GridBased/aquavanjaram_Cijk_Alik_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_152cu/GridBased/aquavanjaram_Cijk_Alik_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_152cu/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8NHS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_152cu/GridBased/aquavanjaram_Cijk_Alik_Bljk_F8NHS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_152cu/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_152cu/GridBased/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_228cu/Equality/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_228cu/Equality/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_228cu/Equality/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_228cu/Equality/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Ailk_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Ailk_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Ailk_Bjlk_BBS_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Ailk_Bjlk_BBS_BH_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Ailk_Bjlk_SB_Bias_HA_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Ailk_Bjlk_SB_Bias_HA_SAV.yaml
@@ -48,8 +48,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Ailk_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Ailk_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Ailk_Bljk_BBS_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Ailk_Bljk_BBS_BH_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_UserArgs.yaml
@@ -49,8 +49,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Ailk_Bljk_SB_Bias_HA_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Ailk_Bljk_SB_Bias_HA_SAV.yaml
@@ -49,8 +49,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Ailk_Bljk_S_MX_B_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Ailk_Bljk_S_MX_B_Bias_HAS_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Alik_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Alik_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Alik_Bljk_SB_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Alik_Bljk_SB_Bias_HAS_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Alik_Bljk_SB_Bias_HA_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Alik_Bljk_SB_Bias_HA_SAV.yaml
@@ -48,8 +48,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_80cu/Equality/aquavanjaram_Cijk_Ailk_Bjlk_BBS_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_80cu/Equality/aquavanjaram_Cijk_Ailk_Bjlk_BBS_BH_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_80cu/Equality/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_80cu/Equality/aquavanjaram_Cijk_Ailk_Bjlk_HHS_BH_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_80cu/Equality/aquavanjaram_Cijk_Ailk_Bjlk_SB_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_80cu/Equality/aquavanjaram_Cijk_Ailk_Bjlk_SB_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_80cu/Equality/aquavanjaram_Cijk_Ailk_Bljk_BBS_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_80cu/Equality/aquavanjaram_Cijk_Ailk_Bljk_BBS_BH_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_80cu/Equality/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_80cu/Equality/aquavanjaram_Cijk_Ailk_Bljk_HHS_BH_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_80cu/Equality/aquavanjaram_Cijk_Alik_Bljk_BBS_STA_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_80cu/Equality/aquavanjaram_Cijk_Alik_Bljk_BBS_STA_BH_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_80cu/Equality/aquavanjaram_Cijk_Alik_Bljk_F8NF8NS_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_80cu/Equality/aquavanjaram_Cijk_Alik_Bljk_F8NF8NS_BH_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_80cu/Equality/aquavanjaram_Cijk_Alik_Bljk_F8NHS_STA_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_80cu/Equality/aquavanjaram_Cijk_Alik_Bljk_F8NHS_STA_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_80cu/Equality/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_80cu/Equality/aquavanjaram_Cijk_Alik_Bljk_HHS_BH_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_80cu/Equality/aquavanjaram_Cijk_Alik_Bljk_HHS_STA_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_80cu/Equality/aquavanjaram_Cijk_Alik_Bljk_HHS_STA_BH_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_80cu/Equality/aquavanjaram_Cijk_Alik_Bljk_SB_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_80cu/Equality/aquavanjaram_Cijk_Alik_Bljk_SB_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bjlk_BBS_BH_Bias_HAS_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bjlk_BBS_BH_Bias_HAS_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bjlk_HHS_BH_Bias_Aux_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bjlk_HHS_BH_Bias_Aux_HAH_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_HAH_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bjlk_HHS_BH_Bias_GG_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bjlk_HHS_BH_Bias_GG_HAH_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bjlk_HHS_BH_Bias_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bjlk_HHS_BH_Bias_HAH_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bjlk_HHS_BH_Bias_HAS_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bjlk_HHS_BH_Bias_HAS_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bjlk_HHS_BH_GG.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bjlk_HHS_BH_GG.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bjlk_HSS_BH_Bias_GG_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bjlk_HSS_BH_Bias_GG_HAH_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bjlk_HSS_BH_Bias_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bjlk_HSS_BH_Bias_HAH_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bjlk_HSS_BH_GG.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bjlk_HSS_BH_GG.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bjlk_SB_Bias_HA_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bjlk_SB_Bias_HA_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bljk_BBS_BH_Bias_HAS_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bljk_BBS_BH_Bias_HAS_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcD_Grad_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcD_Grad_HAH_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_HAH_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bljk_HHS_BH_GG.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bljk_HHS_BH_GG.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bljk_HSS_BH_Bias_AuxS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bljk_HSS_BH_Bias_AuxS_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_HAH_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bljk_HSS_BH_GG.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bljk_HSS_BH_GG.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bljk_SB_Bias_HA_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Ailk_Bljk_SB_Bias_HA_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bjlk_BBS_BH_Bias_HAS_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bjlk_BBS_BH_Bias_HAS_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bjlk_HHS_BH_Bias_Aux_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bjlk_HHS_BH_Bias_Aux_HAH_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_HAH_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bjlk_HHS_BH_Bias_GG_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bjlk_HHS_BH_Bias_GG_HAH_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bjlk_HHS_BH_Bias_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bjlk_HHS_BH_Bias_HAH_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bjlk_HHS_BH_GG.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bjlk_HHS_BH_GG.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bjlk_HSS_BH_Bias_GG_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bjlk_HSS_BH_Bias_GG_HAH_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bjlk_HSS_BH_Bias_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bjlk_HSS_BH_Bias_HAH_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bjlk_HSS_BH_GG.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bjlk_HSS_BH_GG.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bjlk_SB_Bias_HA_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bjlk_SB_Bias_HA_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bljk_BBS_BH_Bias_HAS_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bljk_BBS_BH_Bias_HAS_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bljk_HHS_BH.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bljk_HHS_BH.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bljk_HHS_BH_Bias_Aux_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bljk_HHS_BH_Bias_Aux_HAH_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcD_Grad_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcD_Grad_HAH_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bljk_HHS_BH_Bias_GG_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bljk_HHS_BH_Bias_GG_HAH_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bljk_HHS_BH_Bias_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bljk_HHS_BH_Bias_HAH_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bljk_HHS_BH_GG.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bljk_HHS_BH_GG.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bljk_HSS_BH_Bias_GG_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bljk_HSS_BH_Bias_GG_HAH_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bljk_HSS_BH_Bias_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bljk_HSS_BH_Bias_HAH_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bljk_HSS_BH_GG.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bljk_HSS_BH_GG.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bljk_SB_Bias_HA_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/arcturus/GridBased/arcturus_Cijk_Alik_Bljk_SB_Bias_HA_SAV.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bjlk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bjlk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bjlk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bjlk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bljk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bljk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Ailk_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bjlk_BSS_BH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bjlk_BSS_BH_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bjlk_HSS_BH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bjlk_HSS_BH_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bljk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bljk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1103/GridBased/gfx1103_Cijk_Alik_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/Equality/gfx1150_Cijk_Alik_Bljk_HHS_BH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/Equality/gfx1150_Cijk_Alik_Bljk_HHS_BH_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bjlk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bjlk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bjlk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bjlk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bljk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bljk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Ailk_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bjlk_BSS_BH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bjlk_BSS_BH_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bjlk_HSS_BH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bjlk_HSS_BH_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bljk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bljk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1150/GridBased/gfx1150_Cijk_Alik_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/Equality/gfx1151_Cijk_Alik_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/Equality/gfx1151_Cijk_Alik_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bjlk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bjlk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bjlk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bjlk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bljk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bljk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Ailk_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bjlk_BSS_BH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bjlk_BSS_BH_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bjlk_HSS_BH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bjlk_HSS_BH_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bljk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bljk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1151/GridBased/gfx1151_Cijk_Alik_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bjlk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bjlk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bjlk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bjlk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bljk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bljk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Ailk_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bjlk_BSS_BH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bjlk_BSS_BH_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bjlk_HSS_BH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bjlk_HSS_BH_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bljk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bljk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1152/GridBased/gfx1152_Cijk_Alik_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/Equality/gfx1153_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/Equality/gfx1153_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bjlk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bjlk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bjlk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bjlk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bljk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bljk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Ailk_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bjlk_BSS_BH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bjlk_BSS_BH_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bjlk_HSS_BH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bjlk_HSS_BH_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bljk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bljk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1153/GridBased/gfx1153_Cijk_Alik_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1200/Equality/gfx1200_Cijk_Ailk_Bjlk_HHS_BH_Bias_S_AuxH_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1200/Equality/gfx1200_Cijk_Ailk_Bjlk_HHS_BH_Bias_S_AuxH_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1200/Equality/gfx1200_Cijk_Ailk_Bljk_HHS_BH_Bias_S_AuxH_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1200/Equality/gfx1200_Cijk_Ailk_Bljk_HHS_BH_Bias_S_AuxH_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1200/Equality/gfx1200_Cijk_Alik_Bjlk_HHS_BH_Bias_S_AuxH_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1200/Equality/gfx1200_Cijk_Alik_Bjlk_HHS_BH_Bias_S_AuxH_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1200/Equality/gfx1200_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1200/Equality/gfx1200_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1200/Equality/gfx1200_Cijk_Alik_Bljk_HHS_BH_Bias_S_AuxH_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1200/Equality/gfx1200_Cijk_Alik_Bljk_HHS_BH_Bias_S_AuxH_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1200/GridBased/gfx1200_Cijk_Alik_Bjlk_HHS_BH_Bias_SHB_HA_S_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1200/GridBased/gfx1200_Cijk_Alik_Bjlk_HHS_BH_Bias_SHB_HA_S_SAB_SCD_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1200/GridBased/gfx1200_Cijk_Alik_Bljk_F8BS_BH_Bias_HA_S_SABV_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1200/GridBased/gfx1200_Cijk_Alik_Bljk_F8BS_BH_Bias_HA_S_SABV_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1201/Equality/gfx1201_Cijk_Ailk_Bjlk_HHS_BH_Bias_S_AuxH_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1201/Equality/gfx1201_Cijk_Ailk_Bjlk_HHS_BH_Bias_S_AuxH_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1201/Equality/gfx1201_Cijk_Ailk_Bljk_HHS_BH_Bias_S_AuxH_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1201/Equality/gfx1201_Cijk_Ailk_Bljk_HHS_BH_Bias_S_AuxH_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1201/Equality/gfx1201_Cijk_Alik_Bjlk_HHS_BH_Bias_S_AuxH_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1201/Equality/gfx1201_Cijk_Alik_Bjlk_HHS_BH_Bias_S_AuxH_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1201/Equality/gfx1201_Cijk_Alik_Bljk_F8F8S_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1201/Equality/gfx1201_Cijk_Alik_Bljk_F8F8S_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1201/Equality/gfx1201_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1201/Equality/gfx1201_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1201/Equality/gfx1201_Cijk_Alik_Bljk_HHS_BH_Bias_S_AuxH_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1201/Equality/gfx1201_Cijk_Alik_Bljk_HHS_BH_Bias_S_AuxH_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1201/Equality/gfx1201_Cijk_Alik_Bljk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1201/Equality/gfx1201_Cijk_Alik_Bljk_I8BH_HAI_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1201/GridBased/gfx1201_Cijk_Ailk_Bljk_HHS_BH_Bias_SHB_HA_S_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1201/GridBased/gfx1201_Cijk_Ailk_Bljk_HHS_BH_Bias_SHB_HA_S_SAB_SCD_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1201/GridBased/gfx1201_Cijk_Alik_Bjlk_HHS_BH_Bias_SHB_HA_S_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1201/GridBased/gfx1201_Cijk_Alik_Bjlk_HHS_BH_Bias_SHB_HA_S_SAB_SCD_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1201/GridBased/gfx1201_Cijk_Alik_Bljk_F8BS_BH_Bias_HA_S_SABV_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1201/GridBased/gfx1201_Cijk_Alik_Bljk_F8BS_BH_Bias_HA_S_SABV_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bjlk_BBS_BH_Bias_A_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bjlk_BBS_BH_Bias_A_UserArgs.yaml
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bjlk_BBS_BH_Bias_B_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bjlk_BBS_BH_Bias_B_UserArgs.yaml
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bjlk_BBS_BH_Bias_D_GradB_HA_S_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bjlk_BBS_BH_Bias_D_GradB_HA_S_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx1250
 - gfx1250
 - [Device 73f0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationNoGuard: false
   ActivationType: hipblaslt_all
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bjlk_BBS_BH_GradB_HA_S_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bjlk_BBS_BH_GradB_HA_S_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx1250
 - gfx1250
 - [Device 73f0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationNoGuard: false
   ActivationType: hipblaslt_all
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bjlk_BSS_BH_Bias_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bjlk_BSS_BH_Bias_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bjlk_HHS_BH_Bias_A_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bjlk_HHS_BH_Bias_A_UserArgs.yaml
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bjlk_HHS_BH_Bias_B_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bjlk_HHS_BH_Bias_B_UserArgs.yaml
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bjlk_HHS_BH_Bias_D_GradH_HA_S_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bjlk_HHS_BH_Bias_D_GradH_HA_S_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx1250
 - gfx1250
 - [Device 73f0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationNoGuard: false
   ActivationType: hipblaslt_all
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bjlk_HHS_BH_GradH_HA_S_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bjlk_HHS_BH_GradH_HA_S_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx1250
 - gfx1250
 - [Device 73f0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationNoGuard: false
   ActivationType: hipblaslt_all
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bjlk_HSS_BH_Bias_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bjlk_HSS_BH_Bias_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bjlk_S_MX_B_Bias_SB_HA_S_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bjlk_S_MX_B_Bias_SB_HA_S_SAB_SAV_UserArgs.yaml
@@ -77,8 +77,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bljk_BBS_BH_Bias_A_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bljk_BBS_BH_Bias_A_UserArgs.yaml
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bljk_BBS_BH_Bias_B_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bljk_BBS_BH_Bias_B_UserArgs.yaml
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bljk_BBS_BH_Bias_D_GradB_HA_S_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bljk_BBS_BH_Bias_D_GradB_HA_S_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx1250
 - gfx1250
 - [Device 73f0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationNoGuard: false
   ActivationType: hipblaslt_all
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bljk_BBS_BH_GradB_HA_S_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bljk_BBS_BH_GradB_HA_S_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx1250
 - gfx1250
 - [Device 73f0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationNoGuard: false
   ActivationType: hipblaslt_all
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bljk_BSS_BH_Bias_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bljk_BSS_BH_Bias_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bljk_HHS_BH_Bias_A_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bljk_HHS_BH_Bias_A_UserArgs.yaml
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bljk_HHS_BH_Bias_B_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bljk_HHS_BH_Bias_B_UserArgs.yaml
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bljk_HHS_BH_Bias_D_GradH_HA_S_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bljk_HHS_BH_Bias_D_GradH_HA_S_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx1250
 - gfx1250
 - [Device 73f0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationNoGuard: false
   ActivationType: hipblaslt_all
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bljk_HHS_BH_GradH_HA_S_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bljk_HHS_BH_GradH_HA_S_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx1250
 - gfx1250
 - [Device 73f0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationNoGuard: false
   ActivationType: hipblaslt_all
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bljk_HSS_BH_Bias_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bljk_HSS_BH_Bias_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bljk_S_MX_B_Bias_SB_HA_S_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Ailk_Bljk_S_MX_B_Bias_SB_HA_S_SAB_SAV_UserArgs.yaml
@@ -77,8 +77,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bjlk_BBS_BH_Bias_A_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bjlk_BBS_BH_Bias_A_UserArgs.yaml
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bjlk_BBS_BH_Bias_B_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bjlk_BBS_BH_Bias_B_UserArgs.yaml
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bjlk_BBS_BH_Bias_D_GradB_HA_S_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bjlk_BBS_BH_Bias_D_GradB_HA_S_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx1250
 - gfx1250
 - [Device 73f0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationNoGuard: false
   ActivationType: hipblaslt_all
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bjlk_BBS_BH_GradB_HA_S_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bjlk_BBS_BH_GradB_HA_S_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx1250
 - gfx1250
 - [Device 73f0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationNoGuard: false
   ActivationType: hipblaslt_all
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bjlk_BSS_BH_Bias_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bjlk_BSS_BH_Bias_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bjlk_HHS_BH_Bias_A_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bjlk_HHS_BH_Bias_A_UserArgs.yaml
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bjlk_HHS_BH_Bias_B_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bjlk_HHS_BH_Bias_B_UserArgs.yaml
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bjlk_HHS_BH_Bias_D_GradH_HA_S_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bjlk_HHS_BH_Bias_D_GradH_HA_S_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx1250
 - gfx1250
 - [Device 73f0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationNoGuard: false
   ActivationType: hipblaslt_all
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bjlk_HHS_BH_GradH_HA_S_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bjlk_HHS_BH_GradH_HA_S_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx1250
 - gfx1250
 - [Device 73f0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationNoGuard: false
   ActivationType: hipblaslt_all
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bjlk_HSS_BH_Bias_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bjlk_HSS_BH_Bias_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bjlk_S_MX_B_Bias_SB_HA_S_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bjlk_S_MX_B_Bias_SB_HA_S_SAB_SAV_UserArgs.yaml
@@ -77,8 +77,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bljk_BBS_BH_Bias_A_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bljk_BBS_BH_Bias_A_UserArgs.yaml
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bljk_BBS_BH_Bias_B_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bljk_BBS_BH_Bias_B_UserArgs.yaml
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bljk_BBS_BH_Bias_D_GradB_HA_S_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bljk_BBS_BH_Bias_D_GradB_HA_S_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx1250
 - gfx1250
 - [Device 73f0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationNoGuard: false
   ActivationType: hipblaslt_all
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bljk_BBS_BH_GradB_HA_S_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bljk_BBS_BH_GradB_HA_S_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx1250
 - gfx1250
 - [Device 73f0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationNoGuard: false
   ActivationType: hipblaslt_all
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bljk_BSS_BH_Bias_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bljk_BSS_BH_Bias_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bljk_HHS_BH_Bias_A_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bljk_HHS_BH_Bias_A_UserArgs.yaml
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bljk_HHS_BH_Bias_B_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bljk_HHS_BH_Bias_B_UserArgs.yaml
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bljk_HHS_BH_Bias_D_GradH_HA_S_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bljk_HHS_BH_Bias_D_GradH_HA_S_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx1250
 - gfx1250
 - [Device 73f0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationNoGuard: false
   ActivationType: hipblaslt_all
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bljk_HHS_BH_GradH_HA_S_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bljk_HHS_BH_GradH_HA_S_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx1250
 - gfx1250
 - [Device 73f0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationNoGuard: false
   ActivationType: hipblaslt_all
@@ -73,8 +73,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bljk_HSS_BH_Bias_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bljk_HSS_BH_Bias_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bljk_S_MX_B_Bias_SB_HA_S_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1250/GridBased/gfx1250_Cijk_Alik_Bljk_S_MX_B_Bias_SB_HA_S_SAB_SAV_UserArgs.yaml
@@ -77,8 +77,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Equality/gfx950_Cijk_Ailk_Bjlk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Equality/gfx950_Cijk_Ailk_Bjlk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Equality/gfx950_Cijk_Ailk_Bjlk_S_B_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Equality/gfx950_Cijk_Ailk_Bjlk_S_B_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationNoGuard: false
   ActivationType: hipblaslt_all

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Equality/gfx950_Cijk_Ailk_Bljk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Equality/gfx950_Cijk_Ailk_Bljk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationNoGuard: false
   ActivationType: hipblaslt_all

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Equality/gfx950_Cijk_Alik_Bjlk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Equality/gfx950_Cijk_Alik_Bjlk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Equality/gfx950_Cijk_Alik_Bljk_BBS_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Equality/gfx950_Cijk_Alik_Bljk_BBS_BH_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Equality/gfx950_Cijk_Alik_Bljk_F8B8BS_BH_SAB_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Equality/gfx950_Cijk_Alik_Bljk_F8B8BS_BH_SAB_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Equality/gfx950_Cijk_Alik_Bljk_F8BS_BH_SAB_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Equality/gfx950_Cijk_Alik_Bljk_F8BS_BH_SAB_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Equality/gfx950_Cijk_Alik_Bljk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Equality/gfx950_Cijk_Alik_Bljk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationNoGuard: false
   ActivationType: hipblaslt_all

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bjlk_BBS_BH_Bias_AuxB_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bjlk_BBS_BH_Bias_AuxB_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bjlk_BBS_BH_Bias_BiasSrcB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bjlk_BBS_BH_Bias_BiasSrcB_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bjlk_HHS_BH_Bias_Aux_AH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bjlk_HHS_BH_Bias_Aux_AH_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bjlk_HHS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bjlk_HHS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bjlk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bjlk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bjlk_I8I8S_BH_HAS_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bjlk_I8I8S_BH_HAS_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bjlk_I8II_BH_AI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bjlk_I8II_BH_AI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bjlk_I8IS_BH_HAS_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bjlk_I8IS_BH_HAS_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bjlk_SB_Bias_Aux_A_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bjlk_SB_Bias_Aux_A_SAV_UserArgs.yaml
@@ -60,8 +60,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bjlk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bjlk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
@@ -60,8 +60,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bjlk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bjlk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
@@ -60,8 +60,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bljk_BBS_BH_Bias_AuxB_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bljk_BBS_BH_Bias_AuxB_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bljk_BBS_BH_Bias_BiasSrcD_GradB_AS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bljk_BBS_BH_Bias_BiasSrcD_GradB_AS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bljk_HHS_BH_Bias_Aux_AH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bljk_HHS_BH_Bias_Aux_AH_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bljk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bljk_I8I8S_BH_HAS_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bljk_I8I8S_BH_HAS_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bljk_I8II_BH_AI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bljk_I8II_BH_AI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bljk_I8IS_BH_HAS_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bljk_I8IS_BH_HAS_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bljk_SB_Bias_Aux_A_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bljk_SB_Bias_Aux_A_SAV_UserArgs.yaml
@@ -60,8 +60,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bljk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bljk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
@@ -60,8 +60,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bljk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Ailk_Bljk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
@@ -60,8 +60,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bjlk_BBS_BH_Bias_AuxB_HA_S_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bjlk_BBS_BH_Bias_AuxB_HA_S_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bjlk_HHS_BH_Bias_Aux_AH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bjlk_HHS_BH_Bias_Aux_AH_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bjlk_HHS_BH_Bias_BiasSrcD_Grad_AH_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bjlk_HHS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bjlk_HHS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bjlk_HSS_BH_Bias_AH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bjlk_HSS_BH_Bias_AH_SAV.yaml
@@ -48,8 +48,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseInitialStridesAB: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bjlk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bjlk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bjlk_I8I8S_BH_HAS_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bjlk_I8I8S_BH_HAS_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bjlk_I8II_BH_AI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bjlk_I8II_BH_AI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bjlk_I8IS_BH_HAS_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bjlk_I8IS_BH_HAS_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bjlk_SB_Bias_Aux_A_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bjlk_SB_Bias_Aux_A_SAV_UserArgs.yaml
@@ -60,8 +60,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bjlk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bjlk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
@@ -60,8 +60,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bjlk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bjlk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
@@ -60,8 +60,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bljk_BBS_BH_Bias_AuxB_HAS_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bljk_BBS_BH_Bias_AuxB_HAS_SAV.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bljk_HHS_BH_Bias_Aux_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bljk_HHS_BH_Bias_Aux_HAH_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcA_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcB_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcD_Grad_HAH_SAV.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bljk_HHS_BH_Bias_BiasSrcD_Grad_HAH_SAV.yaml
@@ -53,8 +53,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bljk_HHS_BH_Bias_GG_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bljk_HHS_BH_Bias_GG_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bljk_I8I8S_BH_HAS_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bljk_I8I8S_BH_HAS_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bljk_I8II_BH_AI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bljk_I8II_BH_AI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bljk_I8IS_BH_HAS_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bljk_I8IS_BH_HAS_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bljk_SB_Bias_Aux_A_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bljk_SB_Bias_Aux_A_SAV_UserArgs.yaml
@@ -60,8 +60,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bljk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bljk_SB_Bias_BiasSrcB_SAV_UserArgs.yaml
@@ -60,8 +60,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bljk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/GridBased/gfx950_Cijk_Alik_Bljk_SB_Bias_BiasSrcD_Grad_A_SAV_UserArgs.yaml
@@ -60,8 +60,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_B8F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_B8F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_B8F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_B8F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_B8F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_B8F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_B8F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_B8F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_B8F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_B8F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_BSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_BSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_F8B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_F8B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_F8B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_F8B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_F8B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_F8B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_F8B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_F8B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_F8B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_F8B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_F8F8S_BH_BiasSHB_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_F8F8S_BH_BiasSHB_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_F8H_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_F8H_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_F8H_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_F8H_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_F8SS_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_F8SS_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_HF8_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_HF8_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_HF8_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_HF8_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_SB_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bjlk_SB_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_B8F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_B8F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_B8F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_B8F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_B8F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_B8F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_B8F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_B8F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_B8F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_B8F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_BSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_BSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_F8B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_F8B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_F8B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_F8B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_F8B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_F8B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_F8B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_F8B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_F8B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_F8B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_F8F8S_BH_BiasSHB_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_F8F8S_BH_BiasSHB_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_F8H_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_F8H_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_F8H_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_F8H_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_F8SS_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_F8SS_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_HF8_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_HF8_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_HF8_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_HF8_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_SB_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Ailk_Bljk_SB_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_B8F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_B8F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_B8F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_B8F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_B8F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_B8F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_B8F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_B8F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_B8F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_B8F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_BSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_BSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_F8B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_F8B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_F8B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_F8B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_F8B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_F8B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_F8B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_F8B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_F8B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_F8B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_F8F8S_BH_BiasSHB_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_F8F8S_BH_BiasSHB_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_F8H_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_F8H_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_F8H_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_F8H_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_F8SS_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_F8SS_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_HF8_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_HF8_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_HF8_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_HF8_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_SB_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bjlk_SB_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_B8F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_B8F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_B8F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_B8F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_B8F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_B8F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_B8F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_B8F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_B8F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_B8F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_BSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_BSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_F8B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_F8B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_F8B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_F8B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_F8B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_F8B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_F8B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_F8B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_F8B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_F8B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_F8BS_BH_BiasSB_HAS_SABV_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_F8BS_BH_BiasSB_HAS_SABV_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_F8F8S_BH_BiasSHB_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_F8F8S_BH_BiasSHB_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_F8H_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_F8H_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_F8H_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_F8H_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_F8SS_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_F8SS_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_HF8_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_HF8_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_HF8_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_HF8_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_SB_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_nta4/gfx950_Cijk_Alik_Bljk_SB_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_B8F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_B8F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_B8F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_B8F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_B8F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_B8F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_B8F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_B8F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_B8F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_B8F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_BSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_BSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_F8B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_F8B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_F8B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_F8B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_F8B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_F8B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_F8B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_F8B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_F8B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_F8B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_F8F8S_BH_BiasSHB_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_F8F8S_BH_BiasSHB_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_F8H_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_F8H_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_F8H_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_F8H_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_F8SS_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_F8SS_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_HF8_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_HF8_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_HF8_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_HF8_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_SB_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bjlk_SB_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_B8F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_B8F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_B8F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_B8F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_B8F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_B8F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_B8F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_B8F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_B8F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_B8F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_BSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_BSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_F8B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_F8B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_F8B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_F8B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_F8B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_F8B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_F8B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_F8B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_F8B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_F8B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_F8F8S_BH_BiasSHB_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_F8F8S_BH_BiasSHB_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_F8H_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_F8H_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_F8H_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_F8H_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_F8SS_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_F8SS_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_HF8_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_HF8_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_HF8_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_HF8_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_SB_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Ailk_Bljk_SB_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_B8F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_B8F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_B8F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_B8F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_B8F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_B8F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_B8F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_B8F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_B8F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_B8F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_BSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_BSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_F8B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_F8B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_F8B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_F8B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_F8B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_F8B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_F8B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_F8B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_F8B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_F8B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_F8F8S_BH_BiasSHB_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_F8F8S_BH_BiasSHB_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_F8H_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_F8H_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_F8H_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_F8H_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_F8SS_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_F8SS_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_HF8_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_HF8_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_HF8_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_HF8_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_SB_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bjlk_SB_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_B8F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_B8F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_B8F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_B8F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_B8F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_B8F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_B8F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_B8F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_B8F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_B8F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_BSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_BSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_F8B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_F8B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_F8B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_F8B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_F8B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_F8B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_F8B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_F8B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_F8B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_F8B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_F8BS_BH_BiasSB_HAS_SABV_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_F8BS_BH_BiasSB_HAS_SABV_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_F8F8S_BH_BiasSHB_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_F8F8S_BH_BiasSHB_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_F8H_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_F8H_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_F8H_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_F8H_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_F8SS_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_F8SS_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_HF8_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_HF8_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_HF8_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_HF8_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_SB_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/Origami_ntb4/gfx950_Cijk_Alik_Bljk_SB_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_B8F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_B8F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_B8F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_B8F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_B8F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_B8F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_B8F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_B8F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_B8F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_B8F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_BSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_BSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_F8B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_F8B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_F8B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_F8B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_F8B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_F8B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_F8B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_F8B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_F8B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_F8B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_F8F8S_BH_BiasSHB_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_F8F8S_BH_BiasSHB_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_F8H_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_F8H_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_F8H_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_F8H_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_F8SS_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_F8SS_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_HF8_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_HF8_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_HF8_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_HF8_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_SB_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_SB_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_B8F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_B8F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_B8F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_B8F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_B8F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_B8F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_B8F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_B8F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_B8F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_B8F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_BSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_BSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_F8B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_F8B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_F8B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_F8B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_F8B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_F8B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_F8B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_F8B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_F8B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_F8B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_F8F8S_BH_BiasSHB_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_F8F8S_BH_BiasSHB_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_F8H_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_F8H_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_F8H_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_F8H_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_F8SS_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_F8SS_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_HF8_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_HF8_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_HF8_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_HF8_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_SB_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_SB_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_B8F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_B8F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_B8F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_B8F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_B8F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_B8F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_B8F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_B8F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_B8F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_B8F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_BSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_BSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_F8B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_F8B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_F8B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_F8B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_F8B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_F8B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_F8B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_F8B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_F8B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_F8B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_F8F8S_BH_BiasSHB_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_F8F8S_BH_BiasSHB_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_F8H_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_F8H_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_F8H_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_F8H_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_F8SS_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_F8SS_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_HF8_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_HF8_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_HF8_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_HF8_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_SB_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_SB_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_B8F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_B8F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_B8F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_B8F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_B8F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_B8F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_B8F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_B8F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_B8F8SS_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_B8F8SS_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_B8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_BSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_BSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8B8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8B8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8B8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8B8SS_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8B8SS_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8B8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8BS_BH_BiasSB_HAS_SABV_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8BS_BH_BiasSB_HAS_SABV_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8F8S_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8F8S_BH_BiasSHB_HAS_SAB_SCD_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8F8S_BH_BiasSHB_HAS_SAB_SCD_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8HS_BH_BiasSH_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8H_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8H_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8H_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8H_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8SS_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8SS_BH_BiasSHB_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0, 4, 7]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8SS_BH_BiasS_HAS_SAB_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 1
+  BetaOnlyUseBias: True
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_HF8_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_HF8_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_HF8_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_HF8_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0, 4]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_HSS_BH_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_SB_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/gfx950/Origami/gfx950_Cijk_Alik_Bljk_SB_BiasS_HAS_SAV_UserArgs.yaml
@@ -2,7 +2,7 @@
 - gfx950
 - gfx950
 - [Device 75a0]
-- Activation: 1
+- Activation: True
   ActivationComputeDataType: 0
   ActivationFuncCall: false
   ActivationNoGuard: false
@@ -10,7 +10,7 @@
   AllowNoFreeDims: false
   AssignedDerivedParameters: true
   Batched: true
-  BetaOnlyUseBias: 0
+  BetaOnlyUseBias: False
   BiasDataTypeList: [0]
   BiasSrc: D
   ComplexConjugateA: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bjlk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bjlk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bjlk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bjlk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bljk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bljk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Ailk_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bjlk_BSS_BH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bjlk_BSS_BH_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bjlk_HSS_BH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bjlk_HSS_BH_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -68,8 +68,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bljk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bljk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/GridBased/navi31_Cijk_Alik_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Ailk_Bjlk_HHS_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Ailk_Bjlk_HHS_BH_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Ailk_Bjlk_I8II_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Ailk_Bjlk_I8II_BH_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Ailk_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Ailk_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Ailk_Bljk_BBS_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Ailk_Bljk_BBS_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Ailk_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Ailk_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Ailk_Bljk_HHS_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Ailk_Bljk_HHS_BH_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Ailk_Bljk_HHS_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Ailk_Bljk_HHS_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Ailk_Bljk_I8II_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Ailk_Bljk_I8II_BH_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Alik_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Alik_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Alik_Bljk_BBS_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Alik_Bljk_BBS_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -66,8 +66,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Alik_Bljk_HHS_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Alik_Bljk_HHS_BH_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Alik_Bljk_HHS_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Alik_Bljk_HHS_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Alik_Bljk_I8II_BH_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Alik_Bljk_I8II_BH_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bjlk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bjlk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bjlk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bjlk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bljk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bljk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Ailk_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bjlk_BSS_BH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bjlk_BSS_BH_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bjlk_HSS_BH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bjlk_HSS_BH_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bljk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bljk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/GridBased/navi32_Cijk_Alik_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bjlk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bjlk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bjlk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bjlk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 1
+  TransposeA: False
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bljk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bljk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Ailk_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 0
-  TransposeB: 0
+  TransposeA: False
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bjlk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bjlk_BSS_BH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bjlk_BSS_BH_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bjlk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bjlk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bjlk_HSS_BH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bjlk_HSS_BH_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bjlk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bjlk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 1
+  TransposeA: True
+  TransposeB: True
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bljk_BBS_BH_Bias_AuxB_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bljk_BBS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bljk_BSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bljk_HHS_BH_Bias_AuxH_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: true

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -64,8 +64,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bljk_HSS_BH_Bias_HAS_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 1
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bljk_I8BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bljk_I8BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/GridBased/navi33_Cijk_Alik_Bljk_I8II_BH_HAI_SAV_UserArgs.yaml
@@ -63,8 +63,8 @@
   TileAwareSelection: false
   TileB: 1
   TotalIndices: 4
-  TransposeA: 1
-  TransposeB: 0
+  TransposeA: True
+  TransposeB: False
   UseBeta: true
   UseBias: 0
   UseE: false

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/amaxd/8rn_amaxd.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/amaxd/8rn_amaxd.yaml
@@ -32,8 +32,8 @@ BenchmarkProblems:
       DestDataType: F8N
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -103,8 +103,8 @@ BenchmarkProblems:
       DestDataType: F8N
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -173,8 +173,8 @@ BenchmarkProblems:
       DestDataType: F8N
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -244,8 +244,8 @@ BenchmarkProblems:
       DestDataType: F8N
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       UseBias: 1

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/client/rotate_mode0.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/client/rotate_mode0.yaml
@@ -35,8 +35,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 1

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/client/rotate_mode0_gfx12.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/client/rotate_mode0_gfx12.yaml
@@ -35,8 +35,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 1

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/client/rotate_mode1.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/client/rotate_mode1.yaml
@@ -35,8 +35,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 1

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/client/rotate_mode1_gfx12.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/client/rotate_mode1_gfx12.yaml
@@ -35,8 +35,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 1

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/exception/f16_cf32_nan.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/exception/f16_cf32_nan.yaml
@@ -27,8 +27,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/exception/f16_cf32_nan_gfx11.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/exception/f16_cf32_nan_gfx11.yaml
@@ -27,8 +27,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: False

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/8rn_b_s.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/8rn_b_s.yaml
@@ -27,8 +27,8 @@ BenchmarkProblems:
       DestDataType: B
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation: True
@@ -90,8 +90,8 @@ BenchmarkProblems:
       DestDataType: B
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/ag.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/ag.yaml
@@ -23,8 +23,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -89,8 +89,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -155,8 +155,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -221,8 +221,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       UseBias: 1
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/bf16_tn.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/bf16_tn.yaml
@@ -23,8 +23,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/bf16_tn_predict.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/bf16_tn_predict.yaml
@@ -24,8 +24,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/dot2_gfx942.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/dot2_gfx942.yaml
@@ -19,8 +19,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -84,8 +84,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 1

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/dtl.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/dtl.yaml
@@ -27,8 +27,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -115,8 +115,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -203,8 +203,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -290,8 +290,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -377,8 +377,8 @@ BenchmarkProblems:
       DataType: s
       DestDataType: s
       ComputeDataType: s
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -457,8 +457,8 @@ BenchmarkProblems:
       DataType: s
       DestDataType: s
       ComputeDataType: s
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -538,8 +538,8 @@ BenchmarkProblems:
       DataType: s
       DestDataType: s
       ComputeDataType: s
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -618,8 +618,8 @@ BenchmarkProblems:
       DataType: s
       DestDataType: s
       ComputeDataType: s
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -700,8 +700,8 @@ BenchmarkProblems:
       DestDataType: f8n
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/dtv.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/dtv.yaml
@@ -29,8 +29,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -130,8 +130,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -230,8 +230,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -323,8 +323,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -421,8 +421,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -504,8 +504,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -600,8 +600,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -684,8 +684,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -775,8 +775,8 @@ BenchmarkProblems:
       DataType: s
       DestDataType: s
       ComputeDataType: s
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -860,8 +860,8 @@ BenchmarkProblems:
       DataType: s
       DestDataType: s
       ComputeDataType: s
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -945,8 +945,8 @@ BenchmarkProblems:
       DataType: s
       DestDataType: s
       ComputeDataType: s
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -1032,8 +1032,8 @@ BenchmarkProblems:
       DataType: s
       DestDataType: s
       ComputeDataType: s
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -1118,8 +1118,8 @@ BenchmarkProblems:
       DataType: d
       DestDataType: d
       ComputeDataType: d
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -1199,8 +1199,8 @@ BenchmarkProblems:
       DataType: d
       DestDataType: d
       ComputeDataType: d
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -1280,8 +1280,8 @@ BenchmarkProblems:
       DataType: d
       DestDataType: d
       ComputeDataType: d
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -1361,8 +1361,8 @@ BenchmarkProblems:
       DestDataType: f8n
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -1434,8 +1434,8 @@ BenchmarkProblems:
       DestDataType: f8n
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -1493,8 +1493,8 @@ BenchmarkProblems:
       DestDataType: f8n
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -1555,8 +1555,8 @@ BenchmarkProblems:
       DestDataType: f8n
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -1618,8 +1618,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -1710,8 +1710,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -1798,8 +1798,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -1891,8 +1891,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -1980,8 +1980,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       # UseBias: 1
@@ -2049,8 +2049,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       # UseBias: 1

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/dtv_gfx90a.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/dtv_gfx90a.yaml
@@ -12,7 +12,6 @@ GlobalParameters:
   MaxWorkspaceSize: 13421772800
   DataInitTypeAlpha: 1
   DataInitTypeBeta: 0
-  NumElementsToValidate: -1
   BoundsCheck: 2
   #MaxFileName: 256
 
@@ -27,8 +26,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -105,8 +104,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -178,8 +177,8 @@ BenchmarkProblems:
       DataType: s
       DestDataType: s
       ComputeDataType: s
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -251,8 +250,8 @@ BenchmarkProblems:
       DataType: s
       DestDataType: s
       ComputeDataType: s
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp16_HH_BHS_bf16mfma.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp16_HH_BHS_bf16mfma.yaml
@@ -25,8 +25,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp16_tn.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp16_tn.yaml
@@ -23,8 +23,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -229,8 +229,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp16_use_e.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp16_use_e.yaml
@@ -25,8 +25,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseE: True
@@ -74,8 +74,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseE: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp16fp32mix.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp16fp32mix.yaml
@@ -2,7 +2,6 @@ TestParameters:
   marks: [skip-gfx1100, skip-gfx1101, skip-gfx1102, skip-gfx1200, skip-gfx1201, skip-gfx1250] # not supported yet
 
 GlobalParameters:
-  NumElementsToValidate: -1
   MinimumRequiredVersion: 5.0.0
   PrintLevel: 1
   PrintSolutionRejectionReason: True
@@ -30,8 +29,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias:       1
@@ -84,8 +83,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias:       1
@@ -138,8 +137,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       UseBias:       1
@@ -192,8 +191,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       UseBias:       1
@@ -249,8 +248,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias:       1
@@ -303,8 +302,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       UseBias:       1
@@ -357,8 +356,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias:       1
@@ -411,8 +410,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       UseBias:       1

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp32_nt.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp32_nt.yaml
@@ -17,10 +17,9 @@ BenchmarkProblems:
     - # ProblemType
       OperationType: GEMM
       DataType: s
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
-      Batched: True
       UseBias: 1
       Batched: True
       Activation: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp32_scalealphavec.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp32_scalealphavec.yaml
@@ -29,8 +29,8 @@ BenchmarkProblems:
       DataType: s
       DestDataType: s
       ComputeDataType: s
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       BiasDataTypeList: [s]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp32_tn.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp32_tn.yaml
@@ -20,10 +20,9 @@ BenchmarkProblems:
     - # ProblemType
       OperationType: GEMM
       DataType: s
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
-      Batched: True
       UseBias: 1
       Batched: True
       Activation: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp8bf8nss.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp8bf8nss.yaml
@@ -27,8 +27,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -98,8 +98,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       UseBias: 1

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp8n.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp8n.yaml
@@ -17,7 +17,6 @@ GlobalParameters:
   DataInitTypeBeta: 1
   DataInitTypeBias: 21
   DataInitTypeScaleAlphaVec: 21
-  NumElementsToValidate: -1
   BoundsCheck: 2
 
 BenchmarkProblems:
@@ -31,8 +30,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -104,8 +103,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -166,8 +165,8 @@ BenchmarkProblems:
       DataType: F8N
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp8n_rowwise.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp8n_rowwise.yaml
@@ -34,8 +34,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       BiasDataTypeList: [s]
@@ -95,8 +95,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       BiasDataTypeList: [s]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp8n_use_e.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp8n_use_e.yaml
@@ -17,7 +17,6 @@ GlobalParameters:
   DataInitTypeBeta: 1
   DataInitTypeBias: 21
   DataInitTypeScaleAlphaVec: 21
-  NumElementsToValidate: -1
   BoundsCheck: 2
 
 BenchmarkProblems:
@@ -30,8 +29,8 @@ BenchmarkProblems:
       DataType: F8N
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -95,8 +94,8 @@ BenchmarkProblems:
       DataType: F8N
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp8nfp16mix_fp8nss.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp8nfp16mix_fp8nss.yaml
@@ -12,7 +12,6 @@ GlobalParameters:
   MaxWorkspaceSize: 13421772800
   DataInitTypeAlpha: 1
   DataInitTypeBeta: 1
-  NumElementsToValidate: -1
   BoundsCheck: 2
 
 BenchmarkProblems:
@@ -24,8 +23,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -93,8 +92,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -161,8 +160,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -230,8 +229,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       Activation:    True
@@ -302,8 +301,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -366,8 +365,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       BiasDataTypeList: [s,b]
@@ -422,8 +421,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       BiasDataTypeList: [s,b]
@@ -479,8 +478,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       BiasDataTypeList: [s,b]
@@ -539,8 +538,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -603,8 +602,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       BiasDataTypeList: [s,b]
@@ -659,8 +658,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       BiasDataTypeList: [s,b]
@@ -716,8 +715,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       BiasDataTypeList: [s,b]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp8nfp16mix_hfp8ns.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp8nfp16mix_hfp8ns.yaml
@@ -18,7 +18,6 @@ GlobalParameters:
   DataInitTypeBeta: 1
   DataInitTypeBias: 21
   DataInitTypeScaleAlphaVec: 21
-  NumElementsToValidate: -1
   BoundsCheck: 2
 
 BenchmarkProblems:
@@ -33,8 +32,8 @@ BenchmarkProblems:
       DestDataType: F8N
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -95,8 +94,8 @@ BenchmarkProblems:
       DestDataType: F8N
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -157,8 +156,8 @@ BenchmarkProblems:
       DestDataType: F8N
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -222,8 +221,8 @@ BenchmarkProblems:
       DestDataType: F8N
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -283,8 +282,8 @@ BenchmarkProblems:
       DestDataType: F8N
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       Activation:    True
@@ -344,8 +343,8 @@ BenchmarkProblems:
       DestDataType: F8N
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -406,8 +405,8 @@ BenchmarkProblems:
       DestDataType: F8N
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       Activation:    True
@@ -471,8 +470,8 @@ BenchmarkProblems:
       DestDataType: F8N
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -532,8 +531,8 @@ BenchmarkProblems:
       DestDataType: F8N
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       Activation:    True
@@ -593,8 +592,8 @@ BenchmarkProblems:
       DestDataType: F8N
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -655,8 +654,8 @@ BenchmarkProblems:
       DestDataType: F8N
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       Activation:    True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp8nfp16mix_hhs.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp8nfp16mix_hhs.yaml
@@ -12,7 +12,6 @@ GlobalParameters:
   MaxWorkspaceSize: 13421772800
   DataInitTypeAlpha: 1
   DataInitTypeBeta: 0
-  NumElementsToValidate: -1
   BoundsCheck: 2
 
 BenchmarkProblems:
@@ -27,8 +26,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       BiasDataTypeList: [s,b]
@@ -95,8 +94,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       BiasDataTypeList: [s,b]
@@ -166,8 +165,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       BiasDataTypeList: [s,b]
@@ -222,8 +221,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       BiasDataTypeList: [s,b]
@@ -281,8 +280,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       BiasDataTypeList: [s,b]
@@ -337,8 +336,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       BiasDataTypeList: [s,b]
@@ -393,8 +392,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       BiasDataTypeList: [s,b]
@@ -450,8 +449,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       BiasDataTypeList: [s,b]
@@ -510,8 +509,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       BiasDataTypeList: [s,b]
@@ -566,8 +565,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       BiasDataTypeList: [s,b]
@@ -622,8 +621,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       BiasDataTypeList: [s,b]
@@ -679,8 +678,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       BiasDataTypeList: [s,b]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp8nfp16mix_hhs_lsu4.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp8nfp16mix_hhs_lsu4.yaml
@@ -12,7 +12,6 @@ GlobalParameters:
   MaxWorkspaceSize: 13421772800
   DataInitTypeAlpha: 1
   DataInitTypeBeta: 0
-  NumElementsToValidate: -1
   BoundsCheck: 2
 
 BenchmarkProblems:
@@ -27,8 +26,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard
@@ -102,8 +101,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard
@@ -182,8 +181,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard
@@ -247,8 +246,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard
@@ -315,8 +314,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard
@@ -375,8 +374,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard
@@ -439,8 +438,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard
@@ -499,8 +498,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gemm_bias_strided_batched.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gemm_bias_strided_batched.yaml
@@ -25,8 +25,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -92,8 +92,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -159,8 +159,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -226,8 +226,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -293,8 +293,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -360,8 +360,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -427,8 +427,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -494,8 +494,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -562,8 +562,8 @@ BenchmarkProblems:
       DestDataType: i8
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -630,8 +630,8 @@ BenchmarkProblems:
       DestDataType: i8
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gemm_bias_strided_batched_broadcast.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gemm_bias_strided_batched_broadcast.yaml
@@ -26,8 +26,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -91,8 +91,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -156,8 +156,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -221,8 +221,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -286,8 +286,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -351,8 +351,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -416,8 +416,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -481,8 +481,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -547,8 +547,8 @@ BenchmarkProblems:
       DestDataType: i8
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -613,8 +613,8 @@ BenchmarkProblems:
       DestDataType: i8
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gemm_bias_strided_batched_broadcast_gfx940.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gemm_bias_strided_batched_broadcast_gfx940.yaml
@@ -24,8 +24,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -89,8 +89,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -154,8 +154,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -219,8 +219,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -284,8 +284,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -349,8 +349,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -414,8 +414,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -479,8 +479,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -545,8 +545,8 @@ BenchmarkProblems:
       DestDataType: i8
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -611,8 +611,8 @@ BenchmarkProblems:
       DestDataType: i8
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gemm_bias_strided_batched_gfx940.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gemm_bias_strided_batched_gfx940.yaml
@@ -24,8 +24,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -89,8 +89,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -154,8 +154,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -219,8 +219,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -284,8 +284,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -349,8 +349,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -414,8 +414,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -479,8 +479,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -545,8 +545,8 @@ BenchmarkProblems:
       DestDataType: i8
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -611,8 +611,8 @@ BenchmarkProblems:
       DestDataType: i8
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gemm_ck_gfx942.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gemm_ck_gfx942.yaml
@@ -29,8 +29,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
 
@@ -79,8 +79,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
 

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx11/bf16_tn_gfx11.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx11/bf16_tn_gfx11.yaml
@@ -24,8 +24,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx11/fp16_HH_BHS_bf16mfma_gfx11.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx11/fp16_HH_BHS_bf16mfma_gfx11.yaml
@@ -26,8 +26,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx11/fp16_tn_gfx11.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx11/fp16_tn_gfx11.yaml
@@ -24,8 +24,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx11/fp16_use_e_gfx11.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx11/fp16_use_e_gfx11.yaml
@@ -25,8 +25,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseE: True
@@ -78,8 +78,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseE: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx11/gemm_bias_strided_batched_broadcast_gfx11.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx11/gemm_bias_strided_batched_broadcast_gfx11.yaml
@@ -26,8 +26,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -91,8 +91,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -156,8 +156,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -221,8 +221,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -286,8 +286,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -351,8 +351,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -416,8 +416,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -481,8 +481,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -547,8 +547,8 @@ BenchmarkProblems:
       DestDataType: i8
       ComputeDataType: i
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       #UseBias: True
       Batched: True
@@ -614,8 +614,8 @@ BenchmarkProblems:
       DestDataType: i8
       ComputeDataType: i
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       #UseBias: True
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx11/gemm_bias_strided_batched_gfx11.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx11/gemm_bias_strided_batched_gfx11.yaml
@@ -26,8 +26,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -91,8 +91,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -156,8 +156,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -221,8 +221,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -286,8 +286,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -351,8 +351,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -416,8 +416,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -481,8 +481,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -547,8 +547,8 @@ BenchmarkProblems:
       DestDataType: i8
       ComputeDataType: i
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       #UseBias: True
       Batched: True
@@ -614,8 +614,8 @@ BenchmarkProblems:
       DestDataType: i8
       ComputeDataType: i
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       #UseBias: True
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx11/gsuasb_gfx11.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx11/gsuasb_gfx11.yaml
@@ -30,8 +30,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       BiasDataTypeList: [s]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/8r_b_s_gfx12.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/8r_b_s_gfx12.yaml
@@ -27,8 +27,8 @@ BenchmarkProblems:
       DestDataType: B
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation: True
@@ -92,8 +92,8 @@ BenchmarkProblems:
       DestDataType: B
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/b8b8s_gfx1250.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/b8b8s_gfx1250.yaml
@@ -27,8 +27,8 @@ BenchmarkProblems:
       DestDataType: B8
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       SparseA: False
       Activation: False
@@ -94,8 +94,8 @@ BenchmarkProblems:
       DestDataType: B8
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       SparseA: False
       Activation: False
@@ -160,8 +160,8 @@ BenchmarkProblems:
       DestDataType: B8
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       SparseA: False
       Activation: False
@@ -225,8 +225,8 @@ BenchmarkProblems:
       DestDataType: B8
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       SparseA: False
       Activation: False

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/b8hs_grvw1_gfx12.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/b8hs_grvw1_gfx12.yaml
@@ -41,7 +41,6 @@ GlobalParameters:
   DataInitTypeBeta: 1
   DataInitTypeBias: 21
   DataInitTypeScaleAlphaVec: 21
-  NumElementsToValidate: -1
   BoundsCheck: 2
 
 BenchmarkProblems:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/bf16_tn_gfx12.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/bf16_tn_gfx12.yaml
@@ -24,8 +24,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/bf16_tn_gfx12_predict.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/bf16_tn_gfx12_predict.yaml
@@ -25,8 +25,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/f8f8s_gfx1250.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/f8f8s_gfx1250.yaml
@@ -26,8 +26,8 @@ BenchmarkProblems:
       DestDataType: f8
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       SparseA: False
       Activation: False

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/f8f8s_grvw1_gfx12.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/f8f8s_grvw1_gfx12.yaml
@@ -41,7 +41,6 @@ GlobalParameters:
   DataInitTypeBeta: 1
   DataInitTypeBias: 21
   DataInitTypeScaleAlphaVec: 21
-  NumElementsToValidate: -1
   BoundsCheck: 2
 
 BenchmarkProblems:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/fp16_gfx12.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/fp16_gfx12.yaml
@@ -21,8 +21,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -194,8 +194,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 1
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/fp16_use_e_gfx1250.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/fp16_use_e_gfx1250.yaml
@@ -29,8 +29,8 @@ BenchmarkProblems:
       UseE: True
       Activation: False
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       SparseA: False
       UseBias: 0

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/fp8_gfx12.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/fp8_gfx12.yaml
@@ -30,8 +30,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -108,8 +108,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -173,8 +173,8 @@ BenchmarkProblems:
       DataType: F8
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -239,8 +239,8 @@ BenchmarkProblems:
       DataType: F8
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       Activation:    True
@@ -349,8 +349,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       BiasDataTypeList: [s]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/fp8bf8ss_gfx12.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/fp8bf8ss_gfx12.yaml
@@ -27,8 +27,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -100,8 +100,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       UseBias: 1

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/gemm_bias_strided_batched_broadcast_gfx12.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/gemm_bias_strided_batched_broadcast_gfx12.yaml
@@ -26,8 +26,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -91,8 +91,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -156,8 +156,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -221,8 +221,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -286,8 +286,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -351,8 +351,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -416,8 +416,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -481,8 +481,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/gemm_bias_strided_batched_gfx12.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/gemm_bias_strided_batched_gfx12.yaml
@@ -26,8 +26,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -91,8 +91,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -156,8 +156,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -221,8 +221,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -286,8 +286,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -351,8 +351,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -416,8 +416,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -481,8 +481,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/gsuasb_gfx12.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/gsuasb_gfx12.yaml
@@ -30,8 +30,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       BiasDataTypeList: [s]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/i8_gsu_gfx12.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/i8_gsu_gfx12.yaml
@@ -739,8 +739,8 @@ BenchmarkProblems:
       DestDataType: i8
       ComputeDataType: i
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       #UseBias: True
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/i8i8i_grvw1_gfx12.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/i8i8i_grvw1_gfx12.yaml
@@ -41,7 +41,6 @@ GlobalParameters:
   DataInitTypeBeta: 1
   DataInitTypeBias: 21
   DataInitTypeScaleAlphaVec: 21
-  NumElementsToValidate: -1
   BoundsCheck: 2
 
 BenchmarkProblems:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/i8ii_grvw1_gfx12.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/i8ii_grvw1_gfx12.yaml
@@ -41,7 +41,6 @@ GlobalParameters:
   DataInitTypeBeta: 1
   DataInitTypeBias: 21
   DataInitTypeScaleAlphaVec: 21
-  NumElementsToValidate: -1
   BoundsCheck: 2
 
 BenchmarkProblems:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/xfp32_gfx1250.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/xfp32_gfx1250.yaml
@@ -26,8 +26,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       F32XdlMathOp: X
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       SupportUserArgs: True
@@ -81,8 +81,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       F32XdlMathOp: X
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       SupportUserArgs: True
@@ -136,8 +136,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       F32XdlMathOp: X
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       SupportUserArgs: True
@@ -190,8 +190,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       F32XdlMathOp: X
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       SupportUserArgs: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/bf16_cvt.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/bf16_cvt.yaml
@@ -27,8 +27,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 0
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling.yaml
@@ -32,8 +32,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -726,8 +726,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -840,8 +840,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -896,8 +896,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -943,8 +943,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
 
@@ -1819,8 +1819,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -1866,8 +1866,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
 
@@ -1923,8 +1923,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
 
@@ -2581,8 +2581,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling_tf32.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling_tf32.yaml
@@ -30,8 +30,8 @@ BenchmarkProblems:
       DataType: S
       DestDataType: S
       F32XdlMathOp: X
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -589,8 +589,8 @@ BenchmarkProblems:
       DataType: S
       DestDataType: S
       F32XdlMathOp: X
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -804,8 +804,8 @@ BenchmarkProblems:
       DataType: S
       DestDataType: S
       F32XdlMathOp: X
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       UseBias: 1

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_xfp32.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_xfp32.yaml
@@ -30,8 +30,8 @@ BenchmarkProblems:
       DataType: S
       DestDataType: S
       F32XdlMathOp: X
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -62,8 +62,8 @@ BenchmarkProblems:
       DataType: S
       DestDataType: S
       F32XdlMathOp: X
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -94,8 +94,8 @@ BenchmarkProblems:
       DataType: S
       DestDataType: S
       F32XdlMathOp: X
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 1

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/dot2_gfx950.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/dot2_gfx950.yaml
@@ -18,8 +18,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -83,8 +83,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 1

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/dtl.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/dtl.yaml
@@ -29,8 +29,8 @@ BenchmarkProblems:
       DataType: S
       DestDataType: S
       ComputeDataType: S
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard
@@ -99,8 +99,8 @@ BenchmarkProblems:
       DataType: S
       DestDataType: S
       ComputeDataType: S
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard
@@ -144,8 +144,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -213,8 +213,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -334,8 +334,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       UseBias: 0 # 1
       Batched: True
@@ -383,8 +383,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -447,8 +447,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -515,8 +515,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 0 # 1
       Batched: True
@@ -566,8 +566,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -633,8 +633,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 0 # 1
       Batched: True
@@ -749,8 +749,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 0 # 1
       Batched: True
@@ -861,8 +861,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       UseBias: 0 # 1
       Batched: True
@@ -915,8 +915,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       UseBias: 0 # 1
       Batched: True
@@ -993,8 +993,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 0 # 1
       Batched: True
@@ -1132,8 +1132,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       ActivationFuncCall: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/f16f8mix_ss.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/f16f8mix_ss.yaml
@@ -13,7 +13,6 @@ GlobalParameters:
   MaxWorkspaceSize: 13421772800
   DataInitTypeAlpha: 1
   DataInitTypeBeta: 1
-  NumElementsToValidate: -1
   BoundsCheck: 2
   KeepBuildTmp: True
 #  GenerateSourcesAndExit : True
@@ -29,8 +28,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/f16f8mix_ss_stoch.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/f16f8mix_ss_stoch.yaml
@@ -13,7 +13,6 @@ GlobalParameters:
   MaxWorkspaceSize: 13421772800
   DataInitTypeAlpha: 1
   DataInitTypeBeta: 1
-  NumElementsToValidate: -1
   BoundsCheck: 2
   KeepBuildTmp: True
 #  GenerateSourcesAndExit : True
@@ -29,8 +28,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/f8b8hs.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/f8b8hs.yaml
@@ -25,7 +25,6 @@ GlobalParameters:
   DataInitTypeScaleA: 1
   DataInitTypeScaleB: 1
   MinKForGSU: 1
-  NumElementsToValidate: -1
   # Failures due to this
   BoundsCheck: 2
   MaxLDS: 163840
@@ -43,8 +42,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       #Activation:    True
@@ -120,8 +119,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       #Activation:    True
@@ -199,8 +198,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       #Activation:    True
@@ -276,8 +275,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       #Activation:    True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/f8f16mix_f8s.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/f8f16mix_f8s.yaml
@@ -19,7 +19,6 @@ GlobalParameters:
   DataInitTypeBeta: 1
   DataInitTypeBias: 21
   DataInitTypeScaleAlphaVec: 21
-  NumElementsToValidate: -1
   BoundsCheck: 2
   #KeepBuildTmp: True
   MaxLDS: 163840
@@ -37,8 +36,8 @@ BenchmarkProblems:
       DestDataType: F8
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       Activation:    True
@@ -108,8 +107,8 @@ BenchmarkProblems:
       DestDataType: F8
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -179,8 +178,8 @@ BenchmarkProblems:
       DestDataType: F8
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -250,8 +249,8 @@ BenchmarkProblems:
       DestDataType: F8
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       Activation:    True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/fp8.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/fp8.yaml
@@ -25,7 +25,6 @@ GlobalParameters:
   DataInitTypeScaleA: 1
   DataInitTypeScaleB: 1
   MinKForGSU: 1
-  NumElementsToValidate: -1
   # Failures due to this
   BoundsCheck: 2
   MaxLDS: 163840
@@ -43,8 +42,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       #Activation:    True
@@ -125,8 +124,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       #Activation:    True
@@ -206,8 +205,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       #Activation:    True
@@ -285,8 +284,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       #Activation:    True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/general_wgm.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/general_wgm.yaml
@@ -33,8 +33,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
 

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/kringshift.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/kringshift.yaml
@@ -30,8 +30,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 0
@@ -92,8 +92,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 0
@@ -153,8 +153,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 0

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/lds160K.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/lds160K.yaml
@@ -48,8 +48,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
     

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/lds_tr.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/lds_tr.yaml
@@ -29,8 +29,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 0
       Batched: True
@@ -94,8 +94,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 0
       Batched: True
@@ -156,8 +156,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 0
       Batched: True
@@ -218,8 +218,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 0
       Batched: True
@@ -280,8 +280,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 0
       Batched: True
@@ -344,8 +344,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 0
       Batched: True
@@ -408,8 +408,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 0
       Batched: True
@@ -472,8 +472,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 0
       Batched: True
@@ -536,8 +536,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       UseBias: 0
       Batched: True
@@ -599,8 +599,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       UseBias: 0
       Batched: True
@@ -662,8 +662,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       UseBias: 0
       Batched: True
@@ -725,8 +725,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       UseBias: 0
       Batched: True
@@ -788,8 +788,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 0 # 1
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/plr_zero.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/plr_zero.yaml
@@ -44,8 +44,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard
@@ -208,8 +208,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard
@@ -339,8 +339,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard
@@ -467,8 +467,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard
@@ -596,8 +596,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/ss_bss.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/ss_bss.yaml
@@ -35,8 +35,8 @@ BenchmarkProblems:
       DataType: b
       DestDataType: S
       #F32XdlMathOp: X
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard
@@ -77,8 +77,8 @@ BenchmarkProblems:
       DataTypeA: S
       DataTypeB: S
       DataType: b
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       DestDataType: S
@@ -118,8 +118,8 @@ BenchmarkProblems:
       DataTypeA: S
       DataTypeB: S
       DataType: b
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       DestDataType: S
@@ -167,8 +167,8 @@ BenchmarkProblems:
       DataTypeA: S
       DataTypeB: S
       DataType: b
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       DestDataType: S

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/xfp32.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/xfp32.yaml
@@ -32,8 +32,8 @@ BenchmarkProblems:
       DataType: S
       DestDataType: S
       F32XdlMathOp: X
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard
@@ -144,8 +144,8 @@ BenchmarkProblems:
       DataType: S
       DestDataType: S
       F32XdlMathOp: X
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard
@@ -251,8 +251,8 @@ BenchmarkProblems:
       DataType: S
       DestDataType: S
       F32XdlMathOp: X
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard
@@ -320,8 +320,8 @@ BenchmarkProblems:
       DataType: S
       DestDataType: S
       F32XdlMathOp: X
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gsuasb.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gsuasb.yaml
@@ -30,8 +30,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       BiasDataTypeList: [s]
@@ -80,8 +80,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       BiasDataTypeList: [s]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gsuc.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gsuc.yaml
@@ -22,8 +22,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/hh_f8nhs.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/hh_f8nhs.yaml
@@ -28,8 +28,8 @@ BenchmarkProblems:
       ComputeDataType: S
       HighPrecisionAccumulate: True
       StochasticRounding: True #
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -90,8 +90,8 @@ BenchmarkProblems:
       ComputeDataType: S
       HighPrecisionAccumulate: True
       StochasticRounding: True #
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -152,8 +152,8 @@ BenchmarkProblems:
       ComputeDataType: S
       HighPrecisionAccumulate: True
       StochasticRounding: True #
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -214,8 +214,8 @@ BenchmarkProblems:
       ComputeDataType: S
       HighPrecisionAccumulate: True
       StochasticRounding: True #
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -277,8 +277,8 @@ BenchmarkProblems:
       ComputeDataType: S
       HighPrecisionAccumulate: True
       StochasticRounding: True #
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -339,8 +339,8 @@ BenchmarkProblems:
       ComputeDataType: S
       HighPrecisionAccumulate: True
       StochasticRounding: True #
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -401,8 +401,8 @@ BenchmarkProblems:
       ComputeDataType: S
       HighPrecisionAccumulate: True
       StochasticRounding: True #
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -463,8 +463,8 @@ BenchmarkProblems:
       ComputeDataType: S
       HighPrecisionAccumulate: True
       StochasticRounding: True #
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -526,8 +526,8 @@ BenchmarkProblems:
       ComputeDataType: S
       HighPrecisionAccumulate: True
       StochasticRounding: True #
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -588,8 +588,8 @@ BenchmarkProblems:
       ComputeDataType: S
       HighPrecisionAccumulate: True
       StochasticRounding: True #
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -650,8 +650,8 @@ BenchmarkProblems:
       ComputeDataType: S
       HighPrecisionAccumulate: True
       StochasticRounding: True #
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -712,8 +712,8 @@ BenchmarkProblems:
       ComputeDataType: S
       HighPrecisionAccumulate: True
       StochasticRounding: True #
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       UseBias: 1

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/icache_flush.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/icache_flush.yaml
@@ -33,8 +33,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       SparseA: False
       Activation: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/largeMT.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/largeMT.yaml
@@ -13,7 +13,6 @@ GlobalParameters:
   MaxWorkspaceSize: 13421772800
   DataInitTypeAlpha: 1
   DataInitTypeBeta: 0
-  NumElementsToValidate: -1
   BoundsCheck: 2
 
 BenchmarkProblems:
@@ -27,8 +26,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -114,8 +113,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -205,8 +204,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -290,8 +289,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 1

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/large_size.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/large_size.yaml
@@ -24,8 +24,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/lsu_fnuz.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/lsu_fnuz.yaml
@@ -12,7 +12,6 @@ GlobalParameters:
   MaxWorkspaceSize: 13421772800
   DataInitTypeAlpha: 1
   DataInitTypeBeta: 0
-  NumElementsToValidate: -1
   BoundsCheck: 2
 
 BenchmarkProblems:
@@ -27,8 +26,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -102,8 +101,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -180,8 +179,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -256,8 +255,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -332,8 +331,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -406,8 +405,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation: True
@@ -473,8 +472,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True
@@ -535,8 +534,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -611,8 +610,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/lsu_i8.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/lsu_i8.yaml
@@ -12,7 +12,6 @@ GlobalParameters:
   MaxWorkspaceSize: 13421772800
   DataInitTypeAlpha: 1
   DataInitTypeBeta: 0
-  NumElementsToValidate: -1
   BoundsCheck: 2
 
 BenchmarkProblems:
@@ -27,8 +26,8 @@ BenchmarkProblems:
   #    DestDataType: I
   #    ComputeDataType: I
   #    HighPrecisionAccumulate: True
-  #    TransposeA: 0
-  #    TransposeB: 0
+  #    TransposeA: False
+  #    TransposeB: False
   #    UseBeta: True
   #    Batched: True
   #  - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -109,8 +108,8 @@ BenchmarkProblems:
       DestDataType: I8
       ComputeDataType: I
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard - All problem

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/mix_cvt_after_ds_fnuz.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/mix_cvt_after_ds_fnuz.yaml
@@ -32,8 +32,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation: True
@@ -112,8 +112,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       Activation: True
@@ -192,8 +192,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       Activation: True
@@ -272,8 +272,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation: True
@@ -352,8 +352,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation: True
@@ -432,8 +432,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       Activation: True
@@ -512,8 +512,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       Activation: True
@@ -592,8 +592,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/no_shadowinit.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/no_shadowinit.yaml
@@ -31,8 +31,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias:       1

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/swizzleA.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/swizzleA.yaml
@@ -30,8 +30,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       SwizzleTensorA: True
       UseBeta: True
       Batched: True
@@ -125,8 +125,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       SwizzleTensorA: True
       UseBeta: True
       Batched: True
@@ -196,8 +196,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       SwizzleTensorA: True
       UseBeta: True
       Batched: True
@@ -267,8 +267,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       SwizzleTensorA: True
       UseBeta: True
       Batched: True
@@ -339,8 +339,8 @@ BenchmarkProblems:
       ComputeDataType: s
       F32XdlMathOp: X
       HighPrecisionAccumulate: False
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       SwizzleTensorA: True
       UseBeta: True
       Batched: True
@@ -411,8 +411,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: False
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       SwizzleTensorA: True
       UseBeta: True
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/swizzleB.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/swizzleB.yaml
@@ -30,8 +30,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       SwizzleTensorB: True
       UseBeta: True
       Batched: True
@@ -125,8 +125,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       SwizzleTensorB: True
       UseBeta: True
       Batched: True
@@ -196,8 +196,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       SwizzleTensorB: True
       UseBeta: True
       Batched: True
@@ -267,8 +267,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       SwizzleTensorB: True
       UseBeta: True
       Batched: True
@@ -339,8 +339,8 @@ BenchmarkProblems:
       ComputeDataType: s
       F32XdlMathOp: X
       HighPrecisionAccumulate: False
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       SwizzleTensorB: True
       UseBeta: True
       Batched: True
@@ -411,8 +411,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: False
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       SwizzleTensorB: True
       UseBeta: True
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/tail_small_size.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/tail_small_size.yaml
@@ -17,7 +17,6 @@ GlobalParameters:
   DataInitTypeBeta: 1
   DataInitTypeBias: 21
   DataInitTypeScaleAlphaVec: 21
-  NumElementsToValidate: -1
   BoundsCheck: 2
 
 BenchmarkProblems:
@@ -31,8 +30,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -106,8 +105,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/ulsgro1.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/ulsgro1.yaml
@@ -12,7 +12,6 @@ GlobalParameters:
   MaxWorkspaceSize: 13421772800
   DataInitTypeAlpha: 1
   DataInitTypeBeta: 0
-  NumElementsToValidate: -1
   BoundsCheck: 2
 
 BenchmarkProblems:
@@ -26,8 +25,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -104,8 +103,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -181,8 +180,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       UseBias: 1
@@ -247,8 +246,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       UseBias: 1

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/wgm.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/wgm.yaml
@@ -34,8 +34,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias: 1

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/xfp32.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/xfp32.yaml
@@ -12,7 +12,6 @@ GlobalParameters:
   MaxWorkspaceSize: 13421772800
   DataInitTypeAlpha: 1
   DataInitTypeBeta: 0
-  NumElementsToValidate: -1
   BoundsCheck: 2
 
 BenchmarkProblems:
@@ -26,8 +25,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       F32XdlMathOp: X
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard
@@ -58,8 +57,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       F32XdlMathOp: X
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
     - # BenchmarkProblemSizeGroup - Standard

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gradient/fp16_gradient_activation.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gradient/fp16_gradient_activation.yaml
@@ -25,8 +25,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
@@ -80,8 +80,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gradient/fp16_gradient_bias.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gradient/fp16_gradient_bias.yaml
@@ -25,8 +25,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
@@ -93,8 +93,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
@@ -161,8 +161,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
@@ -232,8 +232,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       Gradient: True
@@ -301,8 +301,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
@@ -373,8 +373,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       Gradient: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gradient/fp8bf8nss_gradient_bias_b.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gradient/fp8bf8nss_gradient_bias_b.yaml
@@ -28,8 +28,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
@@ -98,8 +98,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       Gradient: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gradient/gfx11/fp16_gradient_activation_gfx11.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gradient/gfx11/fp16_gradient_activation_gfx11.yaml
@@ -27,13 +27,13 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
       UseE: True
-      UseBias:       False
+      UseBias:       0
       Activation:    True
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
@@ -82,13 +82,13 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
       UseE: True
-      UseBias:       False
+      UseBias:       0
       Activation:    True
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gradient/gfx11/fp16_gradient_bias_gfx11.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gradient/gfx11/fp16_gradient_bias_gfx11.yaml
@@ -27,13 +27,13 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
       UseE: True
-      UseBias: True
+      UseBias: 1
       BiasSrc: "D"
       Activation: True
       ActivationType: all
@@ -96,13 +96,13 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
       UseE: False
-      UseBias: True
+      UseBias: 1
       BiasSrc: "A"
       Activation: False
       ActivationGuard: False
@@ -164,13 +164,13 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
       UseE: False
-      UseBias: True
+      UseBias: 1
       BiasSrc: "A"
       Activation: False
       ActivationGuard: False
@@ -235,13 +235,13 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       Gradient: True
       UseE: False
-      UseBias: True
+      UseBias: 1
       BiasSrc: "A"
       Activation: False
       ActivationGuard: False
@@ -304,13 +304,13 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
       UseE: False
-      UseBias: True
+      UseBias: 1
       BiasSrc: "B"
       Activation: False
       ActivationGuard: False
@@ -373,13 +373,13 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       Gradient: True
       UseE: False
-      UseBias: True
+      UseBias: 1
       BiasSrc: "B"
       Activation: False
       ActivationGuard: False

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gradient/gfx1250/bbs_bgrada_gfx1250.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gradient/gfx1250/bbs_bgrada_gfx1250.yaml
@@ -46,8 +46,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
@@ -108,8 +108,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
@@ -170,8 +170,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       Gradient: True
@@ -232,8 +232,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       Gradient: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gradient/gfx1250/bbs_bgradb_gfx1250.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gradient/gfx1250/bbs_bgradb_gfx1250.yaml
@@ -46,8 +46,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
@@ -108,8 +108,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
@@ -170,8 +170,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       Gradient: True
@@ -232,8 +232,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       Gradient: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gradient/gfx1250/bbs_bgradd_gfx1250.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gradient/gfx1250/bbs_bgradd_gfx1250.yaml
@@ -46,15 +46,15 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
       UseE: True
       UseBias: 1
       BiasSrc: D
-      Activation: 1
+      Activation: True
       ActivationType: hipblaslt_all
       ActivationNoGuard: False
       # UseScaleAlphaVec: 1
@@ -108,15 +108,15 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
       UseE: True
       UseBias: 1
       BiasSrc: D
-      Activation: 1
+      Activation: True
       ActivationType: hipblaslt_all
       ActivationNoGuard: False
       # UseScaleAlphaVec: 1
@@ -170,15 +170,15 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       Gradient: True
       UseE: True
       UseBias: 1
       BiasSrc: D
-      Activation: 1
+      Activation: True
       ActivationType: hipblaslt_all
       ActivationNoGuard: False
       # UseScaleAlphaVec: 1
@@ -232,15 +232,15 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       Gradient: True
       UseE: True
       UseBias: 1
       BiasSrc: D
-      Activation: 1
+      Activation: True
       ActivationType: hipblaslt_all
       ActivationNoGuard: False
       # UseScaleAlphaVec: 1

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gradient/gfx1250/bbs_dgelu_gfx1250.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gradient/gfx1250/bbs_dgelu_gfx1250.yaml
@@ -46,15 +46,15 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
       UseE: True
       # UseBias: 1
       # BiasSrc: D
-      Activation: 1
+      Activation: True
       ActivationType: hipblaslt_all
       # ActivationNoGuard: False
       # UseScaleAlphaVec: 1
@@ -108,15 +108,15 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
       UseE: True
       # UseBias: 1
       # BiasSrc: D
-      Activation: 1
+      Activation: True
       ActivationType: hipblaslt_all
       # ActivationNoGuard: False
       # UseScaleAlphaVec: 1
@@ -170,15 +170,15 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       Gradient: True
       UseE: True
       # UseBias: 1
       # BiasSrc: D
-      Activation: 1
+      Activation: True
       ActivationType: hipblaslt_all
       # ActivationNoGuard: False
       # UseScaleAlphaVec: 1
@@ -232,15 +232,15 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       Gradient: True
       UseE: True
       # UseBias: 1
       # BiasSrc: D
-      Activation: 1
+      Activation: True
       ActivationType: hipblaslt_all
       # ActivationNoGuard: False
       # UseScaleAlphaVec: 1

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gradient/gfx1250/hhs_bgrada_gfx1250.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gradient/gfx1250/hhs_bgrada_gfx1250.yaml
@@ -46,8 +46,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
@@ -108,8 +108,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
@@ -170,8 +170,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       Gradient: True
@@ -232,8 +232,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       Gradient: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gradient/gfx1250/hhs_bgradb_gfx1250.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gradient/gfx1250/hhs_bgradb_gfx1250.yaml
@@ -46,8 +46,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
@@ -108,8 +108,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
@@ -170,8 +170,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       Gradient: True
@@ -232,8 +232,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       Gradient: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gradient/gfx1250/hhs_bgradd_gfx1250.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gradient/gfx1250/hhs_bgradd_gfx1250.yaml
@@ -46,15 +46,15 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
       UseE: True
       UseBias: 1
       BiasSrc: D
-      Activation: 1
+      Activation: True
       ActivationType: hipblaslt_all
       ActivationNoGuard: False
       # UseScaleAlphaVec: 1
@@ -108,15 +108,15 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
       UseE: True
       UseBias: 1
       BiasSrc: D
-      Activation: 1
+      Activation: True
       ActivationType: hipblaslt_all
       ActivationNoGuard: False
       # UseScaleAlphaVec: 1
@@ -170,15 +170,15 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       Gradient: True
       UseE: True
       UseBias: 1
       BiasSrc: D
-      Activation: 1
+      Activation: True
       ActivationType: hipblaslt_all
       ActivationNoGuard: False
       # UseScaleAlphaVec: 1
@@ -232,15 +232,15 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       Gradient: True
       UseE: True
       UseBias: 1
       BiasSrc: D
-      Activation: 1
+      Activation: True
       ActivationType: hipblaslt_all
       ActivationNoGuard: False
       # UseScaleAlphaVec: 1

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gradient/gfx1250/hhs_dgelu_gfx1250.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gradient/gfx1250/hhs_dgelu_gfx1250.yaml
@@ -46,15 +46,15 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
       UseE: True
       # UseBias: 1
       # BiasSrc: D
-      Activation: 1
+      Activation: True
       ActivationType: hipblaslt_all
       # ActivationNoGuard: False
       # UseScaleAlphaVec: 1
@@ -108,15 +108,15 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
       UseE: True
       # UseBias: 1
       # BiasSrc: D
-      Activation: 1
+      Activation: True
       ActivationType: hipblaslt_all
       # ActivationNoGuard: False
       # UseScaleAlphaVec: 1
@@ -170,15 +170,15 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       Gradient: True
       UseE: True
       # UseBias: 1
       # BiasSrc: D
-      Activation: 1
+      Activation: True
       ActivationType: hipblaslt_all
       # ActivationNoGuard: False
       # UseScaleAlphaVec: 1
@@ -232,15 +232,15 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       Gradient: True
       UseE: True
       # UseBias: 1
       # BiasSrc: D
-      Activation: 1
+      Activation: True
       ActivationType: hipblaslt_all
       # ActivationNoGuard: False
       # UseScaleAlphaVec: 1

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gradient/gfx950/bf16_gradient_bias.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gradient/gfx950/bf16_gradient_bias.yaml
@@ -25,8 +25,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
@@ -93,8 +93,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
@@ -161,8 +161,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
@@ -232,8 +232,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       Gradient: True
@@ -301,8 +301,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Gradient: True
@@ -373,8 +373,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       Gradient: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/groupedgemm/gfx11/grouped_gemm_gfx11.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/groupedgemm/gfx11/grouped_gemm_gfx11.yaml
@@ -26,11 +26,11 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
-      UseBias:       True
+      UseBias:       1
       Activation:    True
       GroupedGemm:   True
     - # BenchmarkProblemSizeGroup - Standard
@@ -75,11 +75,11 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
-      UseBias:       True
+      UseBias:       1
       Activation:    True
       GroupedGemm:   True
     - # BenchmarkProblemSizeGroup - Standard
@@ -124,11 +124,11 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
-      UseBias:       True
+      UseBias:       1
       Activation:    True
       GroupedGemm:   True
     - # BenchmarkProblemSizeGroup - Standard
@@ -173,11 +173,11 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
-      UseBias:       True
+      UseBias:       1
       Activation:    True
       GroupedGemm:   True
     - # BenchmarkProblemSizeGroup - Standard

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/groupedgemm/gfx11/grouped_gemm_userargs_gfx11.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/groupedgemm/gfx11/grouped_gemm_userargs_gfx11.yaml
@@ -32,11 +32,11 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
-      UseBias:       True
+      UseBias:       1
       UseE:          False
       Activation:    True
       GroupedGemm:   True
@@ -85,11 +85,11 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
-      UseBias:       False
+      UseBias:       0
       UseE:          False
       Activation:    False
       GroupedGemm:   True
@@ -138,11 +138,11 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
-      UseBias:       False
+      UseBias:       0
       UseE:          False
       Activation:    False
       GroupedGemm:   True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/groupedgemm/grouped_gemm.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/groupedgemm/grouped_gemm.yaml
@@ -24,8 +24,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias:       1
@@ -74,8 +74,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias:       1
@@ -123,8 +123,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       UseBias:       1
@@ -171,8 +171,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       UseBias:       1

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/groupedgemm/grouped_gemm_ck_gfx942.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/groupedgemm/grouped_gemm_ck_gfx942.yaml
@@ -33,8 +33,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
 
@@ -123,8 +123,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
 
@@ -209,8 +209,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
 
@@ -294,8 +294,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
 

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/groupedgemm/grouped_gemm_userargs.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/groupedgemm/grouped_gemm_userargs.yaml
@@ -31,8 +31,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias:       1
@@ -86,8 +86,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias:       0
@@ -140,8 +140,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       UseBias:       0

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gsu/auto_gsu.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gsu/auto_gsu.yaml
@@ -25,8 +25,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gsu/auto_gsu_zero_dim.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gsu/auto_gsu_zero_dim.yaml
@@ -25,8 +25,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 1
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gsu/gsu_mbsk.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gsu/gsu_mbsk.yaml
@@ -25,8 +25,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 1
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx94x/spmm_f8n_sb.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx94x/spmm_f8n_sb.yaml
@@ -35,7 +35,6 @@ BenchmarkProblems:
       UseBias: 3
       UseScaleAlphaVec: 3
       BiasDataTypeList: [s]
-      BiasDataTypeList: [s]
 
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx94x/spmm_vw_lg_one.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx94x/spmm_vw_lg_one.yaml
@@ -49,8 +49,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Sparse: 1
       Batched: True
@@ -97,8 +97,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Sparse: 1
       Batched: True
@@ -145,8 +145,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Sparse: 1
       Batched: True
@@ -193,8 +193,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Sparse: 1
       Batched: True
@@ -242,8 +242,8 @@ BenchmarkProblems:
       DestDataTyp: i8
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Sparse: 1
       Batched: True
@@ -290,8 +290,8 @@ BenchmarkProblems:
       DestDataTyp: i8
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Sparse: 1
       Batched: True
@@ -338,8 +338,8 @@ BenchmarkProblems:
       DestDataTyp: i8
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Sparse: 1
       Batched: True
@@ -386,8 +386,8 @@ BenchmarkProblems:
       DestDataTyp: i8
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Sparse: 1
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx94x/spmm_vw_lg_one_sb.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx94x/spmm_vw_lg_one_sb.yaml
@@ -49,8 +49,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Sparse: 2
       Batched: True
@@ -98,8 +98,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Sparse: 2
       Batched: True
@@ -147,8 +147,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Sparse: 2
       Batched: True
@@ -196,8 +196,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Sparse: 2
       Batched: True
@@ -246,8 +246,8 @@ BenchmarkProblems:
       DestDataTyp: i8
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Sparse: 2
       Batched: True
@@ -295,8 +295,8 @@ BenchmarkProblems:
       DestDataTyp: i8
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Sparse: 2
       Batched: True
@@ -344,8 +344,8 @@ BenchmarkProblems:
       DestDataTyp: i8
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Sparse: 2
       Batched: True
@@ -393,8 +393,8 @@ BenchmarkProblems:
       DestDataTyp: i8
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Sparse: 2
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx94x/use_sgpr_for_gro.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx94x/use_sgpr_for_gro.yaml
@@ -48,8 +48,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Sparse: 1
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx94x/use_sgpr_for_gro_sb.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx94x/use_sgpr_for_gro_sb.yaml
@@ -48,8 +48,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Sparse: 2
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_b8.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_b8.yaml
@@ -27,8 +27,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -109,8 +109,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -191,8 +191,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -273,8 +273,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -355,8 +355,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -437,8 +437,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -519,8 +519,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -601,8 +601,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_b8_sb.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_b8_sb.yaml
@@ -27,8 +27,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -109,8 +109,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -191,8 +191,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -273,8 +273,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -355,8 +355,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -437,8 +437,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -519,8 +519,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -601,8 +601,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_bf16.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_bf16.yaml
@@ -27,8 +27,8 @@ BenchmarkProblems:
       DestDataType: B
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -108,8 +108,8 @@ BenchmarkProblems:
       DestDataType: B
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -188,8 +188,8 @@ BenchmarkProblems:
       DestDataType: B
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -268,8 +268,8 @@ BenchmarkProblems:
       DestDataType: B
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -349,8 +349,8 @@ BenchmarkProblems:
       DestDataType: B
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -434,8 +434,8 @@ BenchmarkProblems:
       DestDataType: B
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -518,8 +518,8 @@ BenchmarkProblems:
       DestDataType: B
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -608,8 +608,8 @@ BenchmarkProblems:
       DestDataType: B
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_bf16_sb.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_bf16_sb.yaml
@@ -27,8 +27,8 @@ BenchmarkProblems:
       DestDataType: B
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -108,8 +108,8 @@ BenchmarkProblems:
       DestDataType: B
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -188,8 +188,8 @@ BenchmarkProblems:
       DestDataType: B
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -268,8 +268,8 @@ BenchmarkProblems:
       DestDataType: B
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -349,8 +349,8 @@ BenchmarkProblems:
       DestDataType: B
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -434,8 +434,8 @@ BenchmarkProblems:
       DestDataType: B
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -518,8 +518,8 @@ BenchmarkProblems:
       DestDataType: B
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -608,8 +608,8 @@ BenchmarkProblems:
       DestDataType: B
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_f16.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_f16.yaml
@@ -27,8 +27,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -110,8 +110,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -191,8 +191,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -272,8 +272,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -354,8 +354,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -439,8 +439,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -523,8 +523,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -613,8 +613,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_f16_sb.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_f16_sb.yaml
@@ -27,8 +27,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -112,8 +112,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -193,8 +193,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -274,8 +274,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -356,8 +356,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -441,8 +441,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -525,8 +525,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -615,8 +615,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_f8.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_f8.yaml
@@ -27,8 +27,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -109,8 +109,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -191,8 +191,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -273,8 +273,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -355,8 +355,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -437,8 +437,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -519,8 +519,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -601,8 +601,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_f8_sb.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_f8_sb.yaml
@@ -27,8 +27,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -109,8 +109,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -191,8 +191,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -273,8 +273,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -355,8 +355,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -437,8 +437,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -519,8 +519,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -601,8 +601,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_i8.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_i8.yaml
@@ -27,8 +27,8 @@ BenchmarkProblems:
       DestDataType: i8
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -109,8 +109,8 @@ BenchmarkProblems:
       DestDataType: i8
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -191,8 +191,8 @@ BenchmarkProblems:
       DestDataType: i8
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -273,8 +273,8 @@ BenchmarkProblems:
       DestDataType: i8
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -355,8 +355,8 @@ BenchmarkProblems:
       DestDataType: i8
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -437,8 +437,8 @@ BenchmarkProblems:
       DestDataType: i8
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -519,8 +519,8 @@ BenchmarkProblems:
       DestDataType: i8
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -601,8 +601,8 @@ BenchmarkProblems:
       DestDataType: i8
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_i8_sb.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_i8_sb.yaml
@@ -27,8 +27,8 @@ BenchmarkProblems:
       DestDataType: i8
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -109,8 +109,8 @@ BenchmarkProblems:
       DestDataType: i8
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -191,8 +191,8 @@ BenchmarkProblems:
       DestDataType: i8
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -273,8 +273,8 @@ BenchmarkProblems:
       DestDataType: i8
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -355,8 +355,8 @@ BenchmarkProblems:
       DestDataType: i8
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -437,8 +437,8 @@ BenchmarkProblems:
       DestDataType: i8
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -519,8 +519,8 @@ BenchmarkProblems:
       DestDataType: i8
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -601,8 +601,8 @@ BenchmarkProblems:
       DestDataType: i8
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_i8bs.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_i8bs.yaml
@@ -27,8 +27,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -109,8 +109,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_i8hs.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_i8hs.yaml
@@ -27,8 +27,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -109,8 +109,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       UseBias: 3
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_ldstr.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_ldstr.yaml
@@ -28,8 +28,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -99,8 +99,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -170,8 +170,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True
@@ -241,8 +241,8 @@ BenchmarkProblems:
       DestDataType: s
       ComputeDataType: s
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       UseBias: 3
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_vw_lg_one.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_vw_lg_one.yaml
@@ -49,8 +49,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Sparse: 1
       Batched: True
@@ -97,8 +97,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Sparse: 1
       Batched: True
@@ -145,8 +145,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Sparse: 1
       Batched: True
@@ -193,8 +193,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Sparse: 1
       Batched: True
@@ -242,8 +242,8 @@ BenchmarkProblems:
       DestDataTyp: i8
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Sparse: 1
       Batched: True
@@ -290,8 +290,8 @@ BenchmarkProblems:
       DestDataTyp: i8
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Sparse: 1
       Batched: True
@@ -338,8 +338,8 @@ BenchmarkProblems:
       DestDataTyp: i8
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Sparse: 1
       Batched: True
@@ -386,8 +386,8 @@ BenchmarkProblems:
       DestDataTyp: i8
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Sparse: 1
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_vw_lg_one_sb.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_vw_lg_one_sb.yaml
@@ -49,8 +49,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Sparse: 2
       Batched: True
@@ -98,8 +98,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Sparse: 2
       Batched: True
@@ -147,8 +147,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Sparse: 2
       Batched: True
@@ -196,8 +196,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Sparse: 2
       Batched: True
@@ -246,8 +246,8 @@ BenchmarkProblems:
       DestDataTyp: i8
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Sparse: 2
       Batched: True
@@ -295,8 +295,8 @@ BenchmarkProblems:
       DestDataTyp: i8
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Sparse: 2
       Batched: True
@@ -344,8 +344,8 @@ BenchmarkProblems:
       DestDataTyp: i8
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Sparse: 2
       Batched: True
@@ -393,8 +393,8 @@ BenchmarkProblems:
       DestDataTyp: i8
       ComputeDataType: s
       HighPrecisionAccumulate:  True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Sparse: 2
       Batched: True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/streamk/sk_I8gemm_quick.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/streamk/sk_I8gemm_quick.yaml
@@ -27,8 +27,8 @@ BenchmarkProblems:
       DestDataType: I8
       ComputeDataType: I
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -82,8 +82,8 @@ BenchmarkProblems:
       DestDataType: B
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       Activation:    True
@@ -142,8 +142,8 @@ BenchmarkProblems:
       DestDataType: H
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -202,8 +202,8 @@ BenchmarkProblems:
       DestDataType: I
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       Activation:    True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/streamk/sk_f8gemm_quick.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/streamk/sk_f8gemm_quick.yaml
@@ -31,8 +31,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -111,8 +111,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       Activation:    True
@@ -191,8 +191,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -272,8 +272,8 @@ BenchmarkProblems:
       DestDataType: F8
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       Activation:    True
@@ -352,8 +352,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -433,8 +433,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -513,8 +513,8 @@ BenchmarkProblems:
       DestDataType: F8
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       Activation:    True
@@ -594,8 +594,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/streamk/sk_f8ngemm_quick.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/streamk/sk_f8ngemm_quick.yaml
@@ -28,8 +28,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -105,8 +105,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       Activation:    True
@@ -182,8 +182,8 @@ BenchmarkProblems:
       DestDataType: h
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -259,8 +259,8 @@ BenchmarkProblems:
       DestDataType: F8N
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
+      TransposeA: True
+      TransposeB: True
       UseBeta: True
       Batched: True
       Activation:    True
@@ -336,8 +336,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -413,8 +413,8 @@ BenchmarkProblems:
       DestDataType: S
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
+      TransposeA: False
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True
@@ -490,8 +490,8 @@ BenchmarkProblems:
       DestDataType: F8N
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
+      TransposeA: False
+      TransposeB: True
       UseBeta: True
       Batched: True
       Activation:    True
@@ -568,8 +568,8 @@ BenchmarkProblems:
       DestDataType: b
       ComputeDataType: S
       HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
+      TransposeA: True
+      TransposeB: False
       UseBeta: True
       Batched: True
       Activation:    True


### PR DESCRIPTION
## Motivation

We have https://amd-hub.atlassian.net/browse/AIGECORE-2024, where we are giving warning and plan is to upgrade the severity to ERROR

## Technical Details

For all type mismatch between boolean vs int and vice-versa, we are fixing the yaml with correct type.

https://github.com/ROCm/rocm-libraries/commit/6318fdf0f5ef7073fa6e91344caadcfb809a6fad

## Test Plan

Ran script to find all the yaml file with type mismatch and fix such yaml file

## Test Result

After change, did 

- build and see no warning
- ran complete `hipblaslt-test` and no failure
- ran `tox` on `Tensile/common` and no warning/failure


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
