### PR TITLE
[miopen-provider]: Fix clang-tidy naming errors in batchnorm unsupported dtype test

### DIFF
--- a/dnn-providers/miopen-provider/integration_tests/IntegrationGpuBatchnormUnsupportedDataTypes.cpp
+++ b/dnn-providers/miopen-provider/integration_tests/IntegrationGpuBatchnormUnsupportedDataTypes.cpp
@@ -43,7 +43,7 @@ Graph makeGraph(const UnsupportedBnDtypeCase& tc, const TensorLayout& layout = T
     const auto cDims = getDerivedShape(dims);
 
     auto xAttr = makeTensorAttributes("X", tc.io, dims, generateStrides(dims, layout.strideOrder));
-    auto X = std::make_shared<TensorAttributes>(std::move(xAttr));
+    auto x = std::make_shared<TensorAttributes>(std::move(xAttr));
 
     auto meanAttr = makeTensorAttributes("mean", tc.stats, cDims, generateStrides(cDims));
     auto invVarAttr = makeTensorAttributes("inv_variance", tc.stats, cDims, generateStrides(cDims));
@@ -56,8 +56,8 @@ Graph makeGraph(const UnsupportedBnDtypeCase& tc, const TensorLayout& layout = T
     auto bias = std::make_shared<TensorAttributes>(std::move(biasAttr));
 
     BatchnormInferenceAttributes bn;
-    auto Y = g.batchnorm_inference(X, mean, invVar, scale, bias, bn);
-    Y->set_output(true);
+    auto y = g.batchnorm_inference(x, mean, invVar, scale, bias, bn);
+    y->set_output(true);
 
     return g;
 }


### PR DESCRIPTION
## Summary
- Rename local variables `X` → `x` and `Y` → `y` in `IntegrationGpuBatchnormUnsupportedDataTypes.cpp` to satisfy `readability-identifier-naming`, which is treated as warning-as-error and currently breaks `develop`.
- Introduced by #5599 (commit `2a1626426ec`).

## Test plan
- [x] Clean superbuild on `develop` reproduces the failure (1 `FAILED:` target, this file)
- [x] Clean superbuild on this branch (`hipdnn;miopen-provider;hipblaslt-provider`, `GPU_TARGETS=gfx90a`, `CMAKE_BUILD_TYPE=Release`, `rocm-clang.cmake` toolchain) completes successfully
- [x] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)