### PR TITLE
[rocsparse] Add missing create const descr for BSR format

### DIFF
--- a/projects/rocsparse/CHANGELOG.md
+++ b/projects/rocsparse/CHANGELOG.md
@@ -6,6 +6,7 @@ Documentation for rocSPARSE is available at
 ## rocSPARSE 4.6.0 for ROCm 7.13.0
 
 ### Added
+* Added the `rocsparse_create_const_bsr_descr` routine for creating a const sparse BSR matrix descriptor.
 * Added the `rocsparse_spic0` and `rocsparse_spilu0` routines for incomplete factorizations, with strided batched computations enabled.
 * Added the `rocsparse_sptrsv_descr_create` and the `rocsparse_sptrsv_descr_destroy` routines.
 * Added the `rocsparse_singularity` enumeration.

--- a/projects/rocsparse/clients/testings/testing_const_spmat_descr.cpp
+++ b/projects/rocsparse/clients/testings/testing_const_spmat_descr.cpp
@@ -205,8 +205,8 @@ void testing_const_spmat_descr_bad_arg(const Arguments& arg)
         void* bsr_col_ind = (void*)0x4;
         void* bsr_val     = (void*)0x4;
 
-#define PARAMS_CREATE_BSR                                                                       \
-    descr, brows, bcols, bnnz, block_dir, block_dim, bsr_row_ptr, bsr_col_ind, bsr_val,         \
+#define PARAMS_CREATE_BSR                                                               \
+    descr, brows, bcols, bnnz, block_dir, block_dim, bsr_row_ptr, bsr_col_ind, bsr_val, \
         row_ptr_type, col_ind_type, idx_base, data_type
         bad_arg_analysis(rocsparse_create_const_bsr_descr, PARAMS_CREATE_BSR);
 #undef PARAMS_CREATE_BSR
@@ -789,8 +789,8 @@ void testing_const_spmat_descr_bad_arg(const Arguments& arg)
             const void** bsr_col_ind = (const void**)0x4;
             const void** bsr_val     = (const void**)0x4;
 
-#define PARAMS_GET_BSR                                                                          \
-    descr, brows, bcols, bnnz, block_dir, block_dim, bsr_row_ptr, bsr_col_ind, bsr_val,         \
+#define PARAMS_GET_BSR                                                                  \
+    descr, brows, bcols, bnnz, block_dir, block_dim, bsr_row_ptr, bsr_col_ind, bsr_val, \
         row_ptr_type, col_ind_type, idx_base, data_type
             bad_arg_analysis(rocsparse_const_bsr_get, PARAMS_GET_BSR);
 #undef PARAMS_GET_BSR

--- a/projects/rocsparse/clients/testings/testing_const_spmat_descr.cpp
+++ b/projects/rocsparse/clients/testings/testing_const_spmat_descr.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/projects/rocsparse/clients/testings/testing_const_spmat_descr.cpp
+++ b/projects/rocsparse/clients/testings/testing_const_spmat_descr.cpp
@@ -31,6 +31,11 @@ void testing_const_spmat_descr_bad_arg(const Arguments& arg)
     int64_t                     local_rows             = safe_size;
     int64_t                     local_cols             = safe_size;
     int64_t                     local_nnz              = safe_size;
+    int64_t                     local_brows            = safe_size;
+    int64_t                     local_bcols            = safe_size;
+    int64_t                     local_bnnz             = safe_size;
+    rocsparse_direction         local_block_dir        = rocsparse_direction_row;
+    int64_t                     local_block_dim        = safe_size;
     rocsparse_direction         local_ell_block_dir    = rocsparse_direction_row;
     int64_t                     local_ell_block_dim    = safe_size;
     int64_t                     local_ell_cols         = safe_size;
@@ -48,6 +53,11 @@ void testing_const_spmat_descr_bad_arg(const Arguments& arg)
         int64_t                      rows             = local_rows;
         int64_t                      cols             = local_cols;
         int64_t                      nnz              = local_nnz;
+        int64_t                      brows            = local_brows;
+        int64_t                      bcols            = local_bcols;
+        int64_t                      bnnz             = local_bnnz;
+        rocsparse_direction          block_dir        = local_block_dir;
+        int64_t                      block_dim        = local_block_dim;
         rocsparse_direction          ell_block_dir    = local_ell_block_dir;
         int64_t                      ell_block_dim    = local_ell_block_dim;
         int64_t                      ell_cols         = local_ell_cols;
@@ -195,19 +205,19 @@ void testing_const_spmat_descr_bad_arg(const Arguments& arg)
         void* bsr_col_ind = (void*)0x4;
         void* bsr_val     = (void*)0x4;
 
-#define PARAMS_CREATE_BSR                                                                    \
-    descr, rows, cols, nnz, ell_block_dir, ell_block_dim, bsr_row_ptr, bsr_col_ind, bsr_val, \
+#define PARAMS_CREATE_BSR                                                                       \
+    descr, brows, bcols, bnnz, block_dir, block_dim, bsr_row_ptr, bsr_col_ind, bsr_val,         \
         row_ptr_type, col_ind_type, idx_base, data_type
         bad_arg_analysis(rocsparse_create_const_bsr_descr, PARAMS_CREATE_BSR);
 #undef PARAMS_CREATE_BSR
 
-        // nnzb > mb * nb
+        // bnnz > brows * bcols
         EXPECT_ROCSPARSE_STATUS(rocsparse_create_const_bsr_descr(descr,
-                                                                 rows,
-                                                                 cols,
-                                                                 (rows * cols + 1),
-                                                                 ell_block_dir,
-                                                                 ell_block_dim,
+                                                                 brows,
+                                                                 bcols,
+                                                                 (brows * bcols + 1),
+                                                                 block_dir,
+                                                                 block_dim,
                                                                  bsr_row_ptr,
                                                                  bsr_col_ind,
                                                                  bsr_val,
@@ -219,10 +229,10 @@ void testing_const_spmat_descr_bad_arg(const Arguments& arg)
 
         // block_dim == 0
         EXPECT_ROCSPARSE_STATUS(rocsparse_create_const_bsr_descr(descr,
-                                                                 rows,
-                                                                 cols,
-                                                                 nnz,
-                                                                 ell_block_dir,
+                                                                 brows,
+                                                                 bcols,
+                                                                 bnnz,
+                                                                 block_dir,
                                                                  0,
                                                                  bsr_row_ptr,
                                                                  bsr_col_ind,
@@ -393,10 +403,10 @@ void testing_const_spmat_descr_bad_arg(const Arguments& arg)
 
         EXPECT_ROCSPARSE_STATUS(rocsparse_create_const_bsr_descr(descr,
                                                                  0,
-                                                                 cols,
+                                                                 bcols,
                                                                  0,
-                                                                 ell_block_dir,
-                                                                 ell_block_dim,
+                                                                 block_dir,
+                                                                 block_dim,
                                                                  nullptr,
                                                                  nullptr,
                                                                  nullptr,
@@ -408,11 +418,11 @@ void testing_const_spmat_descr_bad_arg(const Arguments& arg)
         EXPECT_ROCSPARSE_STATUS(rocsparse_destroy_spmat_descr(local_descr),
                                 rocsparse_status_success);
         EXPECT_ROCSPARSE_STATUS(rocsparse_create_const_bsr_descr(descr,
-                                                                 rows,
+                                                                 brows,
                                                                  0,
                                                                  0,
-                                                                 ell_block_dir,
-                                                                 ell_block_dim,
+                                                                 block_dir,
+                                                                 block_dim,
                                                                  bsr_row_ptr,
                                                                  nullptr,
                                                                  nullptr,
@@ -424,11 +434,11 @@ void testing_const_spmat_descr_bad_arg(const Arguments& arg)
         EXPECT_ROCSPARSE_STATUS(rocsparse_destroy_spmat_descr(local_descr),
                                 rocsparse_status_success);
         EXPECT_ROCSPARSE_STATUS(rocsparse_create_const_bsr_descr(descr,
-                                                                 rows,
-                                                                 cols,
+                                                                 brows,
+                                                                 bcols,
                                                                  0,
-                                                                 ell_block_dir,
-                                                                 ell_block_dim,
+                                                                 block_dir,
+                                                                 block_dim,
                                                                  bsr_row_ptr,
                                                                  nullptr,
                                                                  nullptr,
@@ -489,6 +499,11 @@ void testing_const_spmat_descr_bad_arg(const Arguments& arg)
         int64_t*              rows             = &local_rows;
         int64_t*              cols             = &local_cols;
         int64_t*              nnz              = &local_nnz;
+        int64_t*              brows            = &local_brows;
+        int64_t*              bcols            = &local_bcols;
+        int64_t*              bnnz             = &local_bnnz;
+        rocsparse_direction*  block_dir        = &local_block_dir;
+        int64_t*              block_dim        = &local_block_dim;
         rocsparse_direction*  ell_block_dir    = &local_ell_block_dir;
         int64_t*              ell_block_dim    = &local_ell_block_dim;
         int64_t*              ell_cols         = &local_ell_cols;
@@ -755,11 +770,11 @@ void testing_const_spmat_descr_bad_arg(const Arguments& arg)
 
         {
             EXPECT_ROCSPARSE_STATUS(rocsparse_create_const_bsr_descr(&local_descr,
-                                                                     local_rows,
-                                                                     local_cols,
-                                                                     local_nnz,
-                                                                     local_ell_block_dir,
-                                                                     local_ell_block_dim,
+                                                                     local_brows,
+                                                                     local_bcols,
+                                                                     local_bnnz,
+                                                                     local_block_dir,
+                                                                     local_block_dim,
                                                                      (const void*)0x4,
                                                                      (const void*)0x4,
                                                                      (const void*)0x4,
@@ -774,8 +789,8 @@ void testing_const_spmat_descr_bad_arg(const Arguments& arg)
             const void** bsr_col_ind = (const void**)0x4;
             const void** bsr_val     = (const void**)0x4;
 
-#define PARAMS_GET_BSR                                                                       \
-    descr, rows, cols, nnz, ell_block_dir, ell_block_dim, bsr_row_ptr, bsr_col_ind, bsr_val, \
+#define PARAMS_GET_BSR                                                                          \
+    descr, brows, bcols, bnnz, block_dir, block_dim, bsr_row_ptr, bsr_col_ind, bsr_val,         \
         row_ptr_type, col_ind_type, idx_base, data_type
             bad_arg_analysis(rocsparse_const_bsr_get, PARAMS_GET_BSR);
 #undef PARAMS_GET_BSR

--- a/projects/rocsparse/clients/testings/testing_const_spmat_descr.cpp
+++ b/projects/rocsparse/clients/testings/testing_const_spmat_descr.cpp
@@ -191,6 +191,48 @@ void testing_const_spmat_descr_bad_arg(const Arguments& arg)
                                                                   data_type),
                                 rocsparse_status_invalid_size);
 
+        void* bsr_row_ptr = (void*)0x4;
+        void* bsr_col_ind = (void*)0x4;
+        void* bsr_val     = (void*)0x4;
+
+#define PARAMS_CREATE_BSR                                                                    \
+    descr, rows, cols, nnz, ell_block_dir, ell_block_dim, bsr_row_ptr, bsr_col_ind, bsr_val, \
+        row_ptr_type, col_ind_type, idx_base, data_type
+        bad_arg_analysis(rocsparse_create_const_bsr_descr, PARAMS_CREATE_BSR);
+#undef PARAMS_CREATE_BSR
+
+        // nnzb > mb * nb
+        EXPECT_ROCSPARSE_STATUS(rocsparse_create_const_bsr_descr(descr,
+                                                                 rows,
+                                                                 cols,
+                                                                 (rows * cols + 1),
+                                                                 ell_block_dir,
+                                                                 ell_block_dim,
+                                                                 bsr_row_ptr,
+                                                                 bsr_col_ind,
+                                                                 bsr_val,
+                                                                 row_ptr_type,
+                                                                 col_ind_type,
+                                                                 idx_base,
+                                                                 data_type),
+                                rocsparse_status_invalid_size);
+
+        // block_dim == 0
+        EXPECT_ROCSPARSE_STATUS(rocsparse_create_const_bsr_descr(descr,
+                                                                 rows,
+                                                                 cols,
+                                                                 nnz,
+                                                                 ell_block_dir,
+                                                                 0,
+                                                                 bsr_row_ptr,
+                                                                 bsr_col_ind,
+                                                                 bsr_val,
+                                                                 row_ptr_type,
+                                                                 col_ind_type,
+                                                                 idx_base,
+                                                                 data_type),
+                                rocsparse_status_invalid_size);
+
         void* ell_col_ind = (void*)0x4;
         void* ell_val     = (void*)0x4;
 
@@ -339,6 +381,55 @@ void testing_const_spmat_descr_bad_arg(const Arguments& arg)
                                                                  cols,
                                                                  0,
                                                                  csc_col_ptr,
+                                                                 nullptr,
+                                                                 nullptr,
+                                                                 row_ptr_type,
+                                                                 col_ind_type,
+                                                                 idx_base,
+                                                                 data_type),
+                                rocsparse_status_success);
+        EXPECT_ROCSPARSE_STATUS(rocsparse_destroy_spmat_descr(local_descr),
+                                rocsparse_status_success);
+
+        EXPECT_ROCSPARSE_STATUS(rocsparse_create_const_bsr_descr(descr,
+                                                                 0,
+                                                                 cols,
+                                                                 0,
+                                                                 ell_block_dir,
+                                                                 ell_block_dim,
+                                                                 nullptr,
+                                                                 nullptr,
+                                                                 nullptr,
+                                                                 row_ptr_type,
+                                                                 col_ind_type,
+                                                                 idx_base,
+                                                                 data_type),
+                                rocsparse_status_success);
+        EXPECT_ROCSPARSE_STATUS(rocsparse_destroy_spmat_descr(local_descr),
+                                rocsparse_status_success);
+        EXPECT_ROCSPARSE_STATUS(rocsparse_create_const_bsr_descr(descr,
+                                                                 rows,
+                                                                 0,
+                                                                 0,
+                                                                 ell_block_dir,
+                                                                 ell_block_dim,
+                                                                 bsr_row_ptr,
+                                                                 nullptr,
+                                                                 nullptr,
+                                                                 row_ptr_type,
+                                                                 col_ind_type,
+                                                                 idx_base,
+                                                                 data_type),
+                                rocsparse_status_success);
+        EXPECT_ROCSPARSE_STATUS(rocsparse_destroy_spmat_descr(local_descr),
+                                rocsparse_status_success);
+        EXPECT_ROCSPARSE_STATUS(rocsparse_create_const_bsr_descr(descr,
+                                                                 rows,
+                                                                 cols,
+                                                                 0,
+                                                                 ell_block_dir,
+                                                                 ell_block_dim,
+                                                                 bsr_row_ptr,
                                                                  nullptr,
                                                                  nullptr,
                                                                  row_ptr_type,
@@ -661,6 +752,58 @@ void testing_const_spmat_descr_bad_arg(const Arguments& arg)
             // Destroy valid descriptors
             EXPECT_ROCSPARSE_STATUS(rocsparse_destroy_spmat_descr(descr), rocsparse_status_success);
         }
+
+        {
+            EXPECT_ROCSPARSE_STATUS(rocsparse_create_const_bsr_descr(&local_descr,
+                                                                     local_rows,
+                                                                     local_cols,
+                                                                     local_nnz,
+                                                                     local_ell_block_dir,
+                                                                     local_ell_block_dim,
+                                                                     (const void*)0x4,
+                                                                     (const void*)0x4,
+                                                                     (const void*)0x4,
+                                                                     local_itype,
+                                                                     local_jtype,
+                                                                     local_base,
+                                                                     local_ttype),
+                                    rocsparse_status_success);
+            rocsparse_const_spmat_descr descr = local_descr;
+
+            const void** bsr_row_ptr = (const void**)0x4;
+            const void** bsr_col_ind = (const void**)0x4;
+            const void** bsr_val     = (const void**)0x4;
+
+#define PARAMS_GET_BSR                                                                       \
+    descr, rows, cols, nnz, ell_block_dir, ell_block_dim, bsr_row_ptr, bsr_col_ind, bsr_val, \
+        row_ptr_type, col_ind_type, idx_base, data_type
+            bad_arg_analysis(rocsparse_const_bsr_get, PARAMS_GET_BSR);
+#undef PARAMS_GET_BSR
+
+#define PARAMS_GET_SIZE descr, rows, cols, nnz
+            bad_arg_analysis(rocsparse_spmat_get_size, PARAMS_GET_SIZE);
+#undef PARAMS_GET_SIZE
+
+#define PARAMS_GET_FORMAT descr, format
+            bad_arg_analysis(rocsparse_spmat_get_format, PARAMS_GET_FORMAT);
+#undef PARAMS_GET_FORMAT
+
+#define PARAMS_GET_INDEX_BASE descr, idx_base
+            bad_arg_analysis(rocsparse_spmat_get_index_base, PARAMS_GET_INDEX_BASE);
+#undef PARAMS_GET_INDEX_BASE
+
+            const void** values = (const void**)0x4;
+#define PARAMS_GET_VALUES descr, values
+            bad_arg_analysis(rocsparse_const_spmat_get_values, PARAMS_GET_VALUES);
+#undef PARAMS_GET_VALUES
+
+#define PARAMS_GET_STRIDED_BATCH descr, batch_count
+            bad_arg_analysis(rocsparse_spmat_get_strided_batch, PARAMS_GET_STRIDED_BATCH);
+#undef PARAMS_GET_STRIDED_BATCH
+
+            // Destroy valid descriptors
+            EXPECT_ROCSPARSE_STATUS(rocsparse_destroy_spmat_descr(descr), rocsparse_status_success);
+        }
     }
 }
 
@@ -689,6 +832,11 @@ void testing_const_spmat_descr(const Arguments& arg)
 
     device_vector<I> bell_col_data(mb * nb);
     device_vector<T> bell_val_data(mb * block_dim * col_width);
+
+    int64_t          bsr_nnzb = std::min<int64_t>(nnz, mb * nb);
+    device_vector<J> bsr_row_ptr_data(mb + 1);
+    device_vector<I> bsr_col_ind_data(bsr_nnzb);
+    device_vector<T> bsr_val_data(bsr_nnzb * block_dim * block_dim);
 
     if(arg.unit_check)
     {
@@ -885,10 +1033,70 @@ void testing_const_spmat_descr(const Arguments& arg)
         ASSERT_EQ(bell_val_data, bell_val);
 
         CHECK_ROCSPARSE_ERROR(rocsparse_destroy_spmat_descr(bell));
-    }
 
-    if(arg.timing)
-    {
+        /*
+        *   BSR
+        */
+        rocsparse_const_spmat_descr bsr;
+        CHECK_ROCSPARSE_ERROR(rocsparse_create_const_bsr_descr(&bsr,
+                                                               mb,
+                                                               nb,
+                                                               bsr_nnzb,
+                                                               block_dir,
+                                                               block_dim,
+                                                               bsr_row_ptr_data,
+                                                               bsr_col_ind_data,
+                                                               bsr_val_data,
+                                                               jtype,
+                                                               itype,
+                                                               base,
+                                                               ttype));
+
+        int64_t              bsr_mb;
+        int64_t              bsr_nb;
+        int64_t              bsr_nnzb_out;
+        int64_t              bsr_block_dim;
+        rocsparse_direction  bsr_block_dir;
+        rocsparse_index_base bsr_base;
+        rocsparse_indextype  bsr_itype;
+        rocsparse_indextype  bsr_jtype;
+        rocsparse_datatype   bsr_ttype;
+        const T*             bsr_val;
+        const J*             bsr_row_ptr;
+        const I*             bsr_col_ind;
+
+        CHECK_ROCSPARSE_ERROR(rocsparse_const_bsr_get(bsr,
+                                                      &bsr_mb,
+                                                      &bsr_nb,
+                                                      &bsr_nnzb_out,
+                                                      &bsr_block_dir,
+                                                      &bsr_block_dim,
+                                                      (const void**)&bsr_row_ptr,
+                                                      (const void**)&bsr_col_ind,
+                                                      (const void**)&bsr_val,
+                                                      &bsr_jtype,
+                                                      &bsr_itype,
+                                                      &bsr_base,
+                                                      &bsr_ttype));
+
+        unit_check_scalar(mb, bsr_mb);
+        unit_check_scalar(nb, bsr_nb);
+        unit_check_scalar(bsr_nnzb, bsr_nnzb_out);
+        unit_check_scalar(block_dim, bsr_block_dim);
+        unit_check_enum(block_dir, bsr_block_dir);
+        unit_check_enum(base, bsr_base);
+        unit_check_enum(itype, bsr_itype);
+        unit_check_enum(jtype, bsr_jtype);
+        unit_check_enum(ttype, bsr_ttype);
+        ASSERT_EQ(bsr_val_data, bsr_val);
+        ASSERT_EQ(bsr_row_ptr_data, bsr_row_ptr);
+        ASSERT_EQ(bsr_col_ind_data, bsr_col_ind);
+
+        bsr_val = nullptr;
+        CHECK_ROCSPARSE_ERROR(rocsparse_const_spmat_get_values(bsr, (const void**)&bsr_val));
+        ASSERT_EQ(bsr_val_data, bsr_val);
+
+        CHECK_ROCSPARSE_ERROR(rocsparse_destroy_spmat_descr(bsr));
     }
 }
 

--- a/projects/rocsparse/docs/reference/api.rst
+++ b/projects/rocsparse/docs/reference/api.rst
@@ -174,6 +174,8 @@ Auxiliary functions
 +-----------------------------------------------------+
 |:cpp:func:`rocsparse_create_const_csc_descr`         |
 +-----------------------------------------------------+
+|:cpp:func:`rocsparse_create_const_bsr_descr`         |
++-----------------------------------------------------+
 |:cpp:func:`rocsparse_create_const_bell_descr`        |
 +-----------------------------------------------------+
 |:cpp:func:`rocsparse_create_const_sell_descr`        |

--- a/projects/rocsparse/docs/reference/auxiliary.rst
+++ b/projects/rocsparse/docs/reference/auxiliary.rst
@@ -268,6 +268,11 @@ rocsparse_create_const_csc_descr
 
 .. doxygenfunction:: rocsparse_create_const_csc_descr
 
+rocsparse_create_const_bsr_descr
+--------------------------------
+
+.. doxygenfunction:: rocsparse_create_const_bsr_descr
+
 rocsparse_create_const_bell_descr
 ---------------------------------
 

--- a/projects/rocsparse/library/include/rocsparse-auxiliary.h
+++ b/projects/rocsparse/library/include/rocsparse-auxiliary.h
@@ -979,6 +979,7 @@ rocsparse_status rocsparse_create_coo_aos_descr(rocsparse_spmat_descr* descr,
  *  \retval rocsparse_status_invalid_size if \p mb or \p nb or \p nnzb \p block_dim is invalid.
  *  \retval rocsparse_status_invalid_value if \p row_ptr_type or \p col_ind_type or \p idx_base or \p data_type or \p block_dir is invalid.
  */
+/**@{*/
 ROCSPARSE_EXPORT
 rocsparse_status rocsparse_create_bsr_descr(rocsparse_spmat_descr* descr,
                                             int64_t                mb,
@@ -993,6 +994,22 @@ rocsparse_status rocsparse_create_bsr_descr(rocsparse_spmat_descr* descr,
                                             rocsparse_indextype    col_ind_type,
                                             rocsparse_index_base   idx_base,
                                             rocsparse_datatype     data_type);
+
+ROCSPARSE_EXPORT
+rocsparse_status rocsparse_create_const_bsr_descr(rocsparse_const_spmat_descr* descr,
+                                                  int64_t                      mb,
+                                                  int64_t                      nb,
+                                                  int64_t                      nnzb,
+                                                  rocsparse_direction          block_dir,
+                                                  int64_t                      block_dim,
+                                                  const void*                  bsr_row_ptr,
+                                                  const void*                  bsr_col_ind,
+                                                  const void*                  bsr_val,
+                                                  rocsparse_indextype          row_ptr_type,
+                                                  rocsparse_indextype          col_ind_type,
+                                                  rocsparse_index_base         idx_base,
+                                                  rocsparse_datatype           data_type);
+/**@}*/
 
 /*! \ingroup aux_module
  *  \brief Create a sparse CSR matrix descriptor

--- a/projects/rocsparse/library/include/rocsparse-auxiliary.h
+++ b/projects/rocsparse/library/include/rocsparse-auxiliary.h
@@ -949,21 +949,21 @@ rocsparse_status rocsparse_create_coo_aos_descr(rocsparse_spmat_descr* descr,
  *  @param[out]
  *  descr        the pointer to the sparse BSR matrix descriptor.
  *  @param[in]
- *  mb           number of rows in the BSR matrix.
+ *  brows        number of block rows in the BSR matrix.
  *  @param[in]
- *  nb           number of columns in the BSR matrix
+ *  bcols        number of block columns in the BSR matrix.
  *  @param[in]
- *  nnzb         number of non-zeros in the BSR matrix.
+ *  bnnz         number of non-zero blocks in the BSR matrix.
  *  @param[in]
  *  block_dir    direction of the internal block storage.
  *  @param[in]
  *  block_dim    dimension of the blocks.
  *  @param[in]
- *  bsr_row_ptr  row offsets of the BSR matrix (must be array of length \p mb+1 ).
+ *  bsr_row_ptr  row offsets of the BSR matrix (must be array of length \p brows+1 ).
  *  @param[in]
- *  bsr_col_ind  column indices of the BSR matrix (must be array of length \p nnzb ).
+ *  bsr_col_ind  column indices of the BSR matrix (must be array of length \p bnnz ).
  *  @param[in]
- *  bsr_val      values of the BSR matrix (must be array of length \p nnzb * \p block_dim * \p block_dim ).
+ *  bsr_val      values of the BSR matrix (must be array of length \p bnnz * \p block_dim * \p block_dim ).
  *  @param[in]
  *  row_ptr_type \ref rocsparse_indextype_i32 or \ref rocsparse_indextype_i64.
  *  @param[in]
@@ -976,15 +976,15 @@ rocsparse_status rocsparse_create_coo_aos_descr(rocsparse_spmat_descr* descr,
  *
  *  \retval rocsparse_status_success the operation completed successfully.
  *  \retval rocsparse_status_invalid_pointer if \p descr or \p bsr_row_ptr or \p bsr_col_ind or \p bsr_val is invalid.
- *  \retval rocsparse_status_invalid_size if \p mb or \p nb or \p nnzb \p block_dim is invalid.
+ *  \retval rocsparse_status_invalid_size if \p brows or \p bcols or \p bnnz \p block_dim is invalid.
  *  \retval rocsparse_status_invalid_value if \p row_ptr_type or \p col_ind_type or \p idx_base or \p data_type or \p block_dir is invalid.
  */
 /**@{*/
 ROCSPARSE_EXPORT
 rocsparse_status rocsparse_create_bsr_descr(rocsparse_spmat_descr* descr,
-                                            int64_t                mb,
-                                            int64_t                nb,
-                                            int64_t                nnzb,
+                                            int64_t                brows,
+                                            int64_t                bcols,
+                                            int64_t                bnnz,
                                             rocsparse_direction    block_dir,
                                             int64_t                block_dim,
                                             void*                  bsr_row_ptr,
@@ -997,9 +997,9 @@ rocsparse_status rocsparse_create_bsr_descr(rocsparse_spmat_descr* descr,
 
 ROCSPARSE_EXPORT
 rocsparse_status rocsparse_create_const_bsr_descr(rocsparse_const_spmat_descr* descr,
-                                                  int64_t                      mb,
-                                                  int64_t                      nb,
-                                                  int64_t                      nnzb,
+                                                  int64_t                      brows,
+                                                  int64_t                      bcols,
+                                                  int64_t                      bnnz,
                                                   rocsparse_direction          block_dir,
                                                   int64_t                      block_dim,
                                                   const void*                  bsr_row_ptr,
@@ -2449,21 +2449,21 @@ rocsparse_status rocsparse_const_sell_get(rocsparse_const_spmat_descr descr,
  *  @param[in]
  *  descr        the pointer to the sparse BSR matrix descriptor.
  *  @param[out]
- *  brows         number of rows in the BSR matrix.
+ *  brows        number of block rows in the BSR matrix.
  *  @param[out]
- *  bcols         number of columns in the BSR matrix
+ *  bcols        number of block columns in the BSR matrix.
  *  @param[out]
- *  bnnz          number of non-zeros in the BSR matrix.
+ *  bnnz         number of non-zero blocks in the BSR matrix.
  *  @param[out]
- *  bdir          storage layout of the dense block matrices.
+ *  block_dir    storage layout of the dense block matrices.
  *  @param[out]
- *  bdim          block dimension.
+ *  block_dim    block dimension.
  *  @param[out]
  *  bsr_row_ptr  row offsets of the BSR matrix (must be array of length \p brows+1 ).
  *  @param[out]
  *  bsr_col_ind  column indices of the BSR matrix (must be array of length \p bnnz ).
  *  @param[out]
- *  bsr_val      values of the BSR matrix (must be array of length \p bnnz * \p bdim * \p bdim ).
+ *  bsr_val      values of the BSR matrix (must be array of length \p bnnz * \p block_dim * \p block_dim ).
  *  @param[out]
  *  row_ptr_type \ref rocsparse_indextype_i32 or \ref rocsparse_indextype_i64.
  *  @param[out]
@@ -2475,9 +2475,10 @@ rocsparse_status rocsparse_const_sell_get(rocsparse_const_spmat_descr descr,
  *               \ref rocsparse_datatype_f32_c or \ref rocsparse_datatype_f64_c.
  *
  *  \retval rocsparse_status_success the operation completed successfully.
- *  \retval rocsparse_status_invalid_pointer if \p descr or \p csr_row_ptr or \p csr_col_ind or \p csr_val is invalid.
- *  \retval rocsparse_status_invalid_size if \p rows or \p cols or \p nnz is invalid.
- *  \retval rocsparse_status_invalid_value if \p row_ptr_type or \p col_ind_type or \p idx_base or \p data_type is invalid.
+ *  \retval rocsparse_status_invalid_pointer if \p descr or \p brows or \p bcols or \p bnnz or
+ *          \p block_dir or \p block_dim or \p bsr_row_ptr or \p bsr_col_ind or \p bsr_val or
+ *          \p row_ptr_type or \p col_ind_type or \p idx_base or \p data_type is invalid.
+ *  \retval rocsparse_status_not_initialized if \p descr has not been initialized.
  */
 /**@{*/
 ROCSPARSE_EXPORT
@@ -2485,8 +2486,8 @@ rocsparse_status rocsparse_bsr_get(const rocsparse_spmat_descr descr,
                                    int64_t*                    brows,
                                    int64_t*                    bcols,
                                    int64_t*                    bnnz,
-                                   rocsparse_direction*        bdir,
-                                   int64_t*                    bdim,
+                                   rocsparse_direction*        block_dir,
+                                   int64_t*                    block_dim,
                                    void**                      bsr_row_ptr,
                                    void**                      bsr_col_ind,
                                    void**                      bsr_val,
@@ -2500,8 +2501,8 @@ rocsparse_status rocsparse_const_bsr_get(rocsparse_const_spmat_descr descr,
                                          int64_t*                    brows,
                                          int64_t*                    bcols,
                                          int64_t*                    bnnz,
-                                         rocsparse_direction*        bdir,
-                                         int64_t*                    bdim,
+                                         rocsparse_direction*        block_dir,
+                                         int64_t*                    block_dim,
                                          const void**                bsr_row_ptr,
                                          const void**                bsr_col_ind,
                                          const void**                bsr_val,

--- a/projects/rocsparse/library/include/rocsparse-types.h
+++ b/projects/rocsparse/library/include/rocsparse-types.h
@@ -158,7 +158,7 @@ typedef struct _rocsparse_spmat_descr* rocsparse_spmat_descr;
  *  The rocSPARSE constant sparse matrix descriptor is a structure holding all properties of a sparse matrix.
  *  It must be initialized using rocsparse_create_const_coo_descr(),
  *  rocsparse_create_const_csr_descr(), rocsparse_create_const_csc_descr(),
- *  or rocsparse_create_const_bell_descr() and the returned
+ *  rocsparse_create_const_bsr_descr(), or rocsparse_create_const_bell_descr() and the returned
  *  descriptor must be passed to all subsequent generic API library calls that involve the sparse matrix.
  *  It should be destroyed at the end using rocsparse_destroy_spmat_descr().
  */

--- a/projects/rocsparse/library/src/auxiliary/rocsparse_auxiliary.cpp
+++ b/projects/rocsparse/library/src/auxiliary/rocsparse_auxiliary.cpp
@@ -2923,9 +2923,9 @@ catch(...)
  * using rocsparse_destroy_spmat_descr(). All data pointers remain valid.
  *******************************************************************************/
 rocsparse_status rocsparse_create_bsr_descr(rocsparse_spmat_descr* descr,
-                                            int64_t                mb,
-                                            int64_t                nb,
-                                            int64_t                nnzb,
+                                            int64_t                brows,
+                                            int64_t                bcols,
+                                            int64_t                bnnz,
                                             rocsparse_direction    block_dir,
                                             int64_t                block_dim,
                                             void*                  bsr_row_ptr,
@@ -2940,16 +2940,16 @@ try
     ROCSPARSE_ROUTINE_TRACE;
 
     ROCSPARSE_CHECKARG_POINTER(0, descr);
-    ROCSPARSE_CHECKARG_SIZE(1, mb);
-    ROCSPARSE_CHECKARG_SIZE(2, nb);
-    ROCSPARSE_CHECKARG_SIZE(3, nnzb);
-    ROCSPARSE_CHECKARG(3, nnzb, (nnzb > mb * nb), rocsparse_status_invalid_size);
+    ROCSPARSE_CHECKARG_SIZE(1, brows);
+    ROCSPARSE_CHECKARG_SIZE(2, bcols);
+    ROCSPARSE_CHECKARG_SIZE(3, bnnz);
+    ROCSPARSE_CHECKARG(3, bnnz, (bnnz > brows * bcols), rocsparse_status_invalid_size);
     ROCSPARSE_CHECKARG_ENUM(4, block_dir);
     ROCSPARSE_CHECKARG_SIZE(5, block_dim);
     ROCSPARSE_CHECKARG(5, block_dim, (block_dim == 0), rocsparse_status_invalid_size);
-    ROCSPARSE_CHECKARG_ARRAY(6, mb, bsr_row_ptr);
-    ROCSPARSE_CHECKARG_ARRAY(7, nnzb, bsr_col_ind);
-    ROCSPARSE_CHECKARG_ARRAY(8, nnzb, bsr_val);
+    ROCSPARSE_CHECKARG_ARRAY(6, brows, bsr_row_ptr);
+    ROCSPARSE_CHECKARG_ARRAY(7, bnnz, bsr_col_ind);
+    ROCSPARSE_CHECKARG_ARRAY(8, bnnz, bsr_val);
     ROCSPARSE_CHECKARG_ENUM(9, row_ptr_type);
     ROCSPARSE_CHECKARG_ENUM(10, col_ind_type);
     ROCSPARSE_CHECKARG_ENUM(11, idx_base);
@@ -2959,9 +2959,9 @@ try
 
     (*descr)->init = true;
 
-    (*descr)->rows = mb;
-    (*descr)->cols = nb;
-    (*descr)->nnz  = nnzb;
+    (*descr)->rows = brows;
+    (*descr)->cols = bcols;
+    (*descr)->nnz  = bnnz;
 
     (*descr)->row_data = bsr_row_ptr;
     (*descr)->col_data = bsr_col_ind;
@@ -3001,9 +3001,9 @@ catch(...)
 // LCOV_EXCL_STOP
 
 rocsparse_status rocsparse_create_const_bsr_descr(rocsparse_const_spmat_descr* descr,
-                                                  int64_t                      mb,
-                                                  int64_t                      nb,
-                                                  int64_t                      nnzb,
+                                                  int64_t                      brows,
+                                                  int64_t                      bcols,
+                                                  int64_t                      bnnz,
                                                   rocsparse_direction          block_dir,
                                                   int64_t                      block_dim,
                                                   const void*                  bsr_row_ptr,
@@ -3018,16 +3018,16 @@ try
     ROCSPARSE_ROUTINE_TRACE;
 
     ROCSPARSE_CHECKARG_POINTER(0, descr);
-    ROCSPARSE_CHECKARG_SIZE(1, mb);
-    ROCSPARSE_CHECKARG_SIZE(2, nb);
-    ROCSPARSE_CHECKARG_SIZE(3, nnzb);
-    ROCSPARSE_CHECKARG(3, nnzb, (nnzb > mb * nb), rocsparse_status_invalid_size);
+    ROCSPARSE_CHECKARG_SIZE(1, brows);
+    ROCSPARSE_CHECKARG_SIZE(2, bcols);
+    ROCSPARSE_CHECKARG_SIZE(3, bnnz);
+    ROCSPARSE_CHECKARG(3, bnnz, (bnnz > brows * bcols), rocsparse_status_invalid_size);
     ROCSPARSE_CHECKARG_ENUM(4, block_dir);
     ROCSPARSE_CHECKARG_SIZE(5, block_dim);
     ROCSPARSE_CHECKARG(5, block_dim, (block_dim == 0), rocsparse_status_invalid_size);
-    ROCSPARSE_CHECKARG_ARRAY(6, mb, bsr_row_ptr);
-    ROCSPARSE_CHECKARG_ARRAY(7, nnzb, bsr_col_ind);
-    ROCSPARSE_CHECKARG_ARRAY(8, nnzb, bsr_val);
+    ROCSPARSE_CHECKARG_ARRAY(6, brows, bsr_row_ptr);
+    ROCSPARSE_CHECKARG_ARRAY(7, bnnz, bsr_col_ind);
+    ROCSPARSE_CHECKARG_ARRAY(8, bnnz, bsr_val);
     ROCSPARSE_CHECKARG_ENUM(9, row_ptr_type);
     ROCSPARSE_CHECKARG_ENUM(10, col_ind_type);
     ROCSPARSE_CHECKARG_ENUM(11, idx_base);
@@ -3037,9 +3037,9 @@ try
 
     new_descr->init = true;
 
-    new_descr->rows = mb;
-    new_descr->cols = nb;
-    new_descr->nnz  = nnzb;
+    new_descr->rows = brows;
+    new_descr->cols = bcols;
+    new_descr->nnz  = bnnz;
 
     new_descr->row_data = nullptr;
     new_descr->col_data = nullptr;
@@ -3412,8 +3412,8 @@ rocsparse_status rocsparse_const_bsr_get(rocsparse_const_spmat_descr descr,
                                          int64_t*                    brows,
                                          int64_t*                    bcols,
                                          int64_t*                    bnnz,
-                                         rocsparse_direction*        bdir,
-                                         int64_t*                    bdim,
+                                         rocsparse_direction*        block_dir,
+                                         int64_t*                    block_dim,
                                          const void**                bsr_row_ptr,
                                          const void**                bsr_col_ind,
                                          const void**                bsr_val,
@@ -3425,36 +3425,20 @@ try
 {
     ROCSPARSE_ROUTINE_TRACE;
 
-    // Check for valid pointers
-    if(descr == nullptr)
-    {
-        return rocsparse_status_invalid_pointer;
-    }
-
-    // Check for invalid size pointers
-    if(brows == nullptr || bcols == nullptr || bnnz == nullptr)
-    {
-        return rocsparse_status_invalid_pointer;
-    }
-
-    // Check for invalid data pointers
-    if(bsr_row_ptr == nullptr || bsr_col_ind == nullptr || bsr_val == nullptr)
-    {
-        return rocsparse_status_invalid_pointer;
-    }
-
-    // Check for invalid property pointers
-    if(row_ptr_type == nullptr || col_ind_type == nullptr || idx_base == nullptr
-       || data_type == nullptr)
-    {
-        return rocsparse_status_invalid_pointer;
-    }
-
-    // Check if descriptor has been initialized
-    if(descr->init == false)
-    {
-        return rocsparse_status_not_initialized;
-    }
+    ROCSPARSE_CHECKARG_POINTER(0, descr);
+    ROCSPARSE_CHECKARG(0, descr, (descr->init == false), rocsparse_status_not_initialized);
+    ROCSPARSE_CHECKARG_POINTER(1, brows);
+    ROCSPARSE_CHECKARG_POINTER(2, bcols);
+    ROCSPARSE_CHECKARG_POINTER(3, bnnz);
+    ROCSPARSE_CHECKARG_POINTER(4, block_dir);
+    ROCSPARSE_CHECKARG_POINTER(5, block_dim);
+    ROCSPARSE_CHECKARG_POINTER(6, bsr_row_ptr);
+    ROCSPARSE_CHECKARG_POINTER(7, bsr_col_ind);
+    ROCSPARSE_CHECKARG_POINTER(8, bsr_val);
+    ROCSPARSE_CHECKARG_POINTER(9, row_ptr_type);
+    ROCSPARSE_CHECKARG_POINTER(10, col_ind_type);
+    ROCSPARSE_CHECKARG_POINTER(11, idx_base);
+    ROCSPARSE_CHECKARG_POINTER(12, data_type);
 
     *brows = descr->rows;
     *bcols = descr->cols;
@@ -3468,8 +3452,8 @@ try
     *col_ind_type = descr->col_type;
     *idx_base     = descr->idx_base;
     *data_type    = descr->data_type;
-    *bdim         = descr->block_dim;
-    *bdir         = descr->block_dir;
+    *block_dim    = descr->block_dim;
+    *block_dir    = descr->block_dir;
     return rocsparse_status_success;
     // LCOV_EXCL_START
 }
@@ -3483,8 +3467,8 @@ rocsparse_status rocsparse_bsr_get(const rocsparse_spmat_descr descr,
                                    int64_t*                    brows,
                                    int64_t*                    bcols,
                                    int64_t*                    bnnz,
-                                   rocsparse_direction*        bdir,
-                                   int64_t*                    bdim,
+                                   rocsparse_direction*        block_dir,
+                                   int64_t*                    block_dim,
                                    void**                      bsr_row_ptr,
                                    void**                      bsr_col_ind,
                                    void**                      bsr_val,
@@ -3496,36 +3480,20 @@ try
 {
     ROCSPARSE_ROUTINE_TRACE;
 
-    // Check for valid pointers
-    if(descr == nullptr)
-    {
-        return rocsparse_status_invalid_pointer;
-    }
-
-    // Check for invalid size pointers
-    if(brows == nullptr || bcols == nullptr || bnnz == nullptr)
-    {
-        return rocsparse_status_invalid_pointer;
-    }
-
-    // Check for invalid data pointers
-    if(bsr_row_ptr == nullptr || bsr_col_ind == nullptr || bsr_val == nullptr)
-    {
-        return rocsparse_status_invalid_pointer;
-    }
-
-    // Check for invalid property pointers
-    if(row_ptr_type == nullptr || col_ind_type == nullptr || idx_base == nullptr
-       || data_type == nullptr)
-    {
-        return rocsparse_status_invalid_pointer;
-    }
-
-    // Check if descriptor has been initialized
-    if(descr->init == false)
-    {
-        return rocsparse_status_not_initialized;
-    }
+    ROCSPARSE_CHECKARG_POINTER(0, descr);
+    ROCSPARSE_CHECKARG(0, descr, (descr->init == false), rocsparse_status_not_initialized);
+    ROCSPARSE_CHECKARG_POINTER(1, brows);
+    ROCSPARSE_CHECKARG_POINTER(2, bcols);
+    ROCSPARSE_CHECKARG_POINTER(3, bnnz);
+    ROCSPARSE_CHECKARG_POINTER(4, block_dir);
+    ROCSPARSE_CHECKARG_POINTER(5, block_dim);
+    ROCSPARSE_CHECKARG_POINTER(6, bsr_row_ptr);
+    ROCSPARSE_CHECKARG_POINTER(7, bsr_col_ind);
+    ROCSPARSE_CHECKARG_POINTER(8, bsr_val);
+    ROCSPARSE_CHECKARG_POINTER(9, row_ptr_type);
+    ROCSPARSE_CHECKARG_POINTER(10, col_ind_type);
+    ROCSPARSE_CHECKARG_POINTER(11, idx_base);
+    ROCSPARSE_CHECKARG_POINTER(12, data_type);
 
     *brows = descr->rows;
     *bcols = descr->cols;
@@ -3539,8 +3507,8 @@ try
     *col_ind_type = descr->col_type;
     *idx_base     = descr->idx_base;
     *data_type    = descr->data_type;
-    *bdim         = descr->block_dim;
-    *bdir         = descr->block_dir;
+    *block_dim    = descr->block_dim;
+    *block_dir    = descr->block_dir;
     return rocsparse_status_success;
     // LCOV_EXCL_START
 }

--- a/projects/rocsparse/library/src/auxiliary/rocsparse_auxiliary.cpp
+++ b/projects/rocsparse/library/src/auxiliary/rocsparse_auxiliary.cpp
@@ -3000,6 +3000,86 @@ catch(...)
 }
 // LCOV_EXCL_STOP
 
+rocsparse_status rocsparse_create_const_bsr_descr(rocsparse_const_spmat_descr* descr,
+                                                  int64_t                      mb,
+                                                  int64_t                      nb,
+                                                  int64_t                      nnzb,
+                                                  rocsparse_direction          block_dir,
+                                                  int64_t                      block_dim,
+                                                  const void*                  bsr_row_ptr,
+                                                  const void*                  bsr_col_ind,
+                                                  const void*                  bsr_val,
+                                                  rocsparse_indextype          row_ptr_type,
+                                                  rocsparse_indextype          col_ind_type,
+                                                  rocsparse_index_base         idx_base,
+                                                  rocsparse_datatype           data_type)
+try
+{
+    ROCSPARSE_ROUTINE_TRACE;
+
+    ROCSPARSE_CHECKARG_POINTER(0, descr);
+    ROCSPARSE_CHECKARG_SIZE(1, mb);
+    ROCSPARSE_CHECKARG_SIZE(2, nb);
+    ROCSPARSE_CHECKARG_SIZE(3, nnzb);
+    ROCSPARSE_CHECKARG(3, nnzb, (nnzb > mb * nb), rocsparse_status_invalid_size);
+    ROCSPARSE_CHECKARG_ENUM(4, block_dir);
+    ROCSPARSE_CHECKARG_SIZE(5, block_dim);
+    ROCSPARSE_CHECKARG(5, block_dim, (block_dim == 0), rocsparse_status_invalid_size);
+    ROCSPARSE_CHECKARG_ARRAY(6, mb, bsr_row_ptr);
+    ROCSPARSE_CHECKARG_ARRAY(7, nnzb, bsr_col_ind);
+    ROCSPARSE_CHECKARG_ARRAY(8, nnzb, bsr_val);
+    ROCSPARSE_CHECKARG_ENUM(9, row_ptr_type);
+    ROCSPARSE_CHECKARG_ENUM(10, col_ind_type);
+    ROCSPARSE_CHECKARG_ENUM(11, idx_base);
+    ROCSPARSE_CHECKARG_ENUM(12, data_type);
+
+    rocsparse_spmat_descr new_descr = new _rocsparse_spmat_descr;
+
+    new_descr->init = true;
+
+    new_descr->rows = mb;
+    new_descr->cols = nb;
+    new_descr->nnz  = nnzb;
+
+    new_descr->row_data = nullptr;
+    new_descr->col_data = nullptr;
+    new_descr->val_data = nullptr;
+
+    new_descr->const_row_data = bsr_row_ptr;
+    new_descr->const_col_data = bsr_col_ind;
+    new_descr->const_val_data = bsr_val;
+
+    new_descr->row_type  = row_ptr_type;
+    new_descr->col_type  = col_ind_type;
+    new_descr->data_type = data_type;
+
+    new_descr->idx_base = idx_base;
+    new_descr->format   = rocsparse_format_bsr;
+
+    new_descr->block_dim = block_dim;
+    new_descr->block_dir = block_dir;
+
+    RETURN_IF_ROCSPARSE_ERROR(rocsparse_create_mat_descr(&new_descr->descr));
+    RETURN_IF_ROCSPARSE_ERROR(rocsparse_create_mat_info(&new_descr->info));
+
+    // Initialize descriptor
+    RETURN_IF_ROCSPARSE_ERROR(rocsparse_set_mat_index_base(new_descr->descr, idx_base));
+
+    new_descr->batch_count                 = 1;
+    new_descr->batch_stride                = 0;
+    new_descr->offsets_batch_stride        = 0;
+    new_descr->columns_values_batch_stride = 0;
+
+    *descr = new_descr;
+    return rocsparse_status_success;
+    // LCOV_EXCL_START
+}
+catch(...)
+{
+    RETURN_ROCSPARSE_EXCEPTION();
+}
+// LCOV_EXCL_STOP
+
 /********************************************************************************
  * \brief rocsparse_destroy_spmat_descr destroys a sparse matrix descriptor.
  *******************************************************************************/


### PR DESCRIPTION
## Motivation

We were missing the create const descr for BSR format: `rocsparse_create_const_bsr_descr`. This PR adds this missing API and corresponding testing.
