### PR TITLE
[MIOPEN] Exclude flaky GPU_GetitemBwd_FP32 test for gfx94X

### DIFF
--- a/projects/miopen/test/gtest/test_categories.yaml
+++ b/projects/miopen/test/gtest/test_categories.yaml
@@ -401,6 +401,16 @@ exclude_gpu:
       - "full"
       - "ex_gpu_gfx950"
 
+  exclude_gpu_gfx94X:
+    test_patterns:
+      - "*GPU_GetitemBwd_FP32*"
+    labels:
+      - "quick"
+      - "standard"
+      - "comprehensive"
+      - "full"
+      - "ex_gpu_gfx94X"
+
 execution_settings:
   default_timeout: 300  # 5 minutes per test
   timeout_multiplier: 2 # Multiplier for all timeouts (1, 1.5, 1.75, 2, etc.)


### PR DESCRIPTION
## Motivation

Stabilize the Rock CI on gfx94X by disabling GPU_GetitemBwd_FP32 which has been failing and passing inconsistently.

## Technical Details

Add GPU_GetitemBwd_FP32 to the exclusion list of gfx94X

## Test Plan

GPU_GetitemBwd_FP32 doesn't run on the Rock CI

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
