### PR TITLE
[hipBLAS] add cleanup workaround

### DIFF
--- a/projects/hipblas/clients/gtest/hipblas_gtest_main.cpp
+++ b/projects/hipblas/clients/gtest/hipblas_gtest_main.cpp
@@ -350,10 +350,11 @@ int main(int argc, char** argv)
     (void)hipDeviceSynchronize();
     (void)hipDeviceReset();
 
+#ifdef WIN32
     // Use quick_exit() to bypass C++ static destructors and atexit() handlers.
     // Post-main cleanup in linked DLLs (HIP runtime) crash in comgr
     std::quick_exit(status);
-
-    // TODO restore
-    // return status
+#else
+    return status;
+#endif
 }

--- a/projects/hipblas/clients/gtest/hipblas_gtest_main.cpp
+++ b/projects/hipblas/clients/gtest/hipblas_gtest_main.cpp
@@ -350,5 +350,10 @@ int main(int argc, char** argv)
     (void)hipDeviceSynchronize();
     (void)hipDeviceReset();
 
-    return status;
+    // Use quick_exit() to bypass C++ static destructors and atexit() handlers.
+    // Post-main cleanup in linked DLLs (HIP runtime) crash in comgr
+    std::quick_exit(status);
+
+    // TODO restore
+    // return status
 }


### PR DESCRIPTION
## Motivation

This pull request updates the program's exit strategy in `hipblas_gtest_main.cpp` to address crashes during post-main cleanup in the HIP runtime. Instead of using a standard return, the code now calls `std::quick_exit` to bypass C++ static destructors and `atexit()` handlers, which helps avoid issues in linked DLLs.

**Exit handling changes:**

* Replaced `return status;` with `std::quick_exit(status);` in `main` to prevent crashes during post-main cleanup in the HIP runtime, as static destructors and `atexit()` handlers are bypassed.
* Added a comment and a TODO to potentially restore the original return statement in the future.