### PR TITLE
[Hipdnn]: Replace compile-time ROCM_PATH define with runtime env var lookup

### DIFF
--- a/dnn-providers/hip-kernel-provider/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/CMakeLists.txt
@@ -14,22 +14,7 @@ dnn_provider_setup_version(hip_kernel_provider ${CMAKE_CURRENT_LIST_DIR})
 
 project(hip-kernel-provider VERSION ${HIP_KERNEL_PROVIDER_VERSION} LANGUAGES CXX)
 
-# Get ROCM_PATH from configuration options as it is required to set include paths for hiprtc
-if(DEFINED ENV{ROCM_PATH} AND NOT "$ENV{ROCM_PATH}" STREQUAL "")
-    set(ROCM_PATH "$ENV{ROCM_PATH}" CACHE PATH "Path to ROCm installation" FORCE)
-    message(STATUS "ROCM_PATH detected from environment.")
-else()
-    if(NOT ROCM_PATH)
-        message(FATAL_ERROR "ROCM_PATH must be set. Please set the ROCM_PATH environment variable or provide -DROCM_PATH=/path/to/rocm to cmake.")
-    endif()
-    message(STATUS "ROCM_PATH detected from build option.")
-endif()
-file(TO_CMAKE_PATH "${ROCM_PATH}" ROCM_PATH)
-set(ROCM_PATH "${ROCM_PATH}" CACHE PATH "Path to ROCm installation" FORCE)
-message(STATUS "Using ROCM_PATH: ${ROCM_PATH}")
-add_compile_definitions(ROCM_PATH="${ROCM_PATH}")
-
-if(NOT WIN32)
+if(NOT WIN32 AND DEFINED ROCM_PATH)
     # Only set if not already specified by user
     if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
         set(CMAKE_INSTALL_PREFIX "${ROCM_PATH}" CACHE PATH "Install path prefix" FORCE)

--- a/dnn-providers/hip-kernel-provider/src/hip/HipKernelCompileOptions.hpp
+++ b/dnn-providers/hip-kernel-provider/src/hip/HipKernelCompileOptions.hpp
@@ -27,17 +27,21 @@ public:
         const hipDeviceProp_t& deviceProps,
         const std::optional<hip_kernel_utils::ActivationMode>& optActivationMode = std::nullopt)
     {
-        // Add ROCm include path to compile options
-#ifdef ROCM_PATH
-        auto rocmIncludeArg = std::string("-I") + ROCM_PATH + "/include";
-        _baseCompileOptions.emplace_back(rocmIncludeArg);
-        HIPDNN_PLUGIN_LOG_INFO(
-            "HipKernelProvider: HIPRTC compile ROCm include path: " << rocmIncludeArg);
-#else
-        HIPDNN_PLUGIN_LOG_WARN(
-            "HipKernelProvider: ROCM_PATH is not set, HIPRTC compile might fail if "
-            "ROCm headers are not in include paths");
-#endif
+        auto rocmPath
+            = hipdnn_data_sdk::utilities::trim(hipdnn_data_sdk::utilities::getEnv("ROCM_PATH"));
+        if(!rocmPath.empty())
+        {
+            auto rocmIncludeArg = std::string("-I") + rocmPath + "/include";
+            _baseCompileOptions.emplace_back(rocmIncludeArg);
+            HIPDNN_PLUGIN_LOG_INFO(
+                "HipKernelProvider: HIPRTC compile ROCm include path: " << rocmIncludeArg);
+        }
+        else
+        {
+            HIPDNN_PLUGIN_LOG_WARN(
+                "HipKernelProvider: ROCM_PATH is not set, HIPRTC compile might fail if "
+                "ROCm headers are not in include paths");
+        }
 
         // Add device arch to compile options
         _baseCompileOptions.emplace_back(std::string("--offload-arch=") + deviceProps.gcnArchName);


### PR DESCRIPTION
## Motivation

The ROCM_PATH preprocessor define baked the build-time ROCm install path into the binary, making it non-relocatable and impossible to override at runtime. Switch HipKernelCompileOptions to read ROCM_PATH from the environment at runtime, matching the existing pattern in LayernormFwdPlan.
