### PR TITLE
[primbench] Add missing '#include <cassert>' in primbench.hpp

### DIFF
--- a/shared/primbench/primbench.hpp
+++ b/shared/primbench/primbench.hpp
@@ -33,6 +33,7 @@
 #include <unistd.h>
 
 #include <array>
+#include <cassert>
 #include <fstream>
 #include <functional>
 #include <iomanip>


### PR DESCRIPTION
## Summary

- Add `#include <cassert>` to `shared/primbench/primbench.hpp`
- The `assert()` call at line 1506 (in `format_eta()`) was added in #5512 without the corresponding include, causing a compile error:   `use of undeclared identifier 'assert'`
- This was not caught in CI because benchmarks are not built during pre-checkin. The failure surfaces when building rocPRIM benchmarks (e.g. in TheRock CI).

TheRock issue: https://github.com/ROCm/TheRock/issues/4739

## Test plan

- Verify rocPRIM benchmarks compile successfully with `BUILD_BENCHMARK=ON`