### PR TITLE
[stinkytofu] Use 8-bit MSB as fallback until compiler supports 16-bit

### DIFF
--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/include/hardware_caps.hpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/include/hardware_caps.hpp
@@ -417,6 +417,12 @@ inline std::map<std::string, int>
     rv["s_delay_alu"]
         = tryAssembler(isaVersion, assemblerPath, "s_delay_alu instid0(VALU_DEP_1)", isDebug);
     rv["HasVgprMSB"] = tryAssembler(isaVersion, assemblerPath, "s_set_vgpr_msb 0", isDebug);
+    // 16-bit MSB form packs the previous-instruction MSB in the high byte
+    // (e.g. 0x0101). Some assemblers accept only the 8-bit form, so probe
+    // the wider encoding separately.
+    rv["HasVgprMSB16"]
+        = rv["HasVgprMSB"]
+          && tryAssembler(isaVersion, assemblerPath, "s_set_vgpr_msb 0x0101", isDebug);
     // workaround: as we generate s_set_vgpr_msb in toString(), we can't calculate inst len correctly.
     rv["ShortBranchMaxLength"] = rv["HasVgprMSB"]? 8192 : 16384;
 

--- a/shared/stinkytofu/include/stinkytofu/bindings/python/Module.hpp
+++ b/shared/stinkytofu/include/stinkytofu/bindings/python/Module.hpp
@@ -59,7 +59,8 @@
     X(PrintAfterPass, std::string)        \
     X(DebugPass, std::string)             \
     X(PassOrderSnapshotJson, std::string) \
-    X(EnableWaitCntInsertion, bool)
+    X(EnableWaitCntInsertion, bool)       \
+    X(HasVgprMSB16, bool)
 
 namespace stinkytofu {
 /**

--- a/shared/stinkytofu/include/stinkytofu/core/PassManager.hpp
+++ b/shared/stinkytofu/include/stinkytofu/core/PassManager.hpp
@@ -109,6 +109,7 @@ class Pass {
 class PassContext {
     GemmTileConfig gemmConfig;
     PassFeatureConfig passConfig;
+    AsmCapsConfig asmCapsConfig;
     uint32_t wavefrontSize = 0;  ///< Computed from gemmConfig.arch
 
     // Global BasicBlock filter applied to all StinkyInstPass instances.
@@ -135,6 +136,14 @@ class PassContext {
 
     const PassFeatureConfig& getPassFeatureConfig() const {
         return passConfig;
+    }
+
+    void setAsmCapsConfig(const AsmCapsConfig& config) {
+        asmCapsConfig = config;
+    }
+
+    const AsmCapsConfig& getAsmCapsConfig() const {
+        return asmCapsConfig;
     }
 
     /// Set global BasicBlock filter for all StinkyInstPass instances.
@@ -256,6 +265,9 @@ class STINKYTOFU_EXPORT PassManager {
 
     // Set pass feature configuration
     void setPassFeatureConfig(const PassFeatureConfig& config);
+
+    // Set assembler capability configuration (propagated from rocisa asmCaps)
+    void setAsmCapsConfig(const AsmCapsConfig& config);
 
     void setBasicBlockFilter(BasicBlockFilter filter) {
         passCtx.setBasicBlockFilter(filter);

--- a/shared/stinkytofu/include/stinkytofu/core/Types.hpp
+++ b/shared/stinkytofu/include/stinkytofu/core/Types.hpp
@@ -95,4 +95,17 @@ struct PassFeatureConfig {
     DagFeatures dagFeatures;
     PassOrderSnapshotConfig passOrderSnapshot;
 };
+
+/// Assembler capability flags propagated from rocisa asmCaps into stinkytofu.
+///
+/// These are target/toolchain capabilities discovered by probing the assembler
+/// (see `initAsmCaps` in rocisa `hardware_caps.hpp`). They are populated by
+/// the rocisa conversion layer and consumed by stinkytofu passes without
+/// introducing a direct dependency on rocisa headers from the pass layer.
+struct AsmCapsConfig {
+    /// Whether the assembler accepts the 16-bit form of `s_set_vgpr_msb`
+    /// (immediate encodes both the current instruction's MSB in the low byte
+    /// and the previous instruction's MSB in the high byte).
+    bool hasVgprMsb16 = false;
+};
 }  // namespace stinkytofu

--- a/shared/stinkytofu/include/stinkytofu/pipeline/ScopeAdaptor.hpp
+++ b/shared/stinkytofu/include/stinkytofu/pipeline/ScopeAdaptor.hpp
@@ -265,6 +265,7 @@ class ScopeAdaptor : public Pass {
     void run(Function& /*outerFunc*/, PassContext& outerCtx) override {
         // Propagate config from outer PassContext to inner PM
         innerPM.setGemmTileConfig(outerCtx.getGemmTileConfig());
+        innerPM.setAsmCapsConfig(outerCtx.getAsmCapsConfig());
         // innerPM.setPassFeatureConfig(outerCtx.getPassFeatureConfig());
 
         if (groupNames.empty()) {

--- a/shared/stinkytofu/src/conversion/rocisa/ToStinkyTofuUtils.cpp
+++ b/shared/stinkytofu/src/conversion/rocisa/ToStinkyTofuUtils.cpp
@@ -785,7 +785,18 @@ std::shared_ptr<StinkyAsmModule> toStinkyTofuModule(
     // Get GfxArchID from architecture array
     GfxArchID archId = getGfxArchID(arch[0], arch[1], arch[2]);
 
-    StinkyAsmModule stinkyAsmModule(moduleName, arch, moduleOptions);
+    // Populate assembler-capability-derived module options from rocisa asmCaps.
+    // This is done here (in the rocisa conversion layer, which is the only
+    // stinkytofu TU allowed to depend on rocisa headers) so that the
+    // stinkytofu library itself stays decoupled from rocisa.
+    StinkyAsmModule::ModuleOptions finalModuleOptions = moduleOptions;
+    {
+        auto probedCaps = rocisa::rocIsa::getInstance().getAsmCaps();
+        finalModuleOptions.HasVgprMSB16 =
+            probedCaps.count("HasVgprMSB16") && probedCaps.at("HasVgprMSB16");
+    }
+
+    StinkyAsmModule stinkyAsmModule(moduleName, arch, finalModuleOptions);
 
     // Add instruction groups registered by the target backend.
     if (auto* pipeline = BackendRegistry::getArchPipeline(arch)) {

--- a/shared/stinkytofu/src/core/PassManager.cpp
+++ b/shared/stinkytofu/src/core/PassManager.cpp
@@ -153,4 +153,8 @@ void PassManager::setKernelConfig(std::array<int, 3> arch, uint32_t ta0, uint32_
 void PassManager::setPassFeatureConfig(const PassFeatureConfig& config) {
     passCtx.setPassFeatureConfig(config);
 }
+
+void PassManager::setAsmCapsConfig(const AsmCapsConfig& config) {
+    passCtx.setAsmCapsConfig(config);
+}
 }  // namespace stinkytofu

--- a/shared/stinkytofu/src/pipeline/backend/Backend.cpp
+++ b/shared/stinkytofu/src/pipeline/backend/Backend.cpp
@@ -58,6 +58,10 @@ void Backend::configurePassManager(PassManager& pm) {
     gemmTileConfig.NumGRM = opts.NumGRM;
     gemmTileConfig.NumWaves = opts.WaveGroup0 * opts.WaveGroup1;
     pm.setGemmTileConfig(gemmTileConfig);
+
+    AsmCapsConfig asmCapsConfig;
+    asmCapsConfig.hasVgprMsb16 = opts.HasVgprMSB16;
+    pm.setAsmCapsConfig(asmCapsConfig);
 }
 
 }  // namespace stinkytofu

--- a/shared/stinkytofu/src/transforms/asm/InsertVgprMsbPass.cpp
+++ b/shared/stinkytofu/src/transforms/asm/InsertVgprMsbPass.cpp
@@ -130,8 +130,9 @@ void emitVgprMsbIfNeeded(int requiredSetVal, bool hasVgpr, int& currentMsb, AsmI
     }
 
     int combinedSetVal = requiredSetVal;
-    if (currentMsb != VgprMsbState::NOT_REQUIRED && currentMsb != VgprMsbState::LABEL_BEGIN)
-        combinedSetVal += (currentMsb << 8);
+    /* if (currentMsb != VgprMsbState::NOT_REQUIRED && currentMsb != VgprMsbState::LABEL_BEGIN)
+        combinedSetVal += (currentMsb << 8); */
+    // Re-enable 16-bit MSB once compiler support is available.
 
     const HwInstDesc* desc = getMCIDByUOp(GFX::s_set_vgpr_msb, archId);
     assert(desc != nullptr && "s_set_vgpr_msb is not supported on this architecture");

--- a/shared/stinkytofu/src/transforms/asm/InsertVgprMsbPass.cpp
+++ b/shared/stinkytofu/src/transforms/asm/InsertVgprMsbPass.cpp
@@ -117,7 +117,7 @@ std::pair<int, bool> computeRequiredMsb(const StinkyInstruction* inst) {
 }
 
 void emitVgprMsbIfNeeded(int requiredSetVal, bool hasVgpr, int& currentMsb, AsmIRBuilder& irBuilder,
-                         GfxArchID archId, IRBase* insertBefore) {
+                         GfxArchID archId, IRBase* insertBefore, bool hasVgprMsb16) {
     if (!hasVgpr || requiredSetVal == currentMsb) {
         if (currentMsb == VgprMsbState::LABEL_BEGIN) currentMsb = VgprMsbState::NOT_REQUIRED;
         return;
@@ -130,9 +130,10 @@ void emitVgprMsbIfNeeded(int requiredSetVal, bool hasVgpr, int& currentMsb, AsmI
     }
 
     int combinedSetVal = requiredSetVal;
-    /* if (currentMsb != VgprMsbState::NOT_REQUIRED && currentMsb != VgprMsbState::LABEL_BEGIN)
-        combinedSetVal += (currentMsb << 8); */
-    // Re-enable 16-bit MSB once compiler support is available.
+    if (hasVgprMsb16 && currentMsb != VgprMsbState::NOT_REQUIRED &&
+        currentMsb != VgprMsbState::LABEL_BEGIN) {
+        combinedSetVal += (currentMsb << 8);
+    }
 
     const HwInstDesc* desc = getMCIDByUOp(GFX::s_set_vgpr_msb, archId);
     assert(desc != nullptr && "s_set_vgpr_msb is not supported on this architecture");
@@ -163,6 +164,8 @@ class InsertVgprMsbPassImpl : public Pass {
         auto arch = passCtx.getGemmTileConfig().arch;
         GfxArchID archId = getGfxArchID(arch[0], arch[1], arch[2]);
 
+        bool hasVgprMsb16 = passCtx.getAsmCapsConfig().hasVgprMsb16;
+
         for (auto bbIt = func.begin(); bbIt != func.end(); ++bbIt) {
             BasicBlock& bb = *bbIt;
             AsmIRBuilder irBuilder(bb, archId);
@@ -180,7 +183,8 @@ class InsertVgprMsbPassImpl : public Pass {
                 if (isPseudoInst(inst)) continue;
 
                 auto [requiredMsb, hasVgpr] = computeRequiredMsb(inst);
-                emitVgprMsbIfNeeded(requiredMsb, hasVgpr, currentMsb, irBuilder, archId, inst);
+                emitVgprMsbIfNeeded(requiredMsb, hasVgpr, currentMsb, irBuilder, archId, inst,
+                                    hasVgprMsb16);
             }
         }
     }


### PR DESCRIPTION
## Motivation
Previously the 16-bit form of `s_set_vgpr_msb` was disabled because not all
assemblers accepted the packed encoding. Now that newer compilers support it,
this PR re-enables the 16-bit form when available, falling back to 8-bit
otherwise.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Enable packed 16-bit VGPR MSB when assembler supports it
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
Run unit tests
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
All existing tests passed.
[----------] Global test environment tear-down
[==========] 453 tests from 35 test suites ran. (510 ms total)
[  PASSED  ] 453 tests.
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [V ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
