### PR TITLE
[hipDNN] RFC: Federated Merge Queues for rocm-libraries

### DIFF
--- a/.github/scripts/github_cli_client.py
+++ b/.github/scripts/github_cli_client.py
@@ -47,7 +47,7 @@ import os
 import requests
 import time
 import logging
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -361,3 +361,107 @@ class GitHubCLIClient:
             else:
                 email = f"{username}@users.noreply.github.com"
         return name, email
+
+    # ── Merge Queue helpers ───────────────────────────────────────────
+
+    def get_pr_reviews(self, repo: str, pr_number: int) -> List[dict]:
+        """Fetch all reviews for a pull request."""
+        url = f"{self.api_url}/repos/{repo}/pulls/{pr_number}/reviews?per_page=100"
+        return self._get_paginated_json(
+            url, f"Failed to fetch reviews for PR #{pr_number} in {repo}"
+        )
+
+    def get_check_runs(self, repo: str, sha: str) -> List[dict]:
+        """Fetch check runs for a commit SHA."""
+        url = f"{self.api_url}/repos/{repo}/commits/{sha}/check-runs?per_page=100"
+        data = self._get_json(url, f"Failed to fetch check runs for {sha}")
+        return data.get("check_runs", [])
+
+    def get_combined_status(self, repo: str, sha: str) -> Dict:
+        """Fetch the combined commit status for a SHA."""
+        url = f"{self.api_url}/repos/{repo}/commits/{sha}/status"
+        return self._get_json(url, f"Failed to fetch status for {sha}")
+
+    def update_pr_branch(self, repo: str, pr_number: int) -> bool:
+        """Update a PR branch by merging the base branch into it.
+
+        Returns True on success, False on conflict or error.
+        """
+        url = f"{self.api_url}/repos/{repo}/pulls/{pr_number}/update-branch"
+        result = self._request_json(
+            "PUT", url, {"expected_head_sha": None},
+            f"Failed to update branch for PR #{pr_number} in {repo}",
+        )
+        # Empty dict with no error means 204/success, or result has "message"
+        if result.get("message") and "merge conflict" in result["message"].lower():
+            return False
+        return True
+
+    def merge_pr(self, repo: str, pr_number: int, method: str = "squash") -> bool:
+        """Merge a pull request. Returns True on success."""
+        url = f"{self.api_url}/repos/{repo}/pulls/{pr_number}/merge"
+        result = self._request_json(
+            "PUT",
+            url,
+            {"merge_method": method},
+            f"Failed to merge PR #{pr_number} in {repo}",
+        )
+        return result.get("merged", False)
+
+    def add_labels(self, repo: str, issue_number: int, labels: List[str]) -> None:
+        """Add labels to an issue or PR."""
+        url = f"{self.api_url}/repos/{repo}/issues/{issue_number}/labels"
+        self._request_json(
+            "POST", url, {"labels": labels},
+            f"Failed to add labels to #{issue_number} in {repo}",
+        )
+
+    def remove_label(self, repo: str, issue_number: int, label: str) -> None:
+        """Remove a single label from an issue or PR."""
+        url = f"{self.api_url}/repos/{repo}/issues/{issue_number}/labels/{label}"
+        self._request_json(
+            "DELETE", url, None,
+            f"Failed to remove label '{label}' from #{issue_number} in {repo}",
+        )
+
+    def add_comment(self, repo: str, issue_number: int, body: str) -> dict:
+        """Add a comment to an issue or PR."""
+        url = f"{self.api_url}/repos/{repo}/issues/{issue_number}/comments"
+        return self._request_json(
+            "POST", url, {"body": body},
+            f"Failed to add comment to #{issue_number} in {repo}",
+        )
+
+    def update_comment(self, repo: str, comment_id: int, body: str) -> dict:
+        """Update an existing comment."""
+        url = f"{self.api_url}/repos/{repo}/issues/comments/{comment_id}"
+        return self._request_json(
+            "PATCH", url, {"body": body},
+            f"Failed to update comment {comment_id} in {repo}",
+        )
+
+    def get_comments(self, repo: str, issue_number: int) -> List[dict]:
+        """Fetch all comments on an issue or PR."""
+        url = f"{self.api_url}/repos/{repo}/issues/{issue_number}/comments?per_page=100"
+        return self._get_paginated_json(
+            url, f"Failed to fetch comments for #{issue_number} in {repo}",
+        )
+
+    def get_collaborator_permission(self, repo: str, username: str) -> str:
+        """Get a user's permission level on a repository."""
+        url = f"{self.api_url}/repos/{repo}/collaborators/{username}/permission"
+        data = self._get_json(
+            url, f"Failed to check permissions for {username} in {repo}"
+        )
+        return data.get("permission", "")
+
+    def search_issues(
+        self, query: str, sort: str = "created", order: str = "asc"
+    ) -> List[dict]:
+        """Search issues/PRs using the GitHub search API."""
+        url = (
+            f"{self.api_url}/search/issues"
+            f"?q={requests.utils.quote(query)}&sort={sort}&order={order}&per_page=100"
+        )
+        data = self._get_json(url, f"Failed to search issues: {query}")
+        return data.get("items", [])

--- a/.github/scripts/github_cli_client.py
+++ b/.github/scripts/github_cli_client.py
@@ -389,11 +389,11 @@ class GitHubCLIClient:
         """
         url = f"{self.api_url}/repos/{repo}/pulls/{pr_number}/update-branch"
         result = self._request_json(
-            "PUT", url, {"expected_head_sha": None},
+            "PUT", url, {},
             f"Failed to update branch for PR #{pr_number} in {repo}",
         )
-        # Empty dict with no error means 204/success, or result has "message"
-        if result.get("message") and "merge conflict" in result["message"].lower():
+        msg = result.get("message", "").lower()
+        if "merge conflict" in msg:
             return False
         return True
 

--- a/.github/scripts/merge_queue.py
+++ b/.github/scripts/merge_queue.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+
+"""
+Merge Queue Logic
+-----------------
+Shared functions for the hipDNN/provider merge queue system.
+
+Provides queue detection, FIFO ordering, multi-queue coordination,
+CI status checking, and PR merge operations.
+"""
+
+import json
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Tuple
+
+from github_cli_client import GitHubCLIClient
+from merge_queue_config import (
+    ALL_QUEUES,
+    LABEL_ACTIVE,
+    LABEL_PREFIX,
+    LABEL_QUEUED,
+    MERGE_METHOD,
+    METADATA_COMMENT_MARKER,
+    PATH_TO_QUEUES,
+    STATUS_COMMENT_MARKER,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def detect_queues(changed_files: List[str]) -> List[str]:
+    """Map changed file paths to the set of merge queues the PR should enter.
+
+    A file matching ``projects/hipdnn/`` enters all queues (core can break
+    providers).  Provider files enter only their own queue.  The union across
+    all changed files is returned, sorted and deduplicated.
+    """
+    queues: set[str] = set()
+    for filepath in changed_files:
+        for prefix, queue_list in PATH_TO_QUEUES.items():
+            if filepath.startswith(prefix):
+                queues.update(queue_list)
+                break  # first prefix match per file is enough
+    return sorted(queues)
+
+
+# ── Metadata comment helpers ─────────────────────────────────────────
+
+
+def _parse_metadata_comment(body: str) -> Optional[dict]:
+    """Extract JSON from a merge-queue metadata HTML comment."""
+    pattern = re.compile(
+        rf"{re.escape(METADATA_COMMENT_MARKER)}\s*(\{{.*?\}})\s*-->",
+        re.DOTALL,
+    )
+    match = pattern.search(body)
+    if match:
+        try:
+            return json.loads(match.group(1))
+        except json.JSONDecodeError:
+            return None
+    return None
+
+
+def _build_metadata_comment(metadata: dict) -> str:
+    """Build the hidden HTML comment that stores queue metadata on a PR."""
+    return f"{METADATA_COMMENT_MARKER} {json.dumps(metadata)} -->"
+
+
+def get_enqueue_metadata(
+    client: GitHubCLIClient, repo: str, pr_number: int
+) -> Optional[dict]:
+    """Read merge-queue metadata from PR comments.  Returns None if not queued."""
+    comments = client.get_comments(repo, pr_number)
+    for comment in comments:
+        meta = _parse_metadata_comment(comment.get("body", ""))
+        if meta is not None:
+            meta["_comment_id"] = comment["id"]
+            return meta
+    return None
+
+
+def _delete_metadata_comment(
+    client: GitHubCLIClient, repo: str, pr_number: int
+) -> None:
+    """Remove the metadata comment from a PR (cleanup on dequeue)."""
+    comments = client.get_comments(repo, pr_number)
+    for comment in comments:
+        if METADATA_COMMENT_MARKER in comment.get("body", ""):
+            url = f"{client.api_url}/repos/{repo}/issues/comments/{comment['id']}"
+            client._request_json("DELETE", url, None, "Failed to delete metadata comment")
+            break
+
+
+# ── Enqueue / Dequeue ────────────────────────────────────────────────
+
+
+def enqueue_pr(
+    client: GitHubCLIClient,
+    repo: str,
+    pr_number: int,
+    queues: List[str],
+    user: str,
+) -> None:
+    """Add a PR to the merge queue.
+
+    Adds the ``mq:queued`` label plus one ``mq:<queue>`` label per queue,
+    and posts a hidden metadata comment for FIFO ordering.
+    """
+    now = datetime.now(timezone.utc).isoformat()
+    metadata = {
+        "enqueued_at": now,
+        "queues": queues,
+        "enqueued_by": user,
+    }
+
+    labels = [LABEL_QUEUED] + [f"{LABEL_PREFIX}{q}" for q in queues]
+    client.add_labels(repo, pr_number, labels)
+    client.add_comment(repo, pr_number, _build_metadata_comment(metadata))
+
+    logger.info(f"PR #{pr_number} enqueued in {queues} by @{user}")
+
+
+def dequeue_pr(
+    client: GitHubCLIClient,
+    repo: str,
+    pr_number: int,
+    reason: str,
+) -> None:
+    """Remove a PR from all merge queues.
+
+    Strips every ``mq:*`` label and posts a comment explaining why.
+    """
+    existing = client.get_existing_labels_on_pr(repo, pr_number)
+    mq_labels = [l for l in existing if l.startswith(LABEL_PREFIX)]
+    for label in mq_labels:
+        client.remove_label(repo, pr_number, label)
+
+    _delete_metadata_comment(client, repo, pr_number)
+    client.add_comment(repo, pr_number, f"**Merge Queue:** {reason}")
+    logger.info(f"PR #{pr_number} dequeued: {reason}")
+
+
+# ── Queue membership queries ────────────────────────────────────────
+
+
+def get_queue_members(
+    client: GitHubCLIClient, repo: str, queue: str
+) -> List[dict]:
+    """Return all PRs in a given queue, sorted oldest-first (FIFO).
+
+    Each entry: ``{"pr_number": int, "enqueued_at": str, "queues": [str]}``.
+    """
+    label = f"{LABEL_PREFIX}{queue}"
+    # Search for open PRs with the queue label AND either queued or active
+    query = (
+        f"repo:{repo} is:pr is:open label:{label} "
+        f"(label:{LABEL_QUEUED} OR label:{LABEL_ACTIVE})"
+    )
+    items = client.search_issues(query, sort="created", order="asc")
+
+    members: list[dict] = []
+    for item in items:
+        pr_num = item["number"]
+        meta = get_enqueue_metadata(client, repo, pr_num)
+        if meta:
+            members.append(
+                {
+                    "pr_number": pr_num,
+                    "enqueued_at": meta["enqueued_at"],
+                    "queues": meta["queues"],
+                }
+            )
+        else:
+            # Fallback: use the issue created_at if metadata is missing
+            members.append(
+                {
+                    "pr_number": pr_num,
+                    "enqueued_at": item.get("created_at", ""),
+                    "queues": [],
+                }
+            )
+
+    # Sort by enqueue timestamp (FIFO)
+    members.sort(key=lambda m: m["enqueued_at"])
+    return members
+
+
+def get_queue_head(
+    client: GitHubCLIClient, repo: str, queue: str
+) -> Optional[int]:
+    """Return the PR number at the front of a queue, or None if empty."""
+    members = get_queue_members(client, repo, queue)
+    return members[0]["pr_number"] if members else None
+
+
+def is_at_front_of_all_queues(
+    client: GitHubCLIClient,
+    repo: str,
+    pr_number: int,
+    queues: List[str],
+) -> Tuple[bool, List[str]]:
+    """Check whether a PR is at the head of every queue it belongs to.
+
+    Returns ``(is_ready, blocking_queues)`` where *blocking_queues* lists
+    the queues where another PR is ahead.
+    """
+    blocking: list[str] = []
+    for queue in queues:
+        head = get_queue_head(client, repo, queue)
+        if head != pr_number:
+            blocking.append(queue)
+    return (len(blocking) == 0, blocking)
+
+
+# ── CI status ────────────────────────────────────────────────────────
+
+
+def check_ci_status(
+    client: GitHubCLIClient, repo: str, pr_number: int
+) -> str:
+    """Check CI status for the PR's current HEAD commit.
+
+    Returns ``"success"``, ``"pending"``, or ``"failure"``.
+    """
+    pr_data = client.get_pr_by_number(repo, pr_number)
+    if not pr_data:
+        return "failure"
+
+    sha = pr_data.get("head", {}).get("sha", "")
+    if not sha:
+        return "failure"
+
+    # Check both check-runs and commit statuses
+    check_runs = client.get_check_runs(repo, sha)
+    combined = client.get_combined_status(repo, sha)
+
+    # If there are no checks at all, treat as pending (CI hasn't started)
+    statuses = combined.get("statuses", [])
+    if not check_runs and not statuses:
+        return "pending"
+
+    # Check runs
+    for run in check_runs:
+        # Skip the merge queue's own status checks
+        if run.get("name", "").startswith("Merge Queue"):
+            continue
+        status = run.get("status", "")
+        conclusion = run.get("conclusion", "")
+        if status != "completed":
+            return "pending"
+        if conclusion not in ("success", "skipped", "neutral"):
+            return "failure"
+
+    # Commit statuses (from status API)
+    combined_state = combined.get("state", "pending")
+    if combined_state == "failure" or combined_state == "error":
+        return "failure"
+    if combined_state == "pending" and statuses:
+        return "pending"
+
+    return "success"
+
+
+# ── Branch update and merge ──────────────────────────────────────────
+
+
+def update_pr_branch(
+    client: GitHubCLIClient, repo: str, pr_number: int
+) -> bool:
+    """Merge the base branch into the PR branch.
+
+    Returns True on success, False on merge conflict.
+    """
+    pr_data = client.get_pr_by_number(repo, pr_number)
+    if not pr_data:
+        return False
+
+    # Check if already up to date
+    mergeable_state = pr_data.get("mergeable_state", "")
+    if mergeable_state == "clean":
+        logger.info(f"PR #{pr_number} is already up to date")
+        return True
+
+    return client.update_pr_branch(repo, pr_number)
+
+
+def merge_pr(
+    client: GitHubCLIClient, repo: str, pr_number: int
+) -> bool:
+    """Squash-merge a PR via the GitHub API."""
+    return client.merge_pr(repo, pr_number, method=MERGE_METHOD)
+
+
+# ── Status comment ───────────────────────────────────────────────────
+
+
+def _find_status_comment(
+    client: GitHubCLIClient, repo: str, pr_number: int
+) -> Optional[int]:
+    """Find the ID of the existing status comment on a PR, if any."""
+    comments = client.get_comments(repo, pr_number)
+    for comment in comments:
+        if STATUS_COMMENT_MARKER in comment.get("body", ""):
+            return comment["id"]
+    return None
+
+
+def update_status_comment(
+    client: GitHubCLIClient,
+    repo: str,
+    pr_number: int,
+    queues: List[str],
+    blocking: List[str],
+) -> None:
+    """Create or update the queue status table comment on a PR."""
+    rows: list[str] = []
+    for queue in queues:
+        members = get_queue_members(client, repo, queue)
+        total = len(members)
+        position = next(
+            (i + 1 for i, m in enumerate(members) if m["pr_number"] == pr_number),
+            total,
+        )
+        if queue in blocking:
+            ahead_pr = members[0]["pr_number"] if members else "?"
+            status = f"Waiting (PR #{ahead_pr} ahead)"
+        elif position == 1:
+            status = "At front"
+        else:
+            status = f"Position {position}"
+        rows.append(f"| `{queue}` | {position}/{total} | {status} |")
+
+    if blocking:
+        overall = f"Waiting for: {', '.join(f'`{q}`' for q in blocking)}"
+    else:
+        overall = "At front of all queues — processing"
+
+    table = "\n".join(rows)
+    body = (
+        f"{STATUS_COMMENT_MARKER} -->\n"
+        f"## Merge Queue Status\n\n"
+        f"| Queue | Position | Status |\n"
+        f"|-------|----------|--------|\n"
+        f"{table}\n\n"
+        f"**Overall:** {overall}"
+    )
+
+    comment_id = _find_status_comment(client, repo, pr_number)
+    if comment_id:
+        client.update_comment(repo, comment_id, body)
+    else:
+        client.add_comment(repo, pr_number, body)

--- a/.github/scripts/merge_queue.py
+++ b/.github/scripts/merge_queue.py
@@ -154,11 +154,9 @@ def get_queue_members(
     Each entry: ``{"pr_number": int, "enqueued_at": str, "queues": [str]}``.
     """
     label = f"{LABEL_PREFIX}{queue}"
-    # Search for open PRs with the queue label AND either queued or active
-    query = (
-        f"repo:{repo} is:pr is:open label:{label} "
-        f"(label:{LABEL_QUEUED} OR label:{LABEL_ACTIVE})"
-    )
+    # Search for open PRs with the queue label.  Any PR carrying this label
+    # is a queue member regardless of whether it is mq:queued or mq:active.
+    query = f"repo:{repo} is:pr is:open label:\"{label}\""
     items = client.search_issues(query, sort="created", order="asc")
 
     members: list[dict] = []

--- a/.github/scripts/merge_queue.py
+++ b/.github/scripts/merge_queue.py
@@ -276,10 +276,14 @@ def update_pr_branch(
     if not pr_data:
         return False
 
-    # Check if already up to date
-    mergeable_state = pr_data.get("mergeable_state", "")
-    if mergeable_state == "clean":
-        logger.info(f"PR #{pr_number} is already up to date")
+    # Check if already up to date — several mergeable_state values mean
+    # the branch doesn't need updating (clean, unstable, has_hooks, etc.)
+    behind = pr_data.get("mergeable_state", "") == "behind"
+    if not behind:
+        logger.info(
+            f"PR #{pr_number} branch does not need updating "
+            f"(mergeable_state={pr_data.get('mergeable_state')})"
+        )
         return True
 
     return client.update_pr_branch(repo, pr_number)

--- a/.github/scripts/merge_queue.py
+++ b/.github/scripts/merge_queue.py
@@ -328,16 +328,30 @@ def update_pr_branch(
     if not pr_data:
         return False
 
-    # Check if already up to date — several mergeable_state values mean
-    # the branch doesn't need updating (clean, unstable, has_hooks, etc.)
-    behind = pr_data.get("mergeable_state", "") == "behind"
-    if not behind:
+    # Check if actually behind using the compare API.
+    # mergeable_state can be "clean" even when behind (it only indicates
+    # conflict status, not whether the branch is up-to-date).
+    head_branch = pr_data.get("head", {}).get("ref", "")
+    base_branch = pr_data.get("base", {}).get("ref", "")
+    if head_branch and base_branch:
+        compare = client._get_json(
+            f"https://api.github.com/repos/{repo}/compare/{base_branch}...{head_branch}",
+            f"compare {base_branch}...{head_branch}",
+        )
+        behind_by = compare.get("behind_by", 0) if compare else 0
+    else:
+        behind_by = 0
+
+    if behind_by == 0:
         logger.info(
-            f"PR #{pr_number} branch does not need updating "
-            f"(mergeable_state={pr_data.get('mergeable_state')})"
+            f"PR #{pr_number} branch is up to date with {base_branch}"
         )
         return True
 
+    logger.info(
+        f"PR #{pr_number} is {behind_by} commit(s) behind {base_branch}, "
+        f"updating branch"
+    )
     return client.update_pr_branch(repo, pr_number)
 
 

--- a/.github/scripts/merge_queue.py
+++ b/.github/scripts/merge_queue.py
@@ -24,8 +24,12 @@ from merge_queue_config import (
     MERGE_METHOD,
     METADATA_COMMENT_MARKER,
     PATH_TO_QUEUES,
-    STATUS_COMMENT_MARKER,
 )
+
+# All merge-queue state for a PR lives in a single comment.  The hidden
+# metadata marker stores the JSON payload; the visible portion shows the
+# queue status table.  Both ``enqueue_pr`` and ``update_status_comment``
+# write to this same comment, keeping PR timelines clean.
 
 logger = logging.getLogger(__name__)
 
@@ -64,34 +68,74 @@ def _parse_metadata_comment(body: str) -> Optional[dict]:
     return None
 
 
-def _build_metadata_comment(metadata: dict) -> str:
-    """Build the hidden HTML comment that stores queue metadata on a PR."""
-    return f"{METADATA_COMMENT_MARKER} {json.dumps(metadata)} -->"
+def _build_status_body(
+    metadata: dict,
+    queues: List[str],
+    queue_positions: Optional[List[dict]] = None,
+    blocking: Optional[List[str]] = None,
+    extra_msg: Optional[str] = None,
+) -> str:
+    """Build the single comment body that holds metadata + status table."""
+    hidden = f"{METADATA_COMMENT_MARKER} {json.dumps(metadata)} -->"
+
+    rows: list[str] = []
+    if queue_positions:
+        for qp in queue_positions:
+            rows.append(
+                f"| `{qp['queue']}` | {qp['position']}/{qp['total']} | {qp['status']} |"
+            )
+    else:
+        # Initial enqueue — no position data yet
+        for q in queues:
+            rows.append(f"| `{q}` | — | Queued |")
+
+    blocking = blocking or []
+    if blocking:
+        overall = f"Waiting for: {', '.join(f'`{q}`' for q in blocking)}"
+    elif queue_positions:
+        overall = "At front of all queues — processing"
+    else:
+        overall = "Queued"
+
+    table = "\n".join(rows)
+    user = metadata.get("enqueued_by", "")
+    header = f"**Merge Queue** — enqueued by @{user}" if user else "**Merge Queue**"
+
+    body = (
+        f"{hidden}\n"
+        f"## {header}\n\n"
+        f"| Queue | Position | Status |\n"
+        f"|-------|----------|--------|\n"
+        f"{table}\n\n"
+        f"**Overall:** {overall}"
+    )
+    if extra_msg:
+        body += f"\n\n{extra_msg}"
+    return body
+
+
+def _find_mq_comment(
+    client: GitHubCLIClient, repo: str, pr_number: int
+) -> Optional[dict]:
+    """Find the merge-queue comment on a PR.  Returns {id, body} or None."""
+    comments = client.get_comments(repo, pr_number)
+    for comment in comments:
+        if METADATA_COMMENT_MARKER in comment.get("body", ""):
+            return {"id": comment["id"], "body": comment["body"]}
+    return None
 
 
 def get_enqueue_metadata(
     client: GitHubCLIClient, repo: str, pr_number: int
 ) -> Optional[dict]:
-    """Read merge-queue metadata from PR comments.  Returns None if not queued."""
-    comments = client.get_comments(repo, pr_number)
-    for comment in comments:
-        meta = _parse_metadata_comment(comment.get("body", ""))
+    """Read merge-queue metadata from the PR's queue comment."""
+    comment = _find_mq_comment(client, repo, pr_number)
+    if comment:
+        meta = _parse_metadata_comment(comment["body"])
         if meta is not None:
             meta["_comment_id"] = comment["id"]
             return meta
     return None
-
-
-def _delete_metadata_comment(
-    client: GitHubCLIClient, repo: str, pr_number: int
-) -> None:
-    """Remove the metadata comment from a PR (cleanup on dequeue)."""
-    comments = client.get_comments(repo, pr_number)
-    for comment in comments:
-        if METADATA_COMMENT_MARKER in comment.get("body", ""):
-            url = f"{client.api_url}/repos/{repo}/issues/comments/{comment['id']}"
-            client._request_json("DELETE", url, None, "Failed to delete metadata comment")
-            break
 
 
 # ── Enqueue / Dequeue ────────────────────────────────────────────────
@@ -106,8 +150,8 @@ def enqueue_pr(
 ) -> None:
     """Add a PR to the merge queue.
 
-    Adds the ``mq:queued`` label plus one ``mq:<queue>`` label per queue,
-    and posts a hidden metadata comment for FIFO ordering.
+    Adds labels and posts a single comment containing both the hidden
+    metadata and the initial status table.
     """
     now = datetime.now(timezone.utc).isoformat()
     metadata = {
@@ -118,7 +162,9 @@ def enqueue_pr(
 
     labels = [LABEL_QUEUED] + [f"{LABEL_PREFIX}{q}" for q in queues]
     client.add_labels(repo, pr_number, labels)
-    client.add_comment(repo, pr_number, _build_metadata_comment(metadata))
+
+    body = _build_status_body(metadata, queues)
+    client.add_comment(repo, pr_number, body)
 
     logger.info(f"PR #{pr_number} enqueued in {queues} by @{user}")
 
@@ -131,15 +177,21 @@ def dequeue_pr(
 ) -> None:
     """Remove a PR from all merge queues.
 
-    Strips every ``mq:*`` label and posts a comment explaining why.
+    Strips every ``mq:*`` label and updates the queue comment with the reason.
     """
     existing = client.get_existing_labels_on_pr(repo, pr_number)
     mq_labels = [l for l in existing if l.startswith(LABEL_PREFIX)]
     for label in mq_labels:
         client.remove_label(repo, pr_number, label)
 
-    _delete_metadata_comment(client, repo, pr_number)
-    client.add_comment(repo, pr_number, f"**Merge Queue:** {reason}")
+    # Update the existing queue comment rather than posting a new one
+    comment = _find_mq_comment(client, repo, pr_number)
+    if comment:
+        client.update_comment(
+            repo, comment["id"], f"**Merge Queue:** {reason}"
+        )
+    else:
+        client.add_comment(repo, pr_number, f"**Merge Queue:** {reason}")
     logger.info(f"PR #{pr_number} dequeued: {reason}")
 
 
@@ -299,17 +351,6 @@ def merge_pr(
 # ── Status comment ───────────────────────────────────────────────────
 
 
-def _find_status_comment(
-    client: GitHubCLIClient, repo: str, pr_number: int
-) -> Optional[int]:
-    """Find the ID of the existing status comment on a PR, if any."""
-    comments = client.get_comments(repo, pr_number)
-    for comment in comments:
-        if STATUS_COMMENT_MARKER in comment.get("body", ""):
-            return comment["id"]
-    return None
-
-
 def update_status_comment(
     client: GitHubCLIClient,
     repo: str,
@@ -317,8 +358,16 @@ def update_status_comment(
     queues: List[str],
     blocking: List[str],
 ) -> None:
-    """Create or update the queue status table comment on a PR."""
-    rows: list[str] = []
+    """Update the queue comment in place with current position data."""
+    comment = _find_mq_comment(client, repo, pr_number)
+    if not comment:
+        return  # no queue comment to update
+
+    metadata = _parse_metadata_comment(comment["body"])
+    if not metadata:
+        return
+
+    queue_positions: list[dict] = []
     for queue in queues:
         members = get_queue_members(client, repo, queue)
         total = len(members)
@@ -333,25 +382,9 @@ def update_status_comment(
             status = "At front"
         else:
             status = f"Position {position}"
-        rows.append(f"| `{queue}` | {position}/{total} | {status} |")
+        queue_positions.append(
+            {"queue": queue, "position": position, "total": total, "status": status}
+        )
 
-    if blocking:
-        overall = f"Waiting for: {', '.join(f'`{q}`' for q in blocking)}"
-    else:
-        overall = "At front of all queues — processing"
-
-    table = "\n".join(rows)
-    body = (
-        f"{STATUS_COMMENT_MARKER} -->\n"
-        f"## Merge Queue Status\n\n"
-        f"| Queue | Position | Status |\n"
-        f"|-------|----------|--------|\n"
-        f"{table}\n\n"
-        f"**Overall:** {overall}"
-    )
-
-    comment_id = _find_status_comment(client, repo, pr_number)
-    if comment_id:
-        client.update_comment(repo, comment_id, body)
-    else:
-        client.add_comment(repo, pr_number, body)
+    body = _build_status_body(metadata, queues, queue_positions, blocking)
+    client.update_comment(repo, comment["id"], body)

--- a/.github/scripts/merge_queue_command.py
+++ b/.github/scripts/merge_queue_command.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+
+"""
+Merge Queue Command Handler
+----------------------------
+Handles ``/merge`` and ``/dequeue`` PR comment commands.
+
+Called by the ``merge-queue-command.yml`` workflow when a comment is
+created on a pull request.
+
+Environment variables (set by the workflow):
+    GH_TOKEN      – GitHub API token
+    REPO          – owner/repo (e.g. ``ROCm/rocm-libraries``)
+    PR_NUMBER     – pull request number
+    COMMENT_BODY  – the full comment text
+    COMMENT_AUTHOR – GitHub login of the commenter
+"""
+
+import logging
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from github_cli_client import GitHubCLIClient
+from merge_queue import (
+    detect_queues,
+    dequeue_pr,
+    enqueue_pr,
+    get_enqueue_metadata,
+    get_queue_members,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    client = GitHubCLIClient()
+    repo = os.environ["REPO"]
+    pr_number = int(os.environ["PR_NUMBER"])
+    comment_body = os.environ["COMMENT_BODY"].strip()
+    comment_author = os.environ["COMMENT_AUTHOR"]
+
+    if comment_body.startswith("/merge"):
+        handle_merge(client, repo, pr_number, comment_author)
+    elif comment_body.startswith("/dequeue"):
+        handle_dequeue(client, repo, pr_number, comment_author)
+    else:
+        logger.info("Comment does not contain a merge queue command")
+
+
+def _has_write_access(client: GitHubCLIClient, repo: str, username: str) -> bool:
+    perm = client.get_collaborator_permission(repo, username)
+    return perm in ("admin", "maintain", "write")
+
+
+def handle_merge(
+    client: GitHubCLIClient, repo: str, pr_number: int, user: str
+) -> None:
+    # Permission check
+    if not _has_write_access(client, repo, user):
+        client.add_comment(
+            repo,
+            pr_number,
+            f"@{user} You need write permission to use `/merge`.",
+        )
+        return
+
+    # Already queued?
+    existing = get_enqueue_metadata(client, repo, pr_number)
+    if existing:
+        client.add_comment(
+            repo,
+            pr_number,
+            "This PR is already in the merge queue. "
+            "Use `/dequeue` to remove it first.",
+        )
+        return
+
+    # Must have at least one approving review
+    reviews = client.get_pr_reviews(repo, pr_number)
+    approved = any(r.get("state") == "APPROVED" for r in reviews)
+    if not approved:
+        client.add_comment(
+            repo,
+            pr_number,
+            "This PR needs at least one approving review before "
+            "it can enter the merge queue.",
+        )
+        return
+
+    # Detect queues from changed files
+    changed_files = client.get_changed_files(repo, pr_number)
+    queues = detect_queues(changed_files)
+    if not queues:
+        client.add_comment(
+            repo,
+            pr_number,
+            "This PR does not touch any merge-queue-managed paths "
+            "(`projects/hipdnn/` or `dnn-providers/*/`). "
+            "It can be merged normally.",
+        )
+        return
+
+    # Enqueue
+    enqueue_pr(client, repo, pr_number, queues, user)
+
+    # Build confirmation with queue positions
+    lines = [f"**Merge Queue:** PR #{pr_number} has been enqueued by @{user}.\n"]
+    lines.append("| Queue | Position |")
+    lines.append("|-------|----------|")
+    for q in queues:
+        members = get_queue_members(client, repo, q)
+        position = next(
+            (i + 1 for i, m in enumerate(members) if m["pr_number"] == pr_number),
+            len(members),
+        )
+        lines.append(f"| `{q}` | {position}/{len(members)} |")
+
+    client.add_comment(repo, pr_number, "\n".join(lines))
+    logger.info(f"PR #{pr_number} enqueued in {queues}")
+
+
+def handle_dequeue(
+    client: GitHubCLIClient, repo: str, pr_number: int, user: str
+) -> None:
+    # PR author or write access can dequeue
+    pr_data = client.get_pr_by_number(repo, pr_number)
+    is_author = pr_data and pr_data.get("user", {}).get("login") == user
+    if not is_author and not _has_write_access(client, repo, user):
+        client.add_comment(
+            repo,
+            pr_number,
+            f"@{user} Only the PR author or a collaborator with write "
+            "permission can use `/dequeue`.",
+        )
+        return
+
+    dequeue_pr(client, repo, pr_number, f"Removed from queue by @{user} via `/dequeue`.")
+    logger.info(f"PR #{pr_number} dequeued by @{user}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/merge_queue_command.py
+++ b/.github/scripts/merge_queue_command.py
@@ -28,7 +28,6 @@ from merge_queue import (
     dequeue_pr,
     enqueue_pr,
     get_enqueue_metadata,
-    get_queue_members,
 )
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
@@ -104,22 +103,8 @@ def handle_merge(
         )
         return
 
-    # Enqueue
+    # Enqueue — posts a single comment with metadata + status table
     enqueue_pr(client, repo, pr_number, queues, user)
-
-    # Build confirmation with queue positions
-    lines = [f"**Merge Queue:** PR #{pr_number} has been enqueued by @{user}.\n"]
-    lines.append("| Queue | Position |")
-    lines.append("|-------|----------|")
-    for q in queues:
-        members = get_queue_members(client, repo, q)
-        position = next(
-            (i + 1 for i, m in enumerate(members) if m["pr_number"] == pr_number),
-            len(members),
-        )
-        lines.append(f"| `{q}` | {position}/{len(members)} |")
-
-    client.add_comment(repo, pr_number, "\n".join(lines))
     logger.info(f"PR #{pr_number} enqueued in {queues}")
 
 

--- a/.github/scripts/merge_queue_command.py
+++ b/.github/scripts/merge_queue_command.py
@@ -79,16 +79,17 @@ def handle_merge(
         return
 
     # Must have at least one approving review
-    reviews = client.get_pr_reviews(repo, pr_number)
-    approved = any(r.get("state") == "APPROVED" for r in reviews)
-    if not approved:
-        client.add_comment(
-            repo,
-            pr_number,
-            "This PR needs at least one approving review before "
-            "it can enter the merge queue.",
-        )
-        return
+    # TODO: Re-enable once deployed to the real repo
+    # reviews = client.get_pr_reviews(repo, pr_number)
+    # approved = any(r.get("state") == "APPROVED" for r in reviews)
+    # if not approved:
+    #     client.add_comment(
+    #         repo,
+    #         pr_number,
+    #         "This PR needs at least one approving review before "
+    #         "it can enter the merge queue.",
+    #     )
+    #     return
 
     # Detect queues from changed files
     changed_files = client.get_changed_files(repo, pr_number)

--- a/.github/scripts/merge_queue_config.py
+++ b/.github/scripts/merge_queue_config.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+"""
+Merge Queue Configuration
+-------------------------
+Path-to-queue mappings and constants for the hipDNN/provider merge queue system.
+
+Queue model:
+- Each provider has its own independent FIFO queue
+- hipDNN core changes enter ALL queues (core can break providers)
+- Provider changes only enter their own queue
+- A PR merges only when at the front of every queue it belongs to
+"""
+
+# Path prefix -> list of queues the PR enters.
+# Order matters for matching: first prefix match wins per file.
+PATH_TO_QUEUES = {
+    "projects/hipdnn/": [
+        "hipdnn",
+        "miopen-provider",
+        "hipblaslt-provider",
+        "hip-kernel-provider",
+        "fusilli-provider",
+        "integration-tests",
+    ],
+    "dnn-providers/miopen-provider/": ["miopen-provider"],
+    "dnn-providers/hipblaslt-provider/": ["hipblaslt-provider"],
+    "dnn-providers/hip-kernel-provider/": ["hip-kernel-provider"],
+    "dnn-providers/fusilli-provider/": ["fusilli-provider"],
+    "dnn-providers/integration-tests/": ["integration-tests"],
+}
+
+ALL_QUEUES = sorted(
+    set(queue for queues in PATH_TO_QUEUES.values() for queue in queues)
+)
+
+LABEL_PREFIX = "mq:"
+LABEL_QUEUED = f"{LABEL_PREFIX}queued"
+LABEL_ACTIVE = f"{LABEL_PREFIX}active"
+
+METADATA_COMMENT_MARKER = "<!-- merge-queue-metadata"
+STATUS_COMMENT_MARKER = "<!-- merge-queue-status"
+
+# The base branch that queued PRs target.
+TARGET_BRANCH = "develop"
+
+# Merge method used when the queue merges a PR.
+MERGE_METHOD = "squash"

--- a/.github/scripts/merge_queue_config.py
+++ b/.github/scripts/merge_queue_config.py
@@ -39,7 +39,6 @@ LABEL_QUEUED = f"{LABEL_PREFIX}queued"
 LABEL_ACTIVE = f"{LABEL_PREFIX}active"
 
 METADATA_COMMENT_MARKER = "<!-- merge-queue-metadata"
-STATUS_COMMENT_MARKER = "<!-- merge-queue-status"
 
 # The base branch that queued PRs target.
 TARGET_BRANCH = "develop"

--- a/.github/scripts/merge_queue_process.py
+++ b/.github/scripts/merge_queue_process.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+
+"""
+Merge Queue Processor
+---------------------
+Scheduled processor that advances the merge queue each cycle.
+
+For each queue, finds the head PR (oldest ``enqueued_at``).  A PR is
+only processed when it is at the front of **all** queues it belongs to.
+
+Processing steps for an eligible PR:
+1. Transition from ``mq:queued`` → ``mq:active``
+2. Update PR branch (merge develop into it)
+3. Wait for CI on the next cycle
+4. On CI success → squash-merge
+5. On CI failure → eject from all queues
+
+Environment variables (set by the workflow):
+    GH_TOKEN – GitHub API token
+    REPO     – owner/repo
+"""
+
+import logging
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from github_cli_client import GitHubCLIClient
+from merge_queue import (
+    check_ci_status,
+    dequeue_pr,
+    get_queue_members,
+    is_at_front_of_all_queues,
+    merge_pr,
+    update_pr_branch,
+    update_status_comment,
+)
+from merge_queue_config import ALL_QUEUES, LABEL_ACTIVE, LABEL_QUEUED
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    client = GitHubCLIClient()
+    repo = os.environ["REPO"]
+
+    # Track PRs already processed this cycle to avoid duplicate work when a
+    # PR appears at the head of multiple queues.
+    processed: set[int] = set()
+
+    for queue in ALL_QUEUES:
+        members = get_queue_members(client, repo, queue)
+        if not members:
+            continue
+
+        head = members[0]
+        pr_number = head["pr_number"]
+
+        if pr_number in processed:
+            continue
+        processed.add(pr_number)
+
+        pr_queues = head["queues"]
+        if not pr_queues:
+            # Missing metadata — skip
+            logger.warning(f"PR #{pr_number} has no queue metadata, skipping")
+            continue
+
+        is_ready, blocking = is_at_front_of_all_queues(
+            client, repo, pr_number, pr_queues
+        )
+
+        # Update the status comment on this PR every cycle
+        update_status_comment(client, repo, pr_number, pr_queues, blocking)
+
+        if not is_ready:
+            logger.info(
+                f"PR #{pr_number} blocked by queues: {blocking}"
+            )
+            continue
+
+        # PR is at the front of all its queues — process it
+        labels = client.get_existing_labels_on_pr(repo, pr_number)
+        is_active = LABEL_ACTIVE in labels
+
+        if not is_active:
+            # First time at front: activate and update branch
+            logger.info(f"Activating PR #{pr_number}: updating branch")
+            client.add_labels(repo, pr_number, [LABEL_ACTIVE])
+            if LABEL_QUEUED in labels:
+                client.remove_label(repo, pr_number, LABEL_QUEUED)
+
+            success = update_pr_branch(client, repo, pr_number)
+            if not success:
+                dequeue_pr(
+                    client,
+                    repo,
+                    pr_number,
+                    "Merge conflict with the base branch. "
+                    "Please rebase and re-enqueue with `/merge`.",
+                )
+            # Either way, wait for next cycle (CI needs to run on the
+            # updated branch, or the PR was ejected).
+            continue
+
+        # Already active — check CI
+        ci = check_ci_status(client, repo, pr_number)
+        logger.info(f"PR #{pr_number} CI status: {ci}")
+
+        if ci == "pending":
+            continue
+
+        if ci == "failure":
+            dequeue_pr(
+                client,
+                repo,
+                pr_number,
+                "CI checks failed while at the front of the merge queue. "
+                "Please fix the failures and re-enqueue with `/merge`.",
+            )
+            continue
+
+        if ci == "success":
+            logger.info(f"Merging PR #{pr_number}")
+            success = merge_pr(client, repo, pr_number)
+            if success:
+                client.add_comment(
+                    repo,
+                    pr_number,
+                    "**Merge Queue:** PR merged successfully.",
+                )
+            else:
+                dequeue_pr(
+                    client,
+                    repo,
+                    pr_number,
+                    "Merge failed unexpectedly. "
+                    "Please check for conflicts and re-enqueue with `/merge`.",
+                )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/merge_queue_process.py
+++ b/.github/scripts/merge_queue_process.py
@@ -116,7 +116,18 @@ def main() -> None:
             # updated branch, or the PR was ejected).
             continue
 
-        # Already active — check CI
+        # Already active — ensure branch is up to date before checking CI
+        success = update_pr_branch(client, repo, pr_number)
+        if not success:
+            dequeue_pr(
+                client,
+                repo,
+                pr_number,
+                "Merge conflict with the base branch. "
+                "Please rebase and re-enqueue with `/merge`.",
+            )
+            continue
+
         ci = check_ci_status(client, repo, pr_number)
         logger.info(f"PR #{pr_number} CI status: {ci}")
 

--- a/.github/scripts/merge_queue_process.py
+++ b/.github/scripts/merge_queue_process.py
@@ -46,8 +46,23 @@ def main() -> None:
     client = GitHubCLIClient()
     repo = os.environ["REPO"]
 
-    # Track PRs already processed this cycle to avoid duplicate work when a
-    # PR appears at the head of multiple queues.
+    # Collect every unique queued PR across all queues so we can update
+    # status comments for *all* of them, not just the heads.
+    all_queued: dict[int, dict] = {}  # pr_number -> member dict
+    for queue in ALL_QUEUES:
+        for member in get_queue_members(client, repo, queue):
+            if member["pr_number"] not in all_queued and member["queues"]:
+                all_queued[member["pr_number"]] = member
+
+    # Update status comments for every queued PR
+    for pr_number, member in all_queued.items():
+        pr_queues = member["queues"]
+        _, blocking = is_at_front_of_all_queues(
+            client, repo, pr_number, pr_queues
+        )
+        update_status_comment(client, repo, pr_number, pr_queues, blocking)
+
+    # Now process heads: only the PR at the front of ALL its queues advances.
     processed: set[int] = set()
 
     for queue in ALL_QUEUES:
@@ -64,16 +79,12 @@ def main() -> None:
 
         pr_queues = head["queues"]
         if not pr_queues:
-            # Missing metadata — skip
             logger.warning(f"PR #{pr_number} has no queue metadata, skipping")
             continue
 
         is_ready, blocking = is_at_front_of_all_queues(
             client, repo, pr_number, pr_queues
         )
-
-        # Update the status comment on this PR every cycle
-        update_status_comment(client, repo, pr_number, pr_queues, blocking)
 
         if not is_ready:
             logger.info(

--- a/.github/workflows/merge-queue-command.yml
+++ b/.github/workflows/merge-queue-command.yml
@@ -1,0 +1,39 @@
+name: Merge Queue Command
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  handle-command:
+    if: >-
+      github.event.issue.pull_request &&
+      (startsWith(github.event.comment.body, '/merge') ||
+       startsWith(github.event.comment.body, '/dequeue'))
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+          sparse-checkout-cone-mode: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - run: pip install requests
+        name: Install dependencies
+
+      - name: Handle merge queue command
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          REPO: ${{ github.repository }}
+        run: python .github/scripts/merge_queue_command.py

--- a/.github/workflows/merge-queue-process.yml
+++ b/.github/workflows/merge-queue-process.yml
@@ -1,0 +1,40 @@
+name: Merge Queue Processor
+
+on:
+  schedule:
+    - cron: "*/3 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  checks: read
+  statuses: read
+
+concurrency:
+  group: merge-queue-processor
+  cancel-in-progress: false
+
+jobs:
+  process:
+    if: github.repository == 'ROCm/rocm-libraries'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+          sparse-checkout-cone-mode: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - run: pip install requests
+        name: Install dependencies
+
+      - name: Process merge queues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: python .github/scripts/merge_queue_process.py

--- a/.github/workflows/merge-queue-process.yml
+++ b/.github/workflows/merge-queue-process.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   process:
-    if: github.repository == 'ROCm/rocm-libraries'
+    # if: github.repository == 'ROCm/rocm-libraries'  # TODO: re-enable for prod
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/merge-queue-status.yml
+++ b/.github/workflows/merge-queue-status.yml
@@ -1,0 +1,52 @@
+name: Merge Queue Status
+
+on:
+  pull_request_target:
+    types: [synchronize]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  eject-on-push:
+    # Only act on PRs that are in the merge queue, and only when a human
+    # pushed (not the bot updating the branch via the processor).
+    if: >-
+      contains(join(github.event.pull_request.labels.*.name, ','), 'mq:') &&
+      github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+          sparse-checkout-cone-mode: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - run: pip install requests
+        name: Install dependencies
+
+      - name: Eject PR from merge queue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          python -c "
+          import os, sys
+          sys.path.insert(0, '.github/scripts')
+          from github_cli_client import GitHubCLIClient
+          from merge_queue import dequeue_pr
+
+          client = GitHubCLIClient()
+          dequeue_pr(
+              client,
+              os.environ['REPO'],
+              int(os.environ['PR_NUMBER']),
+              'New commits were pushed while in the merge queue. '
+              'Removed from all queues — please re-enqueue with \`/merge\` after CI passes.',
+          )
+          "

--- a/.github/workflows/mergify-scopes.yml
+++ b/.github/workflows/mergify-scopes.yml
@@ -1,0 +1,19 @@
+name: Mergify Scopes
+
+on:
+  pull_request:
+    paths:
+      - 'projects/hipdnn/**'
+      - 'dnn-providers/**'
+
+jobs:
+  scopes:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect and upload scopes
+        uses: Mergifyio/gha-mergify-ci@main
+        with:
+          action: scopes
+          token: ${{ secrets.MERGIFY_TOKEN }}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,62 @@
+# Mergify merge queue configuration for hipDNN + DNN providers
+#
+# Each provider scope includes projects/hipdnn/ so that core PRs
+# automatically enter ALL provider scopes and serialize with them.
+# Provider-only PRs enter just their own scope and move independently.
+
+queue_rules:
+  - name: default
+    merge_method: squash
+    batch_size: 1
+    speculative_checks: 1
+    merge_conditions:
+      - check-success=pre-commit
+
+pull_request_rules:
+  - name: Auto-queue hipDNN and provider PRs
+    conditions:
+      - base=develop
+      - or:
+        - files~=^projects/hipdnn/
+        - files~=^dnn-providers/
+    actions:
+      queue:
+
+  - name: Remove from queue on new push
+    conditions:
+      - base=develop
+      - updated-at<2s
+    actions:
+      dequeue:
+        reason: New commits pushed — re-enqueue with the merge queue after CI passes.
+
+scopes:
+  - name: miopen-provider
+    conditions:
+      matching_files:
+        - ^dnn-providers/miopen-provider/
+        - ^projects/hipdnn/
+
+  - name: hipblaslt-provider
+    conditions:
+      matching_files:
+        - ^dnn-providers/hipblaslt-provider/
+        - ^projects/hipdnn/
+
+  - name: hip-kernel-provider
+    conditions:
+      matching_files:
+        - ^dnn-providers/hip-kernel-provider/
+        - ^projects/hipdnn/
+
+  - name: fusilli-provider
+    conditions:
+      matching_files:
+        - ^dnn-providers/fusilli-provider/
+        - ^projects/hipdnn/
+
+  - name: integration-tests
+    conditions:
+      matching_files:
+        - ^dnn-providers/integration-tests/
+        - ^projects/hipdnn/

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,60 +3,40 @@
 # Each provider scope includes projects/hipdnn/ so that core PRs
 # automatically enter ALL provider scopes and serialize with them.
 # Provider-only PRs enter just their own scope and move independently.
+#
+# Queue PRs manually with: @mergifyio queue
 
 queue_rules:
   - name: default
     merge_method: squash
     batch_size: 1
-    speculative_checks: 1
     merge_conditions:
       - check-success=pre-commit
 
-pull_request_rules:
-  - name: Auto-queue hipDNN and provider PRs
-    conditions:
-      - base=develop
-      - or:
-        - files~=^projects/hipdnn/
-        - files~=^dnn-providers/
-    actions:
-      queue:
-
-  - name: Remove from queue on new push
-    conditions:
-      - base=develop
-      - updated-at<2s
-    actions:
-      dequeue:
-        reason: New commits pushed — re-enqueue with the merge queue after CI passes.
-
 scopes:
-  - name: miopen-provider
-    conditions:
-      matching_files:
-        - ^dnn-providers/miopen-provider/
-        - ^projects/hipdnn/
+  source:
+    files:
+      miopen-provider:
+        include:
+          - dnn-providers/miopen-provider/**
+          - projects/hipdnn/**
 
-  - name: hipblaslt-provider
-    conditions:
-      matching_files:
-        - ^dnn-providers/hipblaslt-provider/
-        - ^projects/hipdnn/
+      hipblaslt-provider:
+        include:
+          - dnn-providers/hipblaslt-provider/**
+          - projects/hipdnn/**
 
-  - name: hip-kernel-provider
-    conditions:
-      matching_files:
-        - ^dnn-providers/hip-kernel-provider/
-        - ^projects/hipdnn/
+      hip-kernel-provider:
+        include:
+          - dnn-providers/hip-kernel-provider/**
+          - projects/hipdnn/**
 
-  - name: fusilli-provider
-    conditions:
-      matching_files:
-        - ^dnn-providers/fusilli-provider/
-        - ^projects/hipdnn/
+      fusilli-provider:
+        include:
+          - dnn-providers/fusilli-provider/**
+          - projects/hipdnn/**
 
-  - name: integration-tests
-    conditions:
-      matching_files:
-        - ^dnn-providers/integration-tests/
-        - ^projects/hipdnn/
+      integration-tests:
+        include:
+          - dnn-providers/integration-tests/**
+          - projects/hipdnn/**

--- a/dnn-providers/miopen-provider/README.md
+++ b/dnn-providers/miopen-provider/README.md
@@ -20,3 +20,4 @@ In order to build the plugin standalone, you will need to have installed hipDNN 
 1. Run `ninja` to build the plugin.
 # merge queue clean test
 <!-- mergify test: miopen change -->
+<!-- mergify scopes test: miopen -->

--- a/dnn-providers/miopen-provider/README.md
+++ b/dnn-providers/miopen-provider/README.md
@@ -18,3 +18,4 @@ In order to build the plugin standalone, you will need to have installed hipDNN 
 1. Make a build directory, `mkdir build && cd build`.
 1. Run `cmake -DCMAKE_CXX_COMPILER=<path to amdclang>/clang++ ..` to configure the build.
 1. Run `ninja` to build the plugin.
+# merge queue clean test

--- a/dnn-providers/miopen-provider/README.md
+++ b/dnn-providers/miopen-provider/README.md
@@ -19,3 +19,4 @@ In order to build the plugin standalone, you will need to have installed hipDNN 
 1. Run `cmake -DCMAKE_CXX_COMPILER=<path to amdclang>/clang++ ..` to configure the build.
 1. Run `ninja` to build the plugin.
 # merge queue clean test
+<!-- mergify test: miopen change -->

--- a/docs/rfcs/0001_MergeQueue.md
+++ b/docs/rfcs/0001_MergeQueue.md
@@ -51,13 +51,13 @@ Each PR enters zero or more queues based on the paths it touches. A PR merges on
 
 ### 4.2 Path → Queue mapping
 
-The mapping encodes a single rule: a PR enters the queue of every component whose state it depends on, so it is blocked by anything ahead of it in any of those queues.
+The mapping encodes a single rule: **a PR enters its own queue plus the queue of every downstream component** — those that depend on it and could break if it changes. This ensures the PR serializes with any in-flight work in components it could affect.
 
 | Path changed                          | Queues entered                                                                                          | Why                                                                                                                                                  |
 |---------------------------------------|---------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `projects/hipdnn/**`                  | `hipdnn`, `miopen-provider`, `hipblaslt-provider`, `hip-kernel-provider`, `fusilli-provider`, `integration-tests` (all 6) | Core touches every consumer's interface. Blocks anything queued behind it; blocked by anything ahead of it in any queue.                              |
-| `dnn-providers/<provider>/**`         | `<provider>`, `integration-tests`                                                                       | A provider depends on its own queue and the integration suite. Does **not** enter `hipdnn`; it blocks core only implicitly because core enters its queue. Blocks other providers only indirectly via shared `integration-tests` membership; never directly. |
-| `dnn-providers/integration-tests/**`  | `integration-tests`                                                                                    | Integration-test changes enter only their own queue. Providers already enter `integration-tests` (row above), so an in-flight provider PR serializes with integration-test PRs through the shared queue. Does **not** enter `hipdnn` or any provider queue. |
+| `projects/hipdnn/**`                  | `hipdnn`, `miopen-provider`, `hipblaslt-provider`, `hip-kernel-provider`, `fusilli-provider`, `integration-tests` (all 6) | Core is upstream of every other component — all providers and integration-tests are downstream. A core PR enters all six queues so it serializes with everything. |
+| `dnn-providers/<provider>/**`         | `<provider>`, `integration-tests`                                                                       | Each provider's only downstream component is `integration-tests`. Does **not** enter `hipdnn`; core PRs enter the provider's queue (because providers are downstream of core), which handles that serialization. Providers serialize with each other only indirectly via the shared `integration-tests` queue. |
+| `dnn-providers/integration-tests/**`  | `integration-tests`                                                                                    | Integration-tests has no downstream components, so it enters only its own queue. Upstream components (providers, core) already enter `integration-tests`, so serialization happens through the shared queue. |
 | Anything else                         | none                                                                                                    | Project not opted in.                                                                                                                                |
 
 A PR editing both `projects/hipdnn/api/foo.h` and `dnn-providers/miopen-provider/src/bar.cpp` enters all six queues — core's row is a superset of every provider's row.
@@ -82,9 +82,9 @@ integration-tests   │   ·    │    ·     │     ·     │     ·      │
 
 Three patterns to read off the matrix:
 
-- The `hipdnn core` row is the only fully-marked row — core touches every consumer, so a core PR is gated by every other in-flight PR in the ecosystem.
-- Each provider row has exactly two marks — its own queue and `integration-tests`. Providers serialize with each other only through the shared `integration-tests` queue.
-- The `integration-tests` row has a single mark. Integration-test PRs enter only their own queue, but every provider and core PR also enters that queue, so serialization happens naturally.
+- The `hipdnn core` row is the only fully-marked row — core is upstream of everything, so a core PR enters every downstream queue and is gated by every other in-flight PR in the ecosystem.
+- Each provider row has exactly two marks — its own queue and its one downstream component, `integration-tests`. Providers serialize with each other only through the shared `integration-tests` queue.
+- The `integration-tests` row has a single mark — it has no downstream components. Upstream PRs (providers, core) already enter the `integration-tests` queue, so serialization happens naturally.
 
 #### Worked example: four PRs enqueued in order
 
@@ -135,15 +135,15 @@ Two takeaways:
 
 ### 4.3 Opt-in
 
-Dependencies between components are expressed through queue membership in the `PATH_TO_QUEUES` config. The rule: a PR enters its own component's queue plus the queue of every component it depends on. When a component's PR sits in another component's queue, it serializes with that component's PRs — that is the blocking relationship.
+Dependencies between components are expressed through queue membership in the `PATH_TO_QUEUES` config. The rule: **a PR enters its own queue plus the queue of every downstream component** — those that depend on it. When a component's PR sits in a downstream queue, it serializes with that component's PRs — that is the blocking relationship.
 
 To opt in a new component, two edits are needed:
 
-1. **Add your path entry.** Map your path prefix to a list of queues: your own queue, plus the queue of anything you depend on. For example, a new provider that depends on `integration-tests`:
+1. **Add your path entry.** Map your path prefix to a list of queues: your own queue, plus the queue of every component downstream of you. For example, a new provider whose only downstream component is `integration-tests`:
    ```python
    "dnn-providers/new-provider/": ["new-provider", "integration-tests"],
    ```
-2. **Update upstream entries.** Any component that depends on *you* must add your queue to its list. For hipDNN core (which depends on all providers), add `"new-provider"` to the `projects/hipdnn/` entry so that core PRs serialize with the new provider.
+2. **Update entries of components upstream of you.** Any component that lists you as downstream must add your queue to its list. For hipDNN core (upstream of all providers), add `"new-provider"` to the `projects/hipdnn/` entry so that core PRs serialize with the new provider.
 
 There is no per-project file. Removing the entry (and your queue from other entries) opts a project out cleanly. The initial opt-in set is hipDNN core + four providers + integration-tests. Other rocm-libraries projects are explicitly out of scope for v1.
 

--- a/docs/rfcs/0001_MergeQueue.md
+++ b/docs/rfcs/0001_MergeQueue.md
@@ -1,0 +1,232 @@
+# Merge Queue for the hipDNN Ecosystem
+
+- Contributors: Samuel Reeder
+- **Status**: First draft
+- **Target Branch**: `develop` (only)
+
+## 1. Executive Summary
+
+This RFC proposes a custom, in-repo merge queue that serializes merges across the hipDNN ecosystem. Each component (`hipdnn` core, four providers, `integration-tests`) gets its own FIFO queue. A PR enters every queue of every component it depends on, and merges only when it is at the head of all of them. Authors trigger the queue with a `/merge` PR comment; an in-repo workflow squash-merges PRs as they reach the front.
+
+Initial scope is the hipDNN ecosystem on `develop` only. The queue is opt-in (other rocm-libraries subprojects are unaffected), starts optional (no branch protection changes), and is designed so a project can join later by adding two centralized config entries.
+
+## 2. Problem Statement
+
+- **Provider/core coupling.** A change to hipDNN core can break any provider; a change to a provider can silently regress hipDNN integration. Today, nothing serializes these merges, so two PRs touching coupled code can both pass CI in isolation and break `develop` together.
+- **CI capacity.** Parallel un-rebased merges thrash `develop` and force needless re-runs of expensive provider builds.
+- **Developer overhead.** A reviewer should not have to manually coordinate merge order across components.
+
+We want a system that serializes safely by default, is cheap to opt into, and stays out of contributors' way.
+
+## 3. Goals and Non-Goals
+
+### Goals
+- One FIFO queue per component: `hipdnn`, four providers, `integration-tests`.
+- Cross-blocking that follows dependencies (see §4.2). A PR is blocked by every PR ahead of it in any queue it belongs to.
+- Opt-in per project. Subprojects outside the hipDNN ecosystem are unaffected unless they opt in.
+- `develop` is the only managed target branch.
+- Start optional; provide a clear path to "required" via branch protection.
+- External contributors can use the queue with the same safeguards as anyone else.
+
+### Non-Goals
+- Replacing existing CI workflows.
+- Other rocm-libraries projects in v1.
+- Batched merges (`batch_size > 1`) — deferred.
+- Release or feature branches — `develop` only.
+
+## 4. Design
+
+### 4.1 Queues
+
+Six FIFO queues, one per component:
+
+- `hipdnn`
+- `miopen-provider`
+- `hipblaslt-provider`
+- `hip-kernel-provider`
+- `fusilli-provider`
+- `integration-tests`
+
+Each PR enters zero or more queues based on the paths it touches. A PR merges only when at the head of **every** queue it belongs to.
+
+### 4.2 Path → Queue mapping
+
+The mapping encodes a single rule: a PR enters the queue of every component whose state it depends on, so it is blocked by anything ahead of it in any of those queues.
+
+| Path changed                          | Queues entered                                                                                          | Why                                                                                                                                                  |
+|---------------------------------------|---------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `projects/hipdnn/**`                  | `hipdnn`, `miopen-provider`, `hipblaslt-provider`, `hip-kernel-provider`, `fusilli-provider`, `integration-tests` (all 6) | Core touches every consumer's interface. Blocks anything queued behind it; blocked by anything ahead of it in any queue.                              |
+| `dnn-providers/<provider>/**`         | `<provider>`, `integration-tests`                                                                       | A provider depends on its own queue and the integration suite. Does **not** enter `hipdnn`; it blocks core only implicitly because core enters its queue. Blocks other providers only indirectly via shared `integration-tests` membership; never directly. |
+| `dnn-providers/integration-tests/**`  | `integration-tests`, `miopen-provider`, `hipblaslt-provider`, `hip-kernel-provider`, `fusilli-provider` | Integration tests depend on every provider, and providers depend on the integration suite to stay green. Does **not** enter `hipdnn`; core does not depend on integration tests. |
+| Anything else                         | none                                                                                                    | Project not opted in.                                                                                                                                |
+
+A PR editing both `projects/hipdnn/api/foo.h` and `dnn-providers/miopen-provider/src/bar.cpp` enters all six queues — core's row is a superset of every provider's row.
+
+#### Membership at a glance
+
+```
+                                       QUEUES
+                            ┌─────┬─────┬─────┬─────┬─────┬──────┐
+                            │ hip │ mio │ hbl │ hkp │ fus │ intT │
+PR touches...               │ dnn │ pen │ ast │     │     │      │
+────────────────────────────┼─────┼─────┼─────┼─────┼─────┼──────┤
+projects/hipdnn/**          │  ●  │  ●  │  ●  │  ●  │  ●  │  ●   │
+dnn-providers/miopen-…/**   │  ·  │  ●  │  ·  │  ·  │  ·  │  ●   │
+dnn-providers/hipblaslt-…   │  ·  │  ·  │  ●  │  ·  │  ·  │  ●   │
+dnn-providers/hip-kernel-…  │  ·  │  ·  │  ·  │  ●  │  ·  │  ●   │
+dnn-providers/fusilli-…     │  ·  │  ·  │  ·  │  ·  │  ●  │  ●   │
+dnn-providers/integration-… │  ·  │  ●  │  ●  │  ●  │  ●  │  ●   │
+────────────────────────────┴─────┴─────┴─────┴─────┴─────┴──────┘
+   ● = PR enters this queue     · = PR does not enter this queue
+
+   hipdnn = hipdnn (core)        hkp  = hip-kernel-provider
+   mio    = miopen-provider      fus  = fusilli-provider
+   hbl    = hipblaslt-provider   intT = integration-tests
+```
+
+Two patterns to read off the matrix:
+
+- The `hipdnn` column has exactly one mark — only core PRs ever enter the core queue. Providers and integration tests block core *implicitly*, by sitting ahead of core PRs in the queues that core also enters (every other column).
+- The `projects/hipdnn/**` row is the only fully-marked row — core touches every consumer, so a core PR is gated by every other in-flight PR in the ecosystem.
+
+#### Worked example: four PRs enqueued in order
+
+PRs of four distinct types enter the queue in order — A (core), B (miopen-provider), C (hipblaslt-provider), D (integration-tests). Heads shown leftmost; `→` is "behind".
+
+```
+T₀ — all four enqueued
+
+  hipdnn              │ A
+  miopen-provider     │ A → B       → D
+  hipblaslt-provider  │ A      → C  → D
+  hip-kernel-provider │ A           → D
+  fusilli-provider    │ A           → D
+  integration-tests   │ A → B  → C  → D
+
+  A is at the head of every queue → A merges next.
+
+T₁ — after A merges
+
+  hipdnn              │ (empty)
+  miopen-provider     │ B → D
+  hipblaslt-provider  │ C → D
+  hip-kernel-provider │ D
+  fusilli-provider    │ D
+  integration-tests   │ B → C → D
+
+  B is at the head of {miopen-provider, integration-tests} → B merges next.
+  C is at the head of hipblaslt-provider but blocked by B in integration-tests.
+  D is blocked behind B and C.
+
+T₂ — after B merges
+
+  miopen-provider     │ D
+  hipblaslt-provider  │ C → D
+  hip-kernel-provider │ D
+  fusilli-provider    │ D
+  integration-tests   │ C → D
+
+  C is at the head of {hipblaslt-provider, integration-tests} → C merges next.
+  D is still blocked by C.
+
+T₃ — after C merges
+
+  miopen-provider     │ D
+  hipblaslt-provider  │ D
+  hip-kernel-provider │ D
+  fusilli-provider    │ D
+  integration-tests   │ D
+
+  D is at the head of all five queues it belongs to → D merges.
+```
+
+Two takeaways:
+
+- **B and C never run in parallel** even though they touch different providers — they share `integration-tests`, so the integration suite serializes them. This is the bidirectional integration-tests ↔ providers link doing its job.
+- **If a second core PR E were enqueued at T₂**, it would join the tail of *every* queue — including the ones C and D still sit in — and would have to wait for both to clear before merging. Core is never allowed to overtake an in-flight provider or integration-tests PR.
+
+
+### 4.3 Opt-in
+
+Two centralized edits add a project to the queue:
+
+1. Append a path → queue list to the path/queue config (`PATH_TO_QUEUES`).
+2. Append a corresponding scope block to the Mergify config (for CI status visibility).
+
+There is no per-project file. Removing both entries opts a project out cleanly. The initial opt-in set is hipDNN core + four providers + integration-tests. Other rocm-libraries projects are explicitly out of scope for v1.
+
+### 4.4 PR lifecycle
+
+1. An authorized user (PR author or any user with write/maintain/admin on the repo, per §4.6) comments `/merge`.
+2. The command handler validates eligibility (see §4.6), computes the queue set from the PR's changed paths, applies a `mq:queued` label and one `mq:<queue>` label per queue, and posts a single status comment with a hidden JSON metadata marker.
+3. A processor runs every 3 minutes. For each queue, it picks the head PR (oldest `enqueued_at`). If a PR is at the head of *every* queue it belongs to, the processor labels it `mq:active`, merges `develop` into the PR branch, and waits one cycle for CI to run against the freshly-merged tip.
+4. On the next cycle:
+   - **CI green** → squash-merge.
+   - **CI still pending** → PR keeps `mq:active`, stays at the head, and is retried each cycle until checks settle.
+   - **CI red** → eject with a comment naming the failure; the author re-enqueues with `/merge` after fixing.
+   - **New commits pushed by a non-bot user while queued** → eject (the queue's "what we tested" guarantee no longer holds).
+5. `/dequeue` removes a PR. The PR author or any write-access user can dequeue.
+
+Labels:
+
+- `mq:queued` — waiting at some position in one or more queues.
+- `mq:active` — at the head of all its queues; CI cycle in progress.
+- `mq:<queue>` — membership marker, one per queue the PR belongs to.
+
+### 4.5 Cadence and concurrency
+
+- 3-minute processor cron. Single concurrency group; no overlap, no cancellation.
+- One PR processed per queue per cycle. No batching.
+- The processor commits as `github-actions[bot]` so its merge of `develop` into the PR branch does not trigger the new-commit ejector in step 4.
+
+### 4.6 Permissions
+
+- `/merge`: PR author **or** any user with write/maintain/admin on the repo. The PR-author allowance is what makes the queue usable for external contributors on their own PRs (see §5).
+- `/dequeue`: PR author or write-access user.
+- The squash-merge itself is performed via GitHub's merge API by the bot, so branch-protection rules apply (see §5).
+
+## 5. Open-Source Contributor Policy
+
+**Policy.** External contributors may use `/merge` on their own PRs. The safeguards that apply to any merge — required reviewer approvals and required CI checks — apply unchanged.
+
+**Why this works without extra queue logic.** `develop` today requires a CODEOWNER approval and a passing TheRock CI run. GitHub's merge API enforces these rules on every merge call — including the queue's. If a CODEOWNER hasn't approved or TheRock CI hasn't passed, GitHub rejects the squash. The queue piggybacks on branch protection; it cannot bypass it. Branch protection is the safety net, the queue is the serializer. These protections apply from Phase 1 onward; the queue inherits them, it does not relax them.
+
+**Defense-in-depth.** The command handler should also reject `/merge` on a PR that has not yet been approved, so an unapproved PR doesn't sit in the queue burning processor cycles only to fail at the squash. This is a small check at enqueue time, not a replacement for branch protection.
+
+**Latency.** No priority lane in v1. Uniform 3-minute poll for everyone. Equal latency is simpler and avoids second-tier optics. A priority lane is listed in Future Work.
+
+## 6. Rollout
+
+| Phase | What                                                                                                                                                                                                                                  |
+|-------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1     | Optional. hipDNN-ecosystem opt-in only. No branch-protection changes.                                                                                                                                                                 |
+| 2     | Configure `develop` branch protection: required reviewer approvals + required CI checks. Enable the at-enqueue approval pre-check. Add a non-blocking status check that flags non-queue merges so reviewers can nudge contributors.   |
+| 3     | Add a required status check `merge-queue/managed` on `develop`. The queue bot posts it on every PR — pending until queue squash-merge for PRs touching opted-in paths, immediate success ("skipped — no managed paths") for all others. Path scoping lives in the bot, so branch protection stays one rule and other subprojects feel no friction. Repository admins (gardeners) retain bypass via GitHub's standard admin-override; this is an expected escape hatch for emergencies, not a routine path. |
+| 4     | Extend opt-in to other rocm-libraries subprojects on request.                                                                                                                                                                         |
+
+## 7. Risks
+
+- **3-minute poll** is slow at low load. Acceptable; revisit if it pinches.
+- **Head-of-line stalls.** Cross-queue blocking means a slow core PR at the front of every queue holds up everything else. Mitigated by `/dequeue` and reviewer discipline on core PRs.
+- **Maintenance debt.** Custom in-repo Python is a maintenance cost compared to a hosted service. Accepted; revisit if the scripts grow beyond a single maintainer's head.
+- **Surprise auto-eject** when an author pushes new commits mid-queue. The eject comment must be explicit about why and how to re-enqueue.
+
+## 8. Open Questions
+
+- Should the at-enqueue approval pre-check ship in Phase 1 or wait for Phase 2?
+
+## 9. Future Work
+
+Batch merging (`batch_size > 1`), a priority lane for short-running PRs, a dashboard listing all queue contents, auto-rebase on conflicts, and extending opt-in beyond the hipDNN ecosystem.
+
+## Appendix A: Prototype reference
+
+A working prototype implementing a near-cousin of this design exists on `fork/develop`. The configuration must be reshaped to match this RFC before adoption — specifically, the provider rows in `PATH_TO_QUEUES` must add `integration-tests`, the `dnn-providers/integration-tests/` row must add the four providers, and `merge_queue_command.py` must drop its hard write-access gate to allow PR authors per §4.6. The files involved:
+
+- `.github/workflows/merge-queue-{command,process,status}.yml`
+- `.github/workflows/mergify-scopes.yml`
+- `.github/scripts/merge_queue.py`
+- `.github/scripts/merge_queue_command.py`
+- `.github/scripts/merge_queue_config.py` — the path → queue table from §4.2 lives here
+- `.github/scripts/merge_queue_process.py`
+- `.mergify.yml` — scopes for CI status visibility

--- a/docs/rfcs/0001_MergeQueue.md
+++ b/docs/rfcs/0001_MergeQueue.md
@@ -135,12 +135,17 @@ Two takeaways:
 
 ### 4.3 Opt-in
 
-Two centralized edits add a project to the queue:
+Dependencies between components are expressed through queue membership in the `PATH_TO_QUEUES` config. The rule: a PR enters its own component's queue plus the queue of every component it depends on. When a component's PR sits in another component's queue, it serializes with that component's PRs — that is the blocking relationship.
 
-1. Append a path → queue list to the path/queue config (`PATH_TO_QUEUES`).
-2. Append a corresponding scope block to the Mergify config (for CI status visibility).
+To opt in a new component, two edits are needed:
 
-There is no per-project file. Removing both entries opts a project out cleanly. The initial opt-in set is hipDNN core + four providers + integration-tests. Other rocm-libraries projects are explicitly out of scope for v1.
+1. **Add your path entry.** Map your path prefix to a list of queues: your own queue, plus the queue of anything you depend on. For example, a new provider that depends on `integration-tests`:
+   ```python
+   "dnn-providers/new-provider/": ["new-provider", "integration-tests"],
+   ```
+2. **Update upstream entries.** Any component that depends on *you* must add your queue to its list. For hipDNN core (which depends on all providers), add `"new-provider"` to the `projects/hipdnn/` entry so that core PRs serialize with the new provider.
+
+There is no per-project file. Removing the entry (and your queue from other entries) opts a project out cleanly. The initial opt-in set is hipDNN core + four providers + integration-tests. Other rocm-libraries projects are explicitly out of scope for v1.
 
 ### 4.4 PR lifecycle
 
@@ -235,9 +240,7 @@ Batch merging (`batch_size > 1`), a priority lane for short-running PRs, a dashb
 A working prototype implementing a near-cousin of this design exists on `fork/develop`. The configuration must be reshaped to match this RFC before adoption — specifically, the provider rows in `PATH_TO_QUEUES` must add `integration-tests`, the `dnn-providers/integration-tests/` row must add the four providers, and `merge_queue_command.py` must drop its hard write-access gate to allow PR authors per [§4.6](#46-permissions). The files involved:
 
 - `.github/workflows/merge-queue-{command,process,status}.yml`
-- `.github/workflows/mergify-scopes.yml`
 - `.github/scripts/merge_queue.py`
 - `.github/scripts/merge_queue_command.py`
 - `.github/scripts/merge_queue_config.py` — the path → queue table from [§4.2](#42-path--queue-mapping) lives here
 - `.github/scripts/merge_queue_process.py`
-- `.mergify.yml` — scopes for CI status visibility

--- a/docs/rfcs/0001_MergeQueue.md
+++ b/docs/rfcs/0001_MergeQueue.md
@@ -1,4 +1,4 @@
-# Merge Queue for the hipDNN Ecosystem
+# Federated Merge Queues for rocm-libraries
 
 - Contributors: Samuel Reeder
 - **Status**: First draft
@@ -6,9 +6,9 @@
 
 ## 1. Executive Summary
 
-This RFC proposes a custom, in-repo merge queue that serializes merges across the hipDNN ecosystem. Each component (`hipdnn` core, four providers, `integration-tests`) gets its own FIFO queue. A PR enters every queue of every component it depends on, and merges only when it is at the head of all of them. Authors trigger the queue with a `/merge` PR comment; an in-repo workflow squash-merges PRs as they reach the front.
+This RFC proposes a custom, in-repo merge queue for rocm-libraries that serializes merges across coupled components on `develop`. Each opted-in component gets its own FIFO queue. A PR enters every queue of every component it depends on, and merges only when it is at the head of all of them. Authors trigger the queue with a `/merge` PR comment; an in-repo workflow squash-merges PRs as they reach the front.
 
-Initial scope is the hipDNN ecosystem on `develop` only. The queue is opt-in (other rocm-libraries subprojects are unaffected), starts optional (no branch protection changes), and is designed so a project can join later by adding two centralized config entries.
+Initial scope is the hipDNN ecosystem: `hipdnn` core, four providers (`miopen-provider`, `hipblaslt-provider`, `hip-kernel-provider`, `fusilli-provider`), and `integration-tests`. The queue is opt-in — other rocm-libraries subprojects are unaffected — starts optional (no branch-protection changes), and is designed so any project can join later by adding two centralized config entries.
 
 ## 2. Problem Statement
 
@@ -22,7 +22,7 @@ We want a system that serializes safely by default, is cheap to opt into, and st
 
 ### Goals
 - One FIFO queue per component: `hipdnn`, four providers, `integration-tests`.
-- Cross-blocking that follows dependencies (see §4.2). A PR is blocked by every PR ahead of it in any queue it belongs to.
+- Cross-blocking that follows dependencies (see [§4.2](#42-path--queue-mapping)). A PR is blocked by every PR ahead of it in any queue it belongs to.
 - Opt-in per project. Subprojects outside the hipDNN ecosystem are unaffected unless they opt in.
 - `develop` is the only managed target branch.
 - Start optional; provide a clear path to "required" via branch protection.
@@ -157,8 +157,8 @@ There is no per-project file. Removing both entries opts a project out cleanly. 
 
 ### 4.4 PR lifecycle
 
-1. An authorized user (PR author or any user with write/maintain/admin on the repo, per §4.6) comments `/merge`.
-2. The command handler validates eligibility (see §4.6), computes the queue set from the PR's changed paths, applies a `mq:queued` label and one `mq:<queue>` label per queue, and posts a single status comment with a hidden JSON metadata marker.
+1. An authorized user (PR author or any user with write/maintain/admin on the repo, per [§4.6](#46-permissions)) comments `/merge`.
+2. The command handler validates eligibility (see [§4.6](#46-permissions)), computes the queue set from the PR's changed paths, applies a `mq:queued` label and one `mq:<queue>` label per queue, and posts a single status comment with a hidden JSON metadata marker.
 3. A processor runs every 3 minutes. For each queue, it picks the head PR (oldest `enqueued_at`). If a PR is at the head of *every* queue it belongs to, the processor labels it `mq:active`, merges `develop` into the PR branch, and waits one cycle for CI to run against the freshly-merged tip.
 4. On the next cycle:
    - **CI green** → squash-merge.
@@ -175,25 +175,48 @@ Labels:
 
 ### 4.5 Cadence and concurrency
 
-- 3-minute processor cron. Single concurrency group; no overlap, no cancellation.
+- 3-minute processor cron. Single concurrency group (see [§4.5](#45-cadence-and-concurrency)); no overlap, no cancellation.
 - One PR processed per queue per cycle. No batching.
 - The processor commits as `github-actions[bot]` so its merge of `develop` into the PR branch does not trigger the new-commit ejector in step 4.
 
 ### 4.6 Permissions
 
-- `/merge`: PR author **or** any user with write/maintain/admin on the repo. The PR-author allowance is what makes the queue usable for external contributors on their own PRs (see §5).
+- `/merge`: PR author **or** any user with write/maintain/admin on the repo. The PR-author allowance is what makes the queue usable for external contributors on their own PRs (see [§5](#5-open-source-contributor-policy)).
 - `/dequeue`: PR author or write-access user.
-- The squash-merge itself is performed via GitHub's merge API by the bot, so branch-protection rules apply (see §5).
+- The squash-merge itself is performed via GitHub's merge API by the bot, so branch-protection rules apply (see [§5](#5-open-source-contributor-policy)).
+
+### 4.7 Processing model
+
+Queue state is stored entirely in PR metadata — labels and a hidden JSON comment posted by the command handler at enqueue time — with no external database. The processor reconstructs the full queue picture on every cycle by scanning all open PRs with `mq:queued` or `mq:active` labels.
+
+**Per-cycle algorithm:**
+
+1. **Discover.** List all open PRs targeting `develop` that carry an `mq:queued` or `mq:active` label. For each, parse the metadata comment to recover `enqueued_at` and the set of queues the PR belongs to.
+2. **Build queues.** For each queue, sort member PRs by `enqueued_at` (oldest first). The result is six independent FIFO lists.
+3. **Identify ready PRs.** A PR is *ready* if it is at the head of every queue it belongs to. Scan all queues; collect the set of ready PRs.
+4. **Activate.** For each ready PR not yet labeled `mq:active`:
+   - Merge `develop` into the PR branch. If the merge produces conflicts, eject the PR with a comment explaining the conflict.
+   - Label the PR `mq:active` and remove `mq:queued`.
+   - Skip further evaluation this cycle — CI needs to run against the merged tip before the next step applies.
+5. **Evaluate active PRs.** For each PR already labeled `mq:active`:
+   - All required checks passed → squash-merge via the GitHub merge API.
+   - Any required check failed → eject with a comment naming the failed check.
+   - Checks still pending → no action; the PR stays active and is retried next cycle.
+   - A non-bot user has pushed new commits since activation → eject.
+
+**Consistency guarantees.** The single-concurrency-group constraint ([§4.5](#45-cadence-and-concurrency)) ensures no two processor runs overlap. Because state is reconstructed from PR metadata on every cycle, the processor is stateless and crash-safe — a failed run simply retries on the next 3-minute tick with no stale in-memory state.
+
+**Conflict handling.** If merging `develop` into an active PR's branch produces a merge conflict, the PR is ejected immediately. The eject comment instructs the author to resolve conflicts locally, push, and re-enqueue with `/merge`.
 
 ## 5. Open-Source Contributor Policy
 
 **Policy.** External contributors may use `/merge` on their own PRs. The safeguards that apply to any merge — required reviewer approvals and required CI checks — apply unchanged.
 
-**Why this works without extra queue logic.** `develop` today requires a CODEOWNER approval and a passing TheRock CI run. GitHub's merge API enforces these rules on every merge call — including the queue's. If a CODEOWNER hasn't approved or TheRock CI hasn't passed, GitHub rejects the squash. The queue piggybacks on branch protection; it cannot bypass it. Branch protection is the safety net, the queue is the serializer. These protections apply from Phase 1 onward; the queue inherits them, it does not relax them.
+**Why this works without extra queue logic.** `develop` today requires a CODEOWNER approval and a passing TheRock CI run. GitHub's merge API enforces these rules on every merge call — including the queue's. If a CODEOWNER hasn't approved or TheRock CI hasn't passed, GitHub rejects the squash. The queue piggybacks on branch protection; it cannot bypass it. Branch protection is the safety net, the queue is the serializer. These protections apply from Phase 1 onward (see [§6](#6-rollout)); the queue inherits them, it does not relax them.
 
-**Defense-in-depth.** The command handler should also reject `/merge` on a PR that has not yet been approved, so an unapproved PR doesn't sit in the queue burning processor cycles only to fail at the squash. This is a small check at enqueue time, not a replacement for branch protection.
+**Defense-in-depth.** The command handler should also reject `/merge` on a PR that has not yet been approved, so an unapproved PR doesn't sit in the queue burning processor cycles only to fail at the squash. This is a small check at enqueue time, not a replacement for branch protection. (See Phase 2 in [§6](#6-rollout).)
 
-**Latency.** No priority lane in v1. Uniform 3-minute poll for everyone. Equal latency is simpler and avoids second-tier optics. A priority lane is listed in Future Work.
+**Latency.** No priority lane in v1. Uniform 3-minute poll for everyone. Equal latency is simpler and avoids second-tier optics. A priority lane is listed in [§9](#9-future-work).
 
 ## 6. Rollout
 
@@ -201,13 +224,13 @@ Labels:
 |-------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | 1     | Optional. hipDNN-ecosystem opt-in only. No branch-protection changes.                                                                                                                                                                 |
 | 2     | Configure `develop` branch protection: required reviewer approvals + required CI checks. Enable the at-enqueue approval pre-check. Add a non-blocking status check that flags non-queue merges so reviewers can nudge contributors.   |
-| 3     | Add a required status check `merge-queue/managed` on `develop`. The queue bot posts it on every PR — pending until queue squash-merge for PRs touching opted-in paths, immediate success ("skipped — no managed paths") for all others. Path scoping lives in the bot, so branch protection stays one rule and other subprojects feel no friction. Repository admins (gardeners) retain bypass via GitHub's standard admin-override; this is an expected escape hatch for emergencies, not a routine path. |
+| 3     | Add a required status check `merge-queue/managed` on `develop`. The queue bot posts it on every PR — pending until queue squash-merge for PRs touching opted-in paths, immediate success ("skipped — no managed paths") for all others. Path scoping lives in the bot, so branch protection stays one rule and other subprojects feel no friction. Repository admins (gardeners) retain bypass via GitHub's standard admin-override; this is an expected escape hatch for emergencies, not a routine path. (See [§7](#7-risks) for related concerns.) |
 | 4     | Extend opt-in to other rocm-libraries subprojects on request.                                                                                                                                                                         |
 
 ## 7. Risks
 
 - **3-minute poll** is slow at low load. Acceptable; revisit if it pinches.
-- **Head-of-line stalls.** Cross-queue blocking means a slow core PR at the front of every queue holds up everything else. Mitigated by `/dequeue` and reviewer discipline on core PRs.
+- **Head-of-line stalls.** Cross-queue blocking means a slow core PR at the front of every queue holds up everything else. Mitigated by `/dequeue` (see [§4.4](#44-pr-lifecycle)) and reviewer discipline on core PRs.
 - **Maintenance debt.** Custom in-repo Python is a maintenance cost compared to a hosted service. Accepted; revisit if the scripts grow beyond a single maintainer's head.
 - **Surprise auto-eject** when an author pushes new commits mid-queue. The eject comment must be explicit about why and how to re-enqueue.
 
@@ -221,12 +244,12 @@ Batch merging (`batch_size > 1`), a priority lane for short-running PRs, a dashb
 
 ## Appendix A: Prototype reference
 
-A working prototype implementing a near-cousin of this design exists on `fork/develop`. The configuration must be reshaped to match this RFC before adoption — specifically, the provider rows in `PATH_TO_QUEUES` must add `integration-tests`, the `dnn-providers/integration-tests/` row must add the four providers, and `merge_queue_command.py` must drop its hard write-access gate to allow PR authors per §4.6. The files involved:
+A working prototype implementing a near-cousin of this design exists on `fork/develop`. The configuration must be reshaped to match this RFC before adoption — specifically, the provider rows in `PATH_TO_QUEUES` must add `integration-tests`, the `dnn-providers/integration-tests/` row must add the four providers, and `merge_queue_command.py` must drop its hard write-access gate to allow PR authors per [§4.6](#46-permissions). The files involved:
 
 - `.github/workflows/merge-queue-{command,process,status}.yml`
 - `.github/workflows/mergify-scopes.yml`
 - `.github/scripts/merge_queue.py`
 - `.github/scripts/merge_queue_command.py`
-- `.github/scripts/merge_queue_config.py` — the path → queue table from §4.2 lives here
+- `.github/scripts/merge_queue_config.py` — the path → queue table from [§4.2](#42-path--queue-mapping) lives here
 - `.github/scripts/merge_queue_process.py`
 - `.mergify.yml` — scopes for CI status visibility

--- a/docs/rfcs/0001_MergeQueue.md
+++ b/docs/rfcs/0001_MergeQueue.md
@@ -57,7 +57,7 @@ The mapping encodes a single rule: a PR enters the queue of every component whos
 |---------------------------------------|---------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `projects/hipdnn/**`                  | `hipdnn`, `miopen-provider`, `hipblaslt-provider`, `hip-kernel-provider`, `fusilli-provider`, `integration-tests` (all 6) | Core touches every consumer's interface. Blocks anything queued behind it; blocked by anything ahead of it in any queue.                              |
 | `dnn-providers/<provider>/**`         | `<provider>`, `integration-tests`                                                                       | A provider depends on its own queue and the integration suite. Does **not** enter `hipdnn`; it blocks core only implicitly because core enters its queue. Blocks other providers only indirectly via shared `integration-tests` membership; never directly. |
-| `dnn-providers/integration-tests/**`  | `integration-tests`, `miopen-provider`, `hipblaslt-provider`, `hip-kernel-provider`, `fusilli-provider` | Integration tests depend on every provider, and providers depend on the integration suite to stay green. Does **not** enter `hipdnn`; core does not depend on integration tests. |
+| `dnn-providers/integration-tests/**`  | `integration-tests`                                                                                    | Integration-test changes enter only their own queue. Providers already enter `integration-tests` (row above), so an in-flight provider PR serializes with integration-test PRs through the shared queue. Does **not** enter `hipdnn` or any provider queue. |
 | Anything else                         | none                                                                                                    | Project not opted in.                                                                                                                                |
 
 A PR editing both `projects/hipdnn/api/foo.h` and `dnn-providers/miopen-provider/src/bar.cpp` enters all six queues — core's row is a superset of every provider's row.
@@ -65,29 +65,26 @@ A PR editing both `projects/hipdnn/api/foo.h` and `dnn-providers/miopen-provider
 #### Membership at a glance
 
 ```
-                                       QUEUES
-                            ┌─────┬─────┬─────┬─────┬─────┬──────┐
-                            │ hip │ mio │ hbl │ hkp │ fus │ intT │
-PR touches...               │ dnn │ pen │ ast │     │     │      │
-────────────────────────────┼─────┼─────┼─────┼─────┼─────┼──────┤
-projects/hipdnn/**          │  ●  │  ●  │  ●  │  ●  │  ●  │  ●   │
-dnn-providers/miopen-…/**   │  ·  │  ●  │  ·  │  ·  │  ·  │  ●   │
-dnn-providers/hipblaslt-…   │  ·  │  ·  │  ●  │  ·  │  ·  │  ●   │
-dnn-providers/hip-kernel-…  │  ·  │  ·  │  ·  │  ●  │  ·  │  ●   │
-dnn-providers/fusilli-…     │  ·  │  ·  │  ·  │  ·  │  ●  │  ●   │
-dnn-providers/integration-… │  ·  │  ●  │  ●  │  ●  │  ●  │  ●   │
-────────────────────────────┴─────┴─────┴─────┴─────┴─────┴──────┘
+                                                       QUEUES
+                    ┌────────┬──────────┬───────────┬────────────┬──────────┬─────────────┐
+                    │        │  miopen  │ hipblaslt │ hip-kernel │ fusilli  │ integration │
+PR touches          │ hipdnn │ provider │ provider  │  provider  │ provider │    tests    │
+────────────────────┼────────┼──────────┼───────────┼────────────┼──────────┼─────────────┤
+hipdnn core         │   ●    │    ●     │     ●     │     ●      │    ●     │      ●      │
+miopen-provider     │   ·    │    ●     │     ·     │     ·      │    ·     │      ●      │
+hipblaslt-provider  │   ·    │    ·     │     ●     │     ·      │    ·     │      ●      │
+hip-kernel-provider │   ·    │    ·     │     ·     │     ●      │    ·     │      ●      │
+fusilli-provider    │   ·    │    ·     │     ·     │     ·      │    ●     │      ●      │
+integration-tests   │   ·    │    ·     │     ·     │     ·      │    ·     │      ●      │
+────────────────────┴────────┴──────────┴───────────┴────────────┴──────────┴─────────────┘
    ● = PR enters this queue     · = PR does not enter this queue
-
-   hipdnn = hipdnn (core)        hkp  = hip-kernel-provider
-   mio    = miopen-provider      fus  = fusilli-provider
-   hbl    = hipblaslt-provider   intT = integration-tests
 ```
 
-Two patterns to read off the matrix:
+Three patterns to read off the matrix:
 
-- The `hipdnn` column has exactly one mark — only core PRs ever enter the core queue. Providers and integration tests block core *implicitly*, by sitting ahead of core PRs in the queues that core also enters (every other column).
-- The `projects/hipdnn/**` row is the only fully-marked row — core touches every consumer, so a core PR is gated by every other in-flight PR in the ecosystem.
+- The `hipdnn core` row is the only fully-marked row — core touches every consumer, so a core PR is gated by every other in-flight PR in the ecosystem.
+- Each provider row has exactly two marks — its own queue and `integration-tests`. Providers serialize with each other only through the shared `integration-tests` queue.
+- The `integration-tests` row has a single mark. Integration-test PRs enter only their own queue, but every provider and core PR also enters that queue, so serialization happens naturally.
 
 #### Worked example: four PRs enqueued in order
 
@@ -97,53 +94,43 @@ PRs of four distinct types enter the queue in order — A (core), B (miopen-prov
 T₀ — all four enqueued
 
   hipdnn              │ A
-  miopen-provider     │ A → B       → D
-  hipblaslt-provider  │ A      → C  → D
-  hip-kernel-provider │ A           → D
-  fusilli-provider    │ A           → D
+  miopen-provider     │ A → B
+  hipblaslt-provider  │ A      → C
+  hip-kernel-provider │ A
+  fusilli-provider    │ A
   integration-tests   │ A → B  → C  → D
 
   A is at the head of every queue → A merges next.
 
 T₁ — after A merges
 
-  hipdnn              │ (empty)
-  miopen-provider     │ B → D
-  hipblaslt-provider  │ C → D
-  hip-kernel-provider │ D
-  fusilli-provider    │ D
+  miopen-provider     │ B
+  hipblaslt-provider  │ C
   integration-tests   │ B → C → D
 
   B is at the head of {miopen-provider, integration-tests} → B merges next.
   C is at the head of hipblaslt-provider but blocked by B in integration-tests.
-  D is blocked behind B and C.
+  D is blocked behind B and C in integration-tests.
 
 T₂ — after B merges
 
-  miopen-provider     │ D
-  hipblaslt-provider  │ C → D
-  hip-kernel-provider │ D
-  fusilli-provider    │ D
+  hipblaslt-provider  │ C
   integration-tests   │ C → D
 
   C is at the head of {hipblaslt-provider, integration-tests} → C merges next.
-  D is still blocked by C.
+  D is still blocked by C in integration-tests.
 
 T₃ — after C merges
 
-  miopen-provider     │ D
-  hipblaslt-provider  │ D
-  hip-kernel-provider │ D
-  fusilli-provider    │ D
   integration-tests   │ D
 
-  D is at the head of all five queues it belongs to → D merges.
+  D is at the head of integration-tests (its only queue) → D merges.
 ```
 
 Two takeaways:
 
-- **B and C never run in parallel** even though they touch different providers — they share `integration-tests`, so the integration suite serializes them. This is the bidirectional integration-tests ↔ providers link doing its job.
-- **If a second core PR E were enqueued at T₂**, it would join the tail of *every* queue — including the ones C and D still sit in — and would have to wait for both to clear before merging. Core is never allowed to overtake an in-flight provider or integration-tests PR.
+- **B and C never run in parallel** even though they touch different providers — they share `integration-tests`, so the integration suite serializes them. No cross-entry into each other's provider queues needed; the shared queue is sufficient.
+- **If a second core PR E were enqueued at T₂**, it would join the tail of *every* queue — including `integration-tests` where C and D still sit — and would have to wait for both to clear before merging. Core is never allowed to overtake an in-flight provider or integration-tests PR.
 
 
 ### 4.3 Opt-in
@@ -232,6 +219,7 @@ Queue state is stored entirely in PR metadata — labels and a hidden JSON comme
 - **3-minute poll** is slow at low load. Acceptable; revisit if it pinches.
 - **Head-of-line stalls.** Cross-queue blocking means a slow core PR at the front of every queue holds up everything else. Mitigated by `/dequeue` (see [§4.4](#44-pr-lifecycle)) and reviewer discipline on core PRs.
 - **Maintenance debt.** Custom in-repo Python is a maintenance cost compared to a hosted service. Accepted; revisit if the scripts grow beyond a single maintainer's head.
+- **Serialization throughput.** CI runs often take 6+ hours. Because intersecting PRs (e.g. two provider PRs sharing `integration-tests`) must merge one at a time, each waiting for a full CI cycle, a queue of *n* intersecting PRs takes roughly *n × CI time* to drain. During high-activity periods this could become a significant bottleneck. Batch merging (see [§9](#9-future-work)) is the primary mitigation; until then, reviewers should be aware that queuing order matters and core PRs at the head will block the entire ecosystem for one full CI cycle.
 - **Surprise auto-eject** when an author pushes new commits mid-queue. The eject comment must be explicit about why and how to re-enqueue.
 
 ## 8. Open Questions

--- a/projects/hipdnn/CMakeLists.txt
+++ b/projects/hipdnn/CMakeLists.txt
@@ -355,3 +355,4 @@ endif()
 if(NOT HIPDNN_SKIP_TESTS)
     install_hipdnn_ctest_files()
 endif()
+<!-- core-seq-3: error code expansion -->

--- a/projects/hipdnn/README.md
+++ b/projects/hipdnn/README.md
@@ -118,3 +118,5 @@ The documentation covers the frontend API including:
 ## Contributing
 
 For information about contributing to the hipDNN project, please see the [Contributing Guide](./CONTRIBUTING.md).
+
+<!-- core-seq-1: performance logging flag -->

--- a/projects/hipdnn/README.md
+++ b/projects/hipdnn/README.md
@@ -120,3 +120,4 @@ The documentation covers the frontend API including:
 For information about contributing to the hipDNN project, please see the [Contributing Guide](./CONTRIBUTING.md).
 
 <!-- core-seq-1: performance logging flag -->
+<!-- mergify scopes test: core -->

--- a/projects/hipdnn/docs/ai-rules.md
+++ b/projects/hipdnn/docs/ai-rules.md
@@ -204,3 +204,8 @@ TestConvolutionHeuristicsFp32              TestConvolutionHeuristics
 ## Conditional Guidelines
 
 When modifying public API headers (under `backend/include/`, `frontend/include/hipdnn_frontend/`, `plugin_sdk/include/`), add Doxygen comments (`/** @brief ... */` for classes/functions/files, `///<` for enum values) to any new or changed public API. Exclude `detail/` subdirectories and generated files. For full style details, see `docs/doxygen-guidelines.md`.
+
+<!-- core-seq-2: descriptor validation -->
+
+<!-- core-seq-2: descriptor validation -->
+<!-- core-seq-2: descriptor validation -->


### PR DESCRIPTION
## Motivation

The hipDNN ecosystem (core, four providers, integration-tests) suffers from provider/core coupling without serialization: a core change can silently break any provider, and a provider change can regress the integration suite. Today, parallel uncoordinated merges thrash `develop` and force unnecessary CI re-runs. Reviewers manually coordinate merge order across components. We need a system that serializes these coupled changes safely by default, is cheap to opt into, and stays out of contributors' way.

## Technical Details

This RFC proposes a custom, in-repo merge queue for rocm-libraries with per-component FIFO queues and upstream/downstream cross-blocking. The queue is expressed entirely through two elements:

1. **Queue membership** via `PATH_TO_QUEUES` configuration: each path enters its own component queue plus the queue of every downstream component (those that depend on it). This ensures PRs serialize with in-flight work they could affect.

2. **Per-cycle processing**: a stateless processor reconstructs queue state from PR metadata (labels) every 3 minutes. It identifies PRs at the head of all their queues, merges `develop` into them, waits for CI, and squash-merges on green.

Initial scope is the hipDNN ecosystem on `develop` only. The queue is opt-in — other rocm-libraries subprojects are unaffected unless they explicitly add two config lines. The design supports extension to other projects later. Start optional (Phase 1), with a clear path to "required" via branch-protection status check (Phase 3). External contributors can use the queue; safeguards (CODEOWNER approval, required CI) are enforced by branch protection and apply to every merge.

The RFC covers queue structure, path-to-queue mapping with diagrams, opt-in recipe, PR lifecycle, processing model, permissions, rollout phases, and known risks (3-min poll latency, head-of-line stalls from slow core PRs, serialization throughput due to long CI cycles).

## Test Plan

- [x] Document structure: all sections present, headings correctly formatted
- [x] Hyperlinks: all section references converted to markdown anchors (16 cross-references verified)
- [x] Examples: membership matrix and worked timeline show correct queue states
- [x] Consistency: terminology unified (upstream/downstream), no contradictions between sections
- [x] Review feedback: all eight items from 2026-04-20 review addressed (queue semantics, auth policy, Phase 1 trust model, Phase 3 enforcement, CI-pending state, prototype alignment, path typo, deduplication)

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.