### PR TITLE
[tensilelite] Add timer for LogReporter.postSolution

### DIFF
--- a/projects/hipblaslt/tensilelite/client/include/LogReporter.hpp
+++ b/projects/hipblaslt/tensilelite/client/include/LogReporter.hpp
@@ -28,6 +28,7 @@
 
 #include "CSVStackFile.hpp"
 #include "ResultReporter.hpp"
+#include "TimingInstrumentation.hpp"
 
 #ifndef TENSILELITE_CLIENT_ENABLE_ROCPROFSDK
 #define TENSILELITE_CLIENT_ENABLE_ROCPROFSDK 0
@@ -396,6 +397,7 @@ namespace TensileLite
 
             virtual void postSolution() override
             {
+                ScopedTimer timer("post_solution_log");
                 std::unordered_map<std::string, std::string> curRow;
                 m_csvOutput.readCurrentRow(curRow);
                 bool  validation    = !(curRow[ResultKey::Validation] == "FAILED"


### PR DESCRIPTION
## Motivation & Technical Details

Add missing scoped timer for `post_solution_log`; it is already in the analyze_timing script, but was accidentally dropped from the call site in a previous rebase/split.

## Test Plan

Tested manually.

## Test Result

Pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
