### PR TITLE
[HipDNN]: Update bootstrap scripts: winget, Windows SDK, cleanup

### DIFF
--- a/projects/hipdnn/scripts/rock_dev_bootstrap.py
+++ b/projects/hipdnn/scripts/rock_dev_bootstrap.py
@@ -344,26 +344,18 @@ def do_bootstrap(args: argparse.Namespace) -> None:
 
     python = setup_python(therock_dir)
 
-    # Fetch sources if needed
-    hip_version_a = therock_dir / "short-hip-runtime" / "hip" / "VERSION"
-    hip_version_b = therock_dir / "rocm-systems" / "projects" / "hip" / "VERSION"
-    if not hip_version_a.exists() and not hip_version_b.exists():
-        print("Fetching submodule sources...")
-        fetch_cmd = [str(python), str(therock_dir / "build_tools" / "fetch_sources.py")]
-        # Skip DVC large-file pulls — they require 'dvc' on PATH and are not
-        # needed when using prebuilt CI artifacts.  Pass a dummy project name
-        # that won't match anything so the pull loop is a no-op.
-        if shutil.which("dvc") is None:
-            print()
-            print("  WARNING: 'dvc' not found on PATH — skipping large file pulls.")
-            print(
-                "  Some components may fail to build if they require DVC-managed files."
-            )
-            print("  Install DVC from https://dvc.org/doc/install if needed.")
-            print()
-            fetch_cmd.extend(["--dvc-projects", "_skip"])
-        run_cmd(fetch_cmd, cwd=therock_dir)
+    # Always fetch sources to ensure they're up to date
+    print("Fetching submodule sources...")
+    fetch_cmd = [str(python), str(therock_dir / "build_tools" / "fetch_sources.py")]
+    if shutil.which("dvc") is None:
         print()
+        print("  WARNING: 'dvc' not found on PATH — skipping large file pulls.")
+        print("  Some components may fail to build if they require DVC-managed files.")
+        print("  Install DVC from https://dvc.org/doc/install if needed.")
+        print()
+        fetch_cmd.extend(["--dvc-projects", "_skip"])
+    run_cmd(fetch_cmd, cwd=therock_dir)
+    print()
 
     # Find latest run ID if not specified
     if not run_id:

--- a/projects/hipdnn/scripts/rock_dev_bootstrap_guide.md
+++ b/projects/hipdnn/scripts/rock_dev_bootstrap_guide.md
@@ -1,8 +1,5 @@
 # rock_dev_bootstrap.py — Windows Setup Guide
 
-This document covers the issues encountered when bootstrapping a TheRock-based
-build of hipDNN and miopen-provider on Windows (gfx1151), and their solutions.
-
 ## Prerequisites
 
 Before running the script, ensure you have:
@@ -10,7 +7,10 @@ Before running the script, ensure you have:
 - **Python 3.9+** on PATH
 - **CMake < 4.0** (CMake 4 is not yet supported by TheRock on Windows)
 - **Ninja** on PATH
-- **Visual Studio 2022 Build Tools** (MSVC 19.42+ / VS 17.12+)
+- **Visual Studio 2022 Build Tools** (MSVC 19.42+ / VS 17.12+) **with Windows 11 SDK**
+  - The Windows SDK (`Microsoft.VisualStudio.Component.Windows11SDK.22621`) must be
+    installed — it provides `rc.exe`, `mt.exe`, and system libraries (`kernel32.lib`, etc.)
+  - Run `scripts/windows/windows_build_setup.ps1` to install everything via winget
 - **Git** configured with symlinks and long paths:
   ```
   git config --global core.symlinks true
@@ -20,222 +20,46 @@ Before running the script, ensure you have:
   ```powershell
   reg add HKLM\SYSTEM\CurrentControlSet\Control\FileSystem /v LongPathsEnabled /t REG_DWORD /d 1 /f
   ```
-- **GitHub CLI (`gh`)** installed and authenticated (see Issue #2 below)
+- **GitHub CLI (`gh`)** installed and authenticated (for artifact auto-detection)
 - A **TheRock checkout** (e.g. `D:\develop\claude_workspace\repos\TheRock`)
 
-## Quick Start (known working)
+## Quick Start
 
 ```bash
-# 1. Bootstrap with a known run ID (skip artifact auto-detection)
+# 1. Bootstrap (auto-detects latest nightly):
 python rock_dev_bootstrap.py bootstrap \
     --therock-dir D:/develop/claude_workspace/repos/TheRock \
-    --build-dir D:/develop/claude_workspace/build/therock-gfx1151 \
-    24170213928
+    --build-dir D:/develop/claude_workspace/build/therock-gfx1151
 
-# 2. Configure components for source build
+# 2. Configure components for source build:
 python rock_dev_bootstrap.py configure \
     --therock-dir D:/develop/claude_workspace/repos/TheRock \
     --build-dir D:/develop/claude_workspace/build/therock-gfx1151 \
     hipdnn miopenprovider
 
-# 3. Build
+# 3. Build:
 python rock_dev_bootstrap.py build \
     --build-dir D:/develop/claude_workspace/build/therock-gfx1151 \
     -j24
 ```
 
-## Issues and Solutions
-
-### Issue #1: DVC not found — `fetch_sources.py` fails on Windows
-
-**Symptom:** `fetch_sources.py` exits with code 1 and prints:
-```
-Could not find `dvc` on PATH so large files could not be fetched
-```
-
-**Root cause:** On Windows, `fetch_sources.py` treats missing DVC as fatal
-(unlike Linux where it's a warning). DVC is used to pull large binary files
-for `rocm-libraries` and `rocm-systems`.
-
-**Solution:** The script detects missing DVC and passes `--dvc-projects _skip`
-to `fetch_sources.py`, bypassing the check. A warning is printed. DVC-managed
-files are not needed when using prebuilt CI artifacts.
-
-**If you need DVC:** Install from https://dvc.org/doc/install (version 3.62.0+).
-
----
-
-### Issue #2: GitHub API rate limiting during artifact auto-detection
-
-**Symptom:** `find_latest_artifacts.py` prints repeated warnings and then fails:
-```
-Warning: No GitHub auth available, requests may be rate limited
-Error: GitHub API rate limit exceeded
-```
-
-**Root cause:** Unauthenticated GitHub API requests are limited to 60/hour.
-The artifact search checks one API call per commit and exhausts the limit
-before finding artifacts.
-
-**Solution:** Install the GitHub CLI and authenticate:
+You can also pass a specific run ID to bootstrap if needed:
 ```bash
-# Install gh (via chocolatey, winget, or https://cli.github.com)
-choco install gh
-
-# Authenticate
-gh auth login
+python rock_dev_bootstrap.py bootstrap --therock-dir /path/to/TheRock 24814526637
 ```
 
-TheRock's `find_latest_artifacts.py` will automatically detect `gh` and use
-it for authenticated API requests (5000/hour).
+Find run IDs at: https://github.com/ROCm/TheRock/actions/workflows/ci_nightly.yml
 
----
+## Iterating on Code Changes
 
-### Issue #3: SAML/SSO enforcement for ROCm organization
-
-**Symptom:** After authenticating `gh`, requests fail with:
-```
-Error: gh api request failed: gh: Resource protected by organization SAML enforcement.
-You must grant your Personal Access token access to this organization.
-```
-
-**Root cause:** The ROCm GitHub organization requires SSO authorization for
-personal access tokens.
-
-**Solution:**
-1. Go to GitHub Settings > Personal Access Tokens
-2. Find your token
-3. Click "Configure SSO"
-4. Authorize the `ROCm` organization
-
----
-
-### Issue #4: Artifact auto-detection finds no artifacts for gfx1151
-
-**Symptom:** `find_latest_artifacts.py` checks 50 commits and finds nothing:
-```
-Searching 50 commits on ROCm/TheRock/main for 1 group(s): gfx1151...
-  [1/50] Checking abc123...
-    No artifacts found
-  ...
-No artifacts found in last 50 commits
-```
-
-**Root cause:** The tool checks for an S3 index file named
-`index-gfx1151.html`, but the CI now uploads a single `index.html` (without
-the per-group suffix). This is a naming convention mismatch between
-`find_latest_artifacts.py` and the current CI upload scripts.
-
-**Workaround:** Pass the run ID directly instead of relying on auto-detection:
+After the initial setup, use the `build` command for incremental builds:
 ```bash
-python rock_dev_bootstrap.py bootstrap --therock-dir /path/to/TheRock 24170213928
-```
-
-**Finding a run ID:** Browse the TheRock CI Nightly workflow runs at:
-https://github.com/ROCm/TheRock/actions/workflows/ci_nightly.yml
-
-Pick a recent successful run — the number in the URL is the run ID.
-
-You can also verify artifacts exist for a run by checking S3:
-```
-https://therock-ci-artifacts.s3.amazonaws.com/<run-id>-windows/index.html
-```
-
----
-
-### Issue #5: CMake cannot find MSVC compiler (cl.exe not on PATH)
-
-**Symptom:** CMake configure fails with:
-```
-No CMAKE_C_COMPILER could be found.
-No CMAKE_CXX_COMPILER could be found.
-```
-
-**Root cause:** MSVC requires environment activation via `vcvars64.bat` to
-place `cl.exe` on PATH and set up include/lib paths. The script runs from
-Git Bash where these variables are not set.
-
-**Solution:** The script auto-detects and activates the MSVC environment by:
-1. Searching `D:\develop` and `C:\Program Files\Microsoft Visual Studio` for
-   `vcvars64.bat`
-2. Running it in a temp `.bat` wrapper via `cmd.exe /c`
-3. Capturing the resulting environment variables
-4. Passing them to CMake/ninja subprocess calls
-
-If `cl.exe` is already on PATH (e.g. running from a Developer Command Prompt),
-this step is skipped.
-
-**If auto-detection fails:** Run the script from an "x64 Native Tools Command
-Prompt for VS 2022" instead.
-
----
-
-### Issue #6: vcvarsall.bat activation fails from Python subprocess
-
-**Symptom:** The script finds `vcvarsall.bat` but reports:
-```
-WARNING: vcvarsall.bat failed (exit 1)
-```
-
-**Root cause:** Passing `vcvarsall.bat x64` through `cmd.exe /c` with inline
-quotes and redirects causes path escaping issues in Python's `subprocess.run`.
-
-**Solution:** Changed to use `vcvars64.bat` (no arguments needed, equivalent
-to `vcvarsall.bat x64`) and write a temporary `.bat` file to avoid all quoting
-issues. The temp file runs `vcvars64.bat`, then dumps the environment with
-`set`.
-
----
-
-## Notes for Repeatability
-
-### Workflow for the default `--workflow` flag
-
-The script defaults to `ci_windows.yml` on Windows, but as noted in Issue #4,
-artifact auto-detection is currently broken for gfx1151 due to the S3 index
-naming change. Until this is fixed upstream in TheRock, always pass a run ID
-for the bootstrap step.
-
-### Re-running bootstrap
-
-Running bootstrap again after a partial failure is safe. It will:
-- Skip `fetch_sources.py` if submodule sources already exist
-- Re-download and re-extract artifacts (overwrites existing)
-
-### Re-running configure after a failure
-
-If configure fails partway through, the `.prebuilt` markers may already be
-removed. Re-running configure will report "no .prebuilt marker (will build
-from source)" — this is expected and harmless.
-
-### Iterating on code changes
-
-After the initial setup, you only need the `build` command:
-```bash
-python rock_dev_bootstrap.py build --build-dir D:/develop/claude_workspace/build/therock-gfx1151 -j24
+python rock_dev_bootstrap.py build \
+    --build-dir D:/develop/claude_workspace/build/therock-gfx1151 -j24
 ```
 
 For a clean rebuild of a component:
 ```bash
-python rock_dev_bootstrap.py rebuild --build-dir D:/develop/claude_workspace/build/therock-gfx1151 hipdnn
-```
-
-### Build artifacts location
-
-- **hipDNN binaries:** `build/therock-gfx1151/ml-libs/hipDNN/build/bin/`
-- **miopenprovider plugin:** `build/therock-gfx1151/ml-libs/miopenprovider/build/bin/hipdnn_plugins/engines/miopen_plugin.dll`
-- **hipDNN staged install:** `build/therock-gfx1151/ml-libs/hipDNN/stage/`
-- **miopenprovider staged install:** `build/therock-gfx1151/ml-libs/miopenprovider/stage/`
-
-### Running tests
-
-```bash
-# hipDNN unit tests
-build/therock-gfx1151/ml-libs/hipDNN/build/bin/hipdnn_backend_tests.exe
-
-# miopen-provider unit tests
-build/therock-gfx1151/ml-libs/miopenprovider/build/bin/miopen_plugin_tests.exe
-
-# Filter specific tests
-build/therock-gfx1151/ml-libs/hipDNN/build/bin/hipdnn_backend_tests.exe --gtest_filter="TestBackendDescriptor.*"
+python rock_dev_bootstrap.py rebuild \
+    --build-dir D:/develop/claude_workspace/build/therock-gfx1151 hipdnn
 ```

--- a/projects/hipdnn/scripts/windows/windows_build_setup.ps1
+++ b/projects/hipdnn/scripts/windows/windows_build_setup.ps1
@@ -63,51 +63,47 @@ Write-Host "===================================================`n" -ForegroundCo
 if (-not $SkipPrerequisites) {
     Write-Host "`n=== Section 1: Installing Prerequisites ===" -ForegroundColor Yellow
 
-    # Install Chocolatey if not present
-    if (-not (Get-Command choco -ErrorAction SilentlyContinue)) {
-        Write-Status "Installing Chocolatey..."
-        Set-ExecutionPolicy Bypass -Scope Process -Force
-        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
-        Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
-        Write-Success "Chocolatey installed"
-    } else {
-        Write-Success "Chocolatey already installed"
+    if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+        Write-Error "winget is required but not found."
+        Write-Host "Install 'App Installer' from the Microsoft Store or update Windows."
+        exit 1
     }
+    Write-Success "winget found"
 
-    # Refresh environment variables
-    $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+    $wingetArgs = @("--accept-package-agreements", "--accept-source-agreements")
 
-    # Install Visual Studio Build Tools
-    Write-Status "Installing Visual Studio 2022 Build Tools..."
-    $vsParams = "--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 "
-    $vsParams += "--add Microsoft.VisualStudio.Component.VC.CMake.Project "
-    $vsParams += "--add Microsoft.VisualStudio.Component.VC.ATL "
-    $vsParams += "--add Microsoft.VisualStudio.Component.Windows11SDK.22621 "
-    $vsParams += "--installPath `"$VsBuildToolsPath`""
-
-    choco install visualstudio2022buildtools -y --params "`"$vsParams`"" 2>&1 | Out-Null
-    if ($LASTEXITCODE -eq 0 -or $LASTEXITCODE -eq 3010) {
+    # Install Visual Studio Build Tools with Windows SDK
+    Write-Status "Installing Visual Studio 2022 Build Tools + Windows 11 SDK..."
+    $vsOverride = "--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 "
+    $vsOverride += "--add Microsoft.VisualStudio.Component.VC.CMake.Project "
+    $vsOverride += "--add Microsoft.VisualStudio.Component.VC.ATL "
+    $vsOverride += "--add Microsoft.VisualStudio.Component.Windows11SDK.22621 "
+    $vsOverride += "--installPath `"$VsBuildToolsPath`" --quiet --wait"
+    winget install --id Microsoft.VisualStudio.2022.BuildTools --source winget --override "$vsOverride" @wingetArgs
+    if ($LASTEXITCODE -eq 0) {
         Write-Success "Visual Studio Build Tools installed/updated"
+    } else {
+        Write-Warning "VS Build Tools install exited with code $LASTEXITCODE (may already be installed)"
     }
 
     # Install Git
     Write-Status "Installing Git..."
-    choco install git.install -y --params "'/GitAndUnixToolsOnPath'" 2>&1 | Out-Null
+    winget install --id Git.Git -e --source winget --custom "/o:PathOption=CmdTools" @wingetArgs
     Write-Success "Git installed/updated"
 
     # Install CMake
-    Write-Status "Installing CMake..."
-    choco install cmake --version=$CMAKE_VERSION -y 2>&1 | Out-Null
+    Write-Status "Installing CMake $CMAKE_VERSION..."
+    winget install --id Kitware.CMake -v $CMAKE_VERSION @wingetArgs
     Write-Success "CMake installed/updated"
 
     # Install Ninja
     Write-Status "Installing Ninja..."
-    choco install ninja -y 2>&1 | Out-Null
+    winget install --id ninja-build.ninja @wingetArgs
     Write-Success "Ninja installed/updated"
 
     # Install Python
     Write-Status "Installing Python..."
-    choco install python -y 2>&1 | Out-Null
+    winget install --id Python.Python.3.12 @wingetArgs
     Write-Success "Python installed/updated"
 
     # Refresh PATH


### PR DESCRIPTION
# Summary

  - Replace chocolatey with winget in `windows_build_setup.ps1` — choco silently failed to install the Windows SDK component, leaving
   `kernel32.lib`, `rc.exe`, and `mt.exe` missing
  - Add `_CLANG_BIN_DIR` constant to `rock_dev_bootstrap.py` for Windows tool discovery via `CMAKE_PROGRAM_PATH`
  - Always run `fetch_sources.py` during bootstrap instead of skipping when partial sources exist
  - Rewrite `rock_dev_bootstrap_guide.md`: remove 6 resolved issues, document the Windows SDK requirement, update Quick Start to use auto-detection