### PR TITLE
[MIOpen] cleanup excessive options

### DIFF
--- a/projects/miopen/cmake/EnableCompilerWarnings.cmake
+++ b/projects/miopen/cmake/EnableCompilerWarnings.cmake
@@ -39,7 +39,6 @@ set(__default_cxx_compile_options
     -Wuninitialized
     -Wunreachable-code
     -Wunused
-    -Wno-ignored-qualifiers
     -Wno-sign-compare
 )
 
@@ -52,32 +51,22 @@ set(__clang_cxx_compile_options
     -Wno-exit-time-destructors
     -Wno-extra-semi
     -Wno-extra-semi-stmt
-    -Wno-gnu-zero-variadic-macro-arguments
     -Wno-missing-prototypes
-    -Wno-nested-anon-types
-    -Wno-option-ignored
     -Wno-padded
-    -Wno-sign-conversion
-    -Wno-unknown-warning-option
     -Wno-unused-command-line-argument
     -Wno-weak-vtables
     -Wno-covered-switch-default
-    -Wno-unused-result
     -Wno-unsafe-buffer-usage
     -Wno-deprecated-declarations
     -Wno-global-constructors
     -Wno-reserved-identifier
     -Wno-deprecated
     -Wno-old-style-cast
-    -Wno-language-extension-token
     -Wno-c++11-narrowing
-    -Wno-redundant-parens
-    -Wno-suggest-destructor-override
     -Wno-switch-enum
     -Wno-suggest-override
     -Wno-nonportable-system-include-path
     -Wno-documentation
-    -Wno-enum-constexpr-conversion
     -Wno-unused-parameter
     -Wmissing-noreturn)
 


### PR DESCRIPTION
## Motivation

cleanup excessive switching-warnings-off options which doesn't affect compilation

-Wno-ignored-qualifiers
-Wno-gnu-zero-variadic-macro-arguments
-Wno-nested-anon-types
-Wno-option-ignored
-Wno-sign-conversion
-Wno-unknown-warning-option
-Wno-unused-result
-Wno-language-extension-token
-Wno-redundant-parens
-Wno-suggest-destructor-override
-Wno-enum-constexpr-conversion

## Test Plan

CI shall pass
