### PR TITLE
Update CHANGELOG.md for resolved overflow issue

### DIFF
--- a/projects/rocprim/CHANGELOG.md
+++ b/projects/rocprim/CHANGELOG.md
@@ -8,6 +8,10 @@ Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projec
 
 * Added type trait definitions for `__hip_bfloat16`. This should resolve issues where this type did not work with radix-based algorithms.
 
+### Resolved issues
+
+* Fixed a silent overflow in `rocprim::device_segmented_reduce` where it could exceed the maximum number of HIP threads, resulting in missing output.
+
 ## rocPRIM 4.3.0 for ROCm 7.12
 
 ### Added


### PR DESCRIPTION
## Motivation

Adds info in the rocprim changelog for this issue:

Fixes a silent overflow in the device_segmented_reduce code when the number of segments * blocksize exceeds the maximum number of HIP threads (2^32-1), causing missing output and strange performance anomalies.

## Technical Details

Documentation update

## Test Plan

No testing.

## Test Result

n/a

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
