### PR TITLE
[hipcub] Fix the heap-buffer-overflow of test_hipcub_device_histogram

### DIFF
--- a/projects/hipcub/test/hipcub/test_hipcub_device_histogram.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_device_histogram.cpp
@@ -795,7 +795,7 @@ TYPED_TEST(HipcubDeviceHistogramMultiEven, MultiEven)
             SCOPED_TRACE(testing::Message() << "with seed= " << seed_value);
 
             std::vector<unsigned int> channel_seeds = test_utils::get_random_data<unsigned int>(
-                size,
+                std::max(size, static_cast<size_t>(channels)),
                 std::numeric_limits<unsigned int>::min(),
                 std::numeric_limits<unsigned int>::max(),
                 seed_value
@@ -1097,7 +1097,7 @@ TYPED_TEST(HipcubDeviceHistogramMultiRange, MultiRange)
             SCOPED_TRACE(testing::Message() << "with seed= " << seed_value);
 
             std::vector<unsigned int> channel_seeds = test_utils::get_random_data<unsigned int>(
-                size,
+                std::max(size, static_cast<size_t>(channels)),
                 std::numeric_limits<unsigned int>::min(),
                 std::numeric_limits<unsigned int>::max(),
                 seed_value);


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This PR fixes the heap-buffer-overflow of test_hip_device_histogram reported from the ASAN build. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

The error is from the host side code where we create a vector of size `size` and access it with the assumption that `size` is big enough for `channels`. Unfortunately, there are cases where `size < channels`.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Test test_hip_device_histogram in the ASAN build.

## Test Result

The heap-buffer-overflow error from test_hip_device_histogram no longer appears.

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
