### PR TITLE
[hipblaslt][tensilelite] Extend tensilelite invoke build workflow

### DIFF
--- a/projects/hipblaslt/tensilelite/README.md
+++ b/projects/hipblaslt/tensilelite/README.md
@@ -37,6 +37,12 @@ pip3 install invoke
 # build the client to the default location with defaults
 invoke build-client
 
+# override the default toolchain with a specific ROCm install
+invoke build-client \
+  --gpu-targets gfx950 \
+  --rocm-path /opt/rocm-7.3.0 \
+  --export-compile-commands
+
 # run an individual test
 Tensile/bin/Tensile Tensile/Tests/common/exception/<test>.yaml tensile-out
 ```
@@ -71,6 +77,18 @@ specialized builds (e.g., Debug builds) and setting the architecture.
 cd rocm-libraries/projects/hipblaslt/tensilelite
 TENSILELITE_CLIENT_ARGS="--build-type Debug --gpu-targets gfx90a --clean" tox -e py3 -- Tensile/Tests -m common
 ```
+
+`invoke build-client` follows the existing `tensilelite` CMake preset by default.
+In this repo, that means `/opt/rocm` compiler settings come from the preset, and
+`CMAKE_EXPORT_COMPILE_COMMANDS` and `HIPBLASLT_BUNDLE_PYTHON_DEPS` are already enabled
+by default.
+
+Use these flags when you want to override or make that behavior explicit:
+
+* `--rocm-path <path>`: Override the compiler toolchain to use `<path>/bin/amdclang` and `<path>/bin/amdclang++`
+* `--export-compile-commands`: Explicitly force `CMAKE_EXPORT_COMPILE_COMMANDS=ON`
+* `--bundle-python-deps`: Explicitly force `HIPBLASLT_BUNDLE_PYTHON_DEPS=ON`
+* `--enable-rocprof`: Sets `TENSILELITE_CLIENT_ENABLE_ROCPROFSDK=ON`
 
 ### Options
 

--- a/projects/hipblaslt/tensilelite/tasks.py
+++ b/projects/hipblaslt/tensilelite/tasks.py
@@ -3,6 +3,11 @@
 
 from invoke.tasks import task
 import os
+import shlex
+
+
+def _cmake_bool(value):
+    return "ON" if value else "OFF"
 
 def detect_gpu_arch():
     import subprocess
@@ -37,20 +42,39 @@ def get_gpu_arch(c):
         "build_dir": "Path to client build dir.",
         "build_type": "CMake build type (e.g. Release, Debug).",
         "gpu_targets": "Comma-separated list of GPU targets (e.g. gfx90a,gfx1101).",
+        "rocm_path": "Path to a ROCm install whose amdclang/amdclang++ should be used.",
+        "export_compile_commands": "Enable CMAKE_EXPORT_COMPILE_COMMANDS.",
+        "bundle_python_deps": "Enable HIPBLASLT_BUNDLE_PYTHON_DEPS.",
         "enable_rocprof": "Build tensilelite-client with rocprof.",
     }
 )
-def build_client(c, clean=False, configure=True, build=True, build_dir="build_tmp", build_type="Release", gpu_targets=None, enable_rocprof=False):
+def build_client(
+    c,
+    clean=False,
+    configure=True,
+    build=True,
+    build_dir="build_tmp",
+    build_type="Release",
+    gpu_targets=None,
+    rocm_path=None,
+    export_compile_commands=False,
+    bundle_python_deps=False,
+    enable_rocprof=False,
+):
 
     if gpu_targets is None:
         gpu_targets = detect_gpu_arch()
-        if gpu_targets == "None":
+        if not gpu_targets:
             print("Error: No GPU detected and no gpu_targets provided. Skipping build.")
             return
         print(f"warning: No GPU targets specified. Detected and using: {gpu_targets}")
 
+    if rocm_path:
+        cmake_c_compiler = os.path.join(rocm_path, "bin", "amdclang")
+        cmake_cxx_compiler = os.path.join(rocm_path, "bin", "amdclang++")
+
     if clean and os.path.exists(build_dir):
-        c.run(f"rm -rf {build_dir}")
+        c.run(f"rm -rf {shlex.quote(build_dir)}")
 
     if configure:
         os.makedirs(build_dir, exist_ok=True)
@@ -63,10 +87,18 @@ def build_client(c, clean=False, configure=True, build=True, build_dir="build_tm
             "-B", build_dir,
             f"-DCMAKE_BUILD_TYPE={build_type}",
             f"-DGPU_TARGETS={gpu_targets}",
-            f"-DTENSILELITE_CLIENT_ENABLE_ROCPROFSDK={enable_rocprof}",
+            f"-DTENSILELITE_CLIENT_ENABLE_ROCPROFSDK={_cmake_bool(enable_rocprof)}",
         ]
 
-        c.run(" ".join(cmake_cmd))
+        if rocm_path:
+            cmake_cmd.append(f"-DCMAKE_C_COMPILER={cmake_c_compiler}")
+            cmake_cmd.append(f"-DCMAKE_CXX_COMPILER={cmake_cxx_compiler}")
+        if export_compile_commands:
+            cmake_cmd.append("-DCMAKE_EXPORT_COMPILE_COMMANDS=ON")
+        if bundle_python_deps:
+            cmake_cmd.append("-DHIPBLASLT_BUNDLE_PYTHON_DEPS=ON")
+
+        c.run(shlex.join(cmake_cmd))
 
     if build:
-        c.run(f"cmake --build {build_dir} --parallel")
+        c.run(shlex.join(["cmake", "--build", build_dir, "--parallel"]))


### PR DESCRIPTION
  ## Motivation
  Add `invoke build-client` with a specific ROCm install.
  ## Technical Details
  - Add `--rocm-path`, `--export-compile-commands`, and `--bundle-python-deps` to `invoke build-client`
  - Derive the C and C++ compiler paths from `--rocm-path` when provided
  - Keep default behavior unchanged when no override flags are passed
  ## Test Plan
  - Run `invoke get-gpu-arch`
  - Run `invoke build-client --clean --no-build --build-dir <custom-build-dir> --rocm-path <custom-rocm-path> --export-compile-commands`
  - Run `invoke build-client --clean --no-build --build-dir <default-compat-build-dir>`
  ## Test Result
  - `invoke get-gpu-arch` returned a valid GPU target
  - Configure with `--rocm-path <custom-rocm-path>` succeeded
  - Verified `compile_commands.json` was generated and uses the compiler from the supplied ROCm path
  - Verified the default path still configures successfully without the new override flags
