### PR TITLE
[rocsparse] Fix off-by-one heap-buffer-overflow in shift_offsets temp buffer allocation

### DIFF
--- a/projects/rocsparse/library/src/conversion/rocsparse_csrsort.cpp
+++ b/projects/rocsparse/library/src/conversion/rocsparse_csrsort.cpp
@@ -1,6 +1,6 @@
 /*! \file */
 /* ************************************************************************
- * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2026 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -90,7 +90,7 @@ try
     // perm buffer
     *buffer_size += ((sizeof(rocsparse_int) * nnz - 1) / 256 + 1) * 256;
     // segm buffer
-    *buffer_size += ((sizeof(rocsparse_int) * m) / 256 + 1) * 256;
+    *buffer_size += ((sizeof(rocsparse_int) * (m + 1)) / 256 + 1) * 256;
 
     return rocsparse_status_success;
     // LCOV_EXCL_START
@@ -178,7 +178,7 @@ try
 
     // segm buffer
     rocsparse_int* tmp_segm = reinterpret_cast<rocsparse_int*>(ptr);
-    ptr += ((sizeof(rocsparse_int) * m) / 256 + 1) * 256;
+    ptr += ((sizeof(rocsparse_int) * (m + 1)) / 256 + 1) * 256;
 
     // Index base one requires shift of offset positions
     if(descr->base == rocsparse_index_base_one)

--- a/projects/rocsparse/library/src/util/rocsparse_check_matrix_csr.cpp
+++ b/projects/rocsparse/library/src/util/rocsparse_check_matrix_csr.cpp
@@ -1,6 +1,6 @@
 /*! \file */
 /* ************************************************************************
- * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -130,7 +130,7 @@ rocsparse_status rocsparse::check_matrix_csr_core(rocsparse_handle       handle,
     {
         // offsets buffer
         tmp_offsets = reinterpret_cast<I*>(ptr);
-        ptr += ((sizeof(I) * m) / 256 + 1) * 256;
+        ptr += ((sizeof(I) * (m + 1)) / 256 + 1) * 256;
 
         // columns 1 buffer
         tmp_cols1 = reinterpret_cast<J*>(ptr);

--- a/projects/rocsparse/library/src/util/rocsparse_check_matrix_csr_buffer_size.cpp
+++ b/projects/rocsparse/library/src/util/rocsparse_check_matrix_csr_buffer_size.cpp
@@ -1,6 +1,6 @@
 /*! \file */
 /* ************************************************************************
- * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -59,7 +59,7 @@ rocsparse_status rocsparse::check_matrix_csr_buffer_size_core(rocsparse_handle  
         *buffer_size += ((rocprim_buffer_size - 1) / 256 + 1) * 256;
 
         // offset buffer
-        *buffer_size += ((sizeof(I) * m) / 256 + 1) * 256;
+        *buffer_size += ((sizeof(I) * (m + 1)) / 256 + 1) * 256;
 
         // columns buffer
         *buffer_size += ((sizeof(J) * nnz - 1) / 256 + 1) * 256;

--- a/projects/rocsparse/library/src/util/rocsparse_check_matrix_gebsr.cpp
+++ b/projects/rocsparse/library/src/util/rocsparse_check_matrix_gebsr.cpp
@@ -109,7 +109,7 @@ rocsparse_status rocsparse::check_matrix_gebsr_core(rocsparse_handle       handl
     {
         // offsets buffer
         tmp_offsets = reinterpret_cast<I*>(ptr);
-        ptr += ((sizeof(I) * mb) / 256 + 1) * 256;
+        ptr += ((sizeof(I) * (mb + 1)) / 256 + 1) * 256;
 
         // columns 1 buffer
         tmp_cols1 = reinterpret_cast<J*>(ptr);

--- a/projects/rocsparse/library/src/util/rocsparse_check_matrix_gebsr_buffer_size.cpp
+++ b/projects/rocsparse/library/src/util/rocsparse_check_matrix_gebsr_buffer_size.cpp
@@ -1,6 +1,6 @@
 /*! \file */
 /* ************************************************************************
- * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -61,7 +61,7 @@ rocsparse_status rocsparse::check_matrix_gebsr_buffer_size_core(rocsparse_handle
         *buffer_size += ((rocprim_buffer_size - 1) / 256 + 1) * 256;
 
         // offset buffer
-        *buffer_size += ((sizeof(I) * mb) / 256 + 1) * 256;
+        *buffer_size += ((sizeof(I) * (mb + 1)) / 256 + 1) * 256;
 
         // columns buffer
         *buffer_size += ((sizeof(J) * nnzb - 1) / 256 + 1) * 256;


### PR DESCRIPTION
## Summary

Fix heap-buffer-overflow caused by temporary buffers being allocated for `m` elements
while `shift_offsets_kernel` (and downstream `rocprim::segmented_radix_sort`) processes
`m+1` elements.

## What changed and why

Three pairs of buffer-size / buffer-carving sites allocate `sizeof(T) * m` bytes for a
temporary offsets array. The array is then populated by `shift_offsets_kernel(..., m+1, ...)`
which writes `m+1` values (CSR/BSR row pointers always have `m+1` entries: one per row
plus the final sentinel). The same array is subsequently passed to
`rocprim::segmented_radix_sort` which reads all `m+1` segment boundaries.

This is a 1-element write+read overflow — benign without ASAN, but crashes reliably under
GPU AddressSanitizer (`-fsanitize=address`, `gfx942:xnack+`).

The fix changes `m` → `(m+1)` (or `mb` → `(mb+1)`) in both the `buffer_size` function
and the corresponding runtime carving, keeping them consistent.

### Files changed

| File | Change |
|---|---|
| `rocsparse_check_matrix_csr_buffer_size.cpp:62` | `sizeof(I) * m` → `sizeof(I) * (m + 1)` |
| `rocsparse_check_matrix_csr.cpp:133` | same |
| `rocsparse_check_matrix_gebsr_buffer_size.cpp:64` | `sizeof(I) * mb` → `sizeof(I) * (mb + 1)` |
| `rocsparse_check_matrix_gebsr.cpp:112` | same |
| `rocsparse_csrsort.cpp:93` | `sizeof(rocsparse_int) * m` → `sizeof(rocsparse_int) * (m + 1)` |
| `rocsparse_csrsort.cpp:181` | same |

### Functions fixed directly
- `check_matrix_csr` / `check_matrix_csr_buffer_size`
- `check_matrix_gebsr` / `check_matrix_gebsr_buffer_size`
- `csrsort` / `csrsort_buffer_size`

### Functions fixed by delegation (no code changes needed)
- `check_matrix_csc` → delegates to `check_matrix_csr` with swapped m/n
- `check_matrix_gebsc` → delegates to `check_matrix_gebsr`
- `cscsort` / `coosort` → delegate to `csrsort`

## API / backward compatibility

No API changes. `buffer_size` functions now return a slightly larger value (one extra
element, rounded up to 256-byte alignment — in practice the aligned size is often
unchanged). Callers that already allocated based on the old `buffer_size` output will
continue to work on non-ASAN builds; under ASAN they will now get correct behavior.

## Performance impact

None. The only change is +1 element in a temporary buffer allocation. The aligned size
(`(size / 256 + 1) * 256`) absorbs the extra element in most cases with no additional
memory cost.

## Testing

Verified under GPU ASAN (`gfx942:xnack+`, `-fsanitize=address`):
- All 7 affected tests (`check_matrix_csr`, `check_matrix_csc`, `check_matrix_gebsr`,
  `check_matrix_gebsc`, `csrsort`, `cscsort`, `coosort`) no longer produce
  `heap-buffer-overflow` ASAN errors.
- No regressions in non-ASAN builds.