### PR TITLE
Fix asan issue for device_search and device_find_end

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_search.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_search.hpp
@@ -136,13 +136,25 @@ void search_kernel_shared_impl(InputIterator1 input,
     bool find_pattern = false;
 
     ROCPRIM_SHARED_MEMORY uninitialized_array<key_type, max_shared_key> local_keys_;
-    ROCPRIM_SHARED_MEMORY uninitialized_array<value_type, items_per_block> local_input_;
+    // Hide extra bool shared memory usage with union
+    ROCPRIM_SHARED_MEMORY union
+    {
+        bool                                             check_prev;
+        uninitialized_array<value_type, items_per_block> local_input_;
+    } storage;
 
-    // Check if a key was already found in a place before this block
-    if(block_offset > atomic_load(output))
+    // Check if it can have fit a key and a previous block already found an earlier solution.
+    // This early exit needs to be for the whole block.
+    if(flat_id == 0)
+    {
+        storage.check_prev = block_offset + keys_size > size || block_offset > atomic_load(output);
+    }
+    syncthreads();
+    if(storage.check_prev)
     {
         return;
     }
+    syncthreads();
 
     // Load in key in shared memory
     const size_t batch_size = ceiling_div(keys_size, block_size);
@@ -174,7 +186,7 @@ void search_kernel_shared_impl(InputIterator1 input,
         for(size_t i = 0; i < items_per_thread; i++)
         {
             const size_t index = flat_id * items_per_thread + i;
-            local_input_.emplace(index, elements[i]);
+            storage.local_input_.emplace(index, elements[i]);
         }
     }
     else
@@ -186,18 +198,18 @@ void search_kernel_shared_impl(InputIterator1 input,
             const size_t index_value = block_offset + index;
             if(index_value < size)
             {
-                local_input_.emplace(index, elements[i]);
+                storage.local_input_.emplace(index, elements[i]);
             }
         }
     }
 
     const key_type*   local_keys  = local_keys_.get_unsafe_array();
-    const value_type* local_input = local_input_.get_unsafe_array();
+    const value_type* local_input = storage.local_input_.get_unsafe_array();
 
     syncthreads();
 
-    // Check if it can have fit a key and a key has not yet be found with a lower index.
-    if(offset + block_offset + keys_size > size || offset > atomic_load(output))
+    // Check if a solution is found in this block or in another block during loading.
+    if(block_offset + offset + keys_size > size || block_offset + offset > atomic_load(output))
     {
         return;
     }


### PR DESCRIPTION
## Motivation
device_find_end and device_search have sometimes a heap-use-after-free. This was because of an early exit of a block. In the same block some warps used an old atomic_load(output) value some a new, so blocks were half executed which caused this issue. I made sure the whole block used the same check to determine termination.

The performance was verified on MI300 and was mostly the same, there were a few 3-4% regression,. It is does not appear to be because of the overhead it is not consistent enough over all the benchmarks. It could also be because of the slight variation of when an early termination is done, especially since they are with key_size 10 which has a higher likelihood of a early termination. This is also supported by the fact that there is also a variation between runs.

## Technical Details

The first early termination is done for the whole block or not, using some shared memory. 

## Test Plan
It should pass the tests with ASAN enabled. And should not cause regressions.

## Test Result

It passed the tests with ASAN and no consistent regressions are reported on the MI300.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
