### PR TITLE
[stinkytofu] Add AnalysisManager infrastructure and wire analysis passes

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Common/GlobalParameters.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Common/GlobalParameters.py
@@ -317,7 +317,7 @@ globalParameters["StinkyTofuOptLevel"] = 0
 
 # StinkyTofu debug level (applies per-PM: outer PM + each ScopeAdaptor inner PM)
 # 0: Silent (default)
-# 1: Pass names to stdout (continuous list in execution order)
+# 1: Pass names + AnalysisManager cache activity to stdout
 # 2: Initial IR + IR after each pass to per-PM files:
 #    kernel-OuterPM-{before,after}_passes.txt     (outer PM)
 #    <groupName>-{before,after}_passes.txt        (single-region adapter)

--- a/shared/stinkytofu/include/stinkytofu/analysis/AnalysisRegistration.hpp
+++ b/shared/stinkytofu/include/stinkytofu/analysis/AnalysisRegistration.hpp
@@ -1,0 +1,49 @@
+/* ************************************************************************
+ * Copyright (C) 2025-2026 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * ************************************************************************ */
+#pragma once
+
+#include "stinkytofu/analysis/BBIndexAnalysis.hpp"
+#include "stinkytofu/analysis/LoopAnalysis.hpp"
+#include "stinkytofu/analysis/controlflow/DominanceAnalysis.hpp"
+#include "stinkytofu/core/AnalysisManager.hpp"
+
+namespace stinkytofu {
+/// Register all built-in analyses with an AnalysisManager.
+/// Call this once per PM at pipeline setup time.
+inline void registerAllAnalyses(AnalysisManager& AM) {
+    AM.registerPass<BBIndexAnalysis>();
+    AM.registerPass<DominanceAnalysis>();
+    AM.registerPass<LoopAnalysis>();
+}
+
+/// Convenience: build a PreservedAnalyses that keeps CFG analyses.
+/// Use when a pass reorders instructions but does not add/remove BBs or edges.
+inline PreservedAnalyses preserveCFGAnalyses() {
+    PreservedAnalyses PA;
+    PA.preserve<BBIndexAnalysis>();
+    PA.preserve<DominanceAnalysis>();
+    PA.preserve<LoopAnalysis>();
+    return PA;
+}
+
+}  // namespace stinkytofu

--- a/shared/stinkytofu/include/stinkytofu/analysis/BBIndexAnalysis.hpp
+++ b/shared/stinkytofu/include/stinkytofu/analysis/BBIndexAnalysis.hpp
@@ -1,0 +1,64 @@
+/* ************************************************************************
+ * Copyright (C) 2025-2026 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * ************************************************************************ */
+#pragma once
+
+#include <unordered_map>
+#include <vector>
+
+#include "stinkytofu/core/AnalysisManager.hpp"
+#include "stinkytofu/core/Function.hpp"
+#include "stinkytofu/support/CFGTraversal.hpp"
+
+namespace stinkytofu {
+/// RPO-indexed map from BasicBlock* to unsigned index and vice versa.
+struct BBIndexMap {
+    std::vector<BasicBlock*> rpo;
+    std::unordered_map<const BasicBlock*, unsigned> index;
+};
+
+/// Analysis pass that computes an RPO-indexed BasicBlock map.
+struct BBIndexAnalysis {
+    static inline AnalysisKey Key;
+
+    static AnalysisKey* ID() {
+        return &Key;
+    }
+
+    static const char* name() {
+        return "BBIndexAnalysis";
+    }
+
+    using Result = BBIndexMap;
+
+    static Result run(Function& F, AnalysisManager& /*AM*/) {
+        BBIndexMap result;
+        unsigned idx = 0;
+        traverseCFGInRPO(F, [&](BasicBlock* bb) {
+            result.rpo.push_back(bb);
+            result.index[bb] = idx++;
+        });
+        return result;
+    }
+};
+
+}  // namespace stinkytofu

--- a/shared/stinkytofu/include/stinkytofu/analysis/LoopAnalysis.hpp
+++ b/shared/stinkytofu/include/stinkytofu/analysis/LoopAnalysis.hpp
@@ -1,0 +1,49 @@
+/* ************************************************************************
+ * Copyright (C) 2025-2026 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * ************************************************************************ */
+#pragma once
+
+#include "stinkytofu/core/AnalysisManager.hpp"
+#include "stinkytofu/support/LoopDetection.hpp"
+
+namespace stinkytofu {
+/// Analysis pass that detects natural loops in the CFG.
+/// Wraps detectLoops().
+struct LoopAnalysis {
+    static inline AnalysisKey Key;
+
+    static AnalysisKey* ID() {
+        return &Key;
+    }
+
+    static const char* name() {
+        return "LoopAnalysis";
+    }
+
+    using Result = std::vector<Loop>;
+
+    static Result run(Function& F, AnalysisManager& /*AM*/) {
+        return detectLoops(F);
+    }
+};
+
+}  // namespace stinkytofu

--- a/shared/stinkytofu/include/stinkytofu/analysis/asm/AsmVerifierPass.hpp
+++ b/shared/stinkytofu/include/stinkytofu/analysis/asm/AsmVerifierPass.hpp
@@ -58,7 +58,7 @@ class StinkyIRVerifierPass : public Pass {
     const char* getName() const override {
         return "StinkyIRVerifier";
     }
-    void run(Function& func, PassContext& ctx) override;
+    PreservedAnalyses run(Function& func, PassContext& ctx, AnalysisManager& /*AM*/) override;
 
    private:
     AsmVerifierConfig config_;

--- a/shared/stinkytofu/include/stinkytofu/analysis/controlflow/DominanceAnalysis.hpp
+++ b/shared/stinkytofu/include/stinkytofu/analysis/controlflow/DominanceAnalysis.hpp
@@ -1,0 +1,49 @@
+/* ************************************************************************
+ * Copyright (C) 2025-2026 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * ************************************************************************ */
+#pragma once
+
+#include "stinkytofu/analysis/controlflow/Dominance.hpp"
+#include "stinkytofu/core/AnalysisManager.hpp"
+
+namespace stinkytofu {
+/// Analysis pass that computes dominator tree and dominance frontiers.
+/// Wraps computeDominanceInfo().
+struct DominanceAnalysis {
+    static inline AnalysisKey Key;
+
+    static AnalysisKey* ID() {
+        return &Key;
+    }
+
+    static const char* name() {
+        return "DominanceAnalysis";
+    }
+
+    using Result = DominanceInfo;
+
+    static Result run(Function& F, AnalysisManager& /*AM*/) {
+        return computeDominanceInfo(F);
+    }
+};
+
+}  // namespace stinkytofu

--- a/shared/stinkytofu/include/stinkytofu/analysis/logical/IRVerifierPass.hpp
+++ b/shared/stinkytofu/include/stinkytofu/analysis/logical/IRVerifierPass.hpp
@@ -57,7 +57,7 @@ class LogicalIRVerifierPass : public Pass {
     const char* getName() const override {
         return "LogicalIRVerifier";
     }
-    void run(Function& func, PassContext& ctx) override;
+    PreservedAnalyses run(Function& func, PassContext& ctx, AnalysisManager& /*AM*/) override;
 
    private:
     LogicalIRVerifierConfig config_;

--- a/shared/stinkytofu/include/stinkytofu/core/AnalysisManager.hpp
+++ b/shared/stinkytofu/include/stinkytofu/core/AnalysisManager.hpp
@@ -1,0 +1,229 @@
+/* ************************************************************************
+ * Copyright (C) 2025-2026 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * ************************************************************************ */
+#pragma once
+
+#include <cassert>
+#include <functional>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+namespace stinkytofu {
+class Function;
+
+// -----------------------------------------------------------------------
+// AnalysisKey — unique identifier for an analysis pass.
+//
+// Each analysis declares:  static AnalysisKey Key;
+// The ADDRESS of Key is the unique ID.
+// -----------------------------------------------------------------------
+struct alignas(8) AnalysisKey {};
+
+// -----------------------------------------------------------------------
+// PreservedAnalyses — returned by transform passes to declare what
+// analyses they did NOT invalidate.
+//
+// Default: NOTHING preserved (everything gets evicted).
+// -----------------------------------------------------------------------
+class PreservedAnalyses {
+    std::vector<AnalysisKey*> keys_;
+    bool all_ = false;
+
+   public:
+    static PreservedAnalyses all() {
+        PreservedAnalyses PA;
+        PA.all_ = true;
+        return PA;
+    }
+
+    static PreservedAnalyses none() {
+        return {};
+    }
+
+    template <typename AnalysisT>
+    PreservedAnalyses& preserve() {
+        return preserve(AnalysisT::ID());
+    }
+
+    PreservedAnalyses& preserve(AnalysisKey* key) {
+        keys_.push_back(key);
+        return *this;
+    }
+
+    bool isPreserved(AnalysisKey* key) const {
+        if (all_) return true;
+        for (auto* k : keys_)
+            if (k == key) return true;
+        return false;
+    }
+
+    template <typename AnalysisT>
+    bool isPreserved() const {
+        return isPreserved(AnalysisT::ID());
+    }
+
+    bool areAllPreserved() const {
+        return all_;
+    }
+
+    /// An analysis stays preserved only if both this and other preserve it.
+    void intersect(const PreservedAnalyses& other) {
+        if (other.all_) return;  // this & all = this (unchanged)
+        if (all_) {
+            // all & other = other
+            all_ = false;
+            keys_ = other.keys_;
+            return;
+        }
+        // Keep only keys present in both
+        std::vector<AnalysisKey*> kept;
+        for (auto* k : keys_) {
+            if (other.isPreserved(k)) kept.push_back(k);
+        }
+        keys_ = std::move(kept);
+    }
+};
+
+// -----------------------------------------------------------------------
+// AnalysisResultConcept / AnalysisResultModel
+//
+// Type-erased base and wrapper for cached analysis results.
+// AnalysisManager stores unique_ptr<AnalysisResultConcept> in its cache.
+// AnalysisResultModel<AnalysisT, ResultT> wraps a concrete result type
+// and provides default invalidation (evict if not in PreservedAnalyses).
+// -----------------------------------------------------------------------
+struct AnalysisResultConcept {
+    virtual ~AnalysisResultConcept() = default;
+
+    /// Returns true if this result is invalid and should be evicted.
+    virtual bool invalidate(Function& F, const PreservedAnalyses& PA) = 0;
+};
+
+/// Wraps a concrete result type. Evicted if not in PreservedAnalyses.
+template <typename AnalysisT, typename ResultT>
+struct AnalysisResultModel : AnalysisResultConcept {
+    ResultT Result;
+
+    explicit AnalysisResultModel(ResultT R) : Result(std::move(R)) {}
+
+    bool invalidate(Function&, const PreservedAnalyses& PA) override {
+        return !PA.isPreserved(AnalysisT::ID());
+    }
+};
+
+// -----------------------------------------------------------------------
+// AnalysisManager — lazy, caching manager for analysis results.
+//
+// Each analysis pass is a struct satisfying:
+//
+//   struct SomeAnalysis {
+//       static AnalysisKey Key;
+//       static AnalysisKey* ID() { return &Key; }
+//       static const char* name() { return "SomeAnalysis"; }
+//       using Result = SomeResultType;
+//       static Result run(Function& F, AnalysisManager& AM);
+//   };
+// -----------------------------------------------------------------------
+class AnalysisManager {
+   public:
+    AnalysisManager() = default;
+    ~AnalysisManager() = default;
+
+    AnalysisManager(const AnalysisManager&) = delete;
+    AnalysisManager& operator=(const AnalysisManager&) = delete;
+
+    AnalysisManager(AnalysisManager&&) = default;
+    AnalysisManager& operator=(AnalysisManager&&) = default;
+
+    /// Enable debug logging (cache hits, misses, evictions).
+    void setDebugLogging(bool v) {
+        debugLogging_ = v;
+    }
+
+    /// Register an analysis factory. Called once at pipeline setup.
+    template <typename AnalysisT>
+    void registerPass() {
+        auto factory = [](Function& F,
+                          AnalysisManager& AM) -> std::unique_ptr<AnalysisResultConcept> {
+            using ModelT = AnalysisResultModel<AnalysisT, typename AnalysisT::Result>;
+            return std::make_unique<ModelT>(AnalysisT::run(F, AM));
+        };
+        factories_[AnalysisT::ID()] = {std::move(factory), AnalysisT::name()};
+    }
+
+    /// Get or compute an analysis result (lazy, cached).
+    template <typename AnalysisT>
+    const typename AnalysisT::Result& getResult(Function& F) {
+        auto* key = AnalysisT::ID();
+        auto it = results_.find(key);
+        if (it == results_.end()) {
+            auto fit = factories_.find(key);
+            assert(fit != factories_.end() && "Analysis not registered");
+            if (debugLogging_) debugLog("Computing", fit->second.name);
+            auto result = fit->second.factory(F, *this);
+            auto [ins, ok] = results_.emplace(key, std::move(result));
+            it = ins;
+        } else if (debugLogging_) {
+            debugLog("Cache hit", factories_[key].name);
+        }
+        using ModelT = AnalysisResultModel<AnalysisT, typename AnalysisT::Result>;
+        return static_cast<ModelT&>(*it->second).Result;
+    }
+
+    /// Get cached result only. Returns nullptr if not computed.
+    template <typename AnalysisT>
+    const typename AnalysisT::Result* getCachedResult() const {
+        auto it = results_.find(AnalysisT::ID());
+        if (it == results_.end()) return nullptr;
+        using ModelT = AnalysisResultModel<AnalysisT, typename AnalysisT::Result>;
+        return &static_cast<const ModelT&>(*it->second).Result;
+    }
+
+    /// Evict invalidated results. Called by PM after each transform pass.
+    void invalidate(Function& F, const PreservedAnalyses& PA);
+
+    /// Clear all cached results (new Function).
+    void clear() {
+        results_.clear();
+    }
+
+    /// Dump currently cached analyses to stderr.
+    void dumpCacheState() const;
+
+   private:
+    using Factory =
+        std::function<std::unique_ptr<AnalysisResultConcept>(Function&, AnalysisManager&)>;
+
+    struct FactoryEntry {
+        Factory factory;
+        const char* name;
+    };
+
+    void debugLog(const char* action, const char* analysisName);
+
+    std::unordered_map<AnalysisKey*, FactoryEntry> factories_;
+    std::unordered_map<AnalysisKey*, std::unique_ptr<AnalysisResultConcept>> results_;
+    bool debugLogging_ = false;
+};
+
+}  // namespace stinkytofu

--- a/shared/stinkytofu/include/stinkytofu/core/PassManager.hpp
+++ b/shared/stinkytofu/include/stinkytofu/core/PassManager.hpp
@@ -31,6 +31,7 @@
 #include <vector>
 
 #include "stinkytofu/Export.hpp"
+#include "stinkytofu/core/AnalysisManager.hpp"
 #include "stinkytofu/core/BasicBlock.hpp"
 #include "stinkytofu/core/Function.hpp"
 #include "stinkytofu/core/PassInstrumentation.hpp"
@@ -99,7 +100,7 @@ class Pass {
     virtual ID getPassID() const = 0;
     virtual const char* getName() const = 0;
 
-    virtual void run(Function& func, PassContext& passCtx) = 0;
+    virtual PreservedAnalyses run(Function& func, PassContext& passCtx, AnalysisManager& AM) = 0;
 };
 
 // The PassContext serves as the central state and resource manager for
@@ -282,8 +283,13 @@ class STINKYTOFU_EXPORT PassManager {
         return passCtx;
     }
 
+    AnalysisManager& getAnalysisManager() {
+        return analysisManager;
+    }
+
    protected:
     PassContext passCtx;
+    AnalysisManager analysisManager;
 
     // List of passes to run.
     //

--- a/shared/stinkytofu/include/stinkytofu/ir/DumpStinkyFunctionPass.hpp
+++ b/shared/stinkytofu/include/stinkytofu/ir/DumpStinkyFunctionPass.hpp
@@ -62,7 +62,7 @@ class DumpStinkyFunctionPass : public Pass {
         return "DumpStinkyFunctionPass";
     }
 
-    void run(Function& func, PassContext& passCtx) override;
+    PreservedAnalyses run(Function& func, PassContext& passCtx, AnalysisManager& /*AM*/) override;
 
     const DumpStinkyFunctionPassConfig& getConfig() const {
         return config_;

--- a/shared/stinkytofu/include/stinkytofu/pipeline/ScopeAdaptor.hpp
+++ b/shared/stinkytofu/include/stinkytofu/pipeline/ScopeAdaptor.hpp
@@ -119,6 +119,8 @@ inline void configureDebugOutput(PassManager& pm, const StinkyAsmModule::ModuleO
                     [&](const std::string& n) { debugConfig->addOnlyPrintAfter(n); });
     }
 
+    if (opts.DebugLevel == 1) pm.getAnalysisManager().setDebugLogging(true);
+
     pm.addInstrumentation(std::make_shared<DebugPrintInstrumentation>(std::move(debugConfig)));
 
     if (!opts.DebugPass.empty()) {
@@ -262,7 +264,8 @@ class ScopeAdaptor : public Pass {
           innerPM(std::move(pm)),
           displayName("ScopeAdaptor(" + makeDebugLabel(this->groupNames) + ")") {}
 
-    void run(Function& /*outerFunc*/, PassContext& outerCtx) override {
+    PreservedAnalyses run(Function& /*outerFunc*/, PassContext& outerCtx,
+                          AnalysisManager& /*AM*/) override {
         // Propagate config from outer PassContext to inner PM
         innerPM.setGemmTileConfig(outerCtx.getGemmTileConfig());
         innerPM.setAsmCapsConfig(outerCtx.getAsmCapsConfig());
@@ -270,7 +273,7 @@ class ScopeAdaptor : public Pass {
 
         if (groupNames.empty()) {
             runWholeKernel();
-            return;
+            return PreservedAnalyses::none();
         }
 
         if (groupNames.size() == 1) {
@@ -278,6 +281,7 @@ class ScopeAdaptor : public Pass {
         } else {
             runMultiRegion();
         }
+        return PreservedAnalyses::none();
     }
 
    private:

--- a/shared/stinkytofu/include/stinkytofu/transforms/asm/BuildDefUseChain.hpp
+++ b/shared/stinkytofu/include/stinkytofu/transforms/asm/BuildDefUseChain.hpp
@@ -28,6 +28,7 @@ namespace stinkytofu {
 class BasicBlock;
 class Function;
 class Pass;
+struct DominanceInfo;
 
 /// Builds def-use chains for all instructions in the given Function.
 ///
@@ -61,6 +62,10 @@ class Pass;
 ///
 /// Note: Assumes non-SSA form (physical registers). Requires CFG to be built.
 void buildUseDefChain(Function& func, bool clearExisting);
+
+/// Overload that accepts pre-computed dominance info to avoid
+/// redundant computeDominanceInfo() calls.
+void buildUseDefChain(Function& func, const DominanceInfo& domInfo, bool clearExisting);
 
 /// Creates a Pass that builds the def-use chain for a Function.
 /// Use this to run buildUseDefChain as part of a pass pipeline.

--- a/shared/stinkytofu/include/stinkytofu/transforms/asm/PhiPlacement.hpp
+++ b/shared/stinkytofu/include/stinkytofu/transforms/asm/PhiPlacement.hpp
@@ -27,6 +27,7 @@
 namespace stinkytofu {
 class Function;
 class Pass;
+struct DominanceInfo;
 
 /// Insert PHI instructions at CFG join points where a physical register
 /// has definitions reaching from multiple control flow paths.
@@ -53,6 +54,9 @@ class Pass;
 ///
 /// Assumes: non-SSA form (physical registers), CFG already built.
 void insertPhiInstructions(Function& func, bool clearExisting);
+
+/// Overload that accepts pre-computed dominance info.
+void insertPhiInstructions(Function& func, const DominanceInfo& domInfo, bool clearExisting);
 
 /// Creates a Pass that inserts PHI instructions via insertPhiInstructions().
 std::unique_ptr<Pass> createInsertPhiPass();

--- a/shared/stinkytofu/include/stinkytofu/transforms/logical/IntrinsicExpansionPass.hpp
+++ b/shared/stinkytofu/include/stinkytofu/transforms/logical/IntrinsicExpansionPass.hpp
@@ -57,7 +57,7 @@ class IntrinsicExpansionPass : public Pass {
     IntrinsicExpansionPass();
     ~IntrinsicExpansionPass() override;
 
-    void run(Function& func, PassContext& passCtx) override;
+    PreservedAnalyses run(Function& func, PassContext& passCtx, AnalysisManager& /*AM*/) override;
 
     PassID getPassID() const override {
         return &ID;

--- a/shared/stinkytofu/src/analysis/asm/AsmVerifierPass.cpp
+++ b/shared/stinkytofu/src/analysis/asm/AsmVerifierPass.cpp
@@ -42,7 +42,7 @@ PreservedAnalyses StinkyIRVerifierPass::run(Function& func, PassContext&, Analys
         }
         std::cerr << "[StinkyIRVerifier] " << error;
     }
-    return PreservedAnalyses::none();
+    return PreservedAnalyses::all();
 }
 
 // ===========================================================================

--- a/shared/stinkytofu/src/analysis/asm/AsmVerifierPass.cpp
+++ b/shared/stinkytofu/src/analysis/asm/AsmVerifierPass.cpp
@@ -33,7 +33,7 @@
 namespace stinkytofu {
 char StinkyIRVerifierPass::ID = 0;
 
-void StinkyIRVerifierPass::run(Function& func, PassContext&) {
+PreservedAnalyses StinkyIRVerifierPass::run(Function& func, PassContext&, AnalysisManager& /*AM*/) {
     std::string error = validateStinkyIR(func, config_);
     if (!error.empty()) {
         if (config_.abortOnError) {
@@ -42,6 +42,7 @@ void StinkyIRVerifierPass::run(Function& func, PassContext&) {
         }
         std::cerr << "[StinkyIRVerifier] " << error;
     }
+    return PreservedAnalyses::none();
 }
 
 // ===========================================================================

--- a/shared/stinkytofu/src/analysis/logical/IRVerifierPass.cpp
+++ b/shared/stinkytofu/src/analysis/logical/IRVerifierPass.cpp
@@ -31,11 +31,13 @@
 namespace stinkytofu {
 char LogicalIRVerifierPass::ID = 0;
 
-void LogicalIRVerifierPass::run(Function& func, PassContext&) {
+PreservedAnalyses LogicalIRVerifierPass::run(Function& func, PassContext&,
+                                             AnalysisManager& /*AM*/) {
     std::string error = validateLogicalIR(func, config_);
     if (!error.empty()) {
         STINKY_UNREACHABLE(error.c_str());
     }
+    return PreservedAnalyses::none();
 }
 
 std::string validateLogicalIR(Function& func, const LogicalIRVerifierConfig& config) {

--- a/shared/stinkytofu/src/analysis/logical/IRVerifierPass.cpp
+++ b/shared/stinkytofu/src/analysis/logical/IRVerifierPass.cpp
@@ -37,7 +37,7 @@ PreservedAnalyses LogicalIRVerifierPass::run(Function& func, PassContext&,
     if (!error.empty()) {
         STINKY_UNREACHABLE(error.c_str());
     }
-    return PreservedAnalyses::none();
+    return PreservedAnalyses::all();
 }
 
 std::string validateLogicalIR(Function& func, const LogicalIRVerifierConfig& config) {

--- a/shared/stinkytofu/src/core/AnalysisManager.cpp
+++ b/shared/stinkytofu/src/core/AnalysisManager.cpp
@@ -1,0 +1,62 @@
+/* ************************************************************************
+ * Copyright (C) 2025-2026 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * ************************************************************************ */
+#include "stinkytofu/core/AnalysisManager.hpp"
+
+#include <iostream>
+
+namespace stinkytofu {
+void AnalysisManager::invalidate(Function& F, const PreservedAnalyses& PA) {
+    if (PA.areAllPreserved()) return;
+
+    for (auto it = results_.begin(); it != results_.end();) {
+        if (it->second->invalidate(F, PA)) {
+            if (debugLogging_) {
+                auto fit = factories_.find(it->first);
+                if (fit != factories_.end()) debugLog("Evicting", fit->second.name);
+            }
+            it = results_.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+void AnalysisManager::debugLog(const char* action, const char* analysisName) {
+    std::cerr << "[StinkyTofu] Analysis: " << action << " " << analysisName << "\n";
+}
+
+void AnalysisManager::dumpCacheState() const {
+    std::cerr << "[StinkyTofu] Analysis: Cache state: ";
+    if (results_.empty()) {
+        std::cerr << "empty\n";
+        return;
+    }
+    std::cerr << results_.size() << " cached\n";
+    for (const auto& [key, result] : results_) {
+        auto fit = factories_.find(key);
+        const char* name = (fit != factories_.end()) ? fit->second.name : "?";
+        std::cerr << "[StinkyTofu] Analysis:   " << name << "\n";
+    }
+}
+
+}  // namespace stinkytofu

--- a/shared/stinkytofu/src/core/CMakeLists.txt
+++ b/shared/stinkytofu/src/core/CMakeLists.txt
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 target_sources(stinkytofu PRIVATE
+    AnalysisManager.cpp
     IRBase.cpp
     BasicBlock.cpp
     Function.cpp

--- a/shared/stinkytofu/src/core/PassManager.cpp
+++ b/shared/stinkytofu/src/core/PassManager.cpp
@@ -115,6 +115,7 @@ std::ostream& PassManagerDebugConfig::getOutputStreamInAfter() const {
 //----------------------------------------------------------------------
 void PassManager::run(Function& F) {
     F.setGemmTileConfig(passCtx.getGemmTileConfig());
+    analysisManager.clear();
 
     for (auto& inst : instrumentations) inst->runBegin(F, passCtx);
 
@@ -123,7 +124,8 @@ void PassManager::run(Function& F) {
 
         for (auto& inst : instrumentations) inst->beforePass(passName, F, passCtx);
 
-        pass->run(F, passCtx);
+        PreservedAnalyses PA = pass->run(F, passCtx, analysisManager);
+        analysisManager.invalidate(F, PA);
 
         for (auto& inst : instrumentations) inst->afterPass(passName, F, passCtx);
     }

--- a/shared/stinkytofu/src/ir/DumpStinkyFunctionPass.cpp
+++ b/shared/stinkytofu/src/ir/DumpStinkyFunctionPass.cpp
@@ -40,7 +40,8 @@ std::string pathWithSuffix(const std::string& path, const std::string& newExtWit
 namespace stinkytofu {
 char DumpStinkyFunctionPass::ID = 0;
 
-void DumpStinkyFunctionPass::run(Function& func, PassContext&) {
+PreservedAnalyses DumpStinkyFunctionPass::run(Function& func, PassContext&,
+                                              AnalysisManager& /*AM*/) {
     if (!config_.stirPath.empty()) {
         std::ofstream out(config_.stirPath, std::ios::out | std::ios::trunc);
 
@@ -71,6 +72,7 @@ void DumpStinkyFunctionPass::run(Function& func, PassContext&) {
         StinkyAsmEmitter emitter(config_.emitterOptions);
         emitter.emit(out, func);
     }
+    return PreservedAnalyses::none();
 }
 
 std::unique_ptr<Pass> createDumpStinkyFunctionPass(DumpStinkyFunctionPassConfig config) {

--- a/shared/stinkytofu/src/ir/DumpStinkyFunctionPass.cpp
+++ b/shared/stinkytofu/src/ir/DumpStinkyFunctionPass.cpp
@@ -72,7 +72,7 @@ PreservedAnalyses DumpStinkyFunctionPass::run(Function& func, PassContext&,
         StinkyAsmEmitter emitter(config_.emitterOptions);
         emitter.emit(out, func);
     }
-    return PreservedAnalyses::none();
+    return PreservedAnalyses::all();
 }
 
 std::unique_ptr<Pass> createDumpStinkyFunctionPass(DumpStinkyFunctionPassConfig config) {

--- a/shared/stinkytofu/src/pipeline/backend/Gfx1250Backend.cpp
+++ b/shared/stinkytofu/src/pipeline/backend/Gfx1250Backend.cpp
@@ -106,21 +106,11 @@ bool buildGfx1250Pipeline(PassManager& pm, StinkyAsmModule& module) {
             configureDebugOutput(innerPM, moduleOptions, "loopWithPrefetch+noLoadLoopBody",
                                  debugStreams);
             addGfx1250RegionPasses(innerPM, module, optLevel, moduleOptions.EnableWaitCntInsertion);
+            if (moduleOptions.EnableWaitCntInsertion) {
+                innerPM.addPass(createStinkyWaitCntInsertionPass(true));
+            }
             pm.addPass(createKernelToRegionsPassAdaptor(
                 module, {"loopWithPrefetch", "noLoadLoopBody"}, std::move(innerPM)));
-        }
-
-        // Multi-region adapter for waitcnt reinsertion
-        if (moduleOptions.EnableWaitCntInsertion) {
-            PassManager waitcntPM;
-            registerAllAnalyses(waitcntPM.getAnalysisManager());
-            configureDebugOutput(waitcntPM, moduleOptions, "loopWithPrefetch+noLoadLoopBody",
-                                 debugStreams);
-            waitcntPM.addPass(createCFGBuilderPass());
-            waitcntPM.addPass(createStinkyRemoveWaitCntPass());
-            waitcntPM.addPass(createStinkyWaitCntInsertionPass(true));
-            pm.addPass(createKernelToRegionsPassAdaptor(
-                module, {"loopWithPrefetch", "noLoadLoopBody"}, std::move(waitcntPM)));
         }
     }
 

--- a/shared/stinkytofu/src/pipeline/backend/Gfx1250Backend.cpp
+++ b/shared/stinkytofu/src/pipeline/backend/Gfx1250Backend.cpp
@@ -29,6 +29,7 @@
 
 #include <algorithm>
 
+#include "stinkytofu/analysis/AnalysisRegistration.hpp"
 #include "stinkytofu/analysis/asm/AsmVerifierPass.hpp"
 #include "stinkytofu/bindings/python/Module.hpp"
 #include "stinkytofu/pipeline/BackendRegistry.hpp"
@@ -79,6 +80,7 @@ bool buildGfx1250Pipeline(PassManager& pm, StinkyAsmModule& module) {
     const auto& moduleOptions = module.getModuleOptions();
     const OptLevel optLevel = static_cast<OptLevel>(
         std::max(0, std::min(moduleOptions.OptLevel, static_cast<int>(OptLevel::O3))));
+    registerAllAnalyses(pm.getAnalysisManager());
 
     auto debugStreams = createDebugOutputStreams(moduleOptions);
     configureDebugOutput(pm, moduleOptions, "kernel-OuterPM", debugStreams);
@@ -97,6 +99,7 @@ bool buildGfx1250Pipeline(PassManager& pm, StinkyAsmModule& module) {
         // Process both regions together so the scheduler sees the full CFG.
         {
             PassManager innerPM;
+            registerAllAnalyses(innerPM.getAnalysisManager());
             passFeatureConfig.passOrderSnapshot.titlePrefix = "loopWithPrefetch+noLoadLoopBody";
             innerPM.setPassFeatureConfig(passFeatureConfig);
             configurePassOrderSnapshot(innerPM, snapshotCollector);
@@ -110,6 +113,7 @@ bool buildGfx1250Pipeline(PassManager& pm, StinkyAsmModule& module) {
         // Multi-region adapter for waitcnt reinsertion
         if (moduleOptions.EnableWaitCntInsertion) {
             PassManager waitcntPM;
+            registerAllAnalyses(waitcntPM.getAnalysisManager());
             configureDebugOutput(waitcntPM, moduleOptions, "loopWithPrefetch+noLoadLoopBody",
                                  debugStreams);
             waitcntPM.addPass(createCFGBuilderPass());

--- a/shared/stinkytofu/src/transforms/asm/BuildDefUseChain.cpp
+++ b/shared/stinkytofu/src/transforms/asm/BuildDefUseChain.cpp
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "stinkytofu/analysis/controlflow/Dominance.hpp"
+#include "stinkytofu/analysis/controlflow/DominanceAnalysis.hpp"
 #include "stinkytofu/core/PassManager.hpp"
 #include "stinkytofu/ir/asm/DefUseChainUpdater.hpp"
 #include "stinkytofu/ir/asm/RegisterKey.hpp"
@@ -208,25 +209,28 @@ char BuildUseDefChainPass::ID = 0;
 namespace stinkytofu {
 // Time: O(N*E + R*(N + F) + I), dominated by PHI insertion.
 //       N = blocks, E = edges, R = register keys, F = Sigma|DF[i]|, I = instructions.
-void buildUseDefChain(Function& func, bool clearExisting) {
+void buildUseDefChain(Function& func, const DominanceInfo& domInfo, bool clearExisting) {
     if (func.empty()) return;
 
     // Phase 1: Insert PHIs at correct CFG join points (dominance-frontier based).
-    insertPhiInstructions(func, clearExisting);
+    insertPhiInstructions(func, domInfo, clearExisting);
 
     // Phase 2: Clear all existing chains when rebuilding, so buildChains
     // starts from a clean slate via DefUseChainBuilder.
     if (clearExisting) clearAllChains(func);
 
-    // Phase 3: Compute dominance info for chain construction.
-    DominanceInfo domInfo = computeDominanceInfo(func);
-
-    // Phase 4: Build all def-use chains (PHI and non-PHI) in a single
+    // Phase 3: Build all def-use chains (PHI and non-PHI) in a single
     //          RPO traversal with dominator-inherited reaching definitions.
     buildChains(func, domInfo);
 
-    // Phase 5: Remove PHIs that ended up with no users.
+    // Phase 4: Remove PHIs that ended up with no users.
     for (BasicBlock& bb : func) removeUnusedPhis(bb);
+}
+
+void buildUseDefChain(Function& func, bool clearExisting) {
+    if (func.empty()) return;
+    DominanceInfo domInfo = computeDominanceInfo(func);
+    buildUseDefChain(func, domInfo, clearExisting);
 }
 
 std::unique_ptr<Pass> createBuildUseDefChainPass(bool clearExisting) {

--- a/shared/stinkytofu/src/transforms/asm/BuildDefUseChain.cpp
+++ b/shared/stinkytofu/src/transforms/asm/BuildDefUseChain.cpp
@@ -195,8 +195,9 @@ class BuildUseDefChainPass : public Pass {
         return &BuildUseDefChainPass::ID;
     }
 
-    void run(Function& func, PassContext&) override {
+    PreservedAnalyses run(Function& func, PassContext&, AnalysisManager& /*AM*/) override {
         buildUseDefChain(func, clearExisting_);
+        return PreservedAnalyses::none();
     }
 };
 

--- a/shared/stinkytofu/src/transforms/asm/BuildDefUseChain.cpp
+++ b/shared/stinkytofu/src/transforms/asm/BuildDefUseChain.cpp
@@ -196,8 +196,9 @@ class BuildUseDefChainPass : public Pass {
         return &BuildUseDefChainPass::ID;
     }
 
-    PreservedAnalyses run(Function& func, PassContext&, AnalysisManager& /*AM*/) override {
-        buildUseDefChain(func, clearExisting_);
+    PreservedAnalyses run(Function& func, PassContext&, AnalysisManager& AM) override {
+        const auto& domInfo = AM.getResult<DominanceAnalysis>(func);
+        buildUseDefChain(func, domInfo, clearExisting_);
         return PreservedAnalyses::none();
     }
 };

--- a/shared/stinkytofu/src/transforms/asm/CFGBuilderPass.cpp
+++ b/shared/stinkytofu/src/transforms/asm/CFGBuilderPass.cpp
@@ -45,22 +45,23 @@ class CFGBuilderPassImpl : public Pass {
         return &CFGBuilderPassImpl::ID;
     }
 
-    void run(Function& func, PassContext& passCtx) override {
+    PreservedAnalyses run(Function& func, PassContext& passCtx, AnalysisManager& /*AM*/) override {
         // If the function has more than one BasicBlock, it already has a CFG
-        if (func.size() > 1) return;
+        if (func.size() > 1) return PreservedAnalyses::none();
 
         // If the function is empty or has no entry block, nothing to do
         BasicBlock* flatBB = func.getEntryBlock();
-        if (!flatBB || flatBB->empty()) return;
+        if (!flatBB || flatBB->empty()) return PreservedAnalyses::none();
 
         // Check if we need to split - look for label instructions
-        if (!needsSplitting(flatBB)) return;
+        if (!needsSplitting(flatBB)) return PreservedAnalyses::none();
 
         // Split the flat BasicBlock into multiple BasicBlocks at label boundaries
         splitAtLabels(func, flatBB);
 
         // Build CFG edges based on branches and fall-through
         buildCFGEdges(func);
+        return PreservedAnalyses::none();
     }
 
    private:

--- a/shared/stinkytofu/src/transforms/asm/DeadCodeEliminationPass.cpp
+++ b/shared/stinkytofu/src/transforms/asm/DeadCodeEliminationPass.cpp
@@ -54,7 +54,7 @@ class DeadCodeEliminationPassImpl : public Pass {
         return PassName;
     }
 
-    void run(Function& func, PassContext& passCtx) override {
+    PreservedAnalyses run(Function& func, PassContext& passCtx, AnalysisManager& /*AM*/) override {
         int totalRemoved = 0;
 
         // Process all basic blocks
@@ -73,6 +73,7 @@ class DeadCodeEliminationPassImpl : public Pass {
 
             totalRemoved += removedInBB;
         }
+        return PreservedAnalyses::none();
     }
 
    private:

--- a/shared/stinkytofu/src/transforms/asm/DeadCodeEliminationPass.cpp
+++ b/shared/stinkytofu/src/transforms/asm/DeadCodeEliminationPass.cpp
@@ -25,6 +25,7 @@
 #include <set>
 #include <vector>
 
+#include "stinkytofu/analysis/AnalysisRegistration.hpp"
 #include "stinkytofu/ir/asm/DefUseChainUpdater.hpp"
 #include "stinkytofu/ir/asm/StinkyAsmIR.hpp"
 #include "stinkytofu/support/Casting.hpp"
@@ -73,7 +74,7 @@ class DeadCodeEliminationPassImpl : public Pass {
 
             totalRemoved += removedInBB;
         }
-        return PreservedAnalyses::none();
+        return preserveCFGAnalyses();
     }
 
    private:

--- a/shared/stinkytofu/src/transforms/asm/InsertVgprMsbPass.cpp
+++ b/shared/stinkytofu/src/transforms/asm/InsertVgprMsbPass.cpp
@@ -160,7 +160,7 @@ class InsertVgprMsbPassImpl : public Pass {
         return &InsertVgprMsbPassImpl::ID;
     }
 
-    void run(Function& func, PassContext& passCtx) override {
+    PreservedAnalyses run(Function& func, PassContext& passCtx, AnalysisManager& /*AM*/) override {
         auto arch = passCtx.getGemmTileConfig().arch;
         GfxArchID archId = getGfxArchID(arch[0], arch[1], arch[2]);
 
@@ -187,6 +187,7 @@ class InsertVgprMsbPassImpl : public Pass {
                                     hasVgprMsb16);
             }
         }
+        return PreservedAnalyses::none();
     }
 };
 

--- a/shared/stinkytofu/src/transforms/asm/InsertVgprMsbPass.cpp
+++ b/shared/stinkytofu/src/transforms/asm/InsertVgprMsbPass.cpp
@@ -25,6 +25,7 @@
 #include <cassert>
 #include <string>
 
+#include "stinkytofu/analysis/AnalysisRegistration.hpp"
 #include "stinkytofu/hardware/ArchHelper.hpp"
 #include "stinkytofu/ir/asm/StinkyAsmIR.hpp"
 
@@ -187,7 +188,7 @@ class InsertVgprMsbPassImpl : public Pass {
                                     hasVgprMsb16);
             }
         }
-        return PreservedAnalyses::none();
+        return preserveCFGAnalyses();
     }
 };
 

--- a/shared/stinkytofu/src/transforms/asm/PeepholeOptimizationPass.cpp
+++ b/shared/stinkytofu/src/transforms/asm/PeepholeOptimizationPass.cpp
@@ -26,6 +26,8 @@
 #include <optional>
 #include <vector>
 
+#include "stinkytofu/analysis/AnalysisRegistration.hpp"
+#include "stinkytofu/analysis/controlflow/DominanceAnalysis.hpp"
 #include "stinkytofu/hardware/ArchHelper.hpp"
 #include "stinkytofu/ir/asm/DefUseChainUpdater.hpp"
 #include "stinkytofu/ir/asm/StinkyAsmIR.hpp"
@@ -83,14 +85,14 @@ class PeepholeOptimizationPassImpl : public Pass {
         return &PeepholeOptimizationPassImpl::ID;
     }
 
-    PreservedAnalyses run(Function& func, PassContext& passCtx, AnalysisManager& /*AM*/) override {
+    PreservedAnalyses run(Function& func, PassContext& passCtx, AnalysisManager& AM) override {
         GfxArchID arch =
             getGfxArchID(passCtx.getGemmTileConfig().arch[0], passCtx.getGemmTileConfig().arch[1],
                          passCtx.getGemmTileConfig().arch[2]);
         int totalFusions = 0;
 
-        // TODO: use analysis pass to get def-use chains.
-        buildUseDefChain(func, true);
+        const auto& domInfo = AM.getResult<DominanceAnalysis>(func);
+        buildUseDefChain(func, domInfo, true);
 
         // Apply patterns iteratively until no more patterns match.
         // Rebuild def-use chains once per iteration over the whole function
@@ -110,7 +112,7 @@ class PeepholeOptimizationPassImpl : public Pass {
         }
 
         std::cout << "Peephole Optimization: Applied " << totalFusions << " fusion(s)\n";
-        return PreservedAnalyses::none();
+        return preserveCFGAnalyses();
     }
 
    private:

--- a/shared/stinkytofu/src/transforms/asm/PeepholeOptimizationPass.cpp
+++ b/shared/stinkytofu/src/transforms/asm/PeepholeOptimizationPass.cpp
@@ -83,7 +83,7 @@ class PeepholeOptimizationPassImpl : public Pass {
         return &PeepholeOptimizationPassImpl::ID;
     }
 
-    void run(Function& func, PassContext& passCtx) override {
+    PreservedAnalyses run(Function& func, PassContext& passCtx, AnalysisManager& /*AM*/) override {
         GfxArchID arch =
             getGfxArchID(passCtx.getGemmTileConfig().arch[0], passCtx.getGemmTileConfig().arch[1],
                          passCtx.getGemmTileConfig().arch[2]);
@@ -110,6 +110,7 @@ class PeepholeOptimizationPassImpl : public Pass {
         }
 
         std::cout << "Peephole Optimization: Applied " << totalFusions << " fusion(s)\n";
+        return PreservedAnalyses::none();
     }
 
    private:

--- a/shared/stinkytofu/src/transforms/asm/PhiPlacement.cpp
+++ b/shared/stinkytofu/src/transforms/asm/PhiPlacement.cpp
@@ -26,7 +26,9 @@
 #include <unordered_set>
 #include <vector>
 
+#include "stinkytofu/analysis/AnalysisRegistration.hpp"
 #include "stinkytofu/analysis/controlflow/Dominance.hpp"
+#include "stinkytofu/analysis/controlflow/DominanceAnalysis.hpp"
 #include "stinkytofu/core/PassManager.hpp"
 #include "stinkytofu/hardware/ArchHelper.hpp"
 #include "stinkytofu/ir/asm/RegisterKey.hpp"
@@ -204,9 +206,10 @@ class InsertPhiPass : public Pass {
         return &InsertPhiPass::ID;
     }
 
-    PreservedAnalyses run(Function& func, PassContext&, AnalysisManager& /*AM*/) override {
-        insertPhiInstructions(func, true);
-        return PreservedAnalyses::none();
+    PreservedAnalyses run(Function& func, PassContext&, AnalysisManager& AM) override {
+        const auto& domInfo = AM.getResult<DominanceAnalysis>(func);
+        insertPhiInstructions(func, domInfo, true);
+        return preserveCFGAnalyses();
     }
 };
 

--- a/shared/stinkytofu/src/transforms/asm/PhiPlacement.cpp
+++ b/shared/stinkytofu/src/transforms/asm/PhiPlacement.cpp
@@ -204,8 +204,9 @@ class InsertPhiPass : public Pass {
         return &InsertPhiPass::ID;
     }
 
-    void run(Function& func, PassContext&) override {
+    PreservedAnalyses run(Function& func, PassContext&, AnalysisManager& /*AM*/) override {
         insertPhiInstructions(func, true);
+        return PreservedAnalyses::none();
     }
 };
 

--- a/shared/stinkytofu/src/transforms/asm/PhiPlacement.cpp
+++ b/shared/stinkytofu/src/transforms/asm/PhiPlacement.cpp
@@ -217,31 +217,28 @@ char InsertPhiPass::ID = 0;
 namespace stinkytofu {
 // Time: O(N*E + R*(N + F) + I), N = blocks, E = CFG edges,
 //       R = register keys, F = Sigma|DF[i]|, I = instructions.
-void insertPhiInstructions(Function& func, bool clearExisting) {
+void insertPhiInstructions(Function& func, const DominanceInfo& domInfo, bool clearExisting) {
     if (func.empty()) return;
 
     if (clearExisting) removeExistingPhis(func);
 
-    // --- 1. Dominance analysis ---
-
-    DominanceInfo domInfo = computeDominanceInfo(func);
     const auto& rpo = domInfo.rpo;
     const unsigned N = rpo.size();
     if (N == 0) return;
 
-    // --- 2. Per-block register definitions ---
+    // --- 1. Per-block register definitions ---
 
     auto blockDefs = gatherDefs(rpo);
 
-    // --- 3. Globally-used registers (semi-pruned SSA) ---
+    // --- 2. Globally-used registers (semi-pruned SSA) ---
 
     auto usedRegs = gatherUsedRegs(rpo);
 
-    // --- 4. PHI-placement sites (iterated DF, only for used registers) ---
+    // --- 3. PHI-placement sites (iterated DF, only for used registers) ---
 
     auto phiSites = computePhiSites(blockDefs, domInfo.df, usedRegs, N);
 
-    // --- 5. Create PHI instructions (operands initially nullptr) ---
+    // --- 4. Create PHI instructions (operands initially nullptr) ---
 
     std::vector<RegKeyMap<StinkyInstruction*>> phiInsts(N);
 
@@ -259,11 +256,11 @@ void insertPhiInstructions(Function& func, bool clearExisting) {
         }
     }
 
-    // --- 6. Reaching definitions at block exits ---
+    // --- 5. Reaching definitions at block exits ---
 
     auto reachOut = computeReachOut(rpo, domInfo.idom, blockDefs, phiInsts);
 
-    // --- 7. Resolve PHI operands from predecessor reaching defs ---
+    // --- 6. Resolve PHI operands from predecessor reaching defs ---
 
     for (unsigned i = 0; i < N; ++i) {
         if (phiInsts[i].empty()) continue;
@@ -283,6 +280,12 @@ void insertPhiInstructions(Function& func, bool clearExisting) {
             }
         }
     }
+}
+
+void insertPhiInstructions(Function& func, bool clearExisting) {
+    if (func.empty()) return;
+    DominanceInfo domInfo = computeDominanceInfo(func);
+    insertPhiInstructions(func, domInfo, clearExisting);
 }
 
 std::unique_ptr<Pass> createInsertPhiPass() {

--- a/shared/stinkytofu/src/transforms/asm/RedundantMovEliminationPass.cpp
+++ b/shared/stinkytofu/src/transforms/asm/RedundantMovEliminationPass.cpp
@@ -27,6 +27,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "stinkytofu/analysis/AnalysisRegistration.hpp"
 #include "stinkytofu/ir/asm/DefUseChainUpdater.hpp"
 #include "stinkytofu/ir/asm/StinkyAsmIR.hpp"
 #include "stinkytofu/support/Casting.hpp"
@@ -106,7 +107,7 @@ class RedundantMovEliminationPassImpl : public Pass {
             int eliminated = runOnBasicBlock(bb);
             totalEliminated += eliminated;
         }
-        return PreservedAnalyses::none();
+        return preserveCFGAnalyses();
     }
 
    private:

--- a/shared/stinkytofu/src/transforms/asm/RedundantMovEliminationPass.cpp
+++ b/shared/stinkytofu/src/transforms/asm/RedundantMovEliminationPass.cpp
@@ -95,7 +95,7 @@ class RedundantMovEliminationPassImpl : public Pass {
         return PassName;
     }
 
-    void run(Function& func, PassContext& passCtx) override {
+    PreservedAnalyses run(Function& func, PassContext& passCtx, AnalysisManager& /*AM*/) override {
         int totalEliminated = 0;
 
         // Process all basic blocks
@@ -106,6 +106,7 @@ class RedundantMovEliminationPassImpl : public Pass {
             int eliminated = runOnBasicBlock(bb);
             totalEliminated += eliminated;
         }
+        return PreservedAnalyses::none();
     }
 
    private:

--- a/shared/stinkytofu/src/transforms/asm/ScheduleFirstLRsPass.cpp
+++ b/shared/stinkytofu/src/transforms/asm/ScheduleFirstLRsPass.cpp
@@ -30,6 +30,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "stinkytofu/analysis/AnalysisRegistration.hpp"
 #include "stinkytofu/ir/asm/StinkyAsmIR.hpp"
 
 namespace {
@@ -269,7 +270,7 @@ class ScheduleFirstLRsPass : public StinkyInstPass {
         for (BasicBlock& bb : func) {
             if (passCtx.shouldProcessBasicBlock(bb)) runOnBasicBlock(bb, passCtx);
         }
-        return PreservedAnalyses::none();
+        return preserveCFGAnalyses();
     }
 };
 

--- a/shared/stinkytofu/src/transforms/asm/ScheduleFirstLRsPass.cpp
+++ b/shared/stinkytofu/src/transforms/asm/ScheduleFirstLRsPass.cpp
@@ -265,10 +265,11 @@ class ScheduleFirstLRsPass : public StinkyInstPass {
         scheduleFirstLocalReadWithLatency(bb, passCtx);
     }
 
-    void run(Function& func, PassContext& passCtx) override {
+    PreservedAnalyses run(Function& func, PassContext& passCtx, AnalysisManager& /*AM*/) override {
         for (BasicBlock& bb : func) {
             if (passCtx.shouldProcessBasicBlock(bb)) runOnBasicBlock(bb, passCtx);
         }
+        return PreservedAnalyses::none();
     }
 };
 

--- a/shared/stinkytofu/src/transforms/asm/ScheduleLastLRsPass.cpp
+++ b/shared/stinkytofu/src/transforms/asm/ScheduleLastLRsPass.cpp
@@ -260,10 +260,11 @@ class ScheduleLastLRsPass : public StinkyInstPass {
         scheduleFinalLocalReadWithLatency(bb, passCtx);
     }
 
-    void run(Function& func, PassContext& passCtx) override {
+    PreservedAnalyses run(Function& func, PassContext& passCtx, AnalysisManager& /*AM*/) override {
         for (BasicBlock& bb : func) {
             if (passCtx.shouldProcessBasicBlock(bb)) runOnBasicBlock(bb, passCtx);
         }
+        return PreservedAnalyses::none();
     }
 };
 

--- a/shared/stinkytofu/src/transforms/asm/ScheduleLastLRsPass.cpp
+++ b/shared/stinkytofu/src/transforms/asm/ScheduleLastLRsPass.cpp
@@ -28,6 +28,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "stinkytofu/analysis/AnalysisRegistration.hpp"
 #include "stinkytofu/ir/asm/StinkyAsmIR.hpp"
 
 namespace {
@@ -264,7 +265,7 @@ class ScheduleLastLRsPass : public StinkyInstPass {
         for (BasicBlock& bb : func) {
             if (passCtx.shouldProcessBasicBlock(bb)) runOnBasicBlock(bb, passCtx);
         }
-        return PreservedAnalyses::none();
+        return preserveCFGAnalyses();
     }
 };
 

--- a/shared/stinkytofu/src/transforms/asm/StinkyBuildImplicitDependencyPass.cpp
+++ b/shared/stinkytofu/src/transforms/asm/StinkyBuildImplicitDependencyPass.cpp
@@ -25,6 +25,7 @@
 #include <cassert>
 #include <iostream>
 
+#include "stinkytofu/analysis/AnalysisRegistration.hpp"
 #include "stinkytofu/core/BasicBlock.hpp"
 #include "stinkytofu/core/PassManager.hpp"
 #include "stinkytofu/ir/asm/StinkyAsmIR.hpp"
@@ -155,7 +156,7 @@ class StinkyBuildImplicitDependencyPass : public StinkyInstPass {
         for (BasicBlock& bb : func) {
             if (passCtx.shouldProcessBasicBlock(bb)) setPseudoRegistersInBlock(bb, passCtx);
         }
-        return PreservedAnalyses::none();
+        return preserveCFGAnalyses();
     }
 };
 

--- a/shared/stinkytofu/src/transforms/asm/StinkyBuildImplicitDependencyPass.cpp
+++ b/shared/stinkytofu/src/transforms/asm/StinkyBuildImplicitDependencyPass.cpp
@@ -151,10 +151,11 @@ class StinkyBuildImplicitDependencyPass : public StinkyInstPass {
         return &StinkyBuildImplicitDependencyPass::ID;
     }
 
-    void run(Function& func, PassContext& passCtx) override {
+    PreservedAnalyses run(Function& func, PassContext& passCtx, AnalysisManager& /*AM*/) override {
         for (BasicBlock& bb : func) {
             if (passCtx.shouldProcessBasicBlock(bb)) setPseudoRegistersInBlock(bb, passCtx);
         }
+        return PreservedAnalyses::none();
     }
 };
 

--- a/shared/stinkytofu/src/transforms/asm/StinkyConfigurableWaitCntPass.cpp
+++ b/shared/stinkytofu/src/transforms/asm/StinkyConfigurableWaitCntPass.cpp
@@ -1087,7 +1087,7 @@ class StinkyConfigurableWaitCntPass : public StinkyInstPass {
         return &StinkyConfigurableWaitCntPass::ID;
     }
 
-    void run(Function& func, PassContext& passCtx) override {
+    PreservedAnalyses run(Function& func, PassContext& passCtx, AnalysisManager& /*AM*/) override {
         GfxArchID arch =
             getGfxArchID(passCtx.getGemmTileConfig().arch[0], passCtx.getGemmTileConfig().arch[1],
                          passCtx.getGemmTileConfig().arch[2]);
@@ -1237,6 +1237,7 @@ class StinkyConfigurableWaitCntPass : public StinkyInstPass {
             // If no loops, one iteration is sufficient
             if (!hasLoops && iteration >= 1) break;
         }
+        return PreservedAnalyses::none();
     }
 
     // Allow configuration to be changed

--- a/shared/stinkytofu/src/transforms/asm/StinkyConfigurableWaitCntPass.cpp
+++ b/shared/stinkytofu/src/transforms/asm/StinkyConfigurableWaitCntPass.cpp
@@ -12,6 +12,8 @@
 #include <map>
 #include <vector>
 
+#include "stinkytofu/analysis/AnalysisRegistration.hpp"
+#include "stinkytofu/analysis/BBIndexAnalysis.hpp"
 #include "stinkytofu/hardware/ArchHelper.hpp"
 #include "stinkytofu/ir/asm/StinkyAsmIR.hpp"
 #include "stinkytofu/support/CFGTraversal.hpp"
@@ -1087,21 +1089,23 @@ class StinkyConfigurableWaitCntPass : public StinkyInstPass {
         return &StinkyConfigurableWaitCntPass::ID;
     }
 
-    PreservedAnalyses run(Function& func, PassContext& passCtx, AnalysisManager& /*AM*/) override {
+    PreservedAnalyses run(Function& func, PassContext& passCtx, AnalysisManager& AM) override {
         GfxArchID arch =
             getGfxArchID(passCtx.getGemmTileConfig().arch[0], passCtx.getGemmTileConfig().arch[1],
                          passCtx.getGemmTileConfig().arch[2]);
+
+        const auto& rpo = AM.getResult<BBIndexAnalysis>(func).rpo;
 
         // Map to store wait states for each basic block
         std::map<BasicBlock*, BasicBlockWaitState> blockStates;
 
         // Detect if we have any loops (blocks with back-edges)
         bool hasLoops = false;
-        traverseCFGInRPO(func, [&](BasicBlock* bb) {
+        for (auto* bb : rpo) {
             if (hasLoopBackEdge(bb)) {
                 hasLoops = true;
             }
-        });
+        }
 
         // Iterative dataflow analysis for convergence (needed for loops)
         const int MAX_ITERATIONS = 10;
@@ -1113,8 +1117,8 @@ class StinkyConfigurableWaitCntPass : public StinkyInstPass {
             iteration++;
 
             // Process each BasicBlock in RPO
-            traverseCFGInRPO(func, [&](BasicBlock* bb) {
-                if (bb->empty()) return;
+            for (auto* bb : rpo) {
+                if (bb->empty()) continue;
 
                 // Compute entry state from predecessors
                 MemoryOperationState entryState;
@@ -1232,12 +1236,12 @@ class StinkyConfigurableWaitCntPass : public StinkyInstPass {
                     bbState.exitStates = newExitStates;
                     bbState.processed = true;
                 }
-            });
+            }
 
             // If no loops, one iteration is sufficient
             if (!hasLoops && iteration >= 1) break;
         }
-        return PreservedAnalyses::none();
+        return preserveCFGAnalyses();
     }
 
     // Allow configuration to be changed

--- a/shared/stinkytofu/src/transforms/asm/StinkyDAGSchedulerPass.cpp
+++ b/shared/stinkytofu/src/transforms/asm/StinkyDAGSchedulerPass.cpp
@@ -22,6 +22,10 @@
  * ************************************************************************ */
 #include "stinkytofu/transforms/asm/StinkyDAGSchedulerPass.hpp"
 
+#include "stinkytofu/analysis/AnalysisRegistration.hpp"
+#include "stinkytofu/analysis/BBIndexAnalysis.hpp"
+#include "stinkytofu/analysis/LoopAnalysis.hpp"
+#include "stinkytofu/analysis/controlflow/DominanceAnalysis.hpp"
 #include "stinkytofu/core/BasicBlock.hpp"
 #include "stinkytofu/core/PassManager.hpp"
 #include "stinkytofu/support/CFGTraversal.hpp"
@@ -399,25 +403,29 @@ class StinkyDAGSchedulerPass : public StinkyInstPass {
         return &StinkyDAGSchedulerPass::ID;
     }
 
-    PreservedAnalyses run(Function& func, PassContext& passCtx, AnalysisManager& /*AM*/) override {
+    PreservedAnalyses run(Function& func, PassContext& passCtx, AnalysisManager& AM) override {
         // Build def-use chains so we can look up cross-BB WMMA consumers
         // of ds_reads for wmmaAffinity annotation.
-        buildUseDefChain(func, true);
+        const auto& domInfo = AM.getResult<DominanceAnalysis>(func);
+        buildUseDefChain(func, domInfo, true);
+
+        const auto& rpo = AM.getResult<BBIndexAnalysis>(func).rpo;
 
         // Pre-assign a function-wide index to each WMMA/SWMMA so wmmaAffinity
         // values are comparable across scheduling regions.
         std::unordered_map<StinkyInstruction*, unsigned> wmmaIndex;
         {
             unsigned idx = 0;
-            traverseCFGInRPO(func, [&](BasicBlock* bb) {
+            for (auto* bb : rpo) {
                 for (auto it = bb->begin(); it != bb->end(); ++it) {
-                    StinkyInstruction& inst = getStinkyInst(it);
-                    if (isWMMA(inst) || isSWMMA(inst)) wmmaIndex[&inst] = idx++;
+                    auto* inst = dyn_cast<StinkyInstruction>(it.getNodePtr());
+                    if (!inst) continue;
+                    if (isWMMA(*inst) || isSWMMA(*inst)) wmmaIndex[inst] = idx++;
                 }
-            });
+            }
         }
 
-        auto loops = detectLoops(func);
+        const auto& loops = AM.getResult<LoopAnalysis>(func);
 
         PASS_DEBUG(for (const Loop& loop
                         : loops) {
@@ -445,8 +453,8 @@ class StinkyDAGSchedulerPass : public StinkyInstPass {
             for (BasicBlock* bb : loop.bodyBBs) bbToLoop[bb] = &loop;
         }
 
-        traverseCFGInRPO(func, [&](BasicBlock* bb) {
-            if (!passCtx.shouldProcessBasicBlock(*bb)) return;
+        for (auto* bb : rpo) {
+            if (!passCtx.shouldProcessBasicBlock(*bb)) continue;
 
             auto it = bbToLoop.find(bb);
             if (it != bbToLoop.end()) {
@@ -463,8 +471,8 @@ class StinkyDAGSchedulerPass : public StinkyInstPass {
                 rq->setAnalysisCache(&analysisCache);
                 scheduleInDAG(*bb, *rq, wmmaIndex);
             }
-        });
-        return PreservedAnalyses::none();
+        }
+        return preserveCFGAnalyses();
     }
 };
 

--- a/shared/stinkytofu/src/transforms/asm/StinkyDAGSchedulerPass.cpp
+++ b/shared/stinkytofu/src/transforms/asm/StinkyDAGSchedulerPass.cpp
@@ -399,7 +399,7 @@ class StinkyDAGSchedulerPass : public StinkyInstPass {
         return &StinkyDAGSchedulerPass::ID;
     }
 
-    void run(Function& func, PassContext& passCtx) override {
+    PreservedAnalyses run(Function& func, PassContext& passCtx, AnalysisManager& /*AM*/) override {
         // Build def-use chains so we can look up cross-BB WMMA consumers
         // of ds_reads for wmmaAffinity annotation.
         buildUseDefChain(func, true);
@@ -464,6 +464,7 @@ class StinkyDAGSchedulerPass : public StinkyInstPass {
                 scheduleInDAG(*bb, *rq, wmmaIndex);
             }
         });
+        return PreservedAnalyses::none();
     }
 };
 

--- a/shared/stinkytofu/src/transforms/asm/StinkyRemoveWaitCntPass.cpp
+++ b/shared/stinkytofu/src/transforms/asm/StinkyRemoveWaitCntPass.cpp
@@ -23,6 +23,7 @@
 
 #include "stinkytofu/transforms/asm/StinkyRemoveWaitCntPass.hpp"
 
+#include "stinkytofu/analysis/AnalysisRegistration.hpp"
 #include "stinkytofu/core/PassManager.hpp"
 #include "stinkytofu/ir/asm/StinkyAsmIR.hpp"
 
@@ -71,7 +72,7 @@ class StinkyRemoveWaitCntPass : public StinkyInstPass {
                 removeWaitCntsInBlock(bb, removeTensorWaitCnt);
             }
         }
-        return PreservedAnalyses::none();
+        return preserveCFGAnalyses();
     }
 
    private:

--- a/shared/stinkytofu/src/transforms/asm/StinkyRemoveWaitCntPass.cpp
+++ b/shared/stinkytofu/src/transforms/asm/StinkyRemoveWaitCntPass.cpp
@@ -65,12 +65,13 @@ class StinkyRemoveWaitCntPass : public StinkyInstPass {
         return &StinkyRemoveWaitCntPass::ID;
     }
 
-    void run(Function& func, PassContext& passCtx) override {
+    PreservedAnalyses run(Function& func, PassContext& passCtx, AnalysisManager& /*AM*/) override {
         for (BasicBlock& bb : func) {
             if (passCtx.shouldProcessBasicBlock(bb)) {
                 removeWaitCntsInBlock(bb, removeTensorWaitCnt);
             }
         }
+        return PreservedAnalyses::none();
     }
 
    private:

--- a/shared/stinkytofu/src/transforms/asm/StinkyWaitCntInsertionPass.cpp
+++ b/shared/stinkytofu/src/transforms/asm/StinkyWaitCntInsertionPass.cpp
@@ -206,7 +206,7 @@ class StinkyWaitCntInsertionPass : public StinkyInstPass {
         return &StinkyWaitCntInsertionPass::ID;
     }
 
-    void run(Function& func, PassContext& passCtx) override {
+    PreservedAnalyses run(Function& func, PassContext& passCtx, AnalysisManager& /*AM*/) override {
         GfxArchID arch =
             getGfxArchID(passCtx.getGemmTileConfig().arch[0], passCtx.getGemmTileConfig().arch[1],
                          passCtx.getGemmTileConfig().arch[2]);
@@ -229,6 +229,7 @@ class StinkyWaitCntInsertionPass : public StinkyInstPass {
         }
 
         removePHIs(func, passCtx);
+        return PreservedAnalyses::none();
     }
 
    private:

--- a/shared/stinkytofu/src/transforms/asm/StinkyWaitCntInsertionPass.cpp
+++ b/shared/stinkytofu/src/transforms/asm/StinkyWaitCntInsertionPass.cpp
@@ -28,6 +28,9 @@
 #include <unordered_set>
 #include <vector>
 
+#include "stinkytofu/analysis/AnalysisRegistration.hpp"
+#include "stinkytofu/analysis/BBIndexAnalysis.hpp"
+#include "stinkytofu/analysis/controlflow/DominanceAnalysis.hpp"
 #include "stinkytofu/hardware/ArchHelper.hpp"
 #include "stinkytofu/ir/asm/RegisterKey.hpp"
 #include "stinkytofu/ir/asm/StinkyAsmIR.hpp"
@@ -206,30 +209,32 @@ class StinkyWaitCntInsertionPass : public StinkyInstPass {
         return &StinkyWaitCntInsertionPass::ID;
     }
 
-    PreservedAnalyses run(Function& func, PassContext& passCtx, AnalysisManager& /*AM*/) override {
+    PreservedAnalyses run(Function& func, PassContext& passCtx, AnalysisManager& AM) override {
         GfxArchID arch =
             getGfxArchID(passCtx.getGemmTileConfig().arch[0], passCtx.getGemmTileConfig().arch[1],
                          passCtx.getGemmTileConfig().arch[2]);
 
-        buildUseDefChain(func, true);
+        const auto& domInfo = AM.getResult<DominanceAnalysis>(func);
+        buildUseDefChain(func, domInfo, true);
+        const auto& rpo = AM.getResult<BBIndexAnalysis>(func).rpo;
         rebuildExitMemoryStateForProcessedBlocks(func, passCtx);
 
-        traverseCFGInRPO(func, [&](BasicBlock* bb) {
+        for (auto* bb : rpo) {
             if (!passCtx.shouldProcessBasicBlock(*bb)) {
-                return;
+                continue;
             }
             WaitInsertionList waits = collectWaitsForBlock(*bb);
             insertWaitsForBlock(*bb, arch, waits);
-        });
+        }
 
         // Handle tensor waits for DS reads.
         if (insertTensorWaitCnt) {
-            // handleTensorWaits(func, arch, passCtx);
-            reinsertTensorWaitsHeuristic(func, arch, passCtx);
+            // handleTensorWaits(func, arch, passCtx, rpo);
+            reinsertTensorWaitsHeuristic(func, arch, passCtx, rpo);
         }
 
-        removePHIs(func, passCtx);
-        return PreservedAnalyses::none();
+        removePHIs(func, passCtx, rpo);
+        return preserveCFGAnalyses();
     }
 
    private:
@@ -456,17 +461,18 @@ class StinkyWaitCntInsertionPass : public StinkyInstPass {
     /// heuristic reinsert tensor waitcnts
     /// 1. remove tensor waitcnts in LoopBeginL and LoopEndL basic blocks
     /// 2. insert tensor waitcnts for tensor_load that has memTokens in barrier
-    void reinsertTensorWaitsHeuristic(Function& func, GfxArchID arch, PassContext& passCtx) {
+    void reinsertTensorWaitsHeuristic(Function& func, GfxArchID arch, PassContext& passCtx,
+                                      const std::vector<BasicBlock*>& rpo) {
         // handle only for label_LoopBeginL and label_LoopEndL basic block
         std::unordered_set<std::string> processedLabels = {"label_LoopBeginL", "label_LoopEndL"};
 
-        traverseCFGInRPO(func, [&](BasicBlock* bb) {
+        for (auto* bb : rpo) {
             if (!passCtx.shouldProcessBasicBlock(*bb)) {
-                return;
+                continue;
             }
 
             if (processedLabels.find(bb->getLabel()) == processedLabels.end()) {
-                return;
+                continue;
             }
 
             for (auto it = bb->begin(); it != bb->end();) {
@@ -477,12 +483,12 @@ class StinkyWaitCntInsertionPass : public StinkyInstPass {
                     ++it;
                 }
             }
-        });
+        }
 
         std::deque<StinkyInstruction*> tensorLoads;
-        traverseCFGInRPO(func, [&](BasicBlock* bb) {
+        for (auto* bb : rpo) {
             if (!passCtx.shouldProcessBasicBlock(*bb)) {
-                return;
+                continue;
             }
 
             WaitInsertionList tensorWaits;
@@ -520,11 +526,12 @@ class StinkyWaitCntInsertionPass : public StinkyInstPass {
             }
 
             insertWaitsForBlock(*bb, arch, tensorWaits);
-        });
+        }
     }
 
     /// Handle tensor waits for DS reads.
-    void handleTensorWaits(Function& func, GfxArchID arch, PassContext& passCtx) {
+    void handleTensorWaits(Function& func, GfxArchID arch, PassContext& passCtx,
+                           const std::vector<BasicBlock*>& rpo) {
         struct TensorLoadBlockState {
             std::unordered_map<StinkyInstruction*, int> dsReadSources;
             std::deque<StinkyInstruction*> tensorLoadQueue;
@@ -532,9 +539,9 @@ class StinkyWaitCntInsertionPass : public StinkyInstPass {
 
         std::unordered_map<BasicBlock*, TensorLoadBlockState> tensorLoadStates;
 
-        traverseCFGInRPO(func, [&](BasicBlock* bb) {
+        for (auto* bb : rpo) {
             if (!passCtx.shouldProcessBasicBlock(*bb)) {
-                return;
+                continue;
             }
 
             if (tensorLoadStates.find(bb) == tensorLoadStates.end()) {
@@ -571,11 +578,11 @@ class StinkyWaitCntInsertionPass : public StinkyInstPass {
                     tensorLoadState.dsReadSources[inst] = count;
                 }
             }
-        });
+        }
 
-        traverseCFGInRPO(func, [&](BasicBlock* bb) {
+        for (auto* bb : rpo) {
             if (!passCtx.shouldProcessBasicBlock(*bb)) {
-                return;
+                continue;
             }
 
             auto& currentTensorLoadState = tensorLoadStates[bb];
@@ -652,14 +659,14 @@ class StinkyWaitCntInsertionPass : public StinkyInstPass {
             }
 
             insertWaitsForBlock(*bb, arch, tensorWaits);
-        });
+        }
     }
 
     /// Remove consecutive PHIs at block entry.
-    void removePHIs(Function& func, PassContext& passCtx) {
-        traverseCFGInRPO(func, [&](BasicBlock* bb) {
+    void removePHIs(Function& func, PassContext& passCtx, const std::vector<BasicBlock*>& rpo) {
+        for (auto* bb : rpo) {
             if (!passCtx.shouldProcessBasicBlock(*bb)) {
-                return;
+                continue;
             }
 
             for (auto it = bb->begin(); it != bb->end();) {
@@ -670,7 +677,7 @@ class StinkyWaitCntInsertionPass : public StinkyInstPass {
                     ++it;
                 }
             }
-        });
+        }
     }
 };
 

--- a/shared/stinkytofu/src/transforms/logical/CompositeInstructionLoweringPass.cpp
+++ b/shared/stinkytofu/src/transforms/logical/CompositeInstructionLoweringPass.cpp
@@ -58,7 +58,7 @@ class CompositeInstructionLoweringPassImpl : public Pass {
         return PassName;
     }
 
-    void run(Function& func, PassContext& passCtx) override {
+    PreservedAnalyses run(Function& func, PassContext& passCtx, AnalysisManager& /*AM*/) override {
         GfxArchID arch =
             getGfxArchID(passCtx.getGemmTileConfig().arch[0], passCtx.getGemmTileConfig().arch[1],
                          passCtx.getGemmTileConfig().arch[2]);
@@ -70,6 +70,7 @@ class CompositeInstructionLoweringPassImpl : public Pass {
 
             expandCompositeInstructions(bb, arch);
         }
+        return PreservedAnalyses::none();
     }
 
    private:

--- a/shared/stinkytofu/src/transforms/logical/CompositeInstructionLoweringPass.cpp
+++ b/shared/stinkytofu/src/transforms/logical/CompositeInstructionLoweringPass.cpp
@@ -26,6 +26,7 @@
 #include <string>
 #include <vector>
 
+#include "stinkytofu/analysis/AnalysisRegistration.hpp"
 #include "stinkytofu/core/PassManager.hpp"
 #include "stinkytofu/hardware/ArchHelper.hpp"
 #include "stinkytofu/ir/LogicalToAsmMappings_generated.inc"
@@ -70,7 +71,7 @@ class CompositeInstructionLoweringPassImpl : public Pass {
 
             expandCompositeInstructions(bb, arch);
         }
-        return PreservedAnalyses::none();
+        return preserveCFGAnalyses();
     }
 
    private:

--- a/shared/stinkytofu/src/transforms/logical/IntrinsicExpansionPass.cpp
+++ b/shared/stinkytofu/src/transforms/logical/IntrinsicExpansionPass.cpp
@@ -39,13 +39,14 @@ IntrinsicExpansionPass::IntrinsicExpansionPass() {}
 
 IntrinsicExpansionPass::~IntrinsicExpansionPass() = default;
 
-void IntrinsicExpansionPass::run(Function& func, PassContext& passCtx) {
+PreservedAnalyses IntrinsicExpansionPass::run(Function& func, PassContext& passCtx,
+                                              AnalysisManager& /*AM*/) {
     // Check if intrinsic registry is initialized
     auto& registry = IntrinsicRegistry::instance();
     if (!registry.isInitialized()) {
         std::cerr << "[IntrinsicExpansionPass] Warning: IntrinsicRegistry not initialized, "
                   << "skipping intrinsic expansion\n";
-        return;
+        return PreservedAnalyses::none();
     }
 
     // Process all basic blocks
@@ -55,6 +56,7 @@ void IntrinsicExpansionPass::run(Function& func, PassContext& passCtx) {
 
         expandIntrinsicsInBlock(bb);
     }
+    return PreservedAnalyses::none();
 }
 
 void IntrinsicExpansionPass::expandIntrinsicsInBlock(BasicBlock& bb) {

--- a/shared/stinkytofu/src/transforms/logical/IntrinsicExpansionPass.cpp
+++ b/shared/stinkytofu/src/transforms/logical/IntrinsicExpansionPass.cpp
@@ -26,6 +26,7 @@
 #include <cstring>
 #include <iostream>
 
+#include "stinkytofu/analysis/AnalysisRegistration.hpp"
 #include "stinkytofu/ir/logical/IntrinsicCall.hpp"
 #include "stinkytofu/ir/logical/IntrinsicRegistry.hpp"
 #include "stinkytofu/ir/logical/LogicalInstructions.hpp"
@@ -46,7 +47,7 @@ PreservedAnalyses IntrinsicExpansionPass::run(Function& func, PassContext& passC
     if (!registry.isInitialized()) {
         std::cerr << "[IntrinsicExpansionPass] Warning: IntrinsicRegistry not initialized, "
                   << "skipping intrinsic expansion\n";
-        return PreservedAnalyses::none();
+        return preserveCFGAnalyses();
     }
 
     // Process all basic blocks
@@ -56,7 +57,7 @@ PreservedAnalyses IntrinsicExpansionPass::run(Function& func, PassContext& passC
 
         expandIntrinsicsInBlock(bb);
     }
-    return PreservedAnalyses::none();
+    return preserveCFGAnalyses();
 }
 
 void IntrinsicExpansionPass::expandIntrinsicsInBlock(BasicBlock& bb) {

--- a/shared/stinkytofu/src/transforms/logical/LogicalPeepholePass.cpp
+++ b/shared/stinkytofu/src/transforms/logical/LogicalPeepholePass.cpp
@@ -47,7 +47,7 @@ class LogicalPeepholePassImpl : public Pass {
         return PassName;
     }
 
-    void run(Function& func, PassContext& passCtx) override {
+    PreservedAnalyses run(Function& func, PassContext& passCtx, AnalysisManager& /*AM*/) override {
         optimizationCount = 0;
 
         // Create pattern matcher registry
@@ -61,6 +61,7 @@ class LogicalPeepholePassImpl : public Pass {
 
             runOnBasicBlock(bb, patterns);
         }
+        return PreservedAnalyses::none();
     }
 
     size_t getOptimizationCount() const {

--- a/shared/stinkytofu/src/transforms/logical/LogicalPeepholePass.cpp
+++ b/shared/stinkytofu/src/transforms/logical/LogicalPeepholePass.cpp
@@ -23,6 +23,7 @@
 
 #include "stinkytofu/transforms/logical/LogicalPeepholePass.hpp"
 
+#include "stinkytofu/analysis/AnalysisRegistration.hpp"
 #include "stinkytofu/core/PassManager.hpp"
 #include "stinkytofu/ir/logical/LogicalInstructions.hpp"
 #include "stinkytofu/support/Casting.hpp"
@@ -61,7 +62,7 @@ class LogicalPeepholePassImpl : public Pass {
 
             runOnBasicBlock(bb, patterns);
         }
-        return PreservedAnalyses::none();
+        return preserveCFGAnalyses();
     }
 
     size_t getOptimizationCount() const {

--- a/shared/stinkytofu/src/transforms/logical/ToStinkyAsmPass.cpp
+++ b/shared/stinkytofu/src/transforms/logical/ToStinkyAsmPass.cpp
@@ -196,7 +196,7 @@ class ToStinkyAsmPassImpl : public Pass {
         return PassName;
     }
 
-    void run(Function& func, PassContext& passCtx) override {
+    PreservedAnalyses run(Function& func, PassContext& passCtx, AnalysisManager& /*AM*/) override {
         GfxArchID arch =
             getGfxArchID(passCtx.getGemmTileConfig().arch[0], passCtx.getGemmTileConfig().arch[1],
                          passCtx.getGemmTileConfig().arch[2]);
@@ -208,6 +208,7 @@ class ToStinkyAsmPassImpl : public Pass {
 
             lowerToAsm(bb, arch);
         }
+        return PreservedAnalyses::none();
     }
 
    private:

--- a/shared/stinkytofu/tests/CMakeLists.txt
+++ b/shared/stinkytofu/tests/CMakeLists.txt
@@ -81,6 +81,11 @@ set(UNIT_LOGICAL_TEST_FILES
     unit/logical/LogicalIntrinsicFlowTest.cpp
 )
 
+# Core Infrastructure Tests
+set(UNIT_CORE_TEST_FILES
+    unit/core/AnalysisManagerTest.cpp
+)
+
 # Common/Shared Tests
 set(UNIT_COMMON_TEST_FILES
     unit/ErrorHandlingTest.cpp
@@ -92,6 +97,7 @@ set(UNIT_COMMON_TEST_FILES
 
 # Combine all unit tests
 set(UNIT_TEST_FILES
+    ${UNIT_CORE_TEST_FILES}
     ${UNIT_ASM_TEST_FILES}
     ${UNIT_LOGICAL_TEST_FILES}
     ${UNIT_COMMON_TEST_FILES}

--- a/shared/stinkytofu/tests/unit/asm/BarrierTest.cpp
+++ b/shared/stinkytofu/tests/unit/asm/BarrierTest.cpp
@@ -23,6 +23,7 @@
 #include <gtest/gtest.h>
 
 #include "TestHelpers.hpp"
+#include "stinkytofu/analysis/AnalysisRegistration.hpp"
 #include "stinkytofu/core/PassManager.hpp"
 #include "stinkytofu/ir/asm/StinkyAsmIR.hpp"
 #include "stinkytofu/support/Casting.hpp"
@@ -39,6 +40,7 @@ class BarrierTest : public ::testing::Test {
     GemmTileConfig config;
     std::unique_ptr<Function> func;
     BasicBlock* bb = nullptr;
+    AnalysisManager am;
 
     void SetUp() override {
         config.arch[0] = 12;
@@ -47,6 +49,7 @@ class BarrierTest : public ::testing::Test {
         func = std::make_unique<Function>("barrier_test");
         setFunctionArch(*func, arch);
         bb = func->createBasicBlock("entry");
+        registerAllAnalyses(am);
     }
 
     void TearDown() override {
@@ -67,10 +70,10 @@ class BarrierTest : public ::testing::Test {
         }
 
         auto implicitDepPass = createStinkyBuildImplicitDependencyPass();
-        implicitDepPass->run(*func, ctx);
+        implicitDepPass->run(*func, ctx, am);
 
         auto dagSchedPass = createStinkyDAGSchedulerPass();
-        dagSchedPass->run(*func, ctx);
+        dagSchedPass->run(*func, ctx, am);
     }
 
     /// Create an s_barrier instruction in bb and return it.

--- a/shared/stinkytofu/tests/unit/asm/DAGSchedulerPassTest.cpp
+++ b/shared/stinkytofu/tests/unit/asm/DAGSchedulerPassTest.cpp
@@ -23,6 +23,7 @@
 #include <gtest/gtest.h>
 
 #include "TestHelpers.hpp"
+#include "stinkytofu/analysis/AnalysisRegistration.hpp"
 #include "stinkytofu/core/PassManager.hpp"
 #include "stinkytofu/support/Casting.hpp"
 #include "stinkytofu/transforms/asm/StinkyDAGSchedulerPass.hpp"
@@ -45,6 +46,7 @@ class DAGSchedulerPassTest : public ::testing::Test {
     std::unique_ptr<Function> func;
     BasicBlock* bb = nullptr;
     std::unique_ptr<Pass> pass;
+    AnalysisManager am;
 
     void SetUp() override {
         config.arch[0] = 12;
@@ -54,6 +56,7 @@ class DAGSchedulerPassTest : public ::testing::Test {
         setFunctionArch(*func, arch);
         bb = func->createBasicBlock("entry");
         pass = createStinkyDAGSchedulerPass();
+        registerAllAnalyses(am);
     }
 
     void TearDown() override {
@@ -65,7 +68,7 @@ class DAGSchedulerPassTest : public ::testing::Test {
     void runPass() {
         PassContext ctx;
         ctx.setGemmTileConfig(config);
-        pass->run(*func, ctx);
+        pass->run(*func, ctx, am);
     }
 
     void runPassWithUnrollGemm() {
@@ -74,7 +77,7 @@ class DAGSchedulerPassTest : public ::testing::Test {
         PassFeatureConfig pfc;
         pfc.loopConfig.unrollGemm = true;
         ctx.setPassFeatureConfig(pfc);
-        pass->run(*func, ctx);
+        pass->run(*func, ctx, am);
     }
 
     // Create v_wmma_f32_16x16x16_bf16: dest v[destStart:destStart+7], src0

--- a/shared/stinkytofu/tests/unit/asm/DeadCodeEliminationPassTest.cpp
+++ b/shared/stinkytofu/tests/unit/asm/DeadCodeEliminationPassTest.cpp
@@ -75,6 +75,7 @@ class DeadCodeEliminationPassTest : public ::testing::Test {
     }
 
     GemmTileConfig gemmConfig;
+    AnalysisManager am;
 };
 
 // Test 1: Remove dead store (register overwritten before use)
@@ -96,7 +97,7 @@ v[6] = "st.v_sub_f32"(v[0], v[3])
     passCtx.setGemmTileConfig(gemmConfig);
 
     auto dcePass = createDeadCodeEliminationPass();
-    dcePass->run(*func, passCtx);
+    dcePass->run(*func, passCtx, am);
 
     std::string result = getFunctionIR(*func);
 
@@ -129,7 +130,7 @@ v[0] = "st.v_sub_f32"(v[10], v[11])
     passCtx.setGemmTileConfig(gemmConfig);
 
     auto dcePass = createDeadCodeEliminationPass();
-    dcePass->run(*func, passCtx);
+    dcePass->run(*func, passCtx, am);
 
     std::string result = getFunctionIR(*func);
 
@@ -161,7 +162,7 @@ v[5] = "st.v_fma_f32"(v[3], v[0], 1.0)
     passCtx.setGemmTileConfig(gemmConfig);
 
     auto dcePass = createDeadCodeEliminationPass();
-    dcePass->run(*func, passCtx);
+    dcePass->run(*func, passCtx, am);
 
     std::string result = getFunctionIR(*func);
 
@@ -191,7 +192,7 @@ v[7] = "st.v_fma_f32"(v[3], v[1], 1.0)
     passCtx.setGemmTileConfig(gemmConfig);
 
     auto dcePass = createDeadCodeEliminationPass();
-    dcePass->run(*func, passCtx);
+    dcePass->run(*func, passCtx, am);
 
     std::string result = getFunctionIR(*func);
 
@@ -221,7 +222,7 @@ v[4] = "st.v_mul_f32"(v[1], v[2])
     passCtx.setGemmTileConfig(gemmConfig);
 
     auto dcePass = createDeadCodeEliminationPass();
-    dcePass->run(*func, passCtx);
+    dcePass->run(*func, passCtx, am);
 
     std::string result = getFunctionIR(*func);
 
@@ -246,7 +247,7 @@ TEST_F(DeadCodeEliminationPassTest, EmptyIR) {
     passCtx.setGemmTileConfig(gemmConfig);
 
     auto dcePass = createDeadCodeEliminationPass();
-    dcePass->run(*func, passCtx);
+    dcePass->run(*func, passCtx, am);
     // Empty IR should not cause any errors
 }
 
@@ -267,7 +268,7 @@ TEST_F(DeadCodeEliminationPassTest, AllDeadCode) {
     passCtx.setGemmTileConfig(gemmConfig);
 
     auto dcePass = createDeadCodeEliminationPass();
-    dcePass->run(*func, passCtx);
+    dcePass->run(*func, passCtx, am);
 
     std::string result = getFunctionIR(*func);
 
@@ -300,7 +301,7 @@ v[10] = "st.v_add_f32"(v[6], v[7])
     passCtx.setGemmTileConfig(gemmConfig);
 
     auto dcePass = createDeadCodeEliminationPass();
-    dcePass->run(*func, passCtx);
+    dcePass->run(*func, passCtx, am);
 
     std::string result = getFunctionIR(*func);
 
@@ -337,7 +338,7 @@ v[6] = "st.v_fma_f32"(v[0], v[3], 3.0)
     passCtx.setGemmTileConfig(gemmConfig);
 
     auto dcePass = createDeadCodeEliminationPass();
-    dcePass->run(*func, passCtx);
+    dcePass->run(*func, passCtx, am);
 
     std::string result = getFunctionIR(*func);
 
@@ -365,7 +366,7 @@ v[4] = "st.v_sub_f32"(v[0], v[5])
     passCtx.setGemmTileConfig(gemmConfig);
 
     auto dcePass = createDeadCodeEliminationPass();
-    dcePass->run(*func, passCtx);
+    dcePass->run(*func, passCtx, am);
 
     std::string result = getFunctionIR(*func);
 

--- a/shared/stinkytofu/tests/unit/asm/OptimizationPipelineTest.cpp
+++ b/shared/stinkytofu/tests/unit/asm/OptimizationPipelineTest.cpp
@@ -25,6 +25,7 @@
 #include <sstream>
 #include <string>
 
+#include "stinkytofu/analysis/AnalysisRegistration.hpp"
 #include "stinkytofu/analysis/asm/AsmVerifierPass.hpp"
 #include "stinkytofu/core/PassManager.hpp"
 #include "stinkytofu/ir/asm/StinkyAsmIR.hpp"
@@ -86,6 +87,7 @@ v[0] = "st.v_add_f32"(v[1], v[2])
     int instCountBefore = countInstructions(*func);
 
     PassManager pm;
+    registerAllAnalyses(pm.getAnalysisManager());
     pm.setGemmTileConfig(gemmConfig);
     addPeepholeOptPasses(pm, OptLevel::O0);
     pm.run(*func);
@@ -109,6 +111,7 @@ v[0] = "st.v_add_f32"(v[1], v[2])
     ASSERT_NE(func, nullptr);
 
     PassManager pm;
+    registerAllAnalyses(pm.getAnalysisManager());
     pm.setGemmTileConfig(gemmConfig);
     addPeepholeOptPasses(pm, OptLevel::O1);
 
@@ -130,6 +133,7 @@ v[0] = "st.v_add_f32"(v[1], v[2])
     ASSERT_NE(func, nullptr);
 
     PassManager pm;
+    registerAllAnalyses(pm.getAnalysisManager());
     pm.setGemmTileConfig(gemmConfig);
     addPeepholeOptPasses(pm, OptLevel::O2);
 
@@ -151,6 +155,7 @@ v[0] = "st.v_add_f32"(v[1], v[2])
     ASSERT_NE(func, nullptr);
 
     PassManager pm;
+    registerAllAnalyses(pm.getAnalysisManager());
     pm.setGemmTileConfig(gemmConfig);
     addPeepholeOptPasses(pm, OptLevel::O3);
 

--- a/shared/stinkytofu/tests/unit/asm/PeepholeOptimizationPassTest.cpp
+++ b/shared/stinkytofu/tests/unit/asm/PeepholeOptimizationPassTest.cpp
@@ -26,6 +26,7 @@
 #include <memory>
 #include <sstream>
 
+#include "stinkytofu/analysis/AnalysisRegistration.hpp"
 #include "stinkytofu/core/PassManager.hpp"
 #include "stinkytofu/hardware/ArchHelper.hpp"
 #include "stinkytofu/ir/asm/StinkyAsmIR.hpp"
@@ -43,6 +44,7 @@ class PeepholeOptimizationPassTest : public ::testing::Test {
     std::unique_ptr<Function> func;
     BasicBlock* bb;
     std::unique_ptr<Pass> peepholePass;
+    AnalysisManager am;
 
     void SetUp() override {
         arch = getGfxArchID(12, 5, 0);  // GFX1250
@@ -57,6 +59,7 @@ class PeepholeOptimizationPassTest : public ::testing::Test {
 
         // Create the peephole optimization pass
         peepholePass = createPeepholeOptimizationPass();
+        registerAllAnalyses(am);
     }
 
     void TearDown() override {
@@ -267,7 +270,7 @@ class PeepholeOptimizationPassTest : public ::testing::Test {
         // In production, OptimizationPipeline builds this once at the start
         buildUseDefChain(*func, true);
 
-        peepholePass->run(*func, ctx);
+        peepholePass->run(*func, ctx, am);
     }
 };
 
@@ -698,6 +701,7 @@ class PeepholePassManagerTest : public ::testing::Test, public stinkytofu::PassM
         bb = func.createBasicBlock("entry");
 
         setGemmTileConfig(gemmConfig);
+        registerAllAnalyses(getAnalysisManager());
     }
 
     void TearDown() override {

--- a/shared/stinkytofu/tests/unit/asm/RedundantMovEliminationPassTest.cpp
+++ b/shared/stinkytofu/tests/unit/asm/RedundantMovEliminationPassTest.cpp
@@ -86,6 +86,7 @@ class RedundantMovEliminationPassTest : public ::testing::Test {
     }
 
     GemmTileConfig gemmConfig;
+    AnalysisManager am;
 };
 
 // Test 1: Eliminate redundant mov to same destination
@@ -106,7 +107,7 @@ TEST_F(RedundantMovEliminationPassTest, EliminateSimpleDuplicate) {
     passCtx.setGemmTileConfig(gemmConfig);
 
     auto dupElimPass = createRedundantMovEliminationPass();
-    dupElimPass->run(*func, passCtx);
+    dupElimPass->run(*func, passCtx, am);
 
     std::string result = getFunctionIR(*func);
 
@@ -134,7 +135,7 @@ TEST_F(RedundantMovEliminationPassTest, MultipleDuplicates) {
     passCtx.setGemmTileConfig(gemmConfig);
 
     auto dupElimPass = createRedundantMovEliminationPass();
-    dupElimPass->run(*func, passCtx);
+    dupElimPass->run(*func, passCtx, am);
 
     std::string result = getFunctionIR(*func);
 
@@ -160,7 +161,7 @@ TEST_F(RedundantMovEliminationPassTest, DontEliminateWithModifiedOperand) {
     passCtx.setGemmTileConfig(gemmConfig);
 
     auto dupElimPass = createRedundantMovEliminationPass();
-    dupElimPass->run(*func, passCtx);
+    dupElimPass->run(*func, passCtx, am);
 
     std::string result = getFunctionIR(*func);
 
@@ -185,7 +186,7 @@ TEST_F(RedundantMovEliminationPassTest, DifferentOperands) {
     passCtx.setGemmTileConfig(gemmConfig);
 
     auto dupElimPass = createRedundantMovEliminationPass();
-    dupElimPass->run(*func, passCtx);
+    dupElimPass->run(*func, passCtx, am);
 
     std::string result = getFunctionIR(*func);
 
@@ -206,7 +207,7 @@ TEST_F(RedundantMovEliminationPassTest, EmptyIR) {
     passCtx.setGemmTileConfig(gemmConfig);
 
     auto dupElimPass = createRedundantMovEliminationPass();
-    dupElimPass->run(*func, passCtx);
+    dupElimPass->run(*func, passCtx, am);
     // Empty IR should not cause any errors
 }
 
@@ -230,7 +231,7 @@ TEST_F(RedundantMovEliminationPassTest, NoDuplicates) {
     passCtx.setGemmTileConfig(gemmConfig);
 
     auto dupElimPass = createRedundantMovEliminationPass();
-    dupElimPass->run(*func, passCtx);
+    dupElimPass->run(*func, passCtx, am);
 
     std::string after = getFunctionIR(*func);
 

--- a/shared/stinkytofu/tests/unit/asm/ScopeAdaptorTest.cpp
+++ b/shared/stinkytofu/tests/unit/asm/ScopeAdaptorTest.cpp
@@ -43,13 +43,14 @@ class CountingPass : public Pass {
         return "CountingPass";
     }
 
-    void run(Function& func, PassContext& /*ctx*/) override {
+    PreservedAnalyses run(Function& func, PassContext& /*ctx*/, AnalysisManager& /*AM*/) override {
         count = 0;
         for (auto& bb : func) {
             for (auto& ir : bb) {
                 if (ir.getType() == IRBase::IRType::StinkyTofu) count++;
             }
         }
+        return PreservedAnalyses::none();
     }
 
     int count = 0;

--- a/shared/stinkytofu/tests/unit/asm/WaitCntInsertionTest.cpp
+++ b/shared/stinkytofu/tests/unit/asm/WaitCntInsertionTest.cpp
@@ -25,6 +25,7 @@
 
 #include <vector>
 
+#include "stinkytofu/analysis/AnalysisRegistration.hpp"
 #include "stinkytofu/hardware/ArchHelper.hpp"
 #include "stinkytofu/ir/asm/StinkyAsmIR.hpp"
 #include "stinkytofu/serialization/asm/IRConverter.hpp"
@@ -54,8 +55,10 @@ class WaitCntInsertionTest : public ::testing::Test {
     void runInsertionPass(Function& func) {
         PassContext passCtx;
         passCtx.setGemmTileConfig(gemmConfig);
+        AnalysisManager am;
+        registerAllAnalyses(am);
         auto pass = stinkytofu::createStinkyWaitCntInsertionPass();
-        pass->run(func, passCtx);
+        pass->run(func, passCtx, am);
     }
 
     struct WaitCntInfo {

--- a/shared/stinkytofu/tests/unit/core/AnalysisManagerTest.cpp
+++ b/shared/stinkytofu/tests/unit/core/AnalysisManagerTest.cpp
@@ -1,0 +1,744 @@
+/* ************************************************************************
+ * Copyright (C) 2025-2026 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * ************************************************************************ */
+#include <gtest/gtest.h>
+
+#include "stinkytofu/analysis/AnalysisRegistration.hpp"
+#include "stinkytofu/core/AnalysisManager.hpp"
+#include "stinkytofu/core/PassManager.hpp"
+
+using namespace stinkytofu;
+
+// -----------------------------------------------------------------------
+// Mock analyses for testing
+// -----------------------------------------------------------------------
+
+// A mock analysis with a run counter to verify caching behavior.
+struct CountingAnalysis {
+    static inline AnalysisKey Key;
+    static AnalysisKey* ID() {
+        return &Key;
+    }
+    static const char* name() {
+        return "CountingAnalysis";
+    }
+    struct Result {
+        int value = 42;
+    };
+    static inline int runCount = 0;
+    static Result run(Function& /*F*/, AnalysisManager& /*AM*/) {
+        ++runCount;
+        return Result{};
+    }
+};
+
+// A second independent mock analysis.
+struct SecondAnalysis {
+    static inline AnalysisKey Key;
+    static AnalysisKey* ID() {
+        return &Key;
+    }
+    static const char* name() {
+        return "SecondAnalysis";
+    }
+    struct Result {
+        int value = 99;
+    };
+    static inline int runCount = 0;
+    static Result run(Function& /*F*/, AnalysisManager& /*AM*/) {
+        ++runCount;
+        return Result{};
+    }
+};
+
+// A mock analysis that depends on CountingAnalysis.
+struct DependentAnalysis {
+    static inline AnalysisKey Key;
+    static AnalysisKey* ID() {
+        return &Key;
+    }
+    static const char* name() {
+        return "DependentAnalysis";
+    }
+    struct Result {
+        int derivedValue;
+    };
+    static inline int runCount = 0;
+    static Result run(Function& F, AnalysisManager& AM) {
+        ++runCount;
+        auto& base = AM.getResult<CountingAnalysis>(F);
+        return Result{base.value * 2};
+    }
+};
+
+// -----------------------------------------------------------------------
+// Test fixture
+// -----------------------------------------------------------------------
+
+class AnalysisManagerTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        CountingAnalysis::runCount = 0;
+        SecondAnalysis::runCount = 0;
+        DependentAnalysis::runCount = 0;
+    }
+
+    Function func{"test"};
+};
+
+// -----------------------------------------------------------------------
+// PreservedAnalyses data structure
+// -----------------------------------------------------------------------
+
+TEST_F(AnalysisManagerTest, DefaultIsEmpty) {
+    PreservedAnalyses PA;
+    EXPECT_FALSE(PA.areAllPreserved());
+    EXPECT_FALSE(PA.isPreserved(CountingAnalysis::ID()));
+}
+
+TEST_F(AnalysisManagerTest, All) {
+    auto PA = PreservedAnalyses::all();
+    EXPECT_TRUE(PA.areAllPreserved());
+    EXPECT_TRUE(PA.isPreserved(CountingAnalysis::ID()));
+    EXPECT_TRUE(PA.isPreserved(SecondAnalysis::ID()));
+}
+
+TEST_F(AnalysisManagerTest, None) {
+    auto PA = PreservedAnalyses::none();
+    EXPECT_FALSE(PA.areAllPreserved());
+    EXPECT_FALSE(PA.isPreserved(CountingAnalysis::ID()));
+}
+
+TEST_F(AnalysisManagerTest, PreserveSpecific) {
+    PreservedAnalyses PA;
+    PA.preserve<CountingAnalysis>();
+    EXPECT_TRUE(PA.isPreserved<CountingAnalysis>());
+    EXPECT_FALSE(PA.isPreserved<SecondAnalysis>());
+}
+
+TEST_F(AnalysisManagerTest, PreserveMultiple) {
+    PreservedAnalyses PA;
+    PA.preserve<CountingAnalysis>();
+    PA.preserve<SecondAnalysis>();
+    EXPECT_TRUE(PA.isPreserved<CountingAnalysis>());
+    EXPECT_TRUE(PA.isPreserved<SecondAnalysis>());
+}
+
+TEST_F(AnalysisManagerTest, PreserveCFGGroup) {
+    auto PA = preserveCFGAnalyses();
+    EXPECT_TRUE(PA.isPreserved<BBIndexAnalysis>());
+    EXPECT_TRUE(PA.isPreserved<DominanceAnalysis>());
+    EXPECT_TRUE(PA.isPreserved<LoopAnalysis>());
+}
+
+TEST_F(AnalysisManagerTest, Intersect) {
+    PreservedAnalyses PA1;
+    PA1.preserve<CountingAnalysis>();
+    PA1.preserve<SecondAnalysis>();
+
+    PreservedAnalyses PA2;
+    PA2.preserve<CountingAnalysis>();
+
+    PA1.intersect(PA2);
+    EXPECT_TRUE(PA1.isPreserved<CountingAnalysis>());
+    EXPECT_FALSE(PA1.isPreserved<SecondAnalysis>());
+}
+
+TEST_F(AnalysisManagerTest, IntersectWithAll) {
+    PreservedAnalyses PA;
+    PA.preserve<CountingAnalysis>();
+    PA.preserve<SecondAnalysis>();
+
+    PA.intersect(PreservedAnalyses::all());
+    EXPECT_TRUE(PA.isPreserved<CountingAnalysis>());
+    EXPECT_TRUE(PA.isPreserved<SecondAnalysis>());
+}
+
+TEST_F(AnalysisManagerTest, IntersectWithNone) {
+    PreservedAnalyses PA;
+    PA.preserve<CountingAnalysis>();
+    PA.preserve<SecondAnalysis>();
+
+    PA.intersect(PreservedAnalyses::none());
+    EXPECT_FALSE(PA.isPreserved<CountingAnalysis>());
+    EXPECT_FALSE(PA.isPreserved<SecondAnalysis>());
+}
+
+// -----------------------------------------------------------------------
+// AnalysisManager cache + lazy evaluation
+// -----------------------------------------------------------------------
+
+TEST_F(AnalysisManagerTest, LazyComputation) {
+    AnalysisManager AM;
+    AM.registerPass<CountingAnalysis>();
+
+    EXPECT_EQ(CountingAnalysis::runCount, 0);
+    auto& result = AM.getResult<CountingAnalysis>(func);
+    EXPECT_EQ(CountingAnalysis::runCount, 1);
+    EXPECT_EQ(result.value, 42);
+}
+
+TEST_F(AnalysisManagerTest, CacheHit) {
+    AnalysisManager AM;
+    AM.registerPass<CountingAnalysis>();
+
+    AM.getResult<CountingAnalysis>(func);
+    AM.getResult<CountingAnalysis>(func);
+    EXPECT_EQ(CountingAnalysis::runCount, 1);
+}
+
+TEST_F(AnalysisManagerTest, ClearEvictsAll) {
+    AnalysisManager AM;
+    AM.registerPass<CountingAnalysis>();
+
+    AM.getResult<CountingAnalysis>(func);
+    EXPECT_EQ(CountingAnalysis::runCount, 1);
+
+    AM.clear();
+    AM.getResult<CountingAnalysis>(func);
+    EXPECT_EQ(CountingAnalysis::runCount, 2);
+}
+
+TEST_F(AnalysisManagerTest, GetCachedResultNull) {
+    AnalysisManager AM;
+    AM.registerPass<CountingAnalysis>();
+    EXPECT_EQ(AM.getCachedResult<CountingAnalysis>(), nullptr);
+}
+
+TEST_F(AnalysisManagerTest, GetCachedResultHit) {
+    AnalysisManager AM;
+    AM.registerPass<CountingAnalysis>();
+
+    AM.getResult<CountingAnalysis>(func);
+    auto* cached = AM.getCachedResult<CountingAnalysis>();
+    ASSERT_NE(cached, nullptr);
+    EXPECT_EQ(cached->value, 42);
+}
+
+// -----------------------------------------------------------------------
+// Invalidation
+// -----------------------------------------------------------------------
+
+TEST_F(AnalysisManagerTest, InvalidateEvicts) {
+    AnalysisManager AM;
+    AM.registerPass<CountingAnalysis>();
+
+    AM.getResult<CountingAnalysis>(func);
+    EXPECT_EQ(CountingAnalysis::runCount, 1);
+
+    AM.invalidate(func, PreservedAnalyses::none());
+    AM.getResult<CountingAnalysis>(func);
+    EXPECT_EQ(CountingAnalysis::runCount, 2);
+}
+
+TEST_F(AnalysisManagerTest, PreservationKeeps) {
+    AnalysisManager AM;
+    AM.registerPass<CountingAnalysis>();
+
+    AM.getResult<CountingAnalysis>(func);
+
+    PreservedAnalyses PA;
+    PA.preserve<CountingAnalysis>();
+    AM.invalidate(func, PA);
+
+    AM.getResult<CountingAnalysis>(func);
+    EXPECT_EQ(CountingAnalysis::runCount, 1);
+}
+
+TEST_F(AnalysisManagerTest, AllPreservedKeepsEverything) {
+    AnalysisManager AM;
+    AM.registerPass<CountingAnalysis>();
+    AM.registerPass<SecondAnalysis>();
+
+    AM.getResult<CountingAnalysis>(func);
+    AM.getResult<SecondAnalysis>(func);
+
+    AM.invalidate(func, PreservedAnalyses::all());
+
+    AM.getResult<CountingAnalysis>(func);
+    AM.getResult<SecondAnalysis>(func);
+    EXPECT_EQ(CountingAnalysis::runCount, 1);
+    EXPECT_EQ(SecondAnalysis::runCount, 1);
+}
+
+TEST_F(AnalysisManagerTest, SelectiveInvalidation) {
+    AnalysisManager AM;
+    AM.registerPass<CountingAnalysis>();
+    AM.registerPass<SecondAnalysis>();
+
+    AM.getResult<CountingAnalysis>(func);
+    AM.getResult<SecondAnalysis>(func);
+
+    PreservedAnalyses PA;
+    PA.preserve<CountingAnalysis>();
+    AM.invalidate(func, PA);
+
+    AM.getResult<CountingAnalysis>(func);
+    AM.getResult<SecondAnalysis>(func);
+    EXPECT_EQ(CountingAnalysis::runCount, 1);
+    EXPECT_EQ(SecondAnalysis::runCount, 2);
+}
+
+TEST_F(AnalysisManagerTest, MultipleInvalidations) {
+    AnalysisManager AM;
+    AM.registerPass<CountingAnalysis>();
+
+    AM.getResult<CountingAnalysis>(func);
+    EXPECT_EQ(CountingAnalysis::runCount, 1);
+
+    AM.invalidate(func, PreservedAnalyses::none());
+    AM.getResult<CountingAnalysis>(func);
+    EXPECT_EQ(CountingAnalysis::runCount, 2);
+
+    AM.invalidate(func, PreservedAnalyses::none());
+    AM.getResult<CountingAnalysis>(func);
+    EXPECT_EQ(CountingAnalysis::runCount, 3);
+}
+
+// -----------------------------------------------------------------------
+// Analysis depends on analysis
+// -----------------------------------------------------------------------
+
+TEST_F(AnalysisManagerTest, DependencyTriggersComputation) {
+    AnalysisManager AM;
+    AM.registerPass<CountingAnalysis>();
+    AM.registerPass<DependentAnalysis>();
+
+    auto& result = AM.getResult<DependentAnalysis>(func);
+    EXPECT_EQ(DependentAnalysis::runCount, 1);
+    EXPECT_EQ(CountingAnalysis::runCount, 1);
+    EXPECT_EQ(result.derivedValue, 84);  // 42 * 2
+}
+
+TEST_F(AnalysisManagerTest, DependencyCacheShared) {
+    AnalysisManager AM;
+    AM.registerPass<CountingAnalysis>();
+    AM.registerPass<DependentAnalysis>();
+
+    AM.getResult<DependentAnalysis>(func);
+    auto& base = AM.getResult<CountingAnalysis>(func);
+    EXPECT_EQ(CountingAnalysis::runCount, 1);
+    EXPECT_EQ(base.value, 42);
+}
+
+TEST_F(AnalysisManagerTest, InvalidatingDependency) {
+    AnalysisManager AM;
+    AM.registerPass<CountingAnalysis>();
+    AM.registerPass<DependentAnalysis>();
+
+    AM.getResult<DependentAnalysis>(func);
+    EXPECT_EQ(DependentAnalysis::runCount, 1);
+    EXPECT_EQ(CountingAnalysis::runCount, 1);
+
+    // Invalidate the dependency (CountingAnalysis), keep DependentAnalysis
+    PreservedAnalyses PA;
+    PA.preserve<DependentAnalysis>();
+    AM.invalidate(func, PA);
+
+    // CountingAnalysis was evicted, request it again
+    AM.getResult<CountingAnalysis>(func);
+    EXPECT_EQ(CountingAnalysis::runCount, 2);
+}
+
+// -----------------------------------------------------------------------
+// PassManager + AM integration (end-to-end)
+// -----------------------------------------------------------------------
+
+// Helper: a pass that requests an analysis and preserves everything
+class AnalysisUserPass : public Pass {
+   public:
+    static char ID;
+    std::function<PreservedAnalyses(AnalysisManager&, Function&)> action;
+
+    AnalysisUserPass(std::function<PreservedAnalyses(AnalysisManager&, Function&)> action)
+        : action(std::move(action)) {}
+
+    PassID getPassID() const override {
+        return &ID;
+    }
+    const char* getName() const override {
+        return "AnalysisUserPass";
+    }
+
+    PreservedAnalyses run(Function& func, PassContext& /*ctx*/, AnalysisManager& AM) override {
+        return action(AM, func);
+    }
+};
+char AnalysisUserPass::ID = 0;
+
+TEST_F(AnalysisManagerTest, PipelineCacheReuse) {
+    CountingAnalysis::runCount = 0;
+
+    PassManager PM;
+    PM.getAnalysisManager().registerPass<CountingAnalysis>();
+
+    // PassA: requests CountingAnalysis, preserves it
+    PM.addPass(std::make_unique<AnalysisUserPass>([](AnalysisManager& AM, Function& F) {
+        AM.getResult<CountingAnalysis>(F);
+        PreservedAnalyses PA;
+        PA.preserve<CountingAnalysis>();
+        return PA;
+    }));
+
+    // PassB: requests CountingAnalysis (should be cached)
+    PM.addPass(std::make_unique<AnalysisUserPass>([](AnalysisManager& AM, Function& F) {
+        AM.getResult<CountingAnalysis>(F);
+        return PreservedAnalyses::all();
+    }));
+
+    PM.run(func);
+    EXPECT_EQ(CountingAnalysis::runCount, 1);
+}
+
+TEST_F(AnalysisManagerTest, PipelineRecomputation) {
+    CountingAnalysis::runCount = 0;
+
+    PassManager PM;
+    PM.getAnalysisManager().registerPass<CountingAnalysis>();
+
+    // PassA: requests CountingAnalysis, preserves nothing
+    PM.addPass(std::make_unique<AnalysisUserPass>([](AnalysisManager& AM, Function& F) {
+        AM.getResult<CountingAnalysis>(F);
+        return PreservedAnalyses::none();
+    }));
+
+    // PassB: requests CountingAnalysis (must recompute)
+    PM.addPass(std::make_unique<AnalysisUserPass>([](AnalysisManager& AM, Function& F) {
+        AM.getResult<CountingAnalysis>(F);
+        return PreservedAnalyses::all();
+    }));
+
+    PM.run(func);
+    EXPECT_EQ(CountingAnalysis::runCount, 2);
+}
+
+TEST_F(AnalysisManagerTest, PipelineAllPreserved) {
+    CountingAnalysis::runCount = 0;
+    SecondAnalysis::runCount = 0;
+
+    PassManager PM;
+    PM.getAnalysisManager().registerPass<CountingAnalysis>();
+    PM.getAnalysisManager().registerPass<SecondAnalysis>();
+
+    // PassA: requests both, returns all()
+    PM.addPass(std::make_unique<AnalysisUserPass>([](AnalysisManager& AM, Function& F) {
+        AM.getResult<CountingAnalysis>(F);
+        AM.getResult<SecondAnalysis>(F);
+        return PreservedAnalyses::all();
+    }));
+
+    // PassB: requests both
+    PM.addPass(std::make_unique<AnalysisUserPass>([](AnalysisManager& AM, Function& F) {
+        AM.getResult<CountingAnalysis>(F);
+        AM.getResult<SecondAnalysis>(F);
+        return PreservedAnalyses::all();
+    }));
+
+    PM.run(func);
+    EXPECT_EQ(CountingAnalysis::runCount, 1);
+    EXPECT_EQ(SecondAnalysis::runCount, 1);
+}
+
+TEST_F(AnalysisManagerTest, PipelineNonePreserved) {
+    CountingAnalysis::runCount = 0;
+    SecondAnalysis::runCount = 0;
+
+    PassManager PM;
+    PM.getAnalysisManager().registerPass<CountingAnalysis>();
+    PM.getAnalysisManager().registerPass<SecondAnalysis>();
+
+    // PassA: requests both, returns none()
+    PM.addPass(std::make_unique<AnalysisUserPass>([](AnalysisManager& AM, Function& F) {
+        AM.getResult<CountingAnalysis>(F);
+        AM.getResult<SecondAnalysis>(F);
+        return PreservedAnalyses::none();
+    }));
+
+    // PassB: requests both (must recompute)
+    PM.addPass(std::make_unique<AnalysisUserPass>([](AnalysisManager& AM, Function& F) {
+        AM.getResult<CountingAnalysis>(F);
+        AM.getResult<SecondAnalysis>(F);
+        return PreservedAnalyses::all();
+    }));
+
+    PM.run(func);
+    EXPECT_EQ(CountingAnalysis::runCount, 2);
+    EXPECT_EQ(SecondAnalysis::runCount, 2);
+}
+
+TEST_F(AnalysisManagerTest, ScopeAdaptorEvictsOuterCache) {
+    // Simulate: PassA caches analysis → ScopeAdaptor returns none() →
+    // PassB must recompute. This mirrors the real pattern where
+    // ScopeAdaptor extracts/splices instructions, invalidating everything.
+    CountingAnalysis::runCount = 0;
+
+    PassManager PM;
+    PM.getAnalysisManager().registerPass<CountingAnalysis>();
+
+    // PassA: computes and caches analysis
+    PM.addPass(std::make_unique<AnalysisUserPass>([](AnalysisManager& AM, Function& F) {
+        AM.getResult<CountingAnalysis>(F);
+        return PreservedAnalyses::all();
+    }));
+
+    // Simulated ScopeAdaptor: returns none() (instructions were extracted/spliced)
+    PM.addPass(std::make_unique<AnalysisUserPass>(
+        [](AnalysisManager&, Function&) { return PreservedAnalyses::none(); }));
+
+    // PassB: must recompute — cache was wiped by ScopeAdaptor
+    PM.addPass(std::make_unique<AnalysisUserPass>([](AnalysisManager& AM, Function& F) {
+        AM.getResult<CountingAnalysis>(F);
+        return PreservedAnalyses::all();
+    }));
+
+    PM.run(func);
+    EXPECT_EQ(CountingAnalysis::runCount, 2);  // computed in PassA and PassB
+}
+
+// -----------------------------------------------------------------------
+// Edge cases
+// -----------------------------------------------------------------------
+
+TEST_F(AnalysisManagerTest, EmptyFunction) {
+    // func has no BBs — analyses should handle gracefully
+    AnalysisManager AM;
+    AM.registerPass<BBIndexAnalysis>();
+    AM.registerPass<DominanceAnalysis>();
+    AM.registerPass<LoopAnalysis>();
+
+    auto& bbIndex = AM.getResult<BBIndexAnalysis>(func);
+    EXPECT_TRUE(bbIndex.rpo.empty());
+
+    auto& domInfo = AM.getResult<DominanceAnalysis>(func);
+    EXPECT_TRUE(domInfo.rpo.empty());
+
+    auto& loops = AM.getResult<LoopAnalysis>(func);
+    EXPECT_TRUE(loops.empty());
+}
+
+TEST_F(AnalysisManagerTest, SingleBlockFunction) {
+    func.createBasicBlock("entry");
+
+    AnalysisManager AM;
+    AM.registerPass<BBIndexAnalysis>();
+    AM.registerPass<DominanceAnalysis>();
+    AM.registerPass<LoopAnalysis>();
+
+    auto& bbIndex = AM.getResult<BBIndexAnalysis>(func);
+    EXPECT_EQ(bbIndex.rpo.size(), 1u);
+
+    auto& domInfo = AM.getResult<DominanceAnalysis>(func);
+    EXPECT_EQ(domInfo.rpo.size(), 1u);
+
+    auto& loops = AM.getResult<LoopAnalysis>(func);
+    EXPECT_TRUE(loops.empty());
+}
+
+TEST_F(AnalysisManagerTest, InvalidateEmptyCache) {
+    AnalysisManager AM;
+    AM.registerPass<CountingAnalysis>();
+    // invalidate on empty cache — should not crash
+    AM.invalidate(func, PreservedAnalyses::none());
+}
+
+TEST_F(AnalysisManagerTest, ClearEmptyCache) {
+    AnalysisManager AM;
+    // clear on empty cache — should not crash
+    AM.clear();
+}
+
+TEST_F(AnalysisManagerTest, RegisterPassTwice) {
+    AnalysisManager AM;
+    AM.registerPass<CountingAnalysis>();
+    // Second registration overwrites — should not crash
+    AM.registerPass<CountingAnalysis>();
+
+    auto& result = AM.getResult<CountingAnalysis>(func);
+    EXPECT_EQ(result.value, 42);
+    EXPECT_EQ(CountingAnalysis::runCount, 1);
+}
+
+// -----------------------------------------------------------------------
+// Real analyses with CFG
+// -----------------------------------------------------------------------
+
+TEST_F(AnalysisManagerTest, DiamondCFGAnalyses) {
+    // Build diamond: entry -> then, entry -> else, then -> merge, else -> merge
+    BasicBlock* entry = func.createBasicBlock("entry");
+    BasicBlock* thenBB = func.createBasicBlock("then");
+    BasicBlock* elseBB = func.createBasicBlock("else");
+    BasicBlock* mergeBB = func.createBasicBlock("merge");
+
+    func.addEdge(entry, thenBB);
+    func.addEdge(entry, elseBB);
+    func.addEdge(thenBB, mergeBB);
+    func.addEdge(elseBB, mergeBB);
+
+    AnalysisManager AM;
+    AM.registerPass<BBIndexAnalysis>();
+    AM.registerPass<DominanceAnalysis>();
+    AM.registerPass<LoopAnalysis>();
+
+    auto& bbIndex = AM.getResult<BBIndexAnalysis>(func);
+    EXPECT_EQ(bbIndex.rpo.size(), 4u);
+    EXPECT_EQ(bbIndex.rpo[0], entry);
+    EXPECT_EQ(bbIndex.index.at(entry), 0u);
+
+    auto& domInfo = AM.getResult<DominanceAnalysis>(func);
+    EXPECT_EQ(domInfo.rpo.size(), 4u);
+    // Entry dominates itself
+    EXPECT_EQ(domInfo.idom[0], 0u);
+
+    auto& loops = AM.getResult<LoopAnalysis>(func);
+    EXPECT_TRUE(loops.empty());
+}
+
+TEST_F(AnalysisManagerTest, LoopCFGAnalysis) {
+    // Build loop: entry -> header -> body -> header (back-edge)
+    BasicBlock* entry = func.createBasicBlock("entry");
+    BasicBlock* header = func.createBasicBlock("header");
+    BasicBlock* body = func.createBasicBlock("body");
+    BasicBlock* exit = func.createBasicBlock("exit");
+
+    func.addEdge(entry, header);
+    func.addEdge(header, body);
+    func.addEdge(body, header);
+    func.addEdge(header, exit);
+
+    AnalysisManager AM;
+    AM.registerPass<LoopAnalysis>();
+
+    auto& loops = AM.getResult<LoopAnalysis>(func);
+    EXPECT_EQ(loops.size(), 1u);
+    EXPECT_EQ(loops[0].headerBB, header);
+    EXPECT_EQ(loops[0].latchBB, body);
+}
+
+// -----------------------------------------------------------------------
+// Dependency cascade invalidation
+// -----------------------------------------------------------------------
+
+TEST_F(AnalysisManagerTest, DependencyCascadeRecomputation) {
+    // DependentAnalysis calls AM.getResult<CountingAnalysis> in its run().
+    // Invalidate CountingAnalysis (the dependency), then request DependentAnalysis.
+    // Both should recompute.
+    AnalysisManager AM;
+    AM.registerPass<CountingAnalysis>();
+    AM.registerPass<DependentAnalysis>();
+
+    AM.getResult<DependentAnalysis>(func);
+    EXPECT_EQ(CountingAnalysis::runCount, 1);
+    EXPECT_EQ(DependentAnalysis::runCount, 1);
+
+    // Invalidate both (none preserved)
+    AM.invalidate(func, PreservedAnalyses::none());
+
+    // Request DependentAnalysis again — triggers CountingAnalysis recompute too
+    AM.getResult<DependentAnalysis>(func);
+    EXPECT_EQ(CountingAnalysis::runCount, 2);
+    EXPECT_EQ(DependentAnalysis::runCount, 2);
+}
+
+// -----------------------------------------------------------------------
+// Pipeline ordering and mixed preservation
+// -----------------------------------------------------------------------
+
+TEST_F(AnalysisManagerTest, ThreePassPipelineMixedPreservation) {
+    // PassA computes CountingAnalysis + SecondAnalysis, preserves both.
+    // PassB preserves only CountingAnalysis (evicts SecondAnalysis).
+    // PassC requests both — CountingAnalysis cached, SecondAnalysis recomputed.
+    CountingAnalysis::runCount = 0;
+    SecondAnalysis::runCount = 0;
+
+    PassManager PM;
+    PM.getAnalysisManager().registerPass<CountingAnalysis>();
+    PM.getAnalysisManager().registerPass<SecondAnalysis>();
+
+    PM.addPass(std::make_unique<AnalysisUserPass>([](AnalysisManager& AM, Function& F) {
+        AM.getResult<CountingAnalysis>(F);
+        AM.getResult<SecondAnalysis>(F);
+        return PreservedAnalyses::all();
+    }));
+    PM.addPass(std::make_unique<AnalysisUserPass>([](AnalysisManager& AM, Function& F) {
+        PreservedAnalyses PA;
+        PA.preserve<CountingAnalysis>();
+        return PA;  // evicts SecondAnalysis
+    }));
+    PM.addPass(std::make_unique<AnalysisUserPass>([](AnalysisManager& AM, Function& F) {
+        AM.getResult<CountingAnalysis>(F);
+        AM.getResult<SecondAnalysis>(F);
+        return PreservedAnalyses::all();
+    }));
+
+    PM.run(func);
+    EXPECT_EQ(CountingAnalysis::runCount, 1);  // cached through PassB
+    EXPECT_EQ(SecondAnalysis::runCount, 2);    // evicted by PassB, recomputed in PassC
+}
+
+TEST_F(AnalysisManagerTest, MultiplePMRunsStartFresh) {
+    // PM.run() calls clear() at start. Running PM twice should recompute.
+    CountingAnalysis::runCount = 0;
+
+    PassManager PM;
+    PM.getAnalysisManager().registerPass<CountingAnalysis>();
+
+    PM.addPass(std::make_unique<AnalysisUserPass>([](AnalysisManager& AM, Function& F) {
+        AM.getResult<CountingAnalysis>(F);
+        return PreservedAnalyses::all();
+    }));
+
+    PM.run(func);
+    EXPECT_EQ(CountingAnalysis::runCount, 1);
+
+    PM.run(func);  // clear() at start evicts everything
+    EXPECT_EQ(CountingAnalysis::runCount, 2);
+}
+
+TEST_F(AnalysisManagerTest, GetCachedResultAfterInvalidation) {
+    AnalysisManager AM;
+    AM.registerPass<CountingAnalysis>();
+
+    AM.getResult<CountingAnalysis>(func);
+    EXPECT_NE(AM.getCachedResult<CountingAnalysis>(), nullptr);
+
+    AM.invalidate(func, PreservedAnalyses::none());
+    EXPECT_EQ(AM.getCachedResult<CountingAnalysis>(), nullptr);
+}
+
+TEST_F(AnalysisManagerTest, InterleavedGetResults) {
+    // Request A, then B, then A again — no interference
+    AnalysisManager AM;
+    AM.registerPass<CountingAnalysis>();
+    AM.registerPass<SecondAnalysis>();
+
+    auto& a1 = AM.getResult<CountingAnalysis>(func);
+    EXPECT_EQ(a1.value, 42);
+
+    auto& b = AM.getResult<SecondAnalysis>(func);
+    EXPECT_EQ(b.value, 99);
+
+    auto& a2 = AM.getResult<CountingAnalysis>(func);
+    EXPECT_EQ(a2.value, 42);
+
+    EXPECT_EQ(CountingAnalysis::runCount, 1);  // still cached
+    EXPECT_EQ(SecondAnalysis::runCount, 1);
+}

--- a/shared/stinkytofu/tests/unit/ir/IntrinsicExpansionPassTest.cpp
+++ b/shared/stinkytofu/tests/unit/ir/IntrinsicExpansionPassTest.cpp
@@ -55,6 +55,7 @@ class IntrinsicExpansionPassTest : public ::testing::Test {
 
     GemmTileConfig defaultConfig = {{12, 5, 0}, 128, 128, 64, 0, 0, 0};
     PassContext passCtx;
+    AnalysisManager am;
 };
 
 TEST_F(IntrinsicExpansionPassTest, ExpandSimpleIntrinsic) {
@@ -75,7 +76,7 @@ TEST_F(IntrinsicExpansionPassTest, ExpandSimpleIntrinsic) {
 
     // Run IntrinsicExpansionPass
     auto pass = createIntrinsicExpansionPass();
-    pass->run(func, passCtx);
+    pass->run(func, passCtx, am);
 
     // After expansion, IntrinsicCall should be replaced with expanded instructions
     // ReluF32 expands to 1 instruction (v_max_f32)
@@ -117,7 +118,7 @@ TEST_F(IntrinsicExpansionPassTest, UnknownIntrinsicFails) {
 
     // Run IntrinsicExpansionPass - should fail gracefully
     auto pass = createIntrinsicExpansionPass();
-    pass->run(func, passCtx);
+    pass->run(func, passCtx, am);
 
     // IntrinsicCall should still be there (expansion failed)
     bool hasIntrinsicCall = false;
@@ -153,7 +154,7 @@ TEST_F(IntrinsicExpansionPassTest, MultipleIntrinsicCalls) {
 
     // Run IntrinsicExpansionPass
     auto pass = createIntrinsicExpansionPass();
-    pass->run(func, passCtx);
+    pass->run(func, passCtx, am);
 
     // Should have 2 instructions (each ReluF32 expands to 1 v_max_f32)
     EXPECT_EQ(bb->size(), 2) << "Both IntrinsicCalls should be expanded to v_max_f32";

--- a/shared/stinkytofu/tests/unit/logical/LogicalPeepholePassTest.cpp
+++ b/shared/stinkytofu/tests/unit/logical/LogicalPeepholePassTest.cpp
@@ -46,13 +46,14 @@ class LogicalPeepholePassTest : public ::testing::Test {
 
     void runPass() {
         auto pass = createLogicalPeepholePass();
-        pass->run(func, *passCtx);
+        pass->run(func, *passCtx, am);
     }
 
     Function func{"kernel"};
     std::unique_ptr<PassContext> passCtx;
     BasicBlock* bb;
     GfxArchID arch;
+    AnalysisManager am;
 };
 
 // Test: Pass can be instantiated and run

--- a/shared/stinkytofu/tools/stinkytofu-opt/stinkytofu-opt.cpp
+++ b/shared/stinkytofu/tools/stinkytofu-opt/stinkytofu-opt.cpp
@@ -59,7 +59,7 @@ class DeserializeStinkytofuIRPass : public StinkyInstPass {
         return &DeserializeStinkytofuIRPass::ID;
     }
 
-    void run(Function& func, PassContext& passCtx) override {
+    PreservedAnalyses run(Function& func, PassContext& passCtx, AnalysisManager& /*AM*/) override {
         GfxArchID arch =
             getGfxArchID(passCtx.getGemmTileConfig().arch[0], passCtx.getGemmTileConfig().arch[1],
                          passCtx.getGemmTileConfig().arch[2]);
@@ -76,7 +76,9 @@ class DeserializeStinkytofuIRPass : public StinkyInstPass {
                 std::cerr << "Error: Failed to populate IRList from string. Error code: "
                           << static_cast<int>(result) << "\n";
             }
+            return PreservedAnalyses::none();
         }
+        return PreservedAnalyses::none();
     }
 
    private:

--- a/shared/stinkytofu/tools/stinkytofu-opt/stinkytofu-opt.cpp
+++ b/shared/stinkytofu/tools/stinkytofu-opt/stinkytofu-opt.cpp
@@ -31,6 +31,7 @@
 #include <string>
 #include <vector>
 
+#include "stinkytofu/analysis/AnalysisRegistration.hpp"
 #include "stinkytofu/hardware/ArchHelper.hpp"
 #include "stinkytofu/ir/asm/StinkyAsmIR.hpp"
 #include "stinkytofu/serialization/asm/IRConverter.hpp"
@@ -318,6 +319,7 @@ int main(int argc, char** argv) {
     // Process each function independently
     for (auto& parsedFunc : parsed.functions) {
         stinkytofu::PassManager passManager;
+        stinkytofu::registerAllAnalyses(passManager.getAnalysisManager());
 
         passManager.addInstrumentation(createDebugPrintInstrumentation());
         if (!passFeatureConfig.passOrderSnapshot.jsonPath.empty()) {


### PR DESCRIPTION
## Motivation

Passes currently compute their own analysis data (dominance, loop detection, etc.) independently, leading to redundant work when multiple passes need the same information. This PR introduces an AnalysisManager that computes analyses on demand, caches results for reuse, and invalidates them only when IR-modifying passes require it.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

  AnalysisManager
  - Central registry for analysis passes with lazy computation and result caching
  - Tracks invalidation via PreservedAnalyses returned by each transformation pass
  - Recomputes only the analyses that were invalidated

  Analysis passes
  - DominanceAnalysis — dominator tree and dominance frontiers
  - BBIndexAnalysis — RPO-ordered BasicBlock index map
  - LoopAnalysis — natural loop detection via CFG back-edges

  Pass interface changes
  - Pass::run() now takes AnalysisManager& and returns PreservedAnalyses
  - Transformation passes declare which analyses they preserve (e.g. preserveCFGAnalyses() for instruction reordering that doesn't modify the CFG)
  - Analysis passes are read-only and registered once at pipeline setup via registerAllAnalyses()
  
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

codegen test and unittest passed.

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
