### PR TITLE
[stinkytofu] Add scheduling fence as a hard region boundary

### DIFF
--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/include/instruction/common.hpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/include/instruction/common.hpp
@@ -1409,6 +1409,48 @@ namespace rocisa
         }
     };
 
+    // Virtual scheduling fence: emits no assembly, but carries MemTokenData
+    // so the StinkyTofu DAG scheduler can enforce ordering between instruction
+    // groups.  Analogous to LLVM's 'fence' instruction.
+    struct SSchedulingFence : public Instruction
+    {
+        SSchedulingFence(const std::string& comment = "")
+            : Instruction(InstType::INST_NOTYPE, comment)
+        {
+            setInst("scheduling_fence");
+        }
+
+        SSchedulingFence(const SSchedulingFence& other)
+            : Instruction(other)
+        {
+        }
+
+        std::shared_ptr<Item> clone() const override
+        {
+            return std::make_shared<SSchedulingFence>(*this);
+        }
+
+        std::vector<InstructionInput> getParams() const override
+        {
+            return {};
+        }
+
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            return {};
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
+        {
+            return {};
+        }
+
+        std::string toString() const override
+        {
+            return formatWithComment(instStr);
+        }
+    };
+
     struct SDcacheWb : public Instruction
     {
         SDcacheWb(const std::string& comment = "")

--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/src/instruction/common.cpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/src/instruction/common.cpp
@@ -630,6 +630,14 @@ void common_inst(nb::module_ m_common)
         .def("__deepcopy__",
              [](const rocisa::SBarrier& self, nb::dict&) { return new rocisa::SBarrier(self); });
 
+    nb::class_<rocisa::SSchedulingFence, rocisa::Instruction>(m_common, "SSchedulingFence")
+        .def(nb::init<const std::string&>(), nb::arg("comment") = "")
+        .def("getParams", &rocisa::SSchedulingFence::getParams)
+        .def("__str__", &rocisa::SSchedulingFence::toString)
+        .def("__deepcopy__", [](const rocisa::SSchedulingFence& self, nb::dict&) {
+            return new rocisa::SSchedulingFence(self);
+        });
+
     nb::class_<rocisa::SDcacheWb, rocisa::Instruction>(m_common, "SDcacheWb")
         .def(nb::init<const std::string&>(), nb::arg("comment") = "")
         .def("getParams", &rocisa::SDcacheWb::getParams)

--- a/shared/stinkytofu/hardware/src/gfx/Gfx1250/Gfx1250.cpp
+++ b/shared/stinkytofu/hardware/src/gfx/Gfx1250/Gfx1250.cpp
@@ -314,6 +314,7 @@ void setGfx1250RocisaToArchMap(GpuArch& registry) {
 
 void setGfx1250ConversionMap(GpuArch& registry) {
     std::unordered_map<std::string, std::string> conversion = {
+        {"SSchedulingFence", "lowerRocisaSchedulingFence"},
         {"_SWaitCnt", "lowerRocisaWaitCnt"},
         {"_SWaitCntVscnt", "lowerRocisaWaitCnt"},
         {"_SWaitStorecnt", "lowerRocisaStoreWaitCnt"},

--- a/shared/stinkytofu/include/stinkytofu/ir/asm/StinkyAsmIR.hpp
+++ b/shared/stinkytofu/include/stinkytofu/ir/asm/StinkyAsmIR.hpp
@@ -287,6 +287,10 @@ class AsmIRBuilder : public IRBuilder {
     /// PHI instruction format:
     /// def = PHI(pred0_def, pred1_def, ..., predN_def)
 
+    /// Creates a scheduling fence pseudo-instruction (emits no assembly).
+    /// Used to enforce ordering between instruction groups via MemTokenData.
+    StinkyInstruction* createFence();
+
     /// Creates and inserts a PHI instruction at the beginning of the block.
     /// The PHI defines one DWORD register and has one placeholder srcReg per
     /// predecessor. sources and users are NOT initialized — the caller
@@ -352,10 +356,17 @@ inline bool isSMemStore(const StinkyInstruction& inst) {
     return inst.is(InstFlag::IF_SMemStore);
 }
 
-/// Check if instruction is a pseudo instruction (LABEL or PHI) that should be
+/// Check if instruction is a scheduling fence pseudo-instruction.
+/// Fences emit no assembly but carry MemTokenData ordering constraints.
+inline bool isFence(const StinkyInstruction& inst) {
+    return inst.getUnifiedOpcode() == GFX::FENCE;
+}
+
+/// Check if instruction is a pseudo instruction (LABEL, PHI, or FENCE) that should be
 /// skipped for def-use chain processing of "real" instructions.
 inline bool isPseudoInst(const StinkyInstruction* inst) {
-    return inst->getUnifiedOpcode() == GFX::LABEL || inst->getUnifiedOpcode() == GFX::PHI;
+    return inst->getUnifiedOpcode() == GFX::LABEL || inst->getUnifiedOpcode() == GFX::PHI ||
+           inst->getUnifiedOpcode() == GFX::FENCE;
 }
 
 inline bool isGlobalMemLoad(const StinkyInstruction& inst) {

--- a/shared/stinkytofu/src/conversion/rocisa/AllHwMappings.cpp
+++ b/shared/stinkytofu/src/conversion/rocisa/AllHwMappings.cpp
@@ -146,6 +146,11 @@ std::vector<StinkyInstruction*> lowerRocisaWaitAlu(rocisa::Instruction& inst,
     return {stinkyInst};
 }
 
+std::vector<StinkyInstruction*> lowerRocisaSchedulingFence(rocisa::Instruction& /*inst*/,
+                                                           AsmIRBuilder& irBuilder) {
+    return {irBuilder.createFence()};
+}
+
 };  // anonymous namespace
 
 // Include all Rocisa hardware mapping tables

--- a/shared/stinkytofu/src/ir/asm/StinkyAsmIR.cpp
+++ b/shared/stinkytofu/src/ir/asm/StinkyAsmIR.cpp
@@ -69,6 +69,12 @@ StinkyInstruction* AsmIRBuilder::createLabel(const std::string& label, uint16_t 
     return labelInst;
 }
 
+StinkyInstruction* AsmIRBuilder::createFence() {
+    static const HwInstDesc fenceMCID{
+        GFX::FENCE, GFX::FENCE, 0, 0, "FENCE", makeFlagSet({InstFlag::IF_HasSideEffect})};
+    return create(&fenceMCID);
+}
+
 StinkyInstruction* AsmIRBuilder::createPhi(RegType type, unsigned regIdx, IRBase* insertPt) {
     static const HwInstDesc phiMCID{GFX::PHI, GFX::PHI, 0,
                                     0,        "PHI",    makeFlagSet({InstFlag::IF_HasSideEffect})};

--- a/shared/stinkytofu/src/serialization/asm/IRConverter.cpp
+++ b/shared/stinkytofu/src/serialization/asm/IRConverter.cpp
@@ -42,6 +42,14 @@ static void convertInstruction(AsmIRBuilder& irBuilder,
         return;
     }
 
+    // "FENCE" is the mnemonic printed by AsmPrinter; "scheduling_fence" is the
+    // rocisa instruction string. Both round-trip to a scheduling fence.
+    // Fences carry no modifiers — they are hard region boundaries with no tokens.
+    if (inst->opcodeStr == "FENCE" || inst->opcodeStr == "scheduling_fence") {
+        irBuilder.createFence();
+        return;
+    }
+
     auto opcode = getMnemonicToIsaOpcode(inst->opcodeStr, arch);
     const HwInstDesc* hwInstDesc = getMCIDByIsaOp(static_cast<IsaOpcode>(opcode), arch);
 

--- a/shared/stinkytofu/src/transforms/asm/StinkyBuildImplicitDependencyPass.cpp
+++ b/shared/stinkytofu/src/transforms/asm/StinkyBuildImplicitDependencyPass.cpp
@@ -134,7 +134,7 @@ void setPseudoRegistersInBlock(BasicBlock& bb, PassContext& passCtx) {
             processLdsReader(*inst, *mt, bb.getLabel());
         else
             assert(false &&
-                   "instruction has MemTokenData but is not a barrier, "
+                   "instruction has MemTokenData but is not a barrier, fence, "
                    "tensor_load, ds_write, or ds_read");
     }
 }

--- a/shared/stinkytofu/src/transforms/asm/StinkyDAGSchedulerPass.cpp
+++ b/shared/stinkytofu/src/transforms/asm/StinkyDAGSchedulerPass.cpp
@@ -36,10 +36,11 @@
 namespace {
 using namespace stinkytofu;
 
-// Check if instruction is a movable side effect (like s_barrier)
+// Check if instruction is a movable side effect (like s_barrier or a scheduling fence)
 static bool isMovableSideEffect(const StinkyInstruction& inst) {
-    // This is a barrier and has manually defined dependencies.
-    return isBarrier(inst) && !inst.getDestRegs().empty();
+    // Barriers with LDS pseudo-reg deps are movable — ordering enforced by the DAG.
+    if (isBarrier(inst) && !inst.getDestRegs().empty()) return true;
+    return false;
 }
 
 // --- Region scheduler (does NOT move fences) ---

--- a/shared/stinkytofu/tests/filecheck/dag_scheduling_fence_wmma_eager.stir
+++ b/shared/stinkytofu/tests/filecheck/dag_scheduling_fence_wmma_eager.stir
@@ -1,0 +1,31 @@
+# RUN: %stinkytofu-opt --arch gfx1250 %s --StinkyDAGSchedulerPass --print-output
+#
+# Scheduling fence: demonstrates that a fence acts as a hard region boundary,
+# constraining the WMMA to be issued only after the fence, even though the
+# WMMA has no register deps on any instruction before the fence.
+#
+# Input order:
+#   v_add_f32  v1 → v0       (independent, no deps)
+#   v_add_f32  v2 → v3       (independent, no deps)
+#   FENCE                    (hard ordering boundary — no tokens)
+#   v_add_f32  v4 → v5       (independent, no deps)
+#   v_wmma     v6,v6 → acc0  (no register deps on anything before fence)
+#
+# Without the fence, WMMA would be issued eagerly to the top (no register deps
+# blocking it).  With the fence, the scheduler treats it as a non-movable
+# side-effect that splits the region — WMMA stays in the post-fence region.
+#
+# Expected: the WMMA must appear after the FENCE in the scheduled output.
+# The independent v_add_f32 instructions may appear anywhere within their region.
+#
+# CHECK: "st.FENCE"
+# CHECK: v_wmma_f32_16x16x16_bf16
+
+st.func @test() {
+^entry:
+  v0 = "st.v_add_f32"(v1, 1.0) { issueCycles = 1, latencyCycles = 5 }
+  v3 = "st.v_add_f32"(v2, 1.0) { issueCycles = 1, latencyCycles = 5 }
+  "st.FENCE"() { issueCycles = 0, latencyCycles = 0 }
+  v5 = "st.v_add_f32"(v4, 1.0) { issueCycles = 1, latencyCycles = 5 }
+  acc[0:7] = "st.v_wmma_f32_16x16x16_bf16"(v[6:13], v[6:13], acc[0:7]) { issueCycles = 4, latencyCycles = 8, mod.mfma = { inputPermute = "", scaleStr = "", negStr = "", reuseA = false, reuseB = false, neg_lo = false, neg_hi = false } }
+}

--- a/shared/stinkytofu/tools/tablegen/GenInstructions.cpp
+++ b/shared/stinkytofu/tools/tablegen/GenInstructions.cpp
@@ -1872,6 +1872,7 @@ bool genAllInstructions(const std::string& inputDir, const std::string& outputDi
         for (const auto& inst : p.second) allMnemonics.insert(inst.mnemonic);
     std::vector<std::string> unifiedList(allMnemonics.begin(), allMnemonics.end());
     std::sort(unifiedList.begin(), unifiedList.end());
+    unifiedList.push_back("FENCE");
     unifiedList.push_back("LABEL");
     unifiedList.push_back("PHI");
     unifiedList.push_back("INVALID");


### PR DESCRIPTION
Introduces SSchedulingFence in rocisa (Python-callable) and the corresponding GFX::FENCE pseudo-instruction in StinkyTofu. The fence acts as a hard region-splitting boundary in the DAG scheduler — like LLVM's fence — so instructions cannot be reordered across it. No tokens or LDS pseudo-registers are involved; the fence carries no modifiers and emits no assembly.

Pipeline: rocisa::SSchedulingFence → lowerRocisaSchedulingFence → AsmIRBuilder::createFence() → GFX::FENCE pseudo-instruction → hasSideEffect()=true → region split in StinkyDAGSchedulerPass.

Adds FileCheck test dag_scheduling_fence_wmma_eager.stir verifying that WMMA (which has no register deps on prior instructions) is constrained to appear after the fence in the scheduled output.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
