### PR TITLE
[rocPRIM] Fix memory leak in test_config_dispatch

### DIFF
--- a/projects/rocprim/test/rocprim/test_config_dispatch.cpp
+++ b/projects/rocprim/test/rocprim/test_config_dispatch.cpp
@@ -454,4 +454,7 @@ TEST(RocprimConfigDispatchTests, ExecuteLaunchPlan)
     HIP_CHECK(hipMemcpy(&h_output, d_output, sizeof(target), hipMemcpyDeviceToHost));
     // Should have the same targets as most_common_config.
     ASSERT_EQ(most_common_config<Targets>(current_target), h_output);
+
+	// Clean up
+	HIP_CHECK(hipFree(d_output));
 }


### PR DESCRIPTION
## Motivation
Test RocprimConfigDispatchTests.ExecuteLaunchPlan allocated memory with hipMalloc without a corresponding hipFree.

## Technical Details
This change adds the call to hipFree to fix the memory leak.

## Test Plan

Build and run rocPRIM's test_config_dispatch target with address sanitizer enabled.
Verify that no memory leaks are reported and the tests all pass.

## Test Result

No leaks reported, all tests pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
