### PR TITLE
Revert "[hipDNN] Move SDPA frontend API behind HIPDNN_ENABLE_SDPA feature flag"

### DIFF
--- a/dnn-providers/hip-kernel-provider/src/integration_tests/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/src/integration_tests/CMakeLists.txt
@@ -40,18 +40,12 @@ target_link_libraries(
 add_dependencies(hip_kernel_provider_integration_tests hip_kernel_provider)
 
 if(ENABLE_ASM_SDPA_ENGINE)
-    if(NOT HIPDNN_ENABLE_SDPA)
-        message(WARNING
-                "ENABLE_ASM_SDPA_ENGINE is ON but hipDNN was built with HIPDNN_ENABLE_SDPA=OFF. "
-                "Skipping SDPA integration tests. Rebuild hipDNN with -DHIPDNN_ENABLE_SDPA=ON to enable them.")
-    else()
-        target_sources(hip_kernel_provider_integration_tests PRIVATE
-            asm_sdpa_engine/IntegrationGpuSdpaForward.cpp
-        )
-        target_compile_definitions(hip_kernel_provider_integration_tests PRIVATE
-            AITER_ASM_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../engines/asm_sdpa_engine/asm/asm_kernels"
-        )
-    endif()
+    target_sources(hip_kernel_provider_integration_tests PRIVATE
+        asm_sdpa_engine/IntegrationGpuSdpaForward.cpp
+    )
+    target_compile_definitions(hip_kernel_provider_integration_tests PRIVATE
+        AITER_ASM_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../engines/asm_sdpa_engine/asm/asm_kernels"
+    )
 endif()
 
 clang_tidy_check(hip_kernel_provider_integration_tests)
@@ -60,20 +54,14 @@ add_integration_test_target(hip_kernel_provider_integration_tests ${CMAKE_CURREN
     LABELS slow)
 
 if(ENABLE_ASM_SDPA_ENGINE)
-    if(NOT HIPDNN_ENABLE_SDPA)
-        message(WARNING
-                "ENABLE_ASM_SDPA_ENGINE is ON but hipDNN was built with HIPDNN_ENABLE_SDPA=OFF. "
-                "Skipping SDPA integration test environment setup.")
+    set(ASM_KERNEL_ENV "HIPDNN_AITER_ASM_DIR=${CMAKE_BINARY_DIR}/hip_kernel_provider/asm_kernels")
+    if(COVERAGE_ENVIRONMENT)
+        set_tests_properties(hip_kernel_provider_integration_tests PROPERTIES
+            ENVIRONMENT "${COVERAGE_ENVIRONMENT};${ASM_KERNEL_ENV}"
+        )
     else()
-        set(ASM_KERNEL_ENV "HIPDNN_AITER_ASM_DIR=${CMAKE_BINARY_DIR}/hip_kernel_provider/asm_kernels")
-        if(COVERAGE_ENVIRONMENT)
-            set_tests_properties(hip_kernel_provider_integration_tests PROPERTIES
-                ENVIRONMENT "${COVERAGE_ENVIRONMENT};${ASM_KERNEL_ENV}"
-            )
-        else()
-            set_tests_properties(hip_kernel_provider_integration_tests PROPERTIES
-                ENVIRONMENT "${ASM_KERNEL_ENV}"
-            )
-        endif()
+        set_tests_properties(hip_kernel_provider_integration_tests PROPERTIES
+            ENVIRONMENT "${ASM_KERNEL_ENV}"
+        )
     endif()
 endif()

--- a/dnn-providers/hip-kernel-provider/src/tests/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/src/tests/CMakeLists.txt
@@ -47,13 +47,7 @@ target_link_libraries(
 target_include_directories(hip_kernel_provider_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_LIST_DIR}/../../include)
 
 if(ENABLE_ASM_SDPA_ENGINE)
-    if(NOT HIPDNN_ENABLE_SDPA)
-        message(WARNING
-                "ENABLE_ASM_SDPA_ENGINE is ON but hipDNN was built with HIPDNN_ENABLE_SDPA=OFF. "
-                "Skipping SDPA unit tests. Rebuild hipDNN with -DHIPDNN_ENABLE_SDPA=ON to enable them.")
-    else()
-        add_subdirectory(engines/asm_sdpa_engine)
-    endif()
+    add_subdirectory(engines/asm_sdpa_engine)
 endif()
 
 clang_tidy_check(hip_kernel_provider_tests)

--- a/projects/hipdnn/CMakeLists.txt
+++ b/projects/hipdnn/CMakeLists.txt
@@ -19,21 +19,9 @@ else()
     message(STATUS "hipDNN: JSON serialization enabled (requires nlohmann_json)")
 endif()
 
-option(HIPDNN_ENABLE_SDPA "Enable SDPA (Scaled Dot-Product Attention) support" OFF)
-
-if(HIPDNN_ENABLE_SDPA)
-    message(STATUS "hipDNN: SDPA support enabled")
-else()
-    message(STATUS "hipDNN: SDPA support disabled")
-endif()
-
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 add_compile_definitions(__HIP_PLATFORM_AMD__)
-
-if(HIPDNN_ENABLE_SDPA)
-    add_compile_definitions(HIPDNN_ENABLE_SDPA)
-endif()
 
 if(NOT CMAKE_TOOLCHAIN_FILE)
     set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/cmake/ClangToolChain.cmake"

--- a/projects/hipdnn/frontend/CMakeLists.txt
+++ b/projects/hipdnn/frontend/CMakeLists.txt
@@ -40,7 +40,6 @@ set_target_properties(hipdnn_frontend PROPERTIES
 target_compile_definitions(
     hipdnn_frontend INTERFACE
     $<$<BOOL:${HIPDNN_FRONTEND_SKIP_JSON_LIB}>:HIPDNN_FRONTEND_SKIP_JSON_LIB>
-    $<$<BOOL:${HIPDNN_ENABLE_SDPA}>:HIPDNN_ENABLE_SDPA>
 )
 
 # Generate the config file from template

--- a/projects/hipdnn/frontend/cmake/hipdnn_frontendConfig.cmake.in
+++ b/projects/hipdnn/frontend/cmake/hipdnn_frontendConfig.cmake.in
@@ -7,8 +7,6 @@ include(CMakeFindDependencyMacro)
 find_dependency(hipdnn_data_sdk @HIPDNN_FRONTEND_DATA_SDK_MIN_VERSION@ CONFIG REQUIRED)
 find_dependency(hipdnn_backend @HIPDNN_FRONTEND_BACKEND_MIN_VERSION@ CONFIG REQUIRED)
 
-set(HIPDNN_ENABLE_SDPA @HIPDNN_ENABLE_SDPA@)
-
 include("${CMAKE_CURRENT_LIST_DIR}/hipdnn_frontendTargets.cmake")
 
 check_required_components(hipdnn_frontend)

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Graph.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Graph.hpp
@@ -85,10 +85,8 @@
 #include <hipdnn_frontend/attributes/PointwiseAttributes.hpp>
 #include <hipdnn_frontend/attributes/RMSNormAttributes.hpp>
 #include <hipdnn_frontend/attributes/ReductionAttributes.hpp>
-#ifdef HIPDNN_ENABLE_SDPA
 #include <hipdnn_frontend/attributes/SdpaAttributes.hpp>
 #include <hipdnn_frontend/attributes/SdpaBackwardAttributes.hpp>
-#endif
 #include <hipdnn_frontend/detail/BackendWrapper.hpp>
 #include <hipdnn_frontend/detail/ConvolutionFpropUnpacker.hpp>
 #include <hipdnn_frontend/detail/CreateBackendDescriptor.hpp>
@@ -117,10 +115,8 @@
 #include <hipdnn_frontend/node/PointwiseNode.hpp>
 #include <hipdnn_frontend/node/RMSNormNode.hpp>
 #include <hipdnn_frontend/node/ReductionNode.hpp>
-#ifdef HIPDNN_ENABLE_SDPA
 #include <hipdnn_frontend/node/SdpaBwdNode.hpp>
 #include <hipdnn_frontend/node/SdpaFwdNode.hpp>
-#endif
 #include <hipdnn_frontend/node/detail/TopologicalSortingUtils.hpp>
 
 #ifndef HIPDNN_FRONTEND_SKIP_JSON_LIB
@@ -2561,7 +2557,6 @@ public:
         return outputTensors;
     }
 
-#ifdef HIPDNN_ENABLE_SDPA
     /** @brief Scaled dot-product attention forward pass
      *
      * Computes scaled dot-product attention:
@@ -2702,7 +2697,6 @@ public:
 
         return {dq, dk, dv};
     }
-#endif // HIPDNN_ENABLE_SDPA
 
     /** @brief Convolution forward pass
      *

--- a/projects/hipdnn/frontend/tests/TestGraph.cpp
+++ b/projects/hipdnn/frontend/tests/TestGraph.cpp
@@ -9,9 +9,7 @@
 #include <hipdnn_frontend/attributes/CustomOpAttributes.hpp>
 #include <hipdnn_frontend/attributes/LayernormAttributes.hpp>
 #include <hipdnn_frontend/attributes/PointwiseAttributes.hpp>
-#ifdef HIPDNN_ENABLE_SDPA
 #include <hipdnn_frontend/attributes/SdpaAttributes.hpp>
-#endif
 #include <hipdnn_test_sdk/constants/ConvFpropConstants.hpp>
 #include <hipdnn_test_sdk/utilities/FrontendGraphFactory.hpp>
 #include <hipdnn_test_sdk/utilities/ToVec.hpp>
@@ -4895,7 +4893,6 @@ TEST_F(TestGraph, EngineOverrideConfigFromContentMatchesConvFpropGraph)
     EXPECT_FALSE(config->matchOperation("conv_fprop", {x8, w}).has_value());
 }
 
-#ifdef HIPDNN_ENABLE_SDPA
 TEST_F(TestGraph, SdpaFwdNodeCreation)
 {
     Graph graph;
@@ -4956,7 +4953,6 @@ TEST_F(TestGraph, SdpaFwdNodeCreationWithStats)
     auto validationResult = graph.validate();
     EXPECT_TRUE(validationResult.is_good()) << validationResult.get_message();
 }
-#endif // HIPDNN_ENABLE_SDPA
 
 TEST_F(TestGraph, CustomOpNodeCreation)
 {
@@ -6303,48 +6299,51 @@ TEST_P(TestGraphSerializationRoundTrip, JsonSerializeDeserializeForwardsData)
     EXPECT_EQ(capturedJson, jsonData);
 }
 
-// This needs to be a helper function rather than being defined inline so that we can use preprocessor directives in it.
-// Embedding a directive within a macro has undefined behaviour.
-static std::vector<GraphTopologyParam> getGraphTopologyParams()
-{
-    std::vector<GraphTopologyParam> params = {
-        // Single-node topologies via FrontendGraphFactory
-        {"BatchnormInference",
-         [](Graph& g) { g = FrontendGraphFactory::createBatchnormInferenceGraph(); }},
-        {"BatchnormTraining",
-         [](Graph& g) { g = FrontendGraphFactory::createBatchnormTrainingGraph(); }},
-        {"BatchnormBackward",
-         [](Graph& g) { g = FrontendGraphFactory::createBatchnormBackwardGraph(); }},
-        {"ConvForward", [](Graph& g) { g = FrontendGraphFactory::createConvForwardGraph(); }},
-        {"ConvBackwardData",
-         [](Graph& g) { g = FrontendGraphFactory::createConvBackwardDataGraph(); }},
-        {"ConvBackwardWeights",
-         [](Graph& g) { g = FrontendGraphFactory::createConvBackwardWeightsGraph(); }},
-        {"PointwiseUnary", [](Graph& g) { g = FrontendGraphFactory::createPointwiseUnaryGraph(); }},
-        {"PointwiseBinary",
-         [](Graph& g) { g = FrontendGraphFactory::createPointwiseBinaryGraph(); }},
-        {"Matmul", [](Graph& g) { g = FrontendGraphFactory::createMatmulGraph(); }},
-        {"Layernorm", [](Graph& g) { g = FrontendGraphFactory::createLayernormGraph(); }},
-        {"Rmsnorm", [](Graph& g) { g = FrontendGraphFactory::createRmsnormGraph(); }},
-        {"Reduction", [](Graph& g) { g = FrontendGraphFactory::createReductionGraph(); }},
-#ifdef HIPDNN_ENABLE_SDPA
-        {"SdpaForward", [](Graph& g) { g = FrontendGraphFactory::createSdpaForwardGraph(); }},
-        {"SdpaBackward", [](Graph& g) { g = FrontendGraphFactory::createSdpaBackwardGraph(); }},
-#endif
-        // Multi-node topologies
-        {"ConvFwdBiasActiv",
-         [](Graph& g) { g = FrontendGraphFactory::createConvFwdBiasActivGraph(); }},
-        {"ConvReluFusion", createConvReluFusionGraph},
-        {"PointwiseChain", createPointwiseChainGraph},
-        {"Diamond", createDiamondGraph}};
-
-    return params;
-}
-
 // NOLINTNEXTLINE(cert-err58-cpp)
-INSTANTIATE_TEST_SUITE_P(GraphTopologies,
-                         TestGraphSerializationRoundTrip,
-                         ::testing::ValuesIn(getGraphTopologyParams()),
-                         [](const ::testing::TestParamInfo<GraphTopologyParam>& info) {
-                             return info.param.name;
-                         });
+INSTANTIATE_TEST_SUITE_P(
+    GraphTopologies,
+    TestGraphSerializationRoundTrip,
+    ::testing::Values(
+        // Single-node topologies via FrontendGraphFactory
+        GraphTopologyParam{
+            "BatchnormInference",
+            [](Graph& g) { g = FrontendGraphFactory::createBatchnormInferenceGraph(); }},
+        GraphTopologyParam{
+            "BatchnormTraining",
+            [](Graph& g) { g = FrontendGraphFactory::createBatchnormTrainingGraph(); }},
+        GraphTopologyParam{
+            "BatchnormBackward",
+            [](Graph& g) { g = FrontendGraphFactory::createBatchnormBackwardGraph(); }},
+        GraphTopologyParam{"ConvForward",
+                           [](Graph& g) { g = FrontendGraphFactory::createConvForwardGraph(); }},
+        GraphTopologyParam{
+            "ConvBackwardData",
+            [](Graph& g) { g = FrontendGraphFactory::createConvBackwardDataGraph(); }},
+        GraphTopologyParam{
+            "ConvBackwardWeights",
+            [](Graph& g) { g = FrontendGraphFactory::createConvBackwardWeightsGraph(); }},
+        GraphTopologyParam{"PointwiseUnary",
+                           [](Graph& g) { g = FrontendGraphFactory::createPointwiseUnaryGraph(); }},
+        GraphTopologyParam{
+            "PointwiseBinary",
+            [](Graph& g) { g = FrontendGraphFactory::createPointwiseBinaryGraph(); }},
+        GraphTopologyParam{"Matmul",
+                           [](Graph& g) { g = FrontendGraphFactory::createMatmulGraph(); }},
+        GraphTopologyParam{"Layernorm",
+                           [](Graph& g) { g = FrontendGraphFactory::createLayernormGraph(); }},
+        GraphTopologyParam{"Rmsnorm",
+                           [](Graph& g) { g = FrontendGraphFactory::createRmsnormGraph(); }},
+        GraphTopologyParam{"Reduction",
+                           [](Graph& g) { g = FrontendGraphFactory::createReductionGraph(); }},
+        GraphTopologyParam{"SdpaForward",
+                           [](Graph& g) { g = FrontendGraphFactory::createSdpaForwardGraph(); }},
+        GraphTopologyParam{"SdpaBackward",
+                           [](Graph& g) { g = FrontendGraphFactory::createSdpaBackwardGraph(); }},
+        // Multi-node topologies
+        GraphTopologyParam{
+            "ConvFwdBiasActiv",
+            [](Graph& g) { g = FrontendGraphFactory::createConvFwdBiasActivGraph(); }},
+        GraphTopologyParam{"ConvReluFusion", createConvReluFusionGraph},
+        GraphTopologyParam{"PointwiseChain", createPointwiseChainGraph},
+        GraphTopologyParam{"Diamond", createDiamondGraph}),
+    [](const ::testing::TestParamInfo<GraphTopologyParam>& info) { return info.param.name; });

--- a/projects/hipdnn/samples/CMakeLists.txt
+++ b/projects/hipdnn/samples/CMakeLists.txt
@@ -67,9 +67,7 @@ add_hipdnn_sample(hipdnn_sample_fused_conv_fprop_bias_activ convolution/FusedCon
 add_hipdnn_sample(hipdnn_sample_conv_wgrad convolution/ConvWgrad.cpp)
 add_hipdnn_sample(hipdnn_sample_conv_fprop_deterministic convolution/ConvFpropDeterministic.cpp)
 
-if(HIPDNN_ENABLE_SDPA)
-    add_hipdnn_sample(hipdnn_sample_sdpa_fprop sdpa/SdpaFprop.cpp)
-endif()
+add_hipdnn_sample(hipdnn_sample_sdpa_fprop sdpa/SdpaFprop.cpp)
 
 add_hipdnn_sample(hipdnn_sample_serialization_roundtrip serialization/SerializationRoundTrip.cpp)
 

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/FrontendGraphFactory.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/FrontendGraphFactory.hpp
@@ -18,10 +18,8 @@
 #include <hipdnn_frontend/attributes/PointwiseAttributes.hpp>
 #include <hipdnn_frontend/attributes/RMSNormAttributes.hpp>
 #include <hipdnn_frontend/attributes/ReductionAttributes.hpp>
-#ifdef HIPDNN_ENABLE_SDPA
 #include <hipdnn_frontend/attributes/SdpaAttributes.hpp>
 #include <hipdnn_frontend/attributes/SdpaBackwardAttributes.hpp>
-#endif
 #include <hipdnn_frontend/attributes/TensorAttributes.hpp>
 
 namespace hipdnn_test_sdk::utilities
@@ -43,10 +41,8 @@ enum class OperationType
     LAYERNORM,
     RMSNORM,
     REDUCTION,
-#ifdef HIPDNN_ENABLE_SDPA
     SDPA_FORWARD,
     SDPA_BACKWARD,
-#endif
     POINTWISE_UNARY,
     POINTWISE_BINARY
 };
@@ -85,12 +81,10 @@ public:
             return createRmsnormGraph();
         case OperationType::REDUCTION:
             return createReductionGraph();
-#ifdef HIPDNN_ENABLE_SDPA
         case OperationType::SDPA_FORWARD:
             return createSdpaForwardGraph();
         case OperationType::SDPA_BACKWARD:
             return createSdpaBackwardGraph();
-#endif
         case OperationType::POINTWISE_UNARY:
             return createPointwiseUnaryGraph();
         case OperationType::POINTWISE_BINARY:
@@ -490,7 +484,6 @@ public:
         return graphObj;
     }
 
-#ifdef HIPDNN_ENABLE_SDPA
     /// SDPA Forward graph
     static Graph createSdpaForwardGraph()
     {
@@ -563,7 +556,6 @@ public:
 
         return graphObj;
     }
-#endif // HIPDNN_ENABLE_SDPA
 
     /// Pointwise Unary (RELU_FWD) graph
     static Graph createPointwiseUnaryGraph()
@@ -644,12 +636,10 @@ inline std::string operationTypeToString(OperationType op)
         return "RMSNorm";
     case OperationType::REDUCTION:
         return "Reduction";
-#ifdef HIPDNN_ENABLE_SDPA
     case OperationType::SDPA_FORWARD:
         return "SdpaForward";
     case OperationType::SDPA_BACKWARD:
         return "SdpaBackward";
-#endif
     case OperationType::POINTWISE_UNARY:
         return "PointwiseUnary";
     case OperationType::POINTWISE_BINARY:

--- a/projects/hipdnn/test_sdk/tests/CMakeLists.txt
+++ b/projects/hipdnn/test_sdk/tests/CMakeLists.txt
@@ -76,8 +76,8 @@ add_executable(
     utilities/cpu_graph_executor/TestReductionSignatureKey.cpp
     utilities/cpu_graph_executor/TestRMSNormFwdPlan.cpp
     utilities/cpu_graph_executor/TestRMSNormFwdSignatureKey.cpp
-    $<$<BOOL:${HIPDNN_ENABLE_SDPA}>:utilities/cpu_graph_executor/TestSdpaFwdPlan.cpp>
-    $<$<BOOL:${HIPDNN_ENABLE_SDPA}>:utilities/cpu_graph_executor/TestSdpaFwdSignatureKey.cpp>
+    utilities/cpu_graph_executor/TestSdpaFwdPlan.cpp
+    utilities/cpu_graph_executor/TestSdpaFwdSignatureKey.cpp
     TestVersion.cpp
 )
 

--- a/projects/hipdnn/tests/frontend/CMakeLists.txt
+++ b/projects/hipdnn/tests/frontend/CMakeLists.txt
@@ -56,10 +56,10 @@ add_executable(
     IntegrationRMSNormDescriptorLowering.cpp
     IntegrationRMSNormForward.cpp
     IntegrationSetPluginPathsExt.cpp
-    $<$<BOOL:${HIPDNN_ENABLE_SDPA}>:IntegrationSdpaBwdDescriptorLowering.cpp>
-    $<$<BOOL:${HIPDNN_ENABLE_SDPA}>:IntegrationSdpaBwdLifting.cpp>
-    $<$<BOOL:${HIPDNN_ENABLE_SDPA}>:IntegrationSdpaFwdDescriptorLifting.cpp>
-    $<$<BOOL:${HIPDNN_ENABLE_SDPA}>:IntegrationSdpaFwdDescriptorLowering.cpp>
+    IntegrationSdpaBwdDescriptorLowering.cpp
+    IntegrationSdpaBwdLifting.cpp
+    IntegrationSdpaFwdDescriptorLifting.cpp
+    IntegrationSdpaFwdDescriptorLowering.cpp
 )
 
 target_compile_options(hipdnn_public_frontend_tests PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})


### PR DESCRIPTION
Reverts ROCm/rocm-libraries#6493. Caused issue #6610 during rocm-libraries submodule bump in TheRock. I plan to re-land this work with the appropriate changes to the fusilli provider