### PR TITLE
[miopen] Fix flaky GetitemBwd FP32 test caused by data race in CPU reference

### DIFF
--- a/projects/miopen/test/gtest/getitem.hpp
+++ b/projects/miopen/test/gtest/getitem.hpp
@@ -97,7 +97,9 @@ void cpu_getitem_backward(tensor<T> dy,
     }
 
     // GetItem
-    miopen::par_ford(dy_numel)([&](int32_t o) {
+    // Use serial ford (not par_ford) to avoid a data race: multiple threads can scatter
+    // into the same dx index, and the non-atomic += would produce incorrect reference values.
+    miopen::ford(dy_numel)([&](int32_t o) {
         tensor_layout_t<5> ncdhw(dy_tv, o);
         tensor_layout_t<5> idx(ncdhw);
 


### PR DESCRIPTION
  ## Motivation

Full/GPU_GetitemBwd_FP32.GetitemBwdTest/5 (the fasterrcnn config: dy=4260x4, index=4300, dx=4300x4) intermittently fails with:
Error dx beyond tolerance Error:0.0038722209782747845, Thresholdx10:0.0014999999999999998

The failure is non-deterministic — it depends on CPU thread scheduling — making it a classic flaky test.

  ## Technical Details

cpu_getitem_backward in test/gtest/getitem.hpp uses miopen::par_ford (parallel execution) for the scatter-add loop that accumulates dy values into ref_dx:

```
  miopen::par_ford(dy_numel)([&](int32_t o) {
      // ...
      ref_dx[ref_dx_tv.get_tensor_view_idx(idx)] += dy[...];  // DATA RACE
  });
```
The backward pass is a scatter-add: multiple dy elements map to the same dx index via the index tensor. With 4260 elements scattering into 4300 slots, index collisions are frequent. The non-atomic += means concurrent CPU threads silently lose updates, producing an incorrect ref_dx — and making the GPU result (which correctly uses atomicAdd) appear wrong by comparison.

The fix is to switch to serial miopen::ford. Since this is a reference implementation used only for verification, correctness is paramount and execution speed is not a concern. Serial execution is also faster than parallel atomics in this high-collision scatter pattern due to eliminated cache-line contention.

 ## Test Plan

  - Run Full/GPU_GetitemBwd_FP32.GetitemBwdTest/5 repeatedly to confirm it no longer
  produces intermittent failures.
  - Run the full GPU_GetitemBwd_FP32, GPU_GetitemBwd_FP16, and GPU_GetitemBwd_BFP16
  suites to confirm no regression in the other 5 test cases.

## Test Result

- The root cause (data race in CPU reference) is deterministically eliminated by removing the parallelism. No GPU kernel code was changed; only the correctness of the CPU reference is affected. No regressions expected in other test cases since the serial accumulation is functionally equivalent to the parallel one when there are no collisions.

- Ran the test 2000 times with the fix and was not able to reproduce the previously observed failure.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
