### PR TITLE
[ALMIOPEN-1821] Fix tests that don't skip on no-device

### DIFF
--- a/dnn-providers/miopen-provider/tests/TestMiopenEngineManager.cpp
+++ b/dnn-providers/miopen-provider/tests/TestMiopenEngineManager.cpp
@@ -10,6 +10,7 @@
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 #include <hipdnn_test_sdk/utilities/MockEngineConfig.hpp>
 #include <hipdnn_test_sdk/utilities/MockGraph.hpp>
+#include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
 
 #include "HipdnnMiopenContext.hpp"
 #include "HipdnnMiopenHandle.hpp"
@@ -23,6 +24,8 @@ using ::testing::Return;
 
 TEST(TestMiopenEngineManager, ReturnsApplicableEngineIds)
 {
+    SKIP_IF_NO_DEVICES();
+
     std::set<std::unique_ptr<
         hipdnn_plugin_sdk::IEngine<HipdnnMiopenHandle, HipdnnMiopenSettings, HipdnnMiopenContext>>>
         engines;
@@ -52,6 +55,8 @@ TEST(TestMiopenEngineManager, ReturnsApplicableEngineIds)
 
 TEST(TestMiopenEngineManager, ReturnsMultipleApplicableEngineIds)
 {
+    SKIP_IF_NO_DEVICES();
+
     std::set<std::unique_ptr<
         hipdnn_plugin_sdk::IEngine<HipdnnMiopenHandle, HipdnnMiopenSettings, HipdnnMiopenContext>>>
         engines;
@@ -82,6 +87,8 @@ TEST(TestMiopenEngineManager, ReturnsMultipleApplicableEngineIds)
 
 TEST(TestMiopenEngineManager, ReturnsNoApplicableEngineIds)
 {
+    SKIP_IF_NO_DEVICES();
+
     std::set<std::unique_ptr<
         hipdnn_plugin_sdk::IEngine<HipdnnMiopenHandle, HipdnnMiopenSettings, HipdnnMiopenContext>>>
         engines;
@@ -110,6 +117,8 @@ TEST(TestMiopenEngineManager, ReturnsNoApplicableEngineIds)
 
 TEST(TestMiopenEngineManager, ReturnsEngineDetails)
 {
+    SKIP_IF_NO_DEVICES();
+
     hipdnn_plugin_sdk::EngineManager<HipdnnMiopenHandle, HipdnnMiopenSettings, HipdnnMiopenContext>
         manager;
 
@@ -142,6 +151,8 @@ TEST(TestMiopenEngineManager, ReturnsEngineDetails)
 
 TEST(TestMiopenEngineManager, ThrowsOnInvalidEngineId)
 {
+    SKIP_IF_NO_DEVICES();
+
     hipdnn_plugin_sdk::EngineManager<HipdnnMiopenHandle, HipdnnMiopenSettings, HipdnnMiopenContext>
         manager;
 
@@ -155,6 +166,8 @@ TEST(TestMiopenEngineManager, ThrowsOnInvalidEngineId)
 
 TEST(TestMiopenEngineManager, GetWorkspaceSizeReturnsCorrectValue)
 {
+    SKIP_IF_NO_DEVICES();
+
     hipdnn_plugin_sdk::EngineManager<HipdnnMiopenHandle, HipdnnMiopenSettings, HipdnnMiopenContext>
         manager;
 
@@ -175,6 +188,8 @@ TEST(TestMiopenEngineManager, GetWorkspaceSizeReturnsCorrectValue)
 
 TEST(TestMiopenEngineManager, GetWorkspaceSizeThrowsOnInvalidEngineId)
 {
+    SKIP_IF_NO_DEVICES();
+
     hipdnn_plugin_sdk::EngineManager<HipdnnMiopenHandle, HipdnnMiopenSettings, HipdnnMiopenContext>
         manager;
     HipdnnMiopenHandle dummyHandle = {};
@@ -188,6 +203,8 @@ TEST(TestMiopenEngineManager, GetWorkspaceSizeThrowsOnInvalidEngineId)
 
 TEST(TestMiopenEngineManager, InitializeExecutionContextCallsEngine)
 {
+    SKIP_IF_NO_DEVICES();
+
     auto mockEngine = std::make_unique<MockEngine>();
     EXPECT_CALL(*mockEngine, id()).WillRepeatedly(Return(7));
     EXPECT_CALL(*mockEngine,
@@ -209,6 +226,8 @@ TEST(TestMiopenEngineManager, InitializeExecutionContextCallsEngine)
 
 TEST(TestMiopenEngineManager, InitializeExecutionContextThrowsOnInvalidEngineId)
 {
+    SKIP_IF_NO_DEVICES();
+
     MockHipdnnMiopenContext execCtx;
     hipdnn_plugin_sdk::EngineManager<HipdnnMiopenHandle, HipdnnMiopenSettings, HipdnnMiopenContext>
         manager;

--- a/dnn-providers/miopen-provider/tests/TestMiopenHipdnnPluginExecutionContext.cpp
+++ b/dnn-providers/miopen-provider/tests/TestMiopenHipdnnPluginExecutionContext.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier:  MIT
 
 #include <gtest/gtest.h>
+#include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
 #include <memory>
 
 #include "mocks/MockPlan.hpp"
@@ -45,6 +46,8 @@ TEST(TestMiopenHipdnnMiopenContext, GetPlanThrowsIfNotSet)
 
 TEST(TestMiopenHipdnnMiopenContext, GetWorkspaceSize)
 {
+    SKIP_IF_NO_DEVICES();
+
     HipdnnMiopenContext ctx;
 
     auto mockPlan = std::make_unique<miopen_plugin::MockPlan>();

--- a/dnn-providers/miopen-provider/tests/engines/TestMiopenEngine.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/TestMiopenEngine.cpp
@@ -11,6 +11,7 @@
 #include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/EngineDetailsWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 #include <hipdnn_test_sdk/utilities/MockGraph.hpp>
+#include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
 
 #include "engines/MiopenEngine.hpp"
 #include "mocks/MockHipdnnMiopenContext.hpp"
@@ -23,12 +24,16 @@ using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 
 TEST(TestMiopenEngine, ConstructorAndId)
 {
+    SKIP_IF_NO_DEVICES();
+
     MiopenEngine engine(42);
     EXPECT_EQ(engine.id(), 42);
 }
 
 TEST(TestMiopenEngine, WorkspaceSizeReturnsZeroIfNoPlanBuilders)
 {
+    SKIP_IF_NO_DEVICES();
+
     MiopenEngine engine(1);
 
     HipdnnMiopenHandle dummyHandle;
@@ -41,6 +46,8 @@ TEST(TestMiopenEngine, WorkspaceSizeReturnsZeroIfNoPlanBuilders)
 
 TEST(TestMiopenEngine, WorkspaceSizeReturnsPlanBuilderWorkspace)
 {
+    SKIP_IF_NO_DEVICES();
+
     auto mockPlanBuilder = std::make_unique<MockPlanBuilder>();
     EXPECT_CALL(*mockPlanBuilder, isApplicable(::testing::_, ::testing::_))
         .WillOnce(::testing::Return(true));
@@ -63,6 +70,8 @@ TEST(TestMiopenEngine, WorkspaceSizeReturnsPlanBuilderWorkspace)
 
 TEST(TestMiopenEngine, WorkspaceSizeReturnsMaxPlanBuilderWorkspace)
 {
+    SKIP_IF_NO_DEVICES();
+
     auto mockPlanBuilder = std::make_unique<MockPlanBuilder>();
     auto mockPlanBuilder2 = std::make_unique<MockPlanBuilder>();
 
@@ -96,6 +105,8 @@ TEST(TestMiopenEngine, WorkspaceSizeReturnsMaxPlanBuilderWorkspace)
 
 TEST(TestMiopenEngine, WorkspaceSizeReturnsZeroIfNoPlanBuilderApplicable)
 {
+    SKIP_IF_NO_DEVICES();
+
     auto mockPlanBuilder = std::make_unique<MockPlanBuilder>();
     EXPECT_CALL(*mockPlanBuilder, isApplicable(::testing::_, ::testing::_))
         .WillOnce(::testing::Return(false));
@@ -113,6 +124,8 @@ TEST(TestMiopenEngine, WorkspaceSizeReturnsZeroIfNoPlanBuilderApplicable)
 
 TEST(TestMiopenEngine, IsApplicableReturnsTrueIfAnyPlanBuilderApplicable)
 {
+    SKIP_IF_NO_DEVICES();
+
     auto mockPlanBuilder = std::make_unique<MockPlanBuilder>();
 
     EXPECT_CALL(*mockPlanBuilder, isApplicable(::testing::_, ::testing::_))
@@ -130,6 +143,8 @@ TEST(TestMiopenEngine, IsApplicableReturnsTrueIfAnyPlanBuilderApplicable)
 
 TEST(TestMiopenEngine, IsApplicableReturnsAfterTheFirstApplicablePlanBuilder)
 {
+    SKIP_IF_NO_DEVICES();
+
     auto mockPlanBuilder1 = std::make_unique<MockPlanBuilder>();
     auto mockPlanBuilder2 = std::make_unique<MockPlanBuilder>();
 
@@ -150,6 +165,8 @@ TEST(TestMiopenEngine, IsApplicableReturnsAfterTheFirstApplicablePlanBuilder)
 
 TEST(TestMiopenEngine, IsApplicableReturnsFalseIfNoPlanBuilders)
 {
+    SKIP_IF_NO_DEVICES();
+
     MiopenEngine engine(0);
 
     MockGraph mockGraph;
@@ -161,6 +178,8 @@ TEST(TestMiopenEngine, IsApplicableReturnsFalseIfNoPlanBuilders)
 
 TEST(TestMiopenEngine, IsApplicableReturnsFalseIfNoPlanBuilderApplicable)
 {
+    SKIP_IF_NO_DEVICES();
+
     auto mockPlanBuilder = std::make_unique<MockPlanBuilder>();
     EXPECT_CALL(*mockPlanBuilder, isApplicable(::testing::_, ::testing::_))
         .WillOnce(::testing::Return(false));
@@ -177,6 +196,8 @@ TEST(TestMiopenEngine, IsApplicableReturnsFalseIfNoPlanBuilderApplicable)
 
 TEST(TestMiopenEngine, GetDetailsReturnsSerializedEngineDetails)
 {
+    SKIP_IF_NO_DEVICES();
+
     MiopenEngine engine(1);
     HipdnnMiopenHandle dummyHandle;
     MockGraph mockGraph;
@@ -191,6 +212,8 @@ TEST(TestMiopenEngine, GetDetailsReturnsSerializedEngineDetails)
 
 TEST(TestMiopenEngine, GetDetailsContainsBenchmarkingKnob)
 {
+    SKIP_IF_NO_DEVICES();
+
     MiopenEngine engine(1);
     HipdnnMiopenHandle dummyHandle;
     MockGraph mockGraph;
@@ -224,6 +247,8 @@ TEST(TestMiopenEngine, GetDetailsContainsBenchmarkingKnob)
 
 TEST(TestMiopenEngine, GetDetailsOnlyUsesFirstPlanBuilderCustomKnobs)
 {
+    SKIP_IF_NO_DEVICES();
+
     auto mockPlanBuilder1 = std::make_unique<MockPlanBuilder>();
     auto mockPlanBuilder2 = std::make_unique<MockPlanBuilder>();
 
@@ -286,6 +311,8 @@ TEST(TestMiopenEngine, GetDetailsOnlyUsesFirstPlanBuilderCustomKnobs)
 
 TEST(TestMiopenEngine, InitializeExecutionContextInvokesFirstApplicablePlanBuilder)
 {
+    SKIP_IF_NO_DEVICES();
+
     auto mockPlanBuilder1 = std::make_unique<MockPlanBuilder>();
     auto mockPlanBuilder2 = std::make_unique<MockPlanBuilder>();
 
@@ -319,6 +346,8 @@ TEST(TestMiopenEngine, InitializeExecutionContextInvokesFirstApplicablePlanBuild
 
 TEST(TestMiopenEngine, InitializeExecutionContextThrowsOnInvalidBenchmarkingKnobType)
 {
+    SKIP_IF_NO_DEVICES();
+
     MiopenEngine engine(1);
     MockGraph mockGraph;
     HipdnnMiopenHandle dummyHandle;
@@ -352,6 +381,8 @@ TEST(TestMiopenEngine, InitializeExecutionContextThrowsOnInvalidBenchmarkingKnob
 
 TEST(TestMiopenEngine, InitializeExecutionContextSetsBenchmarkingEnabled)
 {
+    SKIP_IF_NO_DEVICES();
+
     MiopenEngine engine(1);
     MockGraph mockGraph;
     HipdnnMiopenHandle dummyHandle;
@@ -384,6 +415,8 @@ TEST(TestMiopenEngine, InitializeExecutionContextSetsBenchmarkingEnabled)
 
 TEST(TestMiopenEngine, InitializeExecutionContextSetsBenchmarkingDisabled)
 {
+    SKIP_IF_NO_DEVICES();
+
     MiopenEngine engine(1);
     MockGraph mockGraph;
     HipdnnMiopenHandle dummyHandle;
@@ -417,6 +450,8 @@ TEST(TestMiopenEngine, InitializeExecutionContextSetsBenchmarkingDisabled)
 
 TEST(TestMiopenEngine, InitializeExecutionContextDefaultsBenchmarkingDisabledWhenConfigInvalid)
 {
+    SKIP_IF_NO_DEVICES();
+
     MiopenEngine engine(1);
     MockGraph mockGraph;
     HipdnnMiopenHandle dummyHandle;
@@ -432,6 +467,8 @@ TEST(TestMiopenEngine, InitializeExecutionContextDefaultsBenchmarkingDisabledWhe
 
 TEST(TestMiopenEngine, InitializeExecutionContextDefaultsBenchmarkingDisabledWhenNoKnobs)
 {
+    SKIP_IF_NO_DEVICES();
+
     MiopenEngine engine(1);
     MockGraph mockGraph;
     HipdnnMiopenHandle dummyHandle;
@@ -452,6 +489,8 @@ TEST(TestMiopenEngine, InitializeExecutionContextDefaultsBenchmarkingDisabledWhe
 
 TEST(TestMiopenEngine, InitializeExecutionContextSkipsNonApplicableBuilders)
 {
+    SKIP_IF_NO_DEVICES();
+
     auto mockPlanBuilder1 = std::make_unique<MockPlanBuilder>();
     auto mockPlanBuilder2 = std::make_unique<MockPlanBuilder>();
 
@@ -487,6 +526,8 @@ TEST(TestMiopenEngine, InitializeExecutionContextSkipsNonApplicableBuilders)
 
 TEST(TestMiopenEngine, InitializeExecutionContextDoesNotCallBuildPlanIfNoApplicableBuilders)
 {
+    SKIP_IF_NO_DEVICES();
+
     auto mockPlanBuilder1 = std::make_unique<MockPlanBuilder>();
     auto mockPlanBuilder2 = std::make_unique<MockPlanBuilder>();
 

--- a/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormBwdPlan.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormBwdPlan.cpp
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 #include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
+#include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
 
 using namespace miopen_plugin;
 
@@ -164,6 +165,8 @@ TEST(TestBatchnormBwdPlan, FusedModeHasActivationAndBias)
 
 TEST(TestBatchnormBwdPlan, GetWorkspaceSizeReturnsZeroForFusedMode)
 {
+    SKIP_IF_NO_DEVICES();
+
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferActBwdGraph();
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
@@ -191,6 +194,8 @@ TEST(TestBatchnormBwdPlan, GetWorkspaceSizeReturnsZeroForFusedMode)
 
 TEST(TestBatchnormBwdPlan, GetWorkspaceSizeReturnsZero)
 {
+    SKIP_IF_NO_DEVICES();
+
     auto builder = hipdnn_test_sdk::utilities::createValidBatchnormBwdGraph();
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());

--- a/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormFwdTrainingActivPlanBuilder.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormFwdTrainingActivPlanBuilder.cpp
@@ -1,6 +1,8 @@
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier:  MIT
 
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
@@ -8,6 +10,7 @@
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 #include <hipdnn_test_sdk/utilities/MockEngineConfig.hpp>
 #include <hipdnn_test_sdk/utilities/MockGraph.hpp>
+#include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
 
 #include "HipdnnMiopenHandle.hpp"
 #include "engines/plans/MiopenBatchnormFwdTrainingPlanBuilder.hpp"
@@ -21,8 +24,14 @@ using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 class TestMiopenBatchnormFwdTrainingActivPlanBuilder : public ::testing::Test
 {
 protected:
+    void SetUp() override
+    {
+        SKIP_IF_NO_DEVICES();
+        _dummyHandle = std::make_unique<HipdnnMiopenHandle>();
+    }
+
     MiopenBatchnormFwdTrainingPlanBuilder _planBuilder;
-    HipdnnMiopenHandle _dummyHandle;
+    std::unique_ptr<HipdnnMiopenHandle> _dummyHandle;
 };
 
 TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder,
@@ -32,7 +41,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder,
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, graph);
 
     EXPECT_TRUE(applicable);
 }
@@ -42,7 +51,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder, IsApplicableReturnsFalseF
     MockGraph mockGraph;
     EXPECT_CALL(mockGraph, nodeCount()).WillRepeatedly(::testing::Return(3));
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, mockGraph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, mockGraph);
 
     EXPECT_FALSE(applicable);
 }
@@ -53,7 +62,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder, IsApplicableReturnsTrueFo
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, graph);
 
     EXPECT_TRUE(applicable);
 }
@@ -66,7 +75,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder,
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, graph);
 
     EXPECT_TRUE(applicable);
 }
@@ -79,7 +88,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder, IsApplicableReturnsFalseF
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, graph);
 
     EXPECT_FALSE(applicable);
 }
@@ -91,7 +100,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder, GetWorkspaceSizeReturnsZe
                                                                      builder.GetSize());
 
     HipdnnMiopenSettings settings;
-    size_t workspaceSize = _planBuilder.getMaxWorkspaceSize(_dummyHandle, graph, settings);
+    size_t workspaceSize = _planBuilder.getMaxWorkspaceSize(*_dummyHandle, graph, settings);
 
     EXPECT_EQ(workspaceSize, 0u);
 }
@@ -104,7 +113,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder, BuildPlanSetsPlanForValid
     MockEngineConfig mockEngineConfig;
     HipdnnMiopenContext ctx;
 
-    EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, mockEngineConfig, ctx));
+    EXPECT_NO_THROW(_planBuilder.buildPlan(*_dummyHandle, graph, mockEngineConfig, ctx));
     EXPECT_TRUE(ctx.hasValidPlan());
 }
 
@@ -159,7 +168,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder,
     MockEngineConfig mockEngineConfig;
     HipdnnMiopenContext ctx;
 
-    EXPECT_THROW(_planBuilder.buildPlan(_dummyHandle, graph, mockEngineConfig, ctx),
+    EXPECT_THROW(_planBuilder.buildPlan(*_dummyHandle, graph, mockEngineConfig, ctx),
                  std::invalid_argument);
     EXPECT_FALSE(ctx.hasValidPlan());
 }
@@ -262,7 +271,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder,
     MockEngineConfig mockEngineConfig;
     HipdnnMiopenContext ctx;
 
-    EXPECT_THROW(_planBuilder.buildPlan(_dummyHandle, graph, mockEngineConfig, ctx),
+    EXPECT_THROW(_planBuilder.buildPlan(*_dummyHandle, graph, mockEngineConfig, ctx),
                  std::invalid_argument);
     EXPECT_FALSE(ctx.hasValidPlan());
 }
@@ -342,7 +351,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder, IsApplicableReturnsFalseF
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, graph);
 
     EXPECT_FALSE(applicable);
 }
@@ -461,7 +470,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder,
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, graph);
 
     EXPECT_FALSE(applicable);
 }
@@ -480,7 +489,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder, IsApplicableReturnsTrueFo
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    EXPECT_TRUE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_TRUE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder,
@@ -498,7 +507,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder,
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    EXPECT_TRUE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_TRUE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder, BuildPlanSetsPlanFor3dNclSingleNode)
@@ -513,7 +522,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder, BuildPlanSetsPlanFor3dNcl
     MockEngineConfig mockEngineConfig;
     HipdnnMiopenContext ctx;
 
-    EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, mockEngineConfig, ctx));
+    EXPECT_NO_THROW(_planBuilder.buildPlan(*_dummyHandle, graph, mockEngineConfig, ctx));
     EXPECT_TRUE(ctx.hasValidPlan());
 }
 
@@ -533,6 +542,6 @@ TEST_F(TestMiopenBatchnormFwdTrainingActivPlanBuilder, BuildPlanSetsPlanFor3dNlc
     MockEngineConfig mockEngineConfig;
     HipdnnMiopenContext ctx;
 
-    EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, mockEngineConfig, ctx));
+    EXPECT_NO_THROW(_planBuilder.buildPlan(*_dummyHandle, graph, mockEngineConfig, ctx));
     EXPECT_TRUE(ctx.hasValidPlan());
 }

--- a/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormFwdTrainingPlanBuilder.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormFwdTrainingPlanBuilder.cpp
@@ -1,6 +1,8 @@
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier:  MIT
 
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
@@ -8,6 +10,7 @@
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 #include <hipdnn_test_sdk/utilities/MockEngineConfig.hpp>
 #include <hipdnn_test_sdk/utilities/MockGraph.hpp>
+#include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
 
 #include "HipdnnMiopenHandle.hpp"
 #include "engines/plans/MiopenBatchnormFwdTrainingPlanBuilder.hpp"
@@ -19,8 +22,14 @@ using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
 class TestMiopenBatchnormFwdTrainingPlanBuilder : public ::testing::Test
 {
 protected:
+    void SetUp() override
+    {
+        SKIP_IF_NO_DEVICES();
+        _dummyHandle = std::make_unique<HipdnnMiopenHandle>();
+    }
+
     MiopenBatchnormFwdTrainingPlanBuilder _planBuilder;
-    HipdnnMiopenHandle _dummyHandle;
+    std::unique_ptr<HipdnnMiopenHandle> _dummyHandle;
 };
 
 // ============================================================================
@@ -33,7 +42,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, IsApplicableReturnsTrueForVali
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, graph);
 
     EXPECT_TRUE(applicable);
 }
@@ -44,7 +53,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, IsApplicableReturnsTrueForVali
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, graph);
 
     EXPECT_TRUE(applicable);
 }
@@ -54,7 +63,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, IsApplicableReturnsFalseForThr
     MockGraph mockGraph;
     EXPECT_CALL(mockGraph, nodeCount()).WillRepeatedly(::testing::Return(3));
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, mockGraph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, mockGraph);
 
     EXPECT_FALSE(applicable);
 }
@@ -89,7 +98,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, IsApplicableReturnsFalseForWro
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, graph);
 
     EXPECT_FALSE(applicable);
 }
@@ -106,7 +115,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, IsApplicableReturnsFalseForUns
 
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
-    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_FALSE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 // ============================================================================
@@ -121,7 +130,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, IsApplicableReturnsFalseForNon
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, graph);
 
     EXPECT_FALSE(applicable);
 }
@@ -164,7 +173,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, IsApplicableReturnsFalseForWro
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, graph);
 
     EXPECT_FALSE(applicable);
 }
@@ -291,7 +300,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder,
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, graph);
 
     EXPECT_FALSE(applicable);
 }
@@ -408,7 +417,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder,
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, graph);
 
     EXPECT_FALSE(applicable);
 }
@@ -422,7 +431,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, GetWorkspaceSizeReturnsZero)
     MockGraph mockGraph;
 
     HipdnnMiopenSettings settings;
-    size_t workspaceSize = _planBuilder.getMaxWorkspaceSize(_dummyHandle, mockGraph, settings);
+    size_t workspaceSize = _planBuilder.getMaxWorkspaceSize(*_dummyHandle, mockGraph, settings);
 
     EXPECT_EQ(workspaceSize, 0u);
 }
@@ -435,7 +444,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, BuildPlanSetsPlanForValidSingl
     HipdnnMiopenContext ctx;
     MockEngineConfig mockEngineConfig;
 
-    EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, mockEngineConfig, ctx));
+    EXPECT_NO_THROW(_planBuilder.buildPlan(*_dummyHandle, graph, mockEngineConfig, ctx));
     EXPECT_TRUE(ctx.hasValidPlan());
 }
 
@@ -447,7 +456,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, BuildPlanSetsPlanForValidTwoNo
     HipdnnMiopenContext ctx;
     MockEngineConfig mockEngineConfig;
 
-    EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, mockEngineConfig, ctx));
+    EXPECT_NO_THROW(_planBuilder.buildPlan(*_dummyHandle, graph, mockEngineConfig, ctx));
     EXPECT_TRUE(ctx.hasValidPlan());
 }
 
@@ -485,7 +494,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, BuildPlanThrowsForUnsupportedN
     HipdnnMiopenContext ctx;
     MockEngineConfig mockEngineConfig;
 
-    EXPECT_THROW(_planBuilder.buildPlan(_dummyHandle, graph, mockEngineConfig, ctx),
+    EXPECT_THROW(_planBuilder.buildPlan(*_dummyHandle, graph, mockEngineConfig, ctx),
                  hipdnn_plugin_sdk::HipdnnPluginException);
     EXPECT_FALSE(ctx.hasValidPlan());
 }
@@ -585,7 +594,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, IsApplicableReturnsFalseForInv
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, graph);
 
     EXPECT_FALSE(applicable);
 }
@@ -671,7 +680,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, IsApplicableReturnsFalseForInv
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, graph);
 
     EXPECT_FALSE(applicable);
 }
@@ -757,7 +766,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, IsApplicableReturnsFalseForInv
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, graph);
 
     EXPECT_FALSE(applicable);
 }
@@ -853,7 +862,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, IsApplicableReturnsFalseForNon
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, graph);
 
     EXPECT_FALSE(applicable);
 }
@@ -940,7 +949,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder,
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, graph);
 
     EXPECT_FALSE(applicable);
 }
@@ -1040,7 +1049,7 @@ TEST_F(TestMiopenBatchnormFwdTrainingPlanBuilder, IsApplicableReturnsFalseForMix
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, graph);
 
     EXPECT_FALSE(applicable);
 }

--- a/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormPlanBuilder.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormPlanBuilder.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier:  MIT
 
 #include <gtest/gtest.h>
+#include <memory>
 #include <numeric>
 #include <unordered_set>
 
@@ -11,6 +12,7 @@
 #include <hipdnn_test_sdk/utilities/MockEngineConfig.hpp>
 #include <hipdnn_test_sdk/utilities/MockGraph.hpp>
 #include <hipdnn_test_sdk/utilities/MockNode.hpp>
+#include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
 
 #include "HipdnnMiopenHandle.hpp"
 #include "engines/plans/MiopenBatchnormPlanBuilder.hpp"
@@ -63,8 +65,14 @@ void createBatchnormFusionTensorAttributes(
 class TestMiopenBatchnormPlanBuilder : public ::testing::Test
 {
 protected:
+    void SetUp() override
+    {
+        SKIP_IF_NO_DEVICES();
+        _dummyHandle = std::make_unique<HipdnnMiopenHandle>();
+    }
+
     MiopenBatchnormPlanBuilder _planBuilder;
-    HipdnnMiopenHandle _dummyHandle;
+    std::unique_ptr<HipdnnMiopenHandle> _dummyHandle;
     MockEngineConfig _mockEngineConfig;
 };
 
@@ -76,7 +84,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseForGraphWithUnsup
     std::vector<std::unique_ptr<INodeWrapper>> nodeWrappers;
     EXPECT_CALL(mockGraph, nodeWrappers()).WillRepeatedly(::testing::ReturnRef(nodeWrappers));
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, mockGraph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, mockGraph);
 
     EXPECT_FALSE(applicable);
 }
@@ -91,7 +99,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseForUnsupportedAtt
     std::vector<std::unique_ptr<INodeWrapper>> nodeWrappers;
     EXPECT_CALL(mockGraph, nodeWrappers()).WillRepeatedly(::testing::ReturnRef(nodeWrappers));
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, mockGraph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, mockGraph);
 
     EXPECT_FALSE(applicable);
 }
@@ -103,7 +111,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsTrueForFusedTwoNodeGra
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, graph);
 
     EXPECT_TRUE(applicable);
 }
@@ -115,7 +123,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsTrueForFusedThreeNodeG
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, graph);
 
     EXPECT_TRUE(applicable);
 }
@@ -158,7 +166,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseForIncorrectTwoNo
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, graph);
 
     EXPECT_FALSE(applicable);
 }
@@ -209,7 +217,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseForIncorrectThree
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, graph);
 
     EXPECT_FALSE(applicable);
 }
@@ -267,7 +275,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseForTwoNodeFusionU
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_FALSE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 // ============================================================================
@@ -280,7 +288,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsTrueForValidSingleNode
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, graph);
 
     EXPECT_TRUE(applicable);
 }
@@ -295,7 +303,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BackwardIsApplicableReturnsFalseForInvali
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_FALSE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 TEST_F(TestMiopenBatchnormPlanBuilder, BackwardIsApplicableReturnsFalseForInvalidScaleBiasDataType)
@@ -309,7 +317,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BackwardIsApplicableReturnsFalseForInvali
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_FALSE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 TEST_F(TestMiopenBatchnormPlanBuilder, BackwardIsApplicableReturnsFalseForInvalidStatDataType)
@@ -324,7 +332,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BackwardIsApplicableReturnsFalseForInvali
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_FALSE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 TEST_F(TestMiopenBatchnormPlanBuilder, BackwardIsApplicableReturnsFalseForInvalidLayout)
@@ -417,7 +425,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BackwardIsApplicableReturnsFalseForInvali
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_FALSE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 TEST_F(TestMiopenBatchnormPlanBuilder, BackwardIsApplicableReturnsFalseForInsufficientSpatialDims)
@@ -427,7 +435,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BackwardIsApplicableReturnsFalseForInsuff
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_FALSE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 // ============================================================================
@@ -514,7 +522,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseForInvalidLayoutI
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_FALSE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 // ============================================================================
@@ -610,7 +618,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseForNonPackedTenso
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_FALSE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseForThreeNodeUnsupportedActivation)
@@ -685,7 +693,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseForThreeNodeUnsup
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_FALSE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseWhenActivationMissingIn1)
@@ -760,7 +768,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseWhenActivationMis
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_FALSE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseForFourNodeGraph)
@@ -771,7 +779,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseForFourNodeGraph)
     std::vector<std::unique_ptr<INodeWrapper>> nodeWrappers;
     EXPECT_CALL(mockGraph, nodeWrappers()).WillRepeatedly(::testing::ReturnRef(nodeWrappers));
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, mockGraph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, mockGraph);
 
     EXPECT_FALSE(applicable);
 }
@@ -792,7 +800,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseForUnsupportedCom
     nodeWrappers.emplace_back(std::move(nodeB));
     EXPECT_CALL(mockGraph, nodeWrappers()).WillRepeatedly(::testing::ReturnRef(nodeWrappers));
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, mockGraph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, mockGraph);
 
     EXPECT_FALSE(applicable);
 }
@@ -802,7 +810,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, GetMaxWorkspaceSizeReturnsExpectedValue)
     MockGraph mockGraph;
 
     HipdnnMiopenSettings settings;
-    size_t workspaceSize = _planBuilder.getMaxWorkspaceSize(_dummyHandle, mockGraph, settings);
+    size_t workspaceSize = _planBuilder.getMaxWorkspaceSize(*_dummyHandle, mockGraph, settings);
 
     EXPECT_EQ(workspaceSize, 0u);
 }
@@ -815,7 +823,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanSetsPlanForSupportedInferenceNod
                                                                      builder.GetSize());
     HipdnnMiopenContext ctx;
 
-    EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx));
+    EXPECT_NO_THROW(_planBuilder.buildPlan(*_dummyHandle, graph, _mockEngineConfig, ctx));
     EXPECT_TRUE(ctx.hasValidPlan());
 }
 
@@ -827,7 +835,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanSetsPlanForSupportedInferenceWit
                                                                      builder.GetSize());
     HipdnnMiopenContext ctx;
 
-    EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx));
+    EXPECT_NO_THROW(_planBuilder.buildPlan(*_dummyHandle, graph, _mockEngineConfig, ctx));
     EXPECT_TRUE(ctx.hasValidPlan());
 }
 
@@ -839,7 +847,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanSetsPlanForSupportedBackwardNode
                                                                      builder.GetSize());
     HipdnnMiopenContext ctx;
 
-    EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx));
+    EXPECT_NO_THROW(_planBuilder.buildPlan(*_dummyHandle, graph, _mockEngineConfig, ctx));
     EXPECT_TRUE(ctx.hasValidPlan());
 }
 
@@ -851,7 +859,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanSetsPlanForFusedTwoNodeGraph)
                                                                      builder.GetSize());
     HipdnnMiopenContext ctx;
 
-    EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx));
+    EXPECT_NO_THROW(_planBuilder.buildPlan(*_dummyHandle, graph, _mockEngineConfig, ctx));
     EXPECT_TRUE(ctx.hasValidPlan());
 }
 
@@ -863,7 +871,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanSetsPlanForFusedThreeNodeGraph)
                                                                      builder.GetSize());
     HipdnnMiopenContext ctx;
 
-    EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx));
+    EXPECT_NO_THROW(_planBuilder.buildPlan(*_dummyHandle, graph, _mockEngineConfig, ctx));
     EXPECT_TRUE(ctx.hasValidPlan());
 }
 
@@ -899,7 +907,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanThrowsForUnsupportedNodeType)
 
     HipdnnMiopenContext ctx;
 
-    EXPECT_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx),
+    EXPECT_THROW(_planBuilder.buildPlan(*_dummyHandle, graph, _mockEngineConfig, ctx),
                  hipdnn_plugin_sdk::HipdnnPluginException);
     EXPECT_FALSE(ctx.hasValidPlan());
 }
@@ -935,7 +943,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanThrowsForMalformedInferenceAttri
                                                                      builder.GetSize());
     HipdnnMiopenContext ctx;
 
-    EXPECT_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx),
+    EXPECT_THROW(_planBuilder.buildPlan(*_dummyHandle, graph, _mockEngineConfig, ctx),
                  std::invalid_argument);
     EXPECT_FALSE(ctx.hasValidPlan());
 }
@@ -971,7 +979,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanThrowsForMalformedBackwardAttrib
                                                                      builder.GetSize());
     HipdnnMiopenContext ctx;
 
-    EXPECT_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx),
+    EXPECT_THROW(_planBuilder.buildPlan(*_dummyHandle, graph, _mockEngineConfig, ctx),
                  std::invalid_argument);
     EXPECT_FALSE(ctx.hasValidPlan());
 }
@@ -1026,7 +1034,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanThrowsForMalformedTwoNodeFusedGr
 
     HipdnnMiopenContext ctx;
 
-    EXPECT_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx),
+    EXPECT_THROW(_planBuilder.buildPlan(*_dummyHandle, graph, _mockEngineConfig, ctx),
                  std::invalid_argument);
     EXPECT_FALSE(ctx.hasValidPlan());
 }
@@ -1073,7 +1081,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanThrowsForMalformedTwoNodeFusedGr
 
     HipdnnMiopenContext ctx;
 
-    EXPECT_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx),
+    EXPECT_THROW(_planBuilder.buildPlan(*_dummyHandle, graph, _mockEngineConfig, ctx),
                  std::invalid_argument);
     EXPECT_FALSE(ctx.hasValidPlan());
 }
@@ -1150,7 +1158,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanThrowsForMalformedFusedGraphFirs
                                                                      builder.GetSize());
     HipdnnMiopenContext ctx;
 
-    EXPECT_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx),
+    EXPECT_THROW(_planBuilder.buildPlan(*_dummyHandle, graph, _mockEngineConfig, ctx),
                  std::invalid_argument);
     EXPECT_FALSE(ctx.hasValidPlan());
 }
@@ -1218,7 +1226,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanThrowsForMalformedFusedGraphSeco
                                                                      builder.GetSize());
     HipdnnMiopenContext ctx;
 
-    EXPECT_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx),
+    EXPECT_THROW(_planBuilder.buildPlan(*_dummyHandle, graph, _mockEngineConfig, ctx),
                  std::invalid_argument);
     EXPECT_FALSE(ctx.hasValidPlan());
 }
@@ -1286,7 +1294,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanThrowsForMalformedFusedGraphThir
                                                                      builder.GetSize());
     HipdnnMiopenContext ctx;
 
-    EXPECT_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx),
+    EXPECT_THROW(_planBuilder.buildPlan(*_dummyHandle, graph, _mockEngineConfig, ctx),
                  std::invalid_argument);
     EXPECT_FALSE(ctx.hasValidPlan());
 }
@@ -1364,7 +1372,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder,
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_FALSE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 TEST_F(TestMiopenBatchnormPlanBuilder,
@@ -1440,7 +1448,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder,
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_FALSE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseWhenBnBackwardXDiffersFromInference)
@@ -1515,7 +1523,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseWhenBnBackwardXDi
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_FALSE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 TEST_F(TestMiopenBatchnormPlanBuilder,
@@ -1591,7 +1599,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder,
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_FALSE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseWhenBnInferenceOutputIsNotVirtual)
@@ -1666,7 +1674,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseWhenBnInferenceOu
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_FALSE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseWhenActivationOutputIsNotVirtual)
@@ -1741,7 +1749,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseWhenActivationOut
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_FALSE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 TEST_F(TestMiopenBatchnormPlanBuilder,
@@ -1796,7 +1804,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder,
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_FALSE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 TEST_F(TestMiopenBatchnormPlanBuilder,
@@ -1851,7 +1859,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder,
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_FALSE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 // ============================================================================
@@ -1912,7 +1920,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsTrueForFusedTwoNodeGra
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    EXPECT_TRUE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_TRUE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 TEST_F(TestMiopenBatchnormPlanBuilder,
@@ -1970,7 +1978,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder,
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_FALSE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 TEST_F(TestMiopenBatchnormPlanBuilder,
@@ -2028,7 +2036,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder,
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_FALSE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 TEST_F(TestMiopenBatchnormPlanBuilder,
@@ -2086,7 +2094,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder,
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_FALSE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 // ============================================================================
@@ -2103,7 +2111,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsTrueFor3dNclInference)
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    EXPECT_TRUE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_TRUE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsTrueFor3dNlcBackward)
@@ -2115,7 +2123,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsTrueFor3dNlcBackward)
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    EXPECT_TRUE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_TRUE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsTrueFor3dNclVarianceInference)
@@ -2128,7 +2136,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsTrueFor3dNclVarianceIn
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    EXPECT_TRUE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_TRUE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsTrueFor3dNlcFusedTwoNodeGraph)
@@ -2141,7 +2149,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsTrueFor3dNlcFusedTwoNo
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    EXPECT_TRUE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_TRUE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsTrueFor3dNclFusedThreeNodeGraph)
@@ -2154,7 +2162,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsTrueFor3dNclFusedThree
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    EXPECT_TRUE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_TRUE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanSetsPlanFor3dNclInference)
@@ -2168,7 +2176,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanSetsPlanFor3dNclInference)
                                                                      builder.GetSize());
     HipdnnMiopenContext ctx;
 
-    EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx));
+    EXPECT_NO_THROW(_planBuilder.buildPlan(*_dummyHandle, graph, _mockEngineConfig, ctx));
     EXPECT_TRUE(ctx.hasValidPlan());
 }
 
@@ -2182,7 +2190,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanSetsPlanFor3dNlcBackward)
                                                                      builder.GetSize());
     HipdnnMiopenContext ctx;
 
-    EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx));
+    EXPECT_NO_THROW(_planBuilder.buildPlan(*_dummyHandle, graph, _mockEngineConfig, ctx));
     EXPECT_TRUE(ctx.hasValidPlan());
 }
 
@@ -2197,7 +2205,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanSetsPlanFor3dNclVarianceInferenc
                                                                      builder.GetSize());
     HipdnnMiopenContext ctx;
 
-    EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx));
+    EXPECT_NO_THROW(_planBuilder.buildPlan(*_dummyHandle, graph, _mockEngineConfig, ctx));
     EXPECT_TRUE(ctx.hasValidPlan());
 }
 
@@ -2212,7 +2220,7 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanSetsPlanFor3dNlcFusedTwoNodeGrap
                                                                      builder.GetSize());
     HipdnnMiopenContext ctx;
 
-    EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx));
+    EXPECT_NO_THROW(_planBuilder.buildPlan(*_dummyHandle, graph, _mockEngineConfig, ctx));
     EXPECT_TRUE(ctx.hasValidPlan());
 }
 
@@ -2227,6 +2235,6 @@ TEST_F(TestMiopenBatchnormPlanBuilder, BuildPlanSetsPlanFor3dNclFusedThreeNodeGr
                                                                      builder.GetSize());
     HipdnnMiopenContext ctx;
 
-    EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, _mockEngineConfig, ctx));
+    EXPECT_NO_THROW(_planBuilder.buildPlan(*_dummyHandle, graph, _mockEngineConfig, ctx));
     EXPECT_TRUE(ctx.hasValidPlan());
 }

--- a/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenConvBwdPlan.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenConvBwdPlan.cpp
@@ -1,6 +1,8 @@
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier:  MIT
 
+#include <memory>
+
 #include <gtest/gtest.h>
 #include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
@@ -19,9 +21,10 @@ protected:
     void SetUp() override
     {
         SKIP_IF_NO_DEVICES();
+        _handle = std::make_unique<HipdnnMiopenHandle>();
     }
 
-    HipdnnMiopenHandle _handle;
+    std::unique_ptr<HipdnnMiopenHandle> _handle;
 };
 
 TEST(TestConvBwdParams, InitializesAllTensorsFromValidGraph)
@@ -239,7 +242,7 @@ TEST_F(TestGpuConvBwdPlan, CreatesPlanWithValidGraph)
 
     // Create plan
     HipdnnMiopenSettings executionSettings;
-    ConvBwdPlan(_handle, std::move(params), executionSettings);
+    ConvBwdPlan(*_handle, std::move(params), executionSettings);
 }
 
 TEST_F(TestGpuConvBwdPlan, PlanUsesDefaultWorkspaceSizeWhenNoLimitSet)
@@ -258,8 +261,8 @@ TEST_F(TestGpuConvBwdPlan, PlanUsesDefaultWorkspaceSizeWhenNoLimitSet)
     HipdnnMiopenSettings settings;
     settings.setDefaultWorkspaceSize(defaultSize);
 
-    ConvBwdPlan plan(_handle, std::move(params), settings);
-    EXPECT_EQ(plan.getWorkspaceSize(_handle), defaultSize);
+    ConvBwdPlan plan(*_handle, std::move(params), settings);
+    EXPECT_EQ(plan.getWorkspaceSize(*_handle), defaultSize);
 }
 
 TEST_F(TestGpuConvBwdPlan, PlanUsesKnobLimitOverDefault)
@@ -280,8 +283,8 @@ TEST_F(TestGpuConvBwdPlan, PlanUsesKnobLimitOverDefault)
     settings.setDefaultWorkspaceSize(defaultSize);
     settings.setWorkspaceSizeLimit(knobLimit);
 
-    ConvBwdPlan plan(_handle, std::move(params), settings);
-    EXPECT_EQ(plan.getWorkspaceSize(_handle), knobLimit);
+    ConvBwdPlan plan(*_handle, std::move(params), settings);
+    EXPECT_EQ(plan.getWorkspaceSize(*_handle), knobLimit);
 }
 
 TEST_F(TestGpuConvBwdPlan, ThrowsOnInvalidDims)
@@ -320,6 +323,6 @@ TEST_F(TestGpuConvBwdPlan, ThrowsOnInvalidDims)
 
     // Create plan and expect exception
     HipdnnMiopenSettings executionSettings;
-    EXPECT_THROW(ConvBwdPlan(_handle, std::move(params), executionSettings),
+    EXPECT_THROW(ConvBwdPlan(*_handle, std::move(params), executionSettings),
                  hipdnn_plugin_sdk::HipdnnPluginException);
 }

--- a/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenConvFwdBiasActivPlan.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenConvFwdBiasActivPlan.cpp
@@ -1,6 +1,8 @@
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier:  MIT
 
+#include <memory>
+
 #include <gtest/gtest.h>
 #include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
@@ -22,9 +24,10 @@ protected:
     void SetUp() override
     {
         SKIP_IF_NO_DEVICES();
+        _handle = std::make_unique<HipdnnMiopenHandle>();
     }
 
-    HipdnnMiopenHandle _handle;
+    std::unique_ptr<HipdnnMiopenHandle> _handle;
 };
 
 TEST(TestConvFwdBiasActivParams, InitializeFromValidConvFwdActivGraph)
@@ -121,7 +124,7 @@ TEST_F(TestGpuConvFwdBiasActivPlan, CreatePlanWithValidConvFwdActivGraph)
     ConvFwdBiasActivParams params(*convAttr, nullptr, *activAttr, graph.getTensorMap());
 
     HipdnnMiopenSettings executionSettings;
-    ConvFwdBiasActivPlan(_handle, std::move(params), executionSettings);
+    ConvFwdBiasActivPlan(*_handle, std::move(params), executionSettings);
 }
 
 TEST_F(TestGpuConvFwdBiasActivPlan, CreatePlanWithValidConvFwdActivGraphCompileOnly)
@@ -141,7 +144,7 @@ TEST_F(TestGpuConvFwdBiasActivPlan, CreatePlanWithValidConvFwdActivGraphCompileO
     ConvFwdBiasActivParams params(*convAttr, nullptr, *activAttr, graph.getTensorMap());
 
     HipdnnMiopenSettings executionSettings;
-    ConvFwdBiasActivPlan(_handle, std::move(params), executionSettings, true, false);
+    ConvFwdBiasActivPlan(*_handle, std::move(params), executionSettings, true, false);
 }
 
 TEST_F(TestGpuConvFwdBiasActivPlan, CreatePlanWithValidConvFwdActivGraphWorkspaceOnly)
@@ -161,7 +164,7 @@ TEST_F(TestGpuConvFwdBiasActivPlan, CreatePlanWithValidConvFwdActivGraphWorkspac
     ConvFwdBiasActivParams params(*convAttr, nullptr, *activAttr, graph.getTensorMap());
 
     HipdnnMiopenSettings executionSettings;
-    ConvFwdBiasActivPlan(_handle, std::move(params), executionSettings, false, true);
+    ConvFwdBiasActivPlan(*_handle, std::move(params), executionSettings, false, true);
 }
 
 TEST_F(TestGpuConvFwdBiasActivPlan, CreatePlanWithValidConvFwdBiasActivGraph)
@@ -185,7 +188,7 @@ TEST_F(TestGpuConvFwdBiasActivPlan, CreatePlanWithValidConvFwdBiasActivGraph)
     ConvFwdBiasActivParams params(*convAttr, biasAttr, *activAttr, graph.getTensorMap());
 
     HipdnnMiopenSettings executionSettings;
-    ConvFwdBiasActivPlan(_handle, std::move(params), executionSettings);
+    ConvFwdBiasActivPlan(*_handle, std::move(params), executionSettings);
 }
 
 TEST_F(TestGpuConvFwdBiasActivPlan, CreatePlanWithValidConvFwdBiasActivGraphCompileOnly)
@@ -209,7 +212,7 @@ TEST_F(TestGpuConvFwdBiasActivPlan, CreatePlanWithValidConvFwdBiasActivGraphComp
     ConvFwdBiasActivParams params(*convAttr, biasAttr, *activAttr, graph.getTensorMap());
 
     HipdnnMiopenSettings executionSettings;
-    ConvFwdBiasActivPlan(_handle, std::move(params), executionSettings, true, false);
+    ConvFwdBiasActivPlan(*_handle, std::move(params), executionSettings, true, false);
 }
 
 TEST_F(TestGpuConvFwdBiasActivPlan, CreatePlanWithValidConvFwdBiasActivGraphWorkspaceOnly)
@@ -233,5 +236,5 @@ TEST_F(TestGpuConvFwdBiasActivPlan, CreatePlanWithValidConvFwdBiasActivGraphWork
     ConvFwdBiasActivParams params(*convAttr, biasAttr, *activAttr, graph.getTensorMap());
 
     HipdnnMiopenSettings executionSettings;
-    ConvFwdBiasActivPlan(_handle, std::move(params), executionSettings, false, true);
+    ConvFwdBiasActivPlan(*_handle, std::move(params), executionSettings, false, true);
 }

--- a/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenConvFwdBiasActivPlanBuilder.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenConvFwdBiasActivPlanBuilder.cpp
@@ -18,6 +18,7 @@
 #include "tests/common/ActivationCommon.hpp"
 #include "tests/common/ConvolutionCommon.hpp"
 
+#include <memory>
 #include <unordered_map>
 
 using namespace miopen_plugin;
@@ -29,8 +30,14 @@ using namespace hipdnn_frontend::graph;
 class TestMiopenConvFwdBiasActivPlanBuilder : public ::testing::Test
 {
 protected:
+    void SetUp() override
+    {
+        SKIP_IF_NO_DEVICES();
+        _dummyHandle = std::make_unique<HipdnnMiopenHandle>();
+    }
+
     MiopenConvFwdBiasActivPlanBuilder _planBuilder;
-    HipdnnMiopenHandle _dummyHandle;
+    std::unique_ptr<HipdnnMiopenHandle> _dummyHandle;
 };
 
 enum class TypeKey
@@ -119,6 +126,7 @@ protected:
         SKIP_IF_WINDOWS();
 
         SKIP_IF_NO_DEVICES();
+        _handle = std::make_unique<HipdnnMiopenHandle>();
 
         auto param = GetParam();
         auto& convTestCase = param.convTestCase;
@@ -235,7 +243,7 @@ protected:
     }
 
     MiopenConvFwdBiasActivPlanBuilder _planBuilder;
-    HipdnnMiopenHandle _handle;
+    std::unique_ptr<HipdnnMiopenHandle> _handle;
 
     Graph _graphObj;
     bool _isApplicable;
@@ -578,15 +586,15 @@ TEST_P(TestGpuMiopenConvFwdBiasActivPlanBuilder, IsApplicableGetWorkspaceSizeAnd
     auto graph = GraphWrapper(graphBuffer.data(), graphBuffer.size());
     MockEngineConfig mockEngineConfig;
 
-    EXPECT_EQ(_planBuilder.isApplicable(_handle, graph), _isApplicable);
+    EXPECT_EQ(_planBuilder.isApplicable(*_handle, graph), _isApplicable);
 
     if(_isApplicable)
     {
         HipdnnMiopenSettings settings;
-        EXPECT_NO_THROW(_planBuilder.getMaxWorkspaceSize(_handle, graph, settings));
+        EXPECT_NO_THROW(_planBuilder.getMaxWorkspaceSize(*_handle, graph, settings));
 
         HipdnnMiopenContext ctx;
-        ASSERT_NO_THROW(_planBuilder.buildPlan(_handle, graph, mockEngineConfig, ctx));
+        ASSERT_NO_THROW(_planBuilder.buildPlan(*_handle, graph, mockEngineConfig, ctx));
         EXPECT_TRUE(ctx.hasValidPlan());
     }
 }
@@ -602,7 +610,7 @@ TEST_F(TestMiopenConvFwdBiasActivPlanBuilder, IsApplicableReturnsFalseForUnsuppo
         hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                          builder.GetSize());
 
-        bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+        bool applicable = _planBuilder.isApplicable(*_dummyHandle, graph);
         EXPECT_FALSE(applicable);
     }
     {
@@ -610,7 +618,7 @@ TEST_F(TestMiopenConvFwdBiasActivPlanBuilder, IsApplicableReturnsFalseForUnsuppo
         hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                          builder.GetSize());
 
-        bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+        bool applicable = _planBuilder.isApplicable(*_dummyHandle, graph);
         EXPECT_FALSE(applicable);
     }
     {
@@ -618,7 +626,7 @@ TEST_F(TestMiopenConvFwdBiasActivPlanBuilder, IsApplicableReturnsFalseForUnsuppo
         hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                          builder.GetSize());
 
-        bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+        bool applicable = _planBuilder.isApplicable(*_dummyHandle, graph);
         EXPECT_FALSE(applicable);
     }
     {
@@ -626,7 +634,7 @@ TEST_F(TestMiopenConvFwdBiasActivPlanBuilder, IsApplicableReturnsFalseForUnsuppo
         hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                          builder.GetSize());
 
-        bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+        bool applicable = _planBuilder.isApplicable(*_dummyHandle, graph);
         EXPECT_FALSE(applicable);
     }
     {
@@ -634,7 +642,7 @@ TEST_F(TestMiopenConvFwdBiasActivPlanBuilder, IsApplicableReturnsFalseForUnsuppo
         hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                          builder.GetSize());
 
-        bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+        bool applicable = _planBuilder.isApplicable(*_dummyHandle, graph);
         EXPECT_FALSE(applicable);
     }
 }
@@ -644,13 +652,13 @@ TEST_F(TestMiopenConvFwdBiasActivPlanBuilder, IsApplicableReturnsFalseForWrongNo
     {
         MockGraph mockGraph;
         EXPECT_CALL(mockGraph, nodeCount()).WillRepeatedly(::testing::Return(1));
-        bool applicable = _planBuilder.isApplicable(_dummyHandle, mockGraph);
+        bool applicable = _planBuilder.isApplicable(*_dummyHandle, mockGraph);
         EXPECT_FALSE(applicable);
     }
     {
         MockGraph mockGraph;
         EXPECT_CALL(mockGraph, nodeCount()).WillRepeatedly(::testing::Return(4));
-        bool applicable = _planBuilder.isApplicable(_dummyHandle, mockGraph);
+        bool applicable = _planBuilder.isApplicable(*_dummyHandle, mockGraph);
         EXPECT_FALSE(applicable);
     }
 }
@@ -662,7 +670,7 @@ TEST_F(TestMiopenConvFwdBiasActivPlanBuilder, GetWorkspaceSizeThrowsForWrongNode
         EXPECT_CALL(mockGraph, nodeCount()).WillRepeatedly(::testing::Return(1));
 
         HipdnnMiopenSettings settings;
-        EXPECT_THROW(_planBuilder.getMaxWorkspaceSize(_dummyHandle, mockGraph, settings),
+        EXPECT_THROW(_planBuilder.getMaxWorkspaceSize(*_dummyHandle, mockGraph, settings),
                      hipdnn_plugin_sdk::HipdnnPluginException);
     }
     {
@@ -670,7 +678,7 @@ TEST_F(TestMiopenConvFwdBiasActivPlanBuilder, GetWorkspaceSizeThrowsForWrongNode
         EXPECT_CALL(mockGraph, nodeCount()).WillRepeatedly(::testing::Return(4));
 
         HipdnnMiopenSettings settings;
-        EXPECT_THROW(_planBuilder.getMaxWorkspaceSize(_dummyHandle, mockGraph, settings),
+        EXPECT_THROW(_planBuilder.getMaxWorkspaceSize(*_dummyHandle, mockGraph, settings),
                      hipdnn_plugin_sdk::HipdnnPluginException);
     }
 }
@@ -682,7 +690,7 @@ TEST_F(TestMiopenConvFwdBiasActivPlanBuilder, GetWorkspaceSizeThrowsForUnsupport
                                                                      builder.GetSize());
 
     HipdnnMiopenSettings settings;
-    EXPECT_THROW(_planBuilder.getMaxWorkspaceSize(_dummyHandle, graph, settings),
+    EXPECT_THROW(_planBuilder.getMaxWorkspaceSize(*_dummyHandle, graph, settings),
                  hipdnn_plugin_sdk::HipdnnPluginException);
 }
 
@@ -695,7 +703,7 @@ TEST_F(TestMiopenConvFwdBiasActivPlanBuilder, BuildPlanThrowsForWrongNodeCountGr
         EXPECT_CALL(mockGraph, nodeCount()).WillRepeatedly(::testing::Return(1));
         HipdnnMiopenContext ctx;
 
-        EXPECT_THROW(_planBuilder.buildPlan(_dummyHandle, mockGraph, mockConfig, ctx),
+        EXPECT_THROW(_planBuilder.buildPlan(*_dummyHandle, mockGraph, mockConfig, ctx),
                      hipdnn_plugin_sdk::HipdnnPluginException);
         EXPECT_FALSE(ctx.hasValidPlan());
     }
@@ -704,7 +712,7 @@ TEST_F(TestMiopenConvFwdBiasActivPlanBuilder, BuildPlanThrowsForWrongNodeCountGr
         EXPECT_CALL(mockGraph, nodeCount()).WillRepeatedly(::testing::Return(4));
         HipdnnMiopenContext ctx;
 
-        EXPECT_THROW(_planBuilder.buildPlan(_dummyHandle, mockGraph, mockConfig, ctx),
+        EXPECT_THROW(_planBuilder.buildPlan(*_dummyHandle, mockGraph, mockConfig, ctx),
                      hipdnn_plugin_sdk::HipdnnPluginException);
         EXPECT_FALSE(ctx.hasValidPlan());
     }
@@ -718,7 +726,7 @@ TEST_F(TestMiopenConvFwdBiasActivPlanBuilder, BuildPlanThrowsForUnsupportedGraph
     HipdnnMiopenContext ctx;
     MockEngineConfig mockConfig;
 
-    EXPECT_THROW(_planBuilder.buildPlan(_dummyHandle, graph, mockConfig, ctx),
+    EXPECT_THROW(_planBuilder.buildPlan(*_dummyHandle, graph, mockConfig, ctx),
                  hipdnn_plugin_sdk::HipdnnPluginException);
     EXPECT_FALSE(ctx.hasValidPlan());
 }

--- a/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenConvFwdPlan.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenConvFwdPlan.cpp
@@ -1,6 +1,8 @@
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier:  MIT
 
+#include <memory>
+
 #include <gtest/gtest.h>
 #include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
@@ -19,9 +21,10 @@ protected:
     void SetUp() override
     {
         SKIP_IF_NO_DEVICES();
+        _handle = std::make_unique<HipdnnMiopenHandle>();
     }
 
-    HipdnnMiopenHandle _handle;
+    std::unique_ptr<HipdnnMiopenHandle> _handle;
 };
 
 TEST(TestConvFwdParams, InitializesAllTensorsFromValidGraph)
@@ -239,7 +242,7 @@ TEST_F(TestGpuConvFwdPlan, CreatesPlanWithValidGraph)
 
     // Create plan
     HipdnnMiopenSettings executionSettings;
-    ConvFwdPlan(_handle, std::move(params), executionSettings);
+    ConvFwdPlan(*_handle, std::move(params), executionSettings);
 }
 
 TEST_F(TestGpuConvFwdPlan, ThrowsOnInvalidDims)
@@ -278,7 +281,7 @@ TEST_F(TestGpuConvFwdPlan, ThrowsOnInvalidDims)
 
     // Create plan and expect exception
     HipdnnMiopenSettings executionSettings;
-    EXPECT_THROW(ConvFwdPlan(_handle, std::move(params), executionSettings),
+    EXPECT_THROW(ConvFwdPlan(*_handle, std::move(params), executionSettings),
                  hipdnn_plugin_sdk::HipdnnPluginException);
 }
 
@@ -298,8 +301,8 @@ TEST_F(TestGpuConvFwdPlan, PlanUsesDefaultWorkspaceSizeWhenNoLimitSet)
     HipdnnMiopenSettings settings;
     settings.setDefaultWorkspaceSize(defaultSize);
 
-    ConvFwdPlan plan(_handle, std::move(params), settings);
-    EXPECT_EQ(plan.getWorkspaceSize(_handle), defaultSize);
+    ConvFwdPlan plan(*_handle, std::move(params), settings);
+    EXPECT_EQ(plan.getWorkspaceSize(*_handle), defaultSize);
 }
 
 TEST_F(TestGpuConvFwdPlan, PlanUsesKnobLimitOverDefault)
@@ -320,8 +323,8 @@ TEST_F(TestGpuConvFwdPlan, PlanUsesKnobLimitOverDefault)
     settings.setDefaultWorkspaceSize(defaultSize);
     settings.setWorkspaceSizeLimit(knobLimit);
 
-    ConvFwdPlan plan(_handle, std::move(params), settings);
-    EXPECT_EQ(plan.getWorkspaceSize(_handle), knobLimit);
+    ConvFwdPlan plan(*_handle, std::move(params), settings);
+    EXPECT_EQ(plan.getWorkspaceSize(*_handle), knobLimit);
 }
 
 TEST(TestConvFwdParams, AcceptsDeterministicEnabledFlag)

--- a/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenConvPlanBuilder.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenConvPlanBuilder.cpp
@@ -1,6 +1,8 @@
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier:  MIT
 
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
@@ -23,8 +25,14 @@ using namespace hipdnn_test_sdk::utilities;
 class TestMiopenConvPlanBuilder : public ::testing::Test
 {
 protected:
+    void SetUp() override
+    {
+        SKIP_IF_NO_DEVICES();
+        _dummyHandle = std::make_unique<HipdnnMiopenHandle>();
+    }
+
     MiopenConvPlanBuilder _planBuilder;
-    HipdnnMiopenHandle _dummyHandle;
+    std::unique_ptr<HipdnnMiopenHandle> _dummyHandle;
 };
 
 class TestGpuMiopenConvPlanBuilder : public TestMiopenConvPlanBuilder
@@ -32,13 +40,21 @@ class TestGpuMiopenConvPlanBuilder : public TestMiopenConvPlanBuilder
 protected:
     void SetUp() override
     {
-        SKIP_IF_NO_DEVICES();
+        TestMiopenConvPlanBuilder::SetUp();
+        // GTEST_SKIP() in the base only unwinds the base SetUp() frame; without this
+        // guard, _handle would still be constructed and miopenCreate() would throw on
+        // no-device, turning the intended skip into a fixture failure.
+        if(IsSkipped())
+        {
+            return;
+        }
+        _handle = std::make_unique<HipdnnMiopenHandle>();
     }
 
     void executePlan(const hipdnn_plugin_sdk::IPlan<HipdnnMiopenHandle>& plan,
                      const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& graph)
     {
-        size_t workspaceSize = plan.getWorkspaceSize(_handle);
+        size_t workspaceSize = plan.getWorkspaceSize(*_handle);
         hipdnn_data_sdk::utilities::Workspace workspace(workspaceSize);
 
         std::vector<hipdnnPluginDeviceBuffer_t> deviceBuffers;
@@ -63,13 +79,13 @@ protected:
             }
         }
 
-        EXPECT_NO_THROW(plan.execute(_handle,
+        EXPECT_NO_THROW(plan.execute(*_handle,
                                      deviceBuffers.data(),
                                      static_cast<uint32_t>(deviceBuffers.size()),
                                      workspace.get()));
     }
 
-    HipdnnMiopenHandle _handle;
+    std::unique_ptr<HipdnnMiopenHandle> _handle;
 };
 
 TEST_F(TestMiopenConvPlanBuilder, IsApplicableReturnsFalseForMultiNodeGraph)
@@ -77,7 +93,7 @@ TEST_F(TestMiopenConvPlanBuilder, IsApplicableReturnsFalseForMultiNodeGraph)
     MockGraph mockGraph;
     EXPECT_CALL(mockGraph, nodeCount()).WillRepeatedly(::testing::Return(2));
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, mockGraph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, mockGraph);
     EXPECT_FALSE(applicable);
 }
 
@@ -87,7 +103,7 @@ TEST_F(TestMiopenConvPlanBuilder, IsApplicableReturnsFalseForUnsupportedGraph)
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+    bool applicable = _planBuilder.isApplicable(*_dummyHandle, graph);
     EXPECT_FALSE(applicable);
 }
 
@@ -98,7 +114,7 @@ TEST_F(TestGpuMiopenConvPlanBuilder, IsApplicableReturnsTrueForSupportedGraph)
         hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                          builder.GetSize());
 
-        bool applicable = _planBuilder.isApplicable(_handle, graph);
+        bool applicable = _planBuilder.isApplicable(*_handle, graph);
         EXPECT_TRUE(applicable);
     }
 
@@ -107,7 +123,7 @@ TEST_F(TestGpuMiopenConvPlanBuilder, IsApplicableReturnsTrueForSupportedGraph)
         hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                          builder.GetSize());
 
-        bool applicable = _planBuilder.isApplicable(_handle, graph);
+        bool applicable = _planBuilder.isApplicable(*_handle, graph);
         EXPECT_TRUE(applicable);
     }
 
@@ -116,7 +132,7 @@ TEST_F(TestGpuMiopenConvPlanBuilder, IsApplicableReturnsTrueForSupportedGraph)
         hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                          builder.GetSize());
 
-        bool applicable = _planBuilder.isApplicable(_handle, graph);
+        bool applicable = _planBuilder.isApplicable(*_handle, graph);
         EXPECT_TRUE(applicable);
     }
 }
@@ -127,7 +143,7 @@ TEST_F(TestMiopenConvPlanBuilder, GetWorkspaceSizeThrowsForMultiNodeGraph)
     EXPECT_CALL(mockGraph, nodeCount()).WillRepeatedly(::testing::Return(2));
 
     HipdnnMiopenSettings settings;
-    EXPECT_THROW(_planBuilder.getMaxWorkspaceSize(_dummyHandle, mockGraph, settings),
+    EXPECT_THROW(_planBuilder.getMaxWorkspaceSize(*_dummyHandle, mockGraph, settings),
                  hipdnn_plugin_sdk::HipdnnPluginException);
 }
 
@@ -136,7 +152,7 @@ TEST_F(TestMiopenConvPlanBuilder, GetWorkspaceSizeRangeThrowsForMultiNodeGraph)
     MockGraph mockGraph;
     EXPECT_CALL(mockGraph, nodeCount()).WillRepeatedly(::testing::Return(2));
 
-    EXPECT_THROW(_planBuilder.getWorkspaceSizeRange(_dummyHandle, mockGraph),
+    EXPECT_THROW(_planBuilder.getWorkspaceSizeRange(*_dummyHandle, mockGraph),
                  hipdnn_plugin_sdk::HipdnnPluginException);
 }
 
@@ -147,7 +163,7 @@ TEST_F(TestMiopenConvPlanBuilder, GetWorkspaceSizeThrowsForUnsupportedGraph)
                                                                      builder.GetSize());
 
     HipdnnMiopenSettings settings;
-    EXPECT_THROW(_planBuilder.getMaxWorkspaceSize(_dummyHandle, graph, settings),
+    EXPECT_THROW(_planBuilder.getMaxWorkspaceSize(*_dummyHandle, graph, settings),
                  hipdnn_plugin_sdk::HipdnnPluginException);
 }
 
@@ -157,7 +173,7 @@ TEST_F(TestMiopenConvPlanBuilder, GetWorkspaceSizeRangeThrowsForUnsupportedGraph
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    EXPECT_THROW(_planBuilder.getWorkspaceSizeRange(_dummyHandle, graph),
+    EXPECT_THROW(_planBuilder.getWorkspaceSizeRange(*_dummyHandle, graph),
                  hipdnn_plugin_sdk::HipdnnPluginException);
 }
 
@@ -169,7 +185,7 @@ TEST_F(TestGpuMiopenConvPlanBuilder, GetWorkspaceSizeReturnsValueForSupportedGra
                                                                          builder.GetSize());
 
         HipdnnMiopenSettings settings;
-        EXPECT_NO_THROW(_planBuilder.getMaxWorkspaceSize(_handle, graph, settings));
+        EXPECT_NO_THROW(_planBuilder.getMaxWorkspaceSize(*_handle, graph, settings));
     }
 
     {
@@ -178,7 +194,7 @@ TEST_F(TestGpuMiopenConvPlanBuilder, GetWorkspaceSizeReturnsValueForSupportedGra
                                                                          builder.GetSize());
 
         HipdnnMiopenSettings settings;
-        EXPECT_NO_THROW(_planBuilder.getMaxWorkspaceSize(_handle, graph, settings));
+        EXPECT_NO_THROW(_planBuilder.getMaxWorkspaceSize(*_handle, graph, settings));
     }
 
     {
@@ -187,7 +203,7 @@ TEST_F(TestGpuMiopenConvPlanBuilder, GetWorkspaceSizeReturnsValueForSupportedGra
                                                                          builder.GetSize());
 
         HipdnnMiopenSettings settings;
-        EXPECT_NO_THROW(_planBuilder.getMaxWorkspaceSize(_handle, graph, settings));
+        EXPECT_NO_THROW(_planBuilder.getMaxWorkspaceSize(*_handle, graph, settings));
     }
 }
 
@@ -198,7 +214,7 @@ TEST_F(TestMiopenConvPlanBuilder, BuildPlanThrowsForMultiNodeGraph)
     MockEngineConfig mockEngineConfig;
     HipdnnMiopenContext ctx;
 
-    EXPECT_THROW(_planBuilder.buildPlan(_dummyHandle, mockGraph, mockEngineConfig, ctx),
+    EXPECT_THROW(_planBuilder.buildPlan(*_dummyHandle, mockGraph, mockEngineConfig, ctx),
                  hipdnn_plugin_sdk::HipdnnPluginException);
     EXPECT_FALSE(ctx.hasValidPlan());
 }
@@ -211,7 +227,7 @@ TEST_F(TestMiopenConvPlanBuilder, BuildPlanThrowsForUnsupportedGraph)
     MockEngineConfig mockEngineConfig;
     HipdnnMiopenContext ctx;
 
-    EXPECT_THROW(_planBuilder.buildPlan(_dummyHandle, graph, mockEngineConfig, ctx),
+    EXPECT_THROW(_planBuilder.buildPlan(*_dummyHandle, graph, mockEngineConfig, ctx),
                  hipdnn_plugin_sdk::HipdnnPluginException);
     EXPECT_FALSE(ctx.hasValidPlan());
 }
@@ -228,7 +244,7 @@ TEST_F(TestMiopenConvPlanBuilder, IsApplicableReturnsFalseForUnsupportedComputeT
 
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
-    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+    EXPECT_FALSE(_planBuilder.isApplicable(*_dummyHandle, graph));
 }
 
 TEST_F(TestGpuMiopenConvPlanBuilder, BuildPlanCreatesValidPlanForSupportedGraph)
@@ -240,7 +256,7 @@ TEST_F(TestGpuMiopenConvPlanBuilder, BuildPlanCreatesValidPlanForSupportedGraph)
         MockEngineConfig mockEngineConfig;
         HipdnnMiopenContext ctx;
 
-        EXPECT_NO_THROW(_planBuilder.buildPlan(_handle, graph, mockEngineConfig, ctx));
+        EXPECT_NO_THROW(_planBuilder.buildPlan(*_handle, graph, mockEngineConfig, ctx));
         EXPECT_TRUE(ctx.hasValidPlan());
     }
 
@@ -251,7 +267,7 @@ TEST_F(TestGpuMiopenConvPlanBuilder, BuildPlanCreatesValidPlanForSupportedGraph)
         MockEngineConfig mockEngineConfig;
         HipdnnMiopenContext ctx;
 
-        EXPECT_NO_THROW(_planBuilder.buildPlan(_handle, graph, mockEngineConfig, ctx));
+        EXPECT_NO_THROW(_planBuilder.buildPlan(*_handle, graph, mockEngineConfig, ctx));
         EXPECT_TRUE(ctx.hasValidPlan());
     }
 
@@ -262,7 +278,7 @@ TEST_F(TestGpuMiopenConvPlanBuilder, BuildPlanCreatesValidPlanForSupportedGraph)
         MockEngineConfig mockEngineConfig;
         HipdnnMiopenContext ctx;
 
-        EXPECT_NO_THROW(_planBuilder.buildPlan(_handle, graph, mockEngineConfig, ctx));
+        EXPECT_NO_THROW(_planBuilder.buildPlan(*_handle, graph, mockEngineConfig, ctx));
         EXPECT_TRUE(ctx.hasValidPlan());
     }
 }
@@ -273,13 +289,13 @@ TEST_F(TestGpuMiopenConvPlanBuilder, ActualWorkspaceSizeIsWithinRangeFwd)
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    auto range = _planBuilder.getWorkspaceSizeRange(_handle, graph);
+    auto range = _planBuilder.getWorkspaceSizeRange(*_handle, graph);
 
     MockEngineConfig mockEngineConfig;
     HipdnnMiopenContext ctx;
-    _planBuilder.buildPlan(_handle, graph, mockEngineConfig, ctx);
+    _planBuilder.buildPlan(*_handle, graph, mockEngineConfig, ctx);
 
-    size_t actualWorkspace = ctx.plan().getWorkspaceSize(_handle);
+    size_t actualWorkspace = ctx.plan().getWorkspaceSize(*_handle);
 
     EXPECT_GE(actualWorkspace, range.min);
     EXPECT_LE(actualWorkspace, range.max);
@@ -291,13 +307,13 @@ TEST_F(TestGpuMiopenConvPlanBuilder, ActualWorkspaceSizeIsWithinRangeBwd)
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    auto range = _planBuilder.getWorkspaceSizeRange(_handle, graph);
+    auto range = _planBuilder.getWorkspaceSizeRange(*_handle, graph);
 
     MockEngineConfig mockEngineConfig;
     HipdnnMiopenContext ctx;
-    _planBuilder.buildPlan(_handle, graph, mockEngineConfig, ctx);
+    _planBuilder.buildPlan(*_handle, graph, mockEngineConfig, ctx);
 
-    size_t actualWorkspace = ctx.plan().getWorkspaceSize(_handle);
+    size_t actualWorkspace = ctx.plan().getWorkspaceSize(*_handle);
 
     EXPECT_GE(actualWorkspace, range.min);
     EXPECT_LE(actualWorkspace, range.max);
@@ -309,13 +325,13 @@ TEST_F(TestGpuMiopenConvPlanBuilder, ActualWorkspaceSizeIsWithinRangeWrw)
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    auto range = _planBuilder.getWorkspaceSizeRange(_handle, graph);
+    auto range = _planBuilder.getWorkspaceSizeRange(*_handle, graph);
 
     MockEngineConfig mockEngineConfig;
     HipdnnMiopenContext ctx;
-    _planBuilder.buildPlan(_handle, graph, mockEngineConfig, ctx);
+    _planBuilder.buildPlan(*_handle, graph, mockEngineConfig, ctx);
 
-    size_t actualWorkspace = ctx.plan().getWorkspaceSize(_handle);
+    size_t actualWorkspace = ctx.plan().getWorkspaceSize(*_handle);
 
     EXPECT_GE(actualWorkspace, range.min);
     EXPECT_LE(actualWorkspace, range.max);
@@ -348,21 +364,21 @@ TEST_F(TestGpuMiopenConvPlanBuilder, PlanExecutesWithMinWorkspaceLimitFwd)
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    auto range = _planBuilder.getWorkspaceSizeRange(_handle, graph);
+    auto range = _planBuilder.getWorkspaceSizeRange(*_handle, graph);
     ASSERT_NE(range.min, range.max) << "No workspace size range available for testing";
 
     MockEngineConfig mockEngineConfig;
     HipdnnMiopenSettings executionSettings1;
     HipdnnMiopenContext ctx1;
     ctx1.setExecutionSettings(executionSettings1);
-    _planBuilder.buildPlan(_handle, graph, mockEngineConfig, ctx1);
+    _planBuilder.buildPlan(*_handle, graph, mockEngineConfig, ctx1);
     executePlan(ctx1.plan(), graph);
 
     HipdnnMiopenSettings executionSettings2;
     executionSettings2.setWorkspaceSizeLimit(range.min);
     HipdnnMiopenContext ctx2;
     ctx2.setExecutionSettings(executionSettings2);
-    _planBuilder.buildPlan(_handle, graph, mockEngineConfig, ctx2);
+    _planBuilder.buildPlan(*_handle, graph, mockEngineConfig, ctx2);
     executePlan(ctx2.plan(), graph);
 }
 
@@ -393,21 +409,21 @@ TEST_F(TestGpuMiopenConvPlanBuilder, PlanExecutesWithMinWorkspaceLimitBwd)
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    auto range = _planBuilder.getWorkspaceSizeRange(_handle, graph);
+    auto range = _planBuilder.getWorkspaceSizeRange(*_handle, graph);
     ASSERT_NE(range.min, range.max) << "No workspace size range available for testing";
 
     MockEngineConfig mockEngineConfig;
     HipdnnMiopenSettings executionSettings1;
     HipdnnMiopenContext ctx1;
     ctx1.setExecutionSettings(executionSettings1);
-    _planBuilder.buildPlan(_handle, graph, mockEngineConfig, ctx1);
+    _planBuilder.buildPlan(*_handle, graph, mockEngineConfig, ctx1);
     executePlan(ctx1.plan(), graph);
 
     HipdnnMiopenSettings executionSettings2;
     executionSettings2.setWorkspaceSizeLimit(range.min);
     HipdnnMiopenContext ctx2;
     ctx2.setExecutionSettings(executionSettings2);
-    _planBuilder.buildPlan(_handle, graph, mockEngineConfig, ctx2);
+    _planBuilder.buildPlan(*_handle, graph, mockEngineConfig, ctx2);
     executePlan(ctx2.plan(), graph);
 }
 
@@ -438,21 +454,21 @@ TEST_F(TestGpuMiopenConvPlanBuilder, PlanExecutesWithMinWorkspaceLimitWrw)
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    auto range = _planBuilder.getWorkspaceSizeRange(_handle, graph);
+    auto range = _planBuilder.getWorkspaceSizeRange(*_handle, graph);
     ASSERT_NE(range.min, range.max) << "No workspace size range available for testing";
 
     MockEngineConfig mockEngineConfig;
     HipdnnMiopenSettings executionSettings1;
     HipdnnMiopenContext ctx1;
     ctx1.setExecutionSettings(executionSettings1);
-    _planBuilder.buildPlan(_handle, graph, mockEngineConfig, ctx1);
+    _planBuilder.buildPlan(*_handle, graph, mockEngineConfig, ctx1);
     executePlan(ctx1.plan(), graph);
 
     HipdnnMiopenSettings executionSettings2;
     executionSettings2.setWorkspaceSizeLimit(range.min);
     HipdnnMiopenContext ctx2;
     ctx2.setExecutionSettings(executionSettings2);
-    _planBuilder.buildPlan(_handle, graph, mockEngineConfig, ctx2);
+    _planBuilder.buildPlan(*_handle, graph, mockEngineConfig, ctx2);
     executePlan(ctx2.plan(), graph);
 }
 
@@ -462,8 +478,8 @@ TEST_F(TestGpuMiopenConvPlanBuilder, GetCustomKnobsReturnsWorkspaceSizeLimitKnob
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    auto customKnobs = _planBuilder.getCustomKnobs(_handle, graph);
-    const auto range = _planBuilder.getWorkspaceSizeRange(_handle, graph);
+    auto customKnobs = _planBuilder.getCustomKnobs(*_handle, graph);
+    const auto range = _planBuilder.getWorkspaceSizeRange(*_handle, graph);
 
     auto workspaceKnobIt
         = std::find_if(customKnobs.begin(),
@@ -494,7 +510,7 @@ TEST_F(TestMiopenConvPlanBuilder, GetCustomKnobsReturnsEmptyWhenNotApplicable)
     MockGraph mockGraph;
     EXPECT_CALL(mockGraph, nodeCount()).WillRepeatedly(::testing::Return(0));
 
-    auto customKnobs = _planBuilder.getCustomKnobs(_dummyHandle, mockGraph);
+    auto customKnobs = _planBuilder.getCustomKnobs(*_dummyHandle, mockGraph);
 
     EXPECT_TRUE(customKnobs.empty());
 }
@@ -531,7 +547,7 @@ TEST_F(TestGpuMiopenConvPlanBuilder,
 
     HipdnnMiopenSettings executionSettings;
     EXPECT_THROW(
-        _planBuilder.initializeExecutionSettings(_handle, graph, configWrapper, executionSettings),
+        _planBuilder.initializeExecutionSettings(*_handle, graph, configWrapper, executionSettings),
         hipdnn_plugin_sdk::HipdnnPluginException);
 }
 
@@ -564,7 +580,7 @@ TEST_F(TestGpuMiopenConvPlanBuilder, InitializeExecutionSettingsThrowsOnNegative
 
     HipdnnMiopenSettings executionSettings;
     EXPECT_THROW(
-        _planBuilder.initializeExecutionSettings(_handle, graph, configWrapper, executionSettings),
+        _planBuilder.initializeExecutionSettings(*_handle, graph, configWrapper, executionSettings),
         hipdnn_plugin_sdk::HipdnnPluginException);
 }
 
@@ -575,7 +591,7 @@ TEST_F(TestGpuMiopenConvPlanBuilder,
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    const auto range = _planBuilder.getWorkspaceSizeRange(_handle, graph);
+    const auto range = _planBuilder.getWorkspaceSizeRange(*_handle, graph);
 
     // Skip if min is 0 (already tested in BuildPlanThrowsOnNegativeWorkspaceSizeLimit)
     if(range.min == 0)
@@ -607,7 +623,7 @@ TEST_F(TestGpuMiopenConvPlanBuilder,
 
     HipdnnMiopenSettings executionSettings;
     EXPECT_THROW(
-        _planBuilder.initializeExecutionSettings(_handle, graph, configWrapper, executionSettings),
+        _planBuilder.initializeExecutionSettings(*_handle, graph, configWrapper, executionSettings),
         hipdnn_plugin_sdk::HipdnnPluginException);
 }
 
@@ -618,7 +634,7 @@ TEST_F(TestGpuMiopenConvPlanBuilder,
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    const auto range = _planBuilder.getWorkspaceSizeRange(_handle, graph);
+    const auto range = _planBuilder.getWorkspaceSizeRange(*_handle, graph);
 
     if(range.max >= std::numeric_limits<int64_t>::max())
     {
@@ -649,7 +665,7 @@ TEST_F(TestGpuMiopenConvPlanBuilder,
 
     HipdnnMiopenSettings executionSettings;
     EXPECT_THROW(
-        _planBuilder.initializeExecutionSettings(_handle, graph, configWrapper, executionSettings),
+        _planBuilder.initializeExecutionSettings(*_handle, graph, configWrapper, executionSettings),
         hipdnn_plugin_sdk::HipdnnPluginException);
 }
 
@@ -659,7 +675,7 @@ TEST_F(TestGpuMiopenConvPlanBuilder, InitializeExecutionSettingsSetsWorkspaceSiz
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    const auto range = _planBuilder.getWorkspaceSizeRange(_handle, graph);
+    const auto range = _planBuilder.getWorkspaceSizeRange(*_handle, graph);
     const auto testWorkspaceSize = range.min + ((range.max - range.min) / 2);
 
     flatbuffers::FlatBufferBuilder configBuilder;
@@ -685,14 +701,14 @@ TEST_F(TestGpuMiopenConvPlanBuilder, InitializeExecutionSettingsSetsWorkspaceSiz
                                                                                     buffer.size());
 
     HipdnnMiopenSettings executionSettings;
-    EXPECT_NO_THROW(
-        _planBuilder.initializeExecutionSettings(_handle, graph, configWrapper, executionSettings));
+    EXPECT_NO_THROW(_planBuilder.initializeExecutionSettings(
+        *_handle, graph, configWrapper, executionSettings));
 
     MockEngineConfig mockEngineConfig;
     HipdnnMiopenContext ctx;
     ctx.setExecutionSettings(executionSettings);
 
-    EXPECT_NO_THROW(_planBuilder.buildPlan(_handle, graph, mockEngineConfig, ctx));
+    EXPECT_NO_THROW(_planBuilder.buildPlan(*_handle, graph, mockEngineConfig, ctx));
     auto workspaceLimit = executionSettings.workspaceSizeLimit();
     ASSERT_TRUE(workspaceLimit.has_value());
     if(workspaceLimit.has_value())
@@ -718,14 +734,14 @@ TEST_F(TestGpuMiopenConvPlanBuilder,
                                                                                     buffer.size());
 
     HipdnnMiopenSettings executionSettings;
-    EXPECT_NO_THROW(
-        _planBuilder.initializeExecutionSettings(_handle, graph, configWrapper, executionSettings));
+    EXPECT_NO_THROW(_planBuilder.initializeExecutionSettings(
+        *_handle, graph, configWrapper, executionSettings));
 
     MockEngineConfig mockEngineConfig;
     HipdnnMiopenContext ctx;
     ctx.setExecutionSettings(executionSettings);
 
-    EXPECT_NO_THROW(_planBuilder.buildPlan(_handle, graph, mockEngineConfig, ctx));
+    EXPECT_NO_THROW(_planBuilder.buildPlan(*_handle, graph, mockEngineConfig, ctx));
     EXPECT_FALSE(executionSettings.workspaceSizeLimit().has_value());
 }
 
@@ -745,12 +761,12 @@ TEST_F(TestGpuMiopenConvPlanBuilder, InitializeExecutionSettingsSetsDefaultWorks
                                                                                     buffer.size());
 
     HipdnnMiopenSettings settings;
-    _planBuilder.initializeExecutionSettings(_handle, graph, configWrapper, settings);
+    _planBuilder.initializeExecutionSettings(*_handle, graph, configWrapper, settings);
 
     ASSERT_TRUE(settings.defaultWorkspaceSize().has_value());
 
     HipdnnMiopenSettings freshSettings;
-    auto expected = _planBuilder.getMaxWorkspaceSize(_handle, graph, freshSettings);
+    auto expected = _planBuilder.getMaxWorkspaceSize(*_handle, graph, freshSettings);
 
     // NOLINTNEXTLINE(bugprone-unchecked-optional-access,-warnings-as-errors)
     EXPECT_EQ(settings.defaultWorkspaceSize().value(), expected);
@@ -762,7 +778,7 @@ TEST_F(TestGpuMiopenConvPlanBuilder, InitializeExecutionSettingsSetDefaultWhenLi
     hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
                                                                      builder.GetSize());
 
-    const auto range = _planBuilder.getWorkspaceSizeRange(_handle, graph);
+    const auto range = _planBuilder.getWorkspaceSizeRange(*_handle, graph);
 
     flatbuffers::FlatBufferBuilder configBuilder;
     auto knobIdOffset = configBuilder.CreateString("global.workspace_size_limit");
@@ -787,7 +803,7 @@ TEST_F(TestGpuMiopenConvPlanBuilder, InitializeExecutionSettingsSetDefaultWhenLi
                                                                                     buffer.size());
 
     HipdnnMiopenSettings settings;
-    _planBuilder.initializeExecutionSettings(_handle, graph, configWrapper, settings);
+    _planBuilder.initializeExecutionSettings(*_handle, graph, configWrapper, settings);
 
     EXPECT_TRUE(settings.defaultWorkspaceSize().has_value());
 }
@@ -802,7 +818,7 @@ TEST_F(TestGpuMiopenConvPlanBuilder, GetMaxWorkspaceSizeReturnsCachedDefault)
     HipdnnMiopenSettings settings;
     settings.setDefaultWorkspaceSize(cachedValue);
 
-    auto result = _planBuilder.getMaxWorkspaceSize(_handle, graph, settings);
+    auto result = _planBuilder.getMaxWorkspaceSize(*_handle, graph, settings);
     EXPECT_EQ(result, cachedValue);
 }
 
@@ -850,12 +866,12 @@ TEST_F(TestGpuMiopenConvPlanBuilder, InitializeExecutionSettingsSetsDefaultWorks
                                                                                     buffer.size());
 
     HipdnnMiopenSettings settings;
-    _planBuilder.initializeExecutionSettings(_handle, graph, configWrapper, settings);
+    _planBuilder.initializeExecutionSettings(*_handle, graph, configWrapper, settings);
 
     ASSERT_TRUE(settings.defaultWorkspaceSize().has_value());
 
     HipdnnMiopenSettings freshSettings;
-    auto expected = _planBuilder.getMaxWorkspaceSize(_handle, graph, freshSettings);
+    auto expected = _planBuilder.getMaxWorkspaceSize(*_handle, graph, freshSettings);
 
     // NOLINTNEXTLINE(bugprone-unchecked-optional-access,-warnings-as-errors)
     EXPECT_EQ(settings.defaultWorkspaceSize().value(), expected);
@@ -877,12 +893,12 @@ TEST_F(TestGpuMiopenConvPlanBuilder, InitializeExecutionSettingsSetsDefaultWorks
                                                                                     buffer.size());
 
     HipdnnMiopenSettings settings;
-    _planBuilder.initializeExecutionSettings(_handle, graph, configWrapper, settings);
+    _planBuilder.initializeExecutionSettings(*_handle, graph, configWrapper, settings);
 
     ASSERT_TRUE(settings.defaultWorkspaceSize().has_value());
 
     HipdnnMiopenSettings freshSettings;
-    auto expected = _planBuilder.getMaxWorkspaceSize(_handle, graph, freshSettings);
+    auto expected = _planBuilder.getMaxWorkspaceSize(*_handle, graph, freshSettings);
 
     // NOLINTNEXTLINE(bugprone-unchecked-optional-access,-warnings-as-errors)
     EXPECT_EQ(settings.defaultWorkspaceSize().value(), expected);
@@ -898,7 +914,7 @@ TEST_F(TestGpuMiopenConvPlanBuilder, GetMaxWorkspaceSizeReturnsCachedDefaultBwd)
     HipdnnMiopenSettings settings;
     settings.setDefaultWorkspaceSize(cachedValue);
 
-    auto result = _planBuilder.getMaxWorkspaceSize(_handle, graph, settings);
+    auto result = _planBuilder.getMaxWorkspaceSize(*_handle, graph, settings);
     EXPECT_EQ(result, cachedValue);
 }
 
@@ -912,6 +928,6 @@ TEST_F(TestGpuMiopenConvPlanBuilder, GetMaxWorkspaceSizeReturnsCachedDefaultWrw)
     HipdnnMiopenSettings settings;
     settings.setDefaultWorkspaceSize(cachedValue);
 
-    auto result = _planBuilder.getMaxWorkspaceSize(_handle, graph, settings);
+    auto result = _planBuilder.getMaxWorkspaceSize(*_handle, graph, settings);
     EXPECT_EQ(result, cachedValue);
 }

--- a/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenConvWrwPlan.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenConvWrwPlan.cpp
@@ -1,6 +1,8 @@
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier:  MIT
 
+#include <memory>
+
 #include <gtest/gtest.h>
 #include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
@@ -19,9 +21,10 @@ protected:
     void SetUp() override
     {
         SKIP_IF_NO_DEVICES();
+        _handle = std::make_unique<HipdnnMiopenHandle>();
     }
 
-    HipdnnMiopenHandle _handle;
+    std::unique_ptr<HipdnnMiopenHandle> _handle;
 };
 
 TEST(TestConvWrwParams, InitializesAllTensorsFromValidGraph)
@@ -239,7 +242,7 @@ TEST_F(TestGpuConvWrwPlan, CreatesPlanWithValidGraph)
 
     // Create plan
     HipdnnMiopenSettings executionSettings;
-    ConvWrwPlan(_handle, std::move(params), executionSettings);
+    ConvWrwPlan(*_handle, std::move(params), executionSettings);
 }
 
 TEST_F(TestGpuConvWrwPlan, PlanUsesDefaultWorkspaceSizeWhenNoLimitSet)
@@ -258,8 +261,8 @@ TEST_F(TestGpuConvWrwPlan, PlanUsesDefaultWorkspaceSizeWhenNoLimitSet)
     HipdnnMiopenSettings settings;
     settings.setDefaultWorkspaceSize(defaultSize);
 
-    ConvWrwPlan plan(_handle, std::move(params), settings);
-    EXPECT_EQ(plan.getWorkspaceSize(_handle), defaultSize);
+    ConvWrwPlan plan(*_handle, std::move(params), settings);
+    EXPECT_EQ(plan.getWorkspaceSize(*_handle), defaultSize);
 }
 
 TEST_F(TestGpuConvWrwPlan, PlanUsesKnobLimitOverDefault)
@@ -280,8 +283,8 @@ TEST_F(TestGpuConvWrwPlan, PlanUsesKnobLimitOverDefault)
     settings.setDefaultWorkspaceSize(defaultSize);
     settings.setWorkspaceSizeLimit(knobLimit);
 
-    ConvWrwPlan plan(_handle, std::move(params), settings);
-    EXPECT_EQ(plan.getWorkspaceSize(_handle), knobLimit);
+    ConvWrwPlan plan(*_handle, std::move(params), settings);
+    EXPECT_EQ(plan.getWorkspaceSize(*_handle), knobLimit);
 }
 
 TEST_F(TestGpuConvWrwPlan, ThrowsOnInvalidDims)
@@ -320,6 +323,6 @@ TEST_F(TestGpuConvWrwPlan, ThrowsOnInvalidDims)
 
     // Create plan and expect exception
     HipdnnMiopenSettings executionSettings;
-    EXPECT_THROW(ConvWrwPlan(_handle, std::move(params), executionSettings),
+    EXPECT_THROW(ConvWrwPlan(*_handle, std::move(params), executionSettings),
                  hipdnn_plugin_sdk::HipdnnPluginException);
 }

--- a/projects/hipdnn/backend/tests/TestUserLoggingApis.cpp
+++ b/projects/hipdnn/backend/tests/TestUserLoggingApis.cpp
@@ -82,6 +82,7 @@ protected:
 // Test: User callback receives backend logs
 TEST_F(IntegrationBackendUserLoggingApis, UserCallbackReceivesLogs)
 {
+    SKIP_IF_NO_DEVICES();
     auto recorder = IsolatedLogRecorder::withOverrideLevel(HIPDNN_SEV_INFO);
 
     // Register test recording callback
@@ -104,6 +105,7 @@ TEST_F(IntegrationBackendUserLoggingApis, UserCallbackReceivesLogs)
 // Test: Unregister callback with SEV_OFF stops log capture
 TEST_F(IntegrationBackendUserLoggingApis, UnregisterWithSevOffStopsCapture)
 {
+    SKIP_IF_NO_DEVICES();
     auto recorder = IsolatedLogRecorder::withOverrideLevel(HIPDNN_SEV_INFO);
 
     // Register callback
@@ -137,6 +139,7 @@ TEST_F(IntegrationBackendUserLoggingApis, UnregisterWithSevOffStopsCapture)
 // Test: Sync callback executes immediately
 TEST_F(IntegrationBackendUserLoggingApis, SyncCallbackImmediate)
 {
+    SKIP_IF_NO_DEVICES();
     auto recorder = IsolatedLogRecorder::withOverrideLevel(HIPDNN_SEV_INFO);
 
     // Register callback in SYNC mode
@@ -187,6 +190,7 @@ TEST_F(IntegrationBackendUserLoggingApis, RejectsInvalidMode)
 // Test: Callback respects log level filtering
 TEST_F(IntegrationBackendUserLoggingApis, CallbackRespectsLogLevel)
 {
+    SKIP_IF_NO_DEVICES();
     auto recorder = IsolatedLogRecorder::withCurrentLevel();
 
     // Set log level to ERROR (filters out INFO and WARN)
@@ -210,6 +214,7 @@ TEST_F(IntegrationBackendUserLoggingApis, CallbackRespectsLogLevel)
 // Test: Update callback level
 TEST_F(IntegrationBackendUserLoggingApis, UpdateCallbackLevel)
 {
+    SKIP_IF_NO_DEVICES();
     auto recorder = IsolatedLogRecorder::withOverrideLevel(HIPDNN_SEV_INFO);
 
     // Register callback at INFO
@@ -244,6 +249,7 @@ TEST_F(IntegrationBackendUserLoggingApis, UpdateCallbackLevel)
 // Test: Async callback queues logs
 TEST_F(IntegrationBackendUserLoggingApis, AsyncCallbackQueued)
 {
+    SKIP_IF_NO_DEVICES();
     auto recorder = IsolatedLogRecorder::withOverrideLevel(HIPDNN_SEV_INFO);
 
     // Register callback in ASYNC mode
@@ -265,6 +271,7 @@ TEST_F(IntegrationBackendUserLoggingApis, AsyncCallbackQueued)
 // Test: Callback that throws exception is handled
 TEST_F(IntegrationBackendUserLoggingApis, CallbackThrowsException)
 {
+    SKIP_IF_NO_DEVICES();
     // Callback that throws exception
     static bool s_shouldThrow = true;
     auto throwingCallback = [](hipdnnUserLogCallbackHandle_t, hipdnnSeverity_t, const char*) {
@@ -302,6 +309,7 @@ TEST_F(IntegrationBackendUserLoggingApis, CallbackThrowsException)
 // Test: Synchronous guarantee on unregister
 TEST_F(IntegrationBackendUserLoggingApis, SyncGuaranteeOnUnregister)
 {
+    SKIP_IF_NO_DEVICES();
     // Track callback invocations
     static std::atomic<int> s_callbackCount{0};
     static std::atomic<bool> s_callbackActive{false};
@@ -365,6 +373,7 @@ TEST_F(IntegrationBackendUserLoggingApis, SyncGuaranteeOnUnregister)
 // Test: Switch between sync and async mode
 TEST_F(IntegrationBackendUserLoggingApis, SwitchBetweenSyncAndAsync)
 {
+    SKIP_IF_NO_DEVICES();
     auto recorder = IsolatedLogRecorder::withOverrideLevel(HIPDNN_SEV_INFO);
 
     // Start with SYNC mode
@@ -392,6 +401,7 @@ TEST_F(IntegrationBackendUserLoggingApis, SwitchBetweenSyncAndAsync)
 // Test: Switch from async to sync mode
 TEST_F(IntegrationBackendUserLoggingApis, SwitchBetweenAsyncAndSync)
 {
+    SKIP_IF_NO_DEVICES();
     auto recorder = IsolatedLogRecorder::withOverrideLevel(HIPDNN_SEV_INFO);
 
     // Start with ASYNC mode
@@ -419,6 +429,7 @@ TEST_F(IntegrationBackendUserLoggingApis, SwitchBetweenAsyncAndSync)
 // Test: Duplicate registration updates existing
 TEST_F(IntegrationBackendUserLoggingApis, DuplicateUpdatesExisting)
 {
+    SKIP_IF_NO_DEVICES();
     auto recorder = IsolatedLogRecorder::withOverrideLevel(HIPDNN_SEV_INFO);
 
     // Register callback at INFO
@@ -450,6 +461,7 @@ TEST_F(IntegrationBackendUserLoggingApis, DuplicateUpdatesExisting)
 // Test: Concurrent logging with user callback toggle between registered and unregistered
 TEST_F(IntegrationBackendUserLoggingApis, ConcurrentLoggingWithCallbackToggle)
 {
+    SKIP_IF_NO_DEVICES();
     // Redirect default logging to file to avoid console spam when callback is disabled
     _logFile = "concurrent_user_callback_toggle_test.log";
     hipdnn_data_sdk::utilities::setEnv("HIPDNN_LOG_FILE", _logFile.c_str());
@@ -611,6 +623,7 @@ TEST_F(IntegrationBackendUserLoggingApis, ConcurrentLoggingWithCallbackToggle)
 // Test: Reentrant logging from sync callback is prevented (no stack overflow)
 TEST_F(IntegrationBackendUserLoggingApis, ReentrantLoggingPrevented)
 {
+    SKIP_IF_NO_DEVICES();
     // Counter to track recursive attempts
     std::atomic<int> recursiveAttempts{0};
     std::atomic<int> callbackInvocations{0};
@@ -672,6 +685,7 @@ TEST_F(IntegrationBackendUserLoggingApis, ReentrantLoggingPrevented)
 // Test: Multiple callbacks (2 async + 2 sync) all receive logs independently
 TEST_F(IntegrationBackendUserLoggingApis, MultipleCallbacksAllReceiveLogs)
 {
+    SKIP_IF_NO_DEVICES();
     auto countingCallback
         = [](hipdnnUserLogCallbackHandle_t userHandle, hipdnnSeverity_t, const char*) {
               static_cast<std::atomic<int>*>(userHandle)->fetch_add(1);

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/IntegrationTestFixture.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/IntegrationTestFixture.hpp
@@ -29,6 +29,7 @@ namespace hipdnn_tests
 class IntegrationTestFixture : public ::testing::Test
 {
 protected:
+    // NOTE: derived SetUp() overrides must check IsSkipped() after calling the base — GTEST_SKIP() does not unwind into the derived frame.
     void SetUp() override
     {
         SKIP_IF_NO_DEVICES();

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestGraphTensorBundle.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestGraphTensorBundle.cpp
@@ -8,6 +8,7 @@
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
 #include <hipdnn_data_sdk/utilities/TensorView.hpp>
 #include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/GraphTensorBundle.hpp>
 
 using namespace hipdnn_test_sdk::utilities;
@@ -183,6 +184,8 @@ TEST_F(TestGraphTensorBundle, TensorsHaveCorrectDimensions)
 
 TEST_F(TestGraphTensorBundle, ToDeviceVariantPackReturnsCorrectMapping)
 {
+    // Only this test in the suite touches device memory: rawDeviceData() lazily hipMallocs.
+    SKIP_IF_NO_DEVICES();
     auto graphWrapper = buildTestGraph(DataType::FLOAT, DataType::FLOAT, DataType::FLOAT);
     auto& tensorMap = graphWrapper->getTensorMap();
 

--- a/projects/hipdnn/tests/frontend/IntegrationGraphKnobSettingsDescriptorLowering.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationGraphKnobSettingsDescriptorLowering.cpp
@@ -74,6 +74,12 @@ protected:
     void SetUp() override
     {
         IntegrationTestFixture::SetUp();
+        // GTEST_SKIP() in the base only unwinds the base SetUp() frame; without this
+        // guard, the post-base setup below would dereference a null _handle.
+        if(IsSkipped())
+        {
+            return;
+        }
 
         // Query the exact plugin paths the backend resolved when loading,
         // then find the knobs plugin by name. This ensures we dlopen the same


### PR DESCRIPTION
## Summary

Adds `SKIP_IF_NO_DEVICES()` guards to ~17 tests across hipDNN and miopen-provider that previously failed (or aborted the test binary) when run without a GPU.

Three fix patterns:
1. Missing skip on fixture `SetUp()` (hipDNN) — and one derived `SetUp()` that needed `if (IsSkipped()) return;` after the base call, since `GTEST_SKIP()` doesn't unwind into derived frames.
2. miopen-provider fixtures with `HipdnnMiopenHandle` members — the constructor calls `miopenCreate()` and throws on no-device, so the handle is now `std::unique_ptr<HipdnnMiopenHandle>` lazy-initialized in `SetUp()` after the skip.
3. Raw `TEST()` bodies and GMock tests — `SKIP_IF_NO_DEVICES()` prepended to tests that requires a device to execute.

## Test plan

Verified on a no-device system with a non-ASAN superbuild. All six baseline ctest targets PASS where they previously failed.