### PR TITLE
[fusilli-provider] Use unique graph names in parameterized tests

### DIFF
--- a/dnn-providers/fusilli-provider/test/integration/convolution/conv_fprop_parameterized_full.cpp
+++ b/dnn-providers/fusilli-provider/test/integration/convolution/conv_fprop_parameterized_full.cpp
@@ -166,7 +166,8 @@ TEST_P(ConvFpropParameterizedTest, Correctness) {
       ::testing::UnitTest::GetInstance()->current_test_info();
 
   // Get the name of the individual test
-  const char *test_name = test_info->name();
+  const std::string test_name =
+      std::string(test_info->test_suite_name()) + "_" + test_info->name();
 
   const ConvTestCase &tc = GetParam();
 

--- a/dnn-providers/fusilli-provider/test/integration/convolution/simple_conv_fprop_parameterized_stream_device.cpp
+++ b/dnn-providers/fusilli-provider/test/integration/convolution/simple_conv_fprop_parameterized_stream_device.cpp
@@ -121,7 +121,10 @@ TEST_P(ConvFpropIntegrationTest, Basic1x1Convolution) {
 
   // Create graph.
   auto graph = std::make_shared<graph::Graph>();
-  graph->set_name("conv_1x1_test");
+  const auto *test_info =
+      ::testing::UnitTest::GetInstance()->current_test_info();
+  graph->set_name(std::string(test_info->test_suite_name()) + "_" +
+                  test_info->name());
   graph->set_io_data_type(DataType_t::FLOAT)
       .set_compute_data_type(DataType_t::FLOAT);
 

--- a/dnn-providers/fusilli-provider/test/integration/matmul/batched_matmul_parameterized.cpp
+++ b/dnn-providers/fusilli-provider/test/integration/matmul/batched_matmul_parameterized.cpp
@@ -170,7 +170,10 @@ TEST_P(BatchedMatmulParameterizedTest, Correctness) {
 
   // Create graph.
   auto graph = std::make_shared<graph::Graph>();
-  graph->set_name("batched_matmul_parameterized_test");
+  const auto *test_info =
+      ::testing::UnitTest::GetInstance()->current_test_info();
+  graph->set_name(std::string(test_info->test_suite_name()) + "_" +
+                  test_info->name());
   graph->set_io_data_type(DataType_t::FLOAT)
       .set_intermediate_data_type(DataType_t::FLOAT)
       .set_compute_data_type(DataType_t::FLOAT);

--- a/dnn-providers/fusilli-provider/test/integration/matmul/matmul_parameterized.cpp
+++ b/dnn-providers/fusilli-provider/test/integration/matmul/matmul_parameterized.cpp
@@ -151,7 +151,10 @@ TEST_P(MatmulParameterizedTest, Correctness) {
 
   // Create graph.
   auto graph = std::make_shared<graph::Graph>();
-  graph->set_name("matmul_parameterized_test");
+  const auto *test_info =
+      ::testing::UnitTest::GetInstance()->current_test_info();
+  graph->set_name(std::string(test_info->test_suite_name()) + "_" +
+                  test_info->name());
   graph->set_io_data_type(DataType_t::FLOAT)
       .set_intermediate_data_type(DataType_t::FLOAT)
       .set_compute_data_type(DataType_t::FLOAT);


### PR DESCRIPTION
fusilli's file cache is keyed by the (sanitized) graph name, so test variants can't share the same graph name. Switch each parameterized test to combine `test_suite_name()` + `name()` so every variant gets a unique cache slot:

| Test                                                                    | Before                              | After (sanitized)                                            |
|---|---|---|
| ConvFpropParameterizedTest.Correctness (×9 NCHW + ×9 NHWC)              | `Correctness<index>`                | `{NCHW,NHWC}ConvFpropParameterizedTest_Correctness<index>`   |
| MatmulParameterizedTest.Correctness (×6)                                | `matmul_parameterized_test`         | `MatmulMatmulParameterizedTest_Correctness<index>`           |
| BatchedMatmulParameterizedTest.Correctness (×8)                         | `batched_matmul_parameterized_test` | `BatchedMatmulBatchedMatmulParameterizedTest_Correctness<index>` |
| ConvFpropIntegrationTest.Basic1x1Convolution (×2, ×4 multi-GPU)         | `conv_1x1_test`                     | `ConvFpropIntegrationTest_Basic1x1Convolution<index>`        |

Verified with `ctest -j` against the full fusilli-provider suite.
