### PR TITLE
[rocsolver] Remove reference to POTRF_BLOCKSIZE from tuning API refer…

### DIFF
--- a/projects/rocsolver/docs/reference/tuning.rst
+++ b/projects/rocsolver/docs/reference/tuning.rst
@@ -308,17 +308,13 @@ and scales the corresponding row/column. The blocked routine POTRF factorizes a 
 at each step using the unblocked algorithm, provided the matrix is large enough, and updates the trailing matrix with BLAS Level 3
 operations (symmetric rank-k updates), which, in general, can give better performance on the GPU.
 
-POTRF_BLOCKSIZE
-------------------------
-.. doxygendefine:: POTRF_BLOCKSIZE
-
 POTRF_POTF2_SWITCHSIZE
 ------------------------
 .. doxygendefine:: POTRF_POTF2_SWITCHSIZE
 
 .. note::
 
-   These constants have not been tuned for any specific cases.
+   This constant has not been tuned for any specific cases.
 
 sytf2/sytrf and lasyf functions
 =================================


### PR DESCRIPTION
…ence document

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Remove docs reference to variable that has been removed

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Edit API reference document

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Build locally

## Test Result

<!-- Briefly summarize test outcomes. -->
OK

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
