### PR TITLE
[stinkytofu] Fix erasing directives and dag/verifier/dominance robustness

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/TensorDataMover.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/TensorDataMover.py
@@ -105,12 +105,15 @@ class TensorDataMoverLoad(TensorDataMover):
 
     def issueLoad(self, group0: int | str, group1: int | str, group2: Optional[int | str], group3: Optional[int | str]) -> Module:
         mod = Module("tensor load")
+        comment = "sync LDS%u" % self.mem_token[0] if self.mem_token is not None else ""
         if all(g is not None for g in [group2, group3]):
             tensorLoadToLds = TensorLoadToLds(sgpr(group0, self.GROUP0_NUM_SGPR), sgpr(group1, self.GROUP1_NUM_SGPR),\
-                                              sgpr(group2, self.GROUP2_NUM_SGPR), sgpr(group3, self.GROUP3_NUM_SGPR))
+                                              sgpr(group2, self.GROUP2_NUM_SGPR), sgpr(group3, self.GROUP3_NUM_SGPR),\
+                                              comment=comment)
         else:
             tensorLoadToLds = TensorLoadToLds(sgpr(group0, self.GROUP0_NUM_SGPR), sgpr(group1, self.GROUP1_NUM_SGPR),\
-                                              None, None)
+                                              None, None,\
+                                              comment=comment)
 
         if self.mem_token is not None:
             tensorLoadToLds.setMemToken(MemTokenData(self.mem_token))

--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
@@ -11512,6 +11512,7 @@ class KernelWriterAssembly(KernelWriter):
             else:
               ds        = DSModifiers(na=2, offset0=paramList[2], offset1=paramList[3])
               writeInst = LocalWriteX(dstAddr=vgpr(lwa), src0=paramList[0], src1=paramList[1], ds=ds, comment=comment)
+            writeInst.setMemToken(MemTokenData([self.states.ldsWriteTokenIdx]))              
             if self.do["LocalWriteCVT"]:
               localWriteCode.add(localWriteCVTCode)
             if self.do["LocalWrite%s"%tc]:

--- a/shared/stinkytofu/include/stinkytofu/pipeline/ScopeAdaptor.hpp
+++ b/shared/stinkytofu/include/stinkytofu/pipeline/ScopeAdaptor.hpp
@@ -31,6 +31,7 @@
 
 #include "stinkytofu/bindings/python/Module.hpp"
 #include "stinkytofu/core/PassManager.hpp"
+#include "stinkytofu/ir/asm/StinkyAsmDirectives.hpp"
 #include "stinkytofu/ir/asm/StinkyAsmIR.hpp"
 #include "stinkytofu/support/DAGScheduleJsonWriter.hpp"
 #include "stinkytofu/support/DebugPrintInstrumentation.hpp"
@@ -280,6 +281,27 @@ class ScopeAdaptor : public Pass {
     }
 
    private:
+    /// Move IR from [begin, end) into \p bb.
+    /// StinkyInstructions and non-TEXTBLOCK AsmDirectives are preserved;
+    /// TEXTBLOCK directives (comments) are erased.
+    static void moveIRToBlock(IntrusiveListIterator<IRBase> begin,
+                              IntrusiveListIterator<IRBase> end, BasicBlock* bb) {
+        for (auto it = begin; it != end;) {
+            IRBase* ir = it.getNodePtr();
+            it++;
+            if (dyn_cast<StinkyInstruction>(ir)) {
+                bb->appendIR(ir);
+            } else if (const auto* directive = dyn_cast<AsmDirective>(ir)) {
+                if (directive->kind == AsmDirectiveKind::TEXTBLOCK)
+                    ir->erase();
+                else
+                    bb->appendIR(ir);
+            } else {
+                assert(false && "Unexpected non-instruction IR type in scope adaptor");
+            }
+        }
+    }
+
     /// Extract a single group's instruction range to a temp Function,
     /// run the inner PM, and splice results back.
     void runSingleRegion(const std::string& groupName) {
@@ -293,16 +315,7 @@ class ScopeAdaptor : public Pass {
         Function tempFunc("temp");
         BasicBlock* bb = tempFunc.createBasicBlock("entry");
 
-        // Move StinkyInstructions from module to temporary function
-        for (auto it = begin; it != end;) {
-            IRBase* ir = it.getNodePtr();
-            it++;
-            if (dyn_cast<StinkyInstruction>(ir)) {
-                bb->appendIR(ir);
-            } else {
-                ir->erase();
-            }
-        }
+        moveIRToBlock(begin, end, bb);
 
         // Run the inner pipeline
         innerPM.run(tempFunc);
@@ -342,16 +355,7 @@ class ScopeAdaptor : public Pass {
         Function tempFunc("temp");
         BasicBlock* bb = tempFunc.createBasicBlock("entry");
 
-        // Move StinkyInstructions from the combined range
-        for (auto it = combinedBegin; it != combinedEnd;) {
-            IRBase* ir = it.getNodePtr();
-            it++;
-            if (dyn_cast<StinkyInstruction>(ir)) {
-                bb->appendIR(ir);
-            } else {
-                ir->erase();
-            }
-        }
+        moveIRToBlock(combinedBegin, combinedEnd, bb);
 
         // Run the inner pipeline
         innerPM.run(tempFunc);
@@ -394,16 +398,7 @@ class ScopeAdaptor : public Pass {
         Function tempFunc("temp");
         BasicBlock* bb = tempFunc.createBasicBlock("entry");
 
-        // Move all StinkyInstructions from module to temporary function
-        for (auto it = origBB->begin(); it != origBB->end();) {
-            IRBase* ir = it.getNodePtr();
-            it++;
-            if (dyn_cast<StinkyInstruction>(ir)) {
-                bb->appendIR(ir);
-            } else {
-                ir->erase();
-            }
-        }
+        moveIRToBlock(origBB->begin(), origBB->end(), bb);
 
         // Run the inner pipeline
         innerPM.run(tempFunc);

--- a/shared/stinkytofu/src/analysis/asm/AsmVerifierPass.cpp
+++ b/shared/stinkytofu/src/analysis/asm/AsmVerifierPass.cpp
@@ -28,7 +28,6 @@
 #include <sstream>
 
 #include "stinkytofu/ir/asm/StinkyAsmIR.hpp"
-#include "stinkytofu/support/ErrorHandling.hpp"
 
 namespace stinkytofu {
 char StinkyIRVerifierPass::ID = 0;
@@ -62,6 +61,37 @@ static RegType fieldTypeToRegType(FieldType ft) {
             return RegType::S;
         default:
             return RegType::UNKNOWN;
+    }
+}
+
+static bool isScalarRegType(RegType type) {
+    switch (type) {
+        case RegType::S:
+        case RegType::SCC:
+        case RegType::VCC:
+        case RegType::VCC_LO:
+        case RegType::VCC_HI:
+        case RegType::EXEC:
+        case RegType::EXEC_LO:
+        case RegType::EXEC_HI:
+            return true;
+        default:
+            return false;
+    }
+}
+
+static bool isExpectedTypeMatch(FieldType fieldType, RegType expectedType, RegType actualType) {
+    if (expectedType == RegType::UNKNOWN) return true;
+
+    switch (fieldType) {
+        case FieldType::sreg:
+        case FieldType::sreg_m0:
+        case FieldType::sgpr:
+        case FieldType::sdst:
+        case FieldType::ssrc:
+            return isScalarRegType(actualType);
+        default:
+            return actualType == expectedType;
     }
 }
 
@@ -119,7 +149,7 @@ static std::string checkRegisterWidths(const StinkyInstruction* inst,
         }
 
         RegType expectedType = fieldTypeToRegType(field.fieldType);
-        if (expectedType != RegType::UNKNOWN && reg.reg.type != expectedType) {
+        if (!isExpectedTypeMatch(field.fieldType, expectedType, reg.reg.type)) {
             errors << "Instruction '";
             inst->dump(errors);
             errors << "' operand " << (isDest ? "dest[" : "src[") << operandIndex << "] "

--- a/shared/stinkytofu/src/analysis/controlflow/Dominance.cpp
+++ b/shared/stinkytofu/src/analysis/controlflow/Dominance.cpp
@@ -59,7 +59,8 @@ std::vector<unsigned> computeIDom(const std::vector<BasicBlock*>& rpo, const Blo
             unsigned newIdom = DominanceInfo::kUndef;
             for (BasicBlock* p : rpo[i]->getPredecessors()) {
                 auto it = blkIdx.find(p);
-                assert(it != blkIdx.end() && "Block index not found");
+                // RPO is entry-reachable only; skip unreachable predecessors.
+                if (it == blkIdx.end()) continue;
 
                 unsigned pi = it->second;
                 if (idom[pi] == DominanceInfo::kUndef) continue;
@@ -90,7 +91,8 @@ std::vector<std::vector<unsigned>> computeDF(const std::vector<BasicBlock*>& rpo
 
         for (BasicBlock* p : preds) {
             auto it = blkIdx.find(p);
-            assert(it != blkIdx.end() && "Block index not found");
+            // DF is computed for entry-reachable blocks only.
+            if (it == blkIdx.end()) continue;
 
             unsigned runner = it->second;
             while (runner != idom[j]) {

--- a/shared/stinkytofu/src/serialization/asm/IRConverter.cpp
+++ b/shared/stinkytofu/src/serialization/asm/IRConverter.cpp
@@ -27,6 +27,7 @@
 #include "ModifierSerializer.hpp"
 #include "stinkytofu/hardware/ArchHelper.hpp"
 #include "stinkytofu/hardware/GfxIsa.hpp"
+#include "stinkytofu/ir/asm/StinkyAsmDirectives.hpp"
 #include "stinkytofu/ir/asm/StinkyAsmIR.hpp"
 #include "stinkytofu/serialization/asm/IRParser.hpp"
 
@@ -39,6 +40,20 @@ static void convertInstruction(AsmIRBuilder& irBuilder,
                                const std::unique_ptr<ParsedInstruction>& inst, GfxArchID arch) {
     if (inst->isLabel) {
         irBuilder.createLabel(inst->opcodeStr);
+        return;
+    }
+
+    if (inst->opcodeStr == "asm_directive") {
+        AsmDirective* d = irBuilder.createIR<AsmDirective>();
+        if (!inst->srcRegs.empty() &&
+            inst->srcRegs[0].dataType == StinkyRegister::Type::LiteralString) {
+            d->name = inst->srcRegs[0].literalValue;
+            if (d->name == ".set") d->kind = AsmDirectiveKind::SET;
+        }
+        if (inst->srcRegs.size() > 1 &&
+            inst->srcRegs[1].dataType == StinkyRegister::Type::LiteralString) {
+            d->symbol = inst->srcRegs[1].literalValue;
+        }
         return;
     }
 

--- a/shared/stinkytofu/src/serialization/asm/IRParser.cpp
+++ b/shared/stinkytofu/src/serialization/asm/IRParser.cpp
@@ -876,8 +876,17 @@ std::optional<StinkyRegister> IRParser::parseRegister() {
     // v[10], v[14:17], s[0], acc[0:15], BARRIER[0], SCC[0], DS_WRITE[0]
     // Literals: HexLiteral -> LiteralString (spelling preserved); decimal int / float -> numeric
     // literals.
+    // QuotedString: used by st.asm_directive operands (e.g. ".set", "symbol").
 
     TokenKind kind = peek().kind;
+
+    // Handle quoted string literals (e.g. directive operands)
+    if (kind == TokenKind::QuotedString) {
+        const Token& tok = consume();
+        std::string s(tok.text);
+        if (s.size() >= 2 && s.front() == '"' && s.back() == '"') s = s.substr(1, s.size() - 2);
+        return StinkyRegister(s);
+    }
 
     // Handle integer literals
     if (kind == TokenKind::IntegerLiteral) {

--- a/shared/stinkytofu/src/transforms/asm/StinkyBuildImplicitDependencyPass.cpp
+++ b/shared/stinkytofu/src/transforms/asm/StinkyBuildImplicitDependencyPass.cpp
@@ -107,6 +107,48 @@ static void processLdsReader(StinkyInstruction& inst, const MemTokenData& mt,
     for (int tokenId : mt.tokens) addUniqueLdsSrc(inst, tokenId);
 }
 
+static bool isMemTokenCandidate(const StinkyInstruction& inst) {
+    return isTensorLoad(inst) || isDSWrite(inst) || isDSRead(inst);
+}
+
+static const char* memTokenCandidateKind(const StinkyInstruction& inst) {
+    if (isTensorLoad(inst)) return "tensor_load";
+    if (isDSWrite(inst)) return "ds_store";
+    if (isDSRead(inst)) return "ds_load";
+    return "unknown";
+}
+
+static void warnInconsistentMemTokens(const BasicBlock& bb) {
+    bool hasWithToken = false;
+    bool hasWithoutToken = false;
+
+    for (auto it = bb.begin(); it != bb.end(); ++it) {
+        const auto* inst = dyn_cast<StinkyInstruction>(it.getNodePtr());
+        if (!inst || !isMemTokenCandidate(*inst)) continue;
+
+        if (inst->getModifier<MemTokenData>())
+            hasWithToken = true;
+        else
+            hasWithoutToken = true;
+    }
+
+    if (!hasWithToken || !hasWithoutToken) return;
+
+    std::cerr << "[BuildImplicitDep] WARNING: BB \"" << bb.getLabel()
+              << "\" has inconsistent memory tokens — some ds_load/ds_store/tensor_load"
+                 " instructions have MemTokenData while others do not:\n";
+
+    for (auto it = bb.begin(); it != bb.end(); ++it) {
+        const auto* inst = dyn_cast<StinkyInstruction>(it.getNodePtr());
+        if (!inst || !isMemTokenCandidate(*inst)) continue;
+
+        const bool hasToken = inst->getModifier<MemTokenData>() != nullptr;
+        std::cerr << "  " << (hasToken ? "[has token]   " : "[NO TOKEN]    ")
+                  << memTokenCandidateKind(*inst) << " (" << inst->getHwInstDesc()->mnemonic
+                  << ")\n";
+    }
+}
+
 void setPseudoRegistersInBlock(BasicBlock& bb, PassContext& passCtx) {
     if (!passCtx.getPassFeatureConfig().barrierConfig.unrollMovableBarrier) {
         PASS_DEBUG(std::cerr << "[BuildImplicitDep] skip BB label=\"" << bb.getLabel()
@@ -114,16 +156,14 @@ void setPseudoRegistersInBlock(BasicBlock& bb, PassContext& passCtx) {
         return;
     }
 
+    warnInconsistentMemTokens(bb);
+
     for (auto it = bb.begin(); it != bb.end(); ++it) {
         auto* inst = dyn_cast<StinkyInstruction>(it.getNodePtr());
         if (!inst) continue;
 
         const MemTokenData* mt = inst->getModifier<MemTokenData>();
-        if (!mt) {
-            assert(!isTensorLoad(*inst) && !isDSRead(*inst) && !isDSWrite(*inst) &&
-                   "tensor_load/ds_read/ds_write must have MemTokenData");
-            continue;
-        }
+        if (!mt) continue;
         assert(!mt->tokens.empty() && "MemTokenData with empty tokens");
 
         if (isBarrier(*inst))

--- a/shared/stinkytofu/src/transforms/asm/StinkyDAGSchedulerPass.cpp
+++ b/shared/stinkytofu/src/transforms/asm/StinkyDAGSchedulerPass.cpp
@@ -49,7 +49,7 @@ static bool isMovableSideEffect(const StinkyInstruction& inst) {
 // (only when both endpoints are inside the region).
 static void scheduleRegionWithMovableSideEffects(
     IRList::iterator regionStart, IRList::iterator regionEnd, IRList::iterator blockBegin,
-    std::vector<StinkyInstruction*>& scheduled, ReadyQueue& readyQueue,
+    std::vector<IRBase*>& scheduled, ReadyQueue& readyQueue,
     const std::unordered_map<StinkyInstruction*, unsigned>& wmmaIndex) {
     if (regionStart == regionEnd) {
         return;  // Empty region, nothing to schedule.
@@ -308,6 +308,14 @@ static void scheduleRegionWithMovableSideEffects(
     }
 }
 
+static bool hasLdsPseudoRegs(const StinkyInstruction& inst) {
+    for (const StinkyRegister& r : inst.getSrcRegs())
+        if (r.isRegister() && r.reg.type == RegType::LDS) return true;
+    for (const StinkyRegister& r : inst.getDestRegs())
+        if (r.isRegister() && r.reg.type == RegType::LDS) return true;
+    return false;
+}
+
 static bool hasSideEffect(const StinkyInstruction& inst) {
     if (
         // TODO: provide a configurable way to ignore certain instructions,
@@ -317,6 +325,11 @@ static bool hasSideEffect(const StinkyInstruction& inst) {
         //
         isGlobalMemStore(inst) || isBranch(inst) || isBarrier(inst) || isWaitCnt(inst) ||
         isHasSideEffect(inst)) {
+        return true;
+    }
+    // Memory ops without LDS pseudo-registers (no MemTokenData assigned)
+    // must be treated as non-movable side effects to preserve strict ordering.
+    if ((isTensorLoad(inst) || isDSRead(inst) || isDSWrite(inst)) && !hasLdsPseudoRegs(inst)) {
         return true;
     }
     return false;
@@ -334,7 +347,7 @@ static void scheduleInDAG(BasicBlock& bb, ReadyQueue& readyQueue,
 
     if (bb.empty()) return;
 
-    std::vector<StinkyInstruction*> scheduled;
+    std::vector<IRBase*> scheduled;
     scheduled.reserve(bb.size());
 
     BasicBlock::iterator beginIt = bb.begin();
@@ -345,7 +358,20 @@ static void scheduleInDAG(BasicBlock& bb, ReadyQueue& readyQueue,
     BasicBlock::iterator regionStart = beginIt;
 
     for (BasicBlock::iterator it = beginIt; it != endIt; ++it) {
-        StinkyInstruction& inst = getStinkyInst(it);
+        IRBase* irNode = it.getNodePtr();
+        auto* instPtr = dyn_cast<StinkyInstruction>(irNode);
+
+        if (!instPtr) {
+            // Non-instruction IR (e.g. AsmDirective): treat as non-movable
+            // side-effect boundary so its position is strictly preserved.
+            scheduleRegionWithMovableSideEffects(regionStart, it, beginIt, scheduled, readyQueue,
+                                                 wmmaIndex);
+            scheduled.push_back(irNode);
+            regionStart = std::next(it);
+            continue;
+        }
+
+        StinkyInstruction& inst = *instPtr;
         // Only break regions on non-movable side effects
         if (hasSideEffect(inst) && !isMovableSideEffect(inst)) {
             scheduleRegionWithMovableSideEffects(regionStart, it, beginIt, scheduled, readyQueue,
@@ -369,9 +395,9 @@ static void scheduleInDAG(BasicBlock& bb, ReadyQueue& readyQueue,
 
     // Now we have a scheduled list of instructions.
     // Reorder the block to reflect the scheduling (move each to end in order).
-    for (StinkyInstruction* inst : scheduled) {
-        bb.removeIR(inst);
-        bb.appendIR(inst);
+    for (IRBase* ir : scheduled) {
+        bb.removeIR(ir);
+        bb.appendIR(ir);
     }
 
     readyQueue.onFinishBB();
@@ -411,8 +437,9 @@ class StinkyDAGSchedulerPass : public StinkyInstPass {
             unsigned idx = 0;
             traverseCFGInRPO(func, [&](BasicBlock* bb) {
                 for (auto it = bb->begin(); it != bb->end(); ++it) {
-                    StinkyInstruction& inst = getStinkyInst(it);
-                    if (isWMMA(inst) || isSWMMA(inst)) wmmaIndex[&inst] = idx++;
+                    auto* inst = dyn_cast<StinkyInstruction>(it.getNodePtr());
+                    if (!inst) continue;
+                    if (isWMMA(*inst) || isSWMMA(*inst)) wmmaIndex[inst] = idx++;
                 }
             });
         }

--- a/shared/stinkytofu/src/transforms/asm/dag/CDNA3.hpp
+++ b/shared/stinkytofu/src/transforms/asm/dag/CDNA3.hpp
@@ -1,0 +1,347 @@
+/* ************************************************************************
+ * Copyright (C) 2025-2026 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * ************************************************************************ */
+#include <map>
+
+#include "ReadyQueue.hpp"
+#include "stinkytofu/core/PassManager.hpp"
+
+namespace
+{
+    using namespace stinkytofu;
+
+    class CDNA3ReadyQueue : public ReadyQueue
+    {
+        DAGidPriorityQueue mfmaQueue;
+        DAGidPriorityQueue globalReadQueue;
+        DAGidPriorityQueue otherQueue;
+        DAGidPriorityQueue barrierQueue;
+
+        bool isInit = false;
+
+        int globalReadCounter = 0; // tracking global read count during MFMA
+        int globalReadPerMFMA = 1; // global read issue count per MFMA
+
+        int mfmaCounter = 0;
+        // For mfma latency tracking per register
+        std::map<int, int> mfmaRegisterLatencyCounters;
+
+        MFMAIssueConfig mfmaIssueConfig;
+
+        void     updateMFMALatencyCounters(DAGNode* node);
+        bool     isMFMALatencyFree();
+        DAGNode* pickOneFromMFMA();
+        void     MFMAIssueUpdate(DAGNode* node);
+        /// True if MFMA, pickable global read, or otherQueue still has a candidate this step.
+        bool hasNonBarrierWorkRemaining() const;
+
+    public:
+        explicit CDNA3ReadyQueue(const PassContext& passCtx)
+            : ReadyQueue(passCtx)
+        {
+        }
+
+        DAGNode* pickOne() override;
+        void     push(DAGNode* node) override;
+        bool     empty() const override;
+
+        void onInit(IRList::iterator regionStart, IRList::iterator regionEnd) override;
+
+        void onInitRegion(IRList::iterator regionStart,
+                          IRList::iterator regionEnd,
+                          IRList::iterator blockBegin) override;
+    };
+
+    void CDNA3ReadyQueue::updateMFMALatencyCounters(DAGNode* node)
+    {
+        // decrement the latency counters
+        for(auto& [reg, counter] : mfmaRegisterLatencyCounters)
+        {
+            if(counter > 0)
+                counter -= node->inst->issueCycles;
+        }
+    }
+
+    bool CDNA3ReadyQueue::isMFMALatencyFree()
+    {
+        DAGNode* node = mfmaQueue.top();
+        for(const StinkyRegister& dstReg : node->inst->getSrcRegs())
+        {
+            if(!dstReg.isRegister())
+                continue;
+
+            for(unsigned off = 0; off < dstReg.reg.num; ++off)
+            {
+                auto it = mfmaRegisterLatencyCounters.find(dstReg.reg.idx + off);
+                if(it != mfmaRegisterLatencyCounters.end() && it->second > 0)
+                {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    DAGNode* CDNA3ReadyQueue::pickOneFromMFMA()
+    {
+        assert(!mfmaQueue.empty() && "The MFMA queue must not be empty");
+        DAGNode* node = mfmaQueue.top();
+        mfmaQueue.pop();
+        // Use the original latency to avoid mfma issued continuously
+        auto rest
+            = (int)((mfmaIssueConfig.totalIssuedCycles - mfmaIssueConfig.totalMfmaIssuedCycles)
+                    / mfmaIssueConfig.issuedCount);
+        if(mfmaIssueConfig.issuedCount <= 0
+           || (mfmaIssueConfig.issuedCount > 0 && rest < node->inst->latencyCycles))
+        {
+            // interleave mfma with other instructions if possible
+            // mfma inst1 mfma inst2 mfma inst3
+            if(node->inst->latencyCycles >= mfmaIssueConfig.avgIssueInterval)
+            {
+                mfmaCounter = std::max(rest, 1);
+            }
+            else
+            {
+                mfmaCounter = node->inst->latencyCycles;
+            }
+        }
+        else
+        {
+            mfmaCounter = mfmaIssueConfig.avgIssueInterval;
+        }
+        mfmaIssueConfig.issuedCount--;
+        mfmaIssueConfig.totalMfmaIssuedCycles -= node->inst->issueCycles;
+        MFMAIssueUpdate(node);
+        updateMFMALatencyCounters(node);
+        globalReadCounter = 0;
+        return node;
+    }
+
+    void CDNA3ReadyQueue::MFMAIssueUpdate(DAGNode* node)
+    {
+        // Use issue for all instructions
+        mfmaCounter -= node->inst->issueCycles;
+        mfmaIssueConfig.totalIssuedCycles -= node->inst->issueCycles;
+    }
+
+    bool CDNA3ReadyQueue::hasNonBarrierWorkRemaining() const
+    {
+        if(!mfmaQueue.empty())
+            return true;
+        if(!globalReadQueue.empty()
+           && (globalReadCounter < globalReadPerMFMA || otherQueue.empty()))
+            return true;
+        if(!otherQueue.empty())
+            return true;
+        return false;
+    }
+
+    DAGNode* CDNA3ReadyQueue::pickOne()
+    {
+        // Priority 1: Try to schedule MFMA if counter allows
+        // TODO: Need to check if ds_read completes are done for the MFMA
+        // mfmaRegisterLatencyCounters
+        if(!mfmaQueue.empty() && mfmaCounter <= 0 && isMFMALatencyFree())
+        {
+            return pickOneFromMFMA();
+        }
+
+        // Priority 2: Schedule other instructions
+        if(!globalReadQueue.empty())
+        {
+            if(globalReadCounter < globalReadPerMFMA || otherQueue.empty())
+            {
+                DAGNode* globalRead = globalReadQueue.top();
+                globalReadQueue.pop();
+                MFMAIssueUpdate(globalRead);
+                updateMFMALatencyCounters(globalRead);
+                globalReadCounter++;
+                return globalRead;
+            }
+        }
+
+        if(!otherQueue.empty())
+        {
+            DAGNode* node = otherQueue.top();
+            otherQueue.pop();
+            MFMAIssueUpdate(node);
+            // If ds read, add its latency to the counter to mfmaRegisterLatencyCounters
+            // Ignore global read for now
+            if(isDSRead(*node->inst))
+            {
+                for(const StinkyRegister& dstReg : node->inst->getDestRegs())
+                {
+                    if(!dstReg.isRegister())
+                        continue;
+
+                    for(unsigned off = 0; off < dstReg.reg.num; ++off)
+                    {
+                        mfmaRegisterLatencyCounters[dstReg.reg.idx + off]
+                            = node->inst->latencyCycles;
+                    }
+                }
+            }
+            updateMFMALatencyCounters(node);
+
+            return node;
+        }
+
+        // Ready MFMA must run before a barrier when Priority 1 did not already take it — otherwise
+        // barriers steal picks from deferred MFMA and violate "barrier last if possible".
+        if(!mfmaQueue.empty())
+        {
+            return pickOneFromMFMA();
+        }
+
+        assert(!hasNonBarrierWorkRemaining()
+               && "CDNA3 pickOne: barrier only after MFMA / pickable global / other work is gone");
+
+        // Priority 3: movable barriers only when nothing else in the ready set can issue this step.
+        if(!barrierQueue.empty())
+        {
+            DAGNode* barrier = barrierQueue.top();
+            barrierQueue.pop();
+            MFMAIssueUpdate(barrier);
+            updateMFMALatencyCounters(barrier);
+            PASS_DEBUG(std::cerr << "[DAG CDNA3 pickOne] Priority 3 barrierQueue dagId=" << barrier->id
+                                 << " (non-barrier buckets empty for this pick)\n";
+                       barrier->inst->dump(std::cerr);
+                       std::cerr << "\n");
+            return barrier;
+        }
+
+        assert(false && "CDNA3ReadyQueue::pickOne: all buckets empty");
+        return nullptr;
+    }
+
+    void CDNA3ReadyQueue::push(DAGNode* node)
+    {
+        if(isMFMA(*node->inst))
+        {
+            mfmaQueue.push(node);
+            return;
+        }
+
+        if(getPassContext().getPassFeatureConfig().dagFeatures.distributeGlobalRead
+           && isGlobalMemLoad(*node->inst))
+        {
+            globalReadQueue.push(node);
+            return;
+        }
+
+        if(isBarrier(*node->inst))
+        {
+            barrierQueue.push(node);
+            return;
+        }
+
+        otherQueue.push(node);
+    }
+
+    bool CDNA3ReadyQueue::empty() const
+    {
+        return mfmaQueue.empty() && globalReadQueue.empty() && otherQueue.empty()
+               && barrierQueue.empty();
+    }
+
+    void CDNA3ReadyQueue::onInit(IRList::iterator regionStart, IRList::iterator regionEnd)
+    {
+        // For for loop only optimization
+        if(getPassContext().getPassFeatureConfig().loopConfig.unrollGemm == false)
+            return;
+
+        mfmaIssueConfig.latency = 0;
+        for(IRList::iterator it = regionStart; it != regionEnd; ++it)
+        {
+            auto* instPtr = dyn_cast<StinkyInstruction>(it.getNodePtr());
+            if(!instPtr)
+                continue;
+            if(isMFMA(*instPtr) || isSMFMA(*instPtr))
+            {
+                mfmaIssueConfig.latency = instPtr->latencyCycles;
+                break;
+            }
+        }
+
+        isInit = false;
+    }
+
+    void CDNA3ReadyQueue::onInitRegion(IRList::iterator regionStart,
+                                       IRList::iterator regionEnd,
+                                       IRList::iterator blockBegin)
+    {
+        (void)blockBegin;
+        // For for loop only optimization
+        if(getPassContext().getPassFeatureConfig().loopConfig.unrollGemm == false)
+            return;
+
+        mfmaIssueConfig.totalIssuedCycles     = 0;
+        mfmaIssueConfig.totalMfmaIssuedCycles = 0;
+        mfmaIssueConfig.issuedCount           = 0;
+        int totalDSLatency                    = 0;
+        // Get total issued cycles and total ds latency in the region
+        for(IRList::iterator it = regionStart; it != regionEnd; ++it)
+        {
+            auto* instPtr = dyn_cast<StinkyInstruction>(it.getNodePtr());
+            if(!instPtr)
+                continue;
+            StinkyInstruction& inst = *instPtr;
+
+            mfmaIssueConfig.totalIssuedCycles += inst.issueCycles;
+
+            if(isDSRead(inst))
+            {
+                totalDSLatency += inst.latencyCycles;
+            }
+
+            if(isMFMA(inst) || isSMFMA(inst))
+            {
+                mfmaIssueConfig.issuedCount += 1;
+                mfmaIssueConfig.totalMfmaIssuedCycles += inst.issueCycles;
+            }
+        }
+        // Get possible longest average latency
+        // The total issued cycles and total ds latency are in parallel
+        // So we take the larger one to calculate average latency
+        auto totalAvgLatency
+            = (int)std::ceil((float)std::max(mfmaIssueConfig.totalIssuedCycles, totalDSLatency)
+                             / mfmaIssueConfig.issuedCount);
+        // Use the larger one as the mfma average counter
+        // If mfma original latency is larger, then we don't have
+        // to split the non-mfma instructions between mfma instructions
+        if(totalAvgLatency > mfmaIssueConfig.latency)
+        {
+            mfmaIssueConfig.avgIssueInterval = totalAvgLatency;
+        }
+        else
+        {
+            mfmaIssueConfig.avgIssueInterval = mfmaIssueConfig.latency;
+        }
+
+        // Only init in the beginning of the loop
+        if(!isInit)
+        {
+            mfmaCounter = mfmaIssueConfig.avgIssueInterval;
+            isInit      = true;
+        }
+    }
+}

--- a/shared/stinkytofu/src/transforms/asm/dag/CDNA5.hpp
+++ b/shared/stinkytofu/src/transforms/asm/dag/CDNA5.hpp
@@ -61,7 +61,9 @@ static void seedWmmaDsLatencyFromPrefix(IRList::iterator blockBegin, IRList::ite
     std::map<int, int> pending(crossBBResiduals);
 
     for (IRList::iterator it = blockBegin; it != regionStart; ++it) {
-        StinkyInstruction& inst = getStinkyInst(it);
+        auto* instPtr = dyn_cast<StinkyInstruction>(it.getNodePtr());
+        if (!instPtr) continue;
+        StinkyInstruction& inst = *instPtr;
         const int iss = inst.issueCycles;
 
         for (auto pit = pending.begin(); pit != pending.end();) {
@@ -94,9 +96,10 @@ static bool latchBBTailIsWmma(BasicBlock& latchBB) {
     // Walk from tail toward head. Do not use std::prev(end()) on IRList::iterator:
     // end() is nullptr and IntrusiveListIterator::operator-- does not step to tail_.
     for (auto it = latchBB.rbegin(); it != latchBB.rend(); ++it) {
-        StinkyInstruction& inst = getStinkyInst(it);
-        if (isLabel(inst) || isBranch(inst)) continue;
-        return isMatrixInstruction(inst);
+        auto* instPtr = dyn_cast<StinkyInstruction>(it.getNodePtr());
+        if (!instPtr) continue;
+        if (isLabel(*instPtr) || isBranch(*instPtr)) continue;
+        return isMatrixInstruction(*instPtr);
     }
     return false;
 }
@@ -738,7 +741,7 @@ void CDNA5ReadyQueue::onInit(IRList::iterator regionStart, IRList::iterator regi
     deferFirstHeadWmmaActive_ = false;
     deferHeadBalanceThisRegion_ = false;
 
-    currentBB_ = (regionStart != regionEnd) ? getStinkyInst(regionStart).getParent() : nullptr;
+    currentBB_ = (regionStart != regionEnd) ? regionStart->getParent() : nullptr;
 
     if (getPassContext().getPassFeatureConfig().loopConfig.unrollGemm == false) return;
 
@@ -752,9 +755,10 @@ void CDNA5ReadyQueue::onInit(IRList::iterator regionStart, IRList::iterator regi
 
     wmmaIssueConfig.latency = 0;
     for (IRList::iterator it = regionStart; it != regionEnd; ++it) {
-        StinkyInstruction& inst = getStinkyInst(it);
-        if (isMatrixInstruction(inst)) {
-            wmmaIssueConfig.latency = inst.latencyCycles;
+        auto* instPtr = dyn_cast<StinkyInstruction>(it.getNodePtr());
+        if (!instPtr) continue;
+        if (isMatrixInstruction(*instPtr)) {
+            wmmaIssueConfig.latency = instPtr->latencyCycles;
             break;
         }
     }
@@ -801,7 +805,7 @@ void CDNA5ReadyQueue::onInitRegion(IRList::iterator regionStart, IRList::iterato
     // where the first region's empty prefix meant no deferral).
     const Loop* loop = getLoop();
     deferHeadBalanceThisRegion_ = deferFirstHeadWmmaActive_ && loop &&
-                                  loop->headerBB == getStinkyInst(blockBegin).getParent() &&
+                                  loop->headerBB == blockBegin->getParent() &&
                                   regionStart != blockBegin;
 
     seedWmmaDsLatencyFromPrefix(blockBegin, regionStart, wmmaRegisterLatencyCounters,
@@ -813,7 +817,9 @@ void CDNA5ReadyQueue::onInitRegion(IRList::iterator regionStart, IRList::iterato
     int totalDSLatency = 0;
     hasWMMAInRegion_ = false;
     for (IRList::iterator it = regionStart; it != regionEnd; ++it) {
-        StinkyInstruction& inst = getStinkyInst(it);
+        auto* instPtr = dyn_cast<StinkyInstruction>(it.getNodePtr());
+        if (!instPtr) continue;
+        StinkyInstruction& inst = *instPtr;
 
         wmmaIssueConfig.totalIssuedCycles += inst.issueCycles;
 

--- a/shared/stinkytofu/tests/filecheck/barrier_token_group_ordering.stir
+++ b/shared/stinkytofu/tests/filecheck/barrier_token_group_ordering.stir
@@ -16,31 +16,28 @@
 #   - barrier_signal before barrier_wait
 #   - barrier_wait before post-barrier loads
 #
-# Group 0 pre-barrier: ds_load
-# CHECK: ds_load_b128{{.*}}tokens = [0]
+# Group 2 pre-barrier: {tensor_load, ds_load} before signal
+# CHECK: LDS2 = "st.tensor_load_to_lds"(s[24:27], s[28:35]){{.*}}
+# CHECK: v[8:11] = "st.ds_load_b128"(v24, LDS2)
+# CHECK: LDS2 = "st.s_barrier_signal"(-1, LDS2)
+# CHECK: LDS2 = "st.s_barrier_wait"(-1, LDS2)
 #
-# Group 2 pre-barrier: tensor_load, ds_load, then signal/wait
-# CHECK: tensor_load_to_lds{{.*}}tokens = [2]
-# CHECK: ds_load_b128{{.*}}tokens = [2]
-# CHECK: s_barrier_signal{{.*}}tokens = [2]
-# CHECK: s_barrier_wait{{.*}}tokens = [2]
+# Group 1: tensor_load before signal, signal before wait
+# CHECK: LDS1 = "st.tensor_load_to_lds"(s[12:15], s[16:23])
+# CHECK: LDS1 = "st.s_barrier_signal"(-1, LDS1)
+# CHECK: LDS1 = "st.s_barrier_wait"(-1, LDS1)
 #
-# Group 1 pre-barrier: tensor_load, then signal/wait
-# CHECK: tensor_load_to_lds{{.*}}tokens = [1]
-# CHECK: s_barrier_signal{{.*}}tokens = [1]
-# CHECK: s_barrier_wait{{.*}}tokens = [1]
+# Group 2 post-barrier: ds_load and tensor_load after wait
+# CHECK: v[12:15] = "st.ds_load_b128"(v28, LDS2)
+# CHECK: LDS2 = "st.tensor_load_to_lds"(s[36:39], s[40:47])
 #
-# Group 2 post-barrier: ds_load, tensor_load
-# CHECK: ds_load_b128{{.*}}tokens = [2]
-# CHECK: tensor_load_to_lds{{.*}}tokens = [2]
-#
-# Group 1 post-barrier: ds_load
-# CHECK: ds_load_b128{{.*}}tokens = [1]
+# Group 1 post-barrier: ds_load after wait
+# CHECK: v[4:7] = "st.ds_load_b128"(v20, LDS1)
 #
 # Group 0 post-barrier: signal, wait, tensor_load
-# CHECK: s_barrier_signal{{.*}}tokens = [0]
-# CHECK: s_barrier_wait{{.*}}tokens = [0]
-# CHECK: tensor_load_to_lds{{.*}}tokens = [0]
+# CHECK: LDS0 = "st.s_barrier_signal"(-1, LDS0)
+# CHECK: LDS0 = "st.s_barrier_wait"(-1, LDS0)
+# CHECK: LDS0 = "st.tensor_load_to_lds"(s[0:3], s[4:11])
 
 st.func @test() {
 ^entry:

--- a/shared/stinkytofu/tests/filecheck/dag_asm_directive_preservation.stir
+++ b/shared/stinkytofu/tests/filecheck/dag_asm_directive_preservation.stir
@@ -1,0 +1,37 @@
+# RUN: %stinkytofu-opt --arch gfx1250 %s --StinkyDAGSchedulerPass --print-output
+#
+# AsmDirective preservation: .set directives act as non-movable
+# side-effect boundaries in the DAG scheduler. Their relative order
+# among instructions must be strictly preserved.
+#
+# Input:  ds_load A, ds_load B, .set symA, ds_load C, ds_load D, .set symB, WMMA0, WMMA1
+# Expect: ds_loads may reorder within each region, but .set directives
+#         stay at their original boundary positions.
+#
+# Region 1 (before symA): two ds_loads
+# CHECK: ds_load_b128
+# CHECK: ds_load_b128
+# Directive boundary
+# CHECK: asm_directive{{.*}}symA
+# Region 2 (between symA and symB): two ds_loads
+# CHECK: ds_load_b128
+# CHECK: ds_load_b128
+# Directive boundary
+# CHECK: asm_directive{{.*}}symB
+# Region 3 (after symB): WMMAs
+# CHECK: v_wmma_f32_16x16x16_bf16
+# CHECK: v_wmma_f32_16x16x16_bf16
+# No directives should appear after the WMMAs
+# CHECK-NOT: asm_directive
+
+st.func @test() {
+^entry:
+  v[8:11] = "st.ds_load_b128"(v100) { issueCycles = 1, latencyCycles = 56, mod.ds = { na = 1, offset = 0, gds = false }, mod.memtoken = { tokens = [0] } }
+  v[12:15] = "st.ds_load_b128"(v100) { issueCycles = 1, latencyCycles = 56, mod.ds = { na = 1, offset = 32, gds = false }, mod.memtoken = { tokens = [0] } }
+  "st.asm_directive"(".set", "symA")
+  v[16:19] = "st.ds_load_b128"(v100) { issueCycles = 1, latencyCycles = 56, mod.ds = { na = 1, offset = 8192, gds = false }, mod.memtoken = { tokens = [0] } }
+  v[20:23] = "st.ds_load_b128"(v100) { issueCycles = 1, latencyCycles = 56, mod.ds = { na = 1, offset = 8224, gds = false }, mod.memtoken = { tokens = [0] } }
+  "st.asm_directive"(".set", "symB")
+  v[0:7] = "st.v_wmma_f32_16x16x16_bf16"(v[8:15], v[16:23], v[0:7]) { issueCycles = 4, latencyCycles = 8, mod.mfma = { inputPermute = "", scaleStr = "", negStr = "", reuseA = false, reuseB = false, neg_lo = false, neg_hi = false } }
+  v[0:7] = "st.v_wmma_f32_16x16x16_bf16"(v[16:23], v[20:23], v[0:7]) { issueCycles = 4, latencyCycles = 8, mod.mfma = { inputPermute = "", scaleStr = "", negStr = "", reuseA = false, reuseB = false, neg_lo = false, neg_hi = false } }
+}

--- a/shared/stinkytofu/tests/filecheck/dag_dsread_aaaab_to_baaaa.stir
+++ b/shared/stinkytofu/tests/filecheck/dag_dsread_aaaab_to_baaaa.stir
@@ -1,4 +1,4 @@
-# RUN: %stinkytofu-opt --arch gfx1250 %s --StinkyDAGSchedulerPass --print-output
+# RUN: %stinkytofu-opt --arch gfx1250 %s --StinkyBuildImplicitDependencyPass --StinkyDAGSchedulerPass --print-output
 #
 # DS read reordering: AAAAB → BAAAA.
 # 2 ds_loads per operand (filling 8-wide WMMA operands).

--- a/shared/stinkytofu/tests/filecheck/dag_dsread_aabb_to_abab.stir
+++ b/shared/stinkytofu/tests/filecheck/dag_dsread_aabb_to_abab.stir
@@ -1,4 +1,4 @@
-# RUN: %stinkytofu-opt --arch gfx1250 %s --StinkyDAGSchedulerPass --print-output
+# RUN: %stinkytofu-opt --arch gfx1250 %s --StinkyBuildImplicitDependencyPass --StinkyDAGSchedulerPass --print-output
 #
 # Ascending mode: AABB → ABAB by WMMA affinity.
 # Original: A0A0 A1A1 B0B0 B1B1. A0+B0 feed WMMA0, A1+B1 feed WMMA1.

--- a/shared/stinkytofu/tests/filecheck/dag_dsread_zigzag_abba.stir
+++ b/shared/stinkytofu/tests/filecheck/dag_dsread_zigzag_abba.stir
@@ -1,4 +1,4 @@
-# RUN: %stinkytofu-opt --arch gfx1250 %s --ds-read-order=AscendingCache --StinkyDAGSchedulerPass --print-output
+# RUN: %stinkytofu-opt --arch gfx1250 %s --StinkyBuildImplicitDependencyPass --ds-read-order=AscendingCache --StinkyDAGSchedulerPass --print-output
 #
 # AscendingCache zigzag: AABB → ABBA across WMMA groups.
 # Original: A0A0 A1A1 B0B0 B1B1. A0+B0 feed WMMA0, A1+B1 feed WMMA1.

--- a/shared/stinkytofu/tests/filecheck/tensor_load_dag_with_wmma.stir
+++ b/shared/stinkytofu/tests/filecheck/tensor_load_dag_with_wmma.stir
@@ -1,4 +1,4 @@
-# RUN: %stinkytofu-opt --arch gfx1250 %s --StinkyDAGSchedulerPass --print-output
+# RUN: %stinkytofu-opt --arch gfx1250 %s --StinkyBuildImplicitDependencyPass --StinkyDAGSchedulerPass --print-output
 #
 # DS reads + WMMAs with tensor_loads + distributeGlobalRead throttle.
 #


### PR DESCRIPTION
## Motivation

This PR fixed several issues:

    - AsmDirectives should be preserved in ScopeAdaptor and treat as non-movable side-effect boundaries in DAG scheduler

    - Fix verifier to accept any scalar reg type for scalar field types

    - Skip unreachable predecessors in dominance computation instead of asserting
      The activation processing (label_Activation_None_VW8) is not reachable from
      the extracted entry BasicBlock

    - Treat memory ops without LDS pseudo-regs as non-movable side effects

## Technical Details

## Test Plan

Run stinkytofu unittest.

## Test Result

stinkytofu unittest and filechecks are passed.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
