### PR TITLE
[hipDNN] Fix example plugin clang-tidy errors.

### DIFF
--- a/projects/hipdnn/samples/example_engine_plugin/tests/TestConvFwdPlanBuilder.cpp
+++ b/projects/hipdnn/samples/example_engine_plugin/tests/TestConvFwdPlanBuilder.cpp
@@ -20,7 +20,6 @@
 
 using namespace example_provider;
 using namespace example_provider::test_helpers;
-using hipdnn_flatbuffers_sdk::flatbuffer_utilities::EngineConfigWrapper;
 using hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper;
 using ::testing::_; // NOLINT(bugprone-reserved-identifier)
 using ::testing::Return;
@@ -42,7 +41,7 @@ protected:
 TEST_F(ConvFwdPlanBuilderTest, IsApplicable_SingleNodeConvFwd_ReturnsTrue)
 {
     auto fbb = createConvFwdGraph();
-    GraphWrapper graph(fbb.GetBufferPointer(), fbb.GetSize());
+    const GraphWrapper graph(fbb.GetBufferPointer(), fbb.GetSize());
     ASSERT_TRUE(graph.isValid());
     EXPECT_TRUE(_planBuilder->isApplicable(_handle, graph));
 }
@@ -50,7 +49,7 @@ TEST_F(ConvFwdPlanBuilderTest, IsApplicable_SingleNodeConvFwd_ReturnsTrue)
 TEST_F(ConvFwdPlanBuilderTest, IsApplicable_ReluFwdGraph_ReturnsFalse)
 {
     auto fbb = createReluFwdGraph();
-    GraphWrapper graph(fbb.GetBufferPointer(), fbb.GetSize());
+    const GraphWrapper graph(fbb.GetBufferPointer(), fbb.GetSize());
     ASSERT_TRUE(graph.isValid());
     EXPECT_FALSE(_planBuilder->isApplicable(_handle, graph));
 }
@@ -58,7 +57,7 @@ TEST_F(ConvFwdPlanBuilderTest, IsApplicable_ReluFwdGraph_ReturnsFalse)
 TEST_F(ConvFwdPlanBuilderTest, IsApplicable_NonReluPointwise_ReturnsFalse)
 {
     auto fbb = createNonReluPointwiseGraph();
-    GraphWrapper graph(fbb.GetBufferPointer(), fbb.GetSize());
+    const GraphWrapper graph(fbb.GetBufferPointer(), fbb.GetSize());
     ASSERT_TRUE(graph.isValid());
     EXPECT_FALSE(_planBuilder->isApplicable(_handle, graph));
 }
@@ -66,7 +65,7 @@ TEST_F(ConvFwdPlanBuilderTest, IsApplicable_NonReluPointwise_ReturnsFalse)
 TEST_F(ConvFwdPlanBuilderTest, IsApplicable_MultiNodeGraph_ReturnsFalse)
 {
     auto fbb = createMultiNodeConvGraph();
-    GraphWrapper graph(fbb.GetBufferPointer(), fbb.GetSize());
+    const GraphWrapper graph(fbb.GetBufferPointer(), fbb.GetSize());
     ASSERT_TRUE(graph.isValid());
     EXPECT_FALSE(_planBuilder->isApplicable(_handle, graph));
 }
@@ -76,7 +75,7 @@ TEST_F(ConvFwdPlanBuilderTest, IsApplicable_NonUnitDilation_ReturnsFalse)
     // Create a ConvFwd graph with dilation={2,2} on a large enough input (8x8)
     // so the output dimensions remain positive: outH = (8 - (2*(3-1)+1)) / 1 + 1 = 4
     auto fbb = createConvFwdGraph(1, 2, 3, 1, 1, 8, 8, 1, 3, 3, 0, 0, 1, 1, 2, 2);
-    GraphWrapper graph(fbb.GetBufferPointer(), fbb.GetSize());
+    const GraphWrapper graph(fbb.GetBufferPointer(), fbb.GetSize());
     ASSERT_TRUE(graph.isValid());
     EXPECT_FALSE(_planBuilder->isApplicable(_handle, graph));
 }
@@ -84,7 +83,7 @@ TEST_F(ConvFwdPlanBuilderTest, IsApplicable_NonUnitDilation_ReturnsFalse)
 TEST_F(ConvFwdPlanBuilderTest, GetMaxWorkspaceSize_ReturnsZero)
 {
     auto fbb = createConvFwdGraph();
-    GraphWrapper graph(fbb.GetBufferPointer(), fbb.GetSize());
+    const GraphWrapper graph(fbb.GetBufferPointer(), fbb.GetSize());
     const ExampleProviderSettings settings;
     EXPECT_EQ(_planBuilder->getMaxWorkspaceSize(_handle, graph, settings), 0u);
 }
@@ -92,7 +91,7 @@ TEST_F(ConvFwdPlanBuilderTest, GetMaxWorkspaceSize_ReturnsZero)
 TEST_F(ConvFwdPlanBuilderTest, GetCustomKnobs_ReturnsBlockSizeKnob)
 {
     auto fbb = createConvFwdGraph();
-    GraphWrapper graph(fbb.GetBufferPointer(), fbb.GetSize());
+    const GraphWrapper graph(fbb.GetBufferPointer(), fbb.GetSize());
     const auto knobs = _planBuilder->getCustomKnobs(_handle, graph);
     ASSERT_EQ(knobs.size(), 1u);
     EXPECT_EQ(knobs[0].knob_id, "BLOCK_SIZE");
@@ -101,7 +100,7 @@ TEST_F(ConvFwdPlanBuilderTest, GetCustomKnobs_ReturnsBlockSizeKnob)
 TEST_F(ConvFwdPlanBuilderTest, BuildPlan_SetsPlanOnContext)
 {
     auto graphFbb = createConvFwdGraph();
-    GraphWrapper graph(graphFbb.GetBufferPointer(), graphFbb.GetSize());
+    const GraphWrapper graph(graphFbb.GetBufferPointer(), graphFbb.GetSize());
     auto configFbb = createEngineConfig(0);
     const hipdnn_flatbuffers_sdk::flatbuffer_utilities::EngineConfigWrapper config(
         configFbb.GetBufferPointer(), configFbb.GetSize());

--- a/projects/hipdnn/samples/example_engine_plugin/tests/TestExampleProviderEngine.cpp
+++ b/projects/hipdnn/samples/example_engine_plugin/tests/TestExampleProviderEngine.cpp
@@ -82,8 +82,8 @@ TEST_F(ExampleProviderEngineTest, IsApplicable_WithMatchingBuilder_ReturnsTrue)
     engine.addPlanBuilder(std::make_unique<MockPlanBuilder>(true));
 
     auto fbb = createReluFwdGraph();
-    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(fbb.GetBufferPointer(),
-                                                                     fbb.GetSize());
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(fbb.GetBufferPointer(),
+                                                                           fbb.GetSize());
     ASSERT_TRUE(graph.isValid());
     EXPECT_TRUE(engine.isApplicable(_handle, graph));
 }
@@ -94,8 +94,8 @@ TEST_F(ExampleProviderEngineTest, IsApplicable_WithNoMatchingBuilder_ReturnsFals
     engine.addPlanBuilder(std::make_unique<MockPlanBuilder>(false));
 
     auto fbb = createReluFwdGraph();
-    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(fbb.GetBufferPointer(),
-                                                                     fbb.GetSize());
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(fbb.GetBufferPointer(),
+                                                                           fbb.GetSize());
     ASSERT_TRUE(graph.isValid());
     EXPECT_FALSE(engine.isApplicable(_handle, graph));
 }

--- a/projects/hipdnn/samples/example_engine_plugin/tests/TestReluPlanBuilder.cpp
+++ b/projects/hipdnn/samples/example_engine_plugin/tests/TestReluPlanBuilder.cpp
@@ -43,8 +43,8 @@ protected:
 TEST_F(ReluPlanBuilderTest, IsApplicable_SingleNodeReluFwd_ReturnsTrue)
 {
     auto fbb = createReluFwdGraph();
-    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(fbb.GetBufferPointer(),
-                                                                     fbb.GetSize());
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(fbb.GetBufferPointer(),
+                                                                           fbb.GetSize());
     ASSERT_TRUE(graph.isValid());
     EXPECT_TRUE(_planBuilder->isApplicable(_handle, graph));
 }
@@ -52,8 +52,8 @@ TEST_F(ReluPlanBuilderTest, IsApplicable_SingleNodeReluFwd_ReturnsTrue)
 TEST_F(ReluPlanBuilderTest, IsApplicable_NonReluPointwise_ReturnsFalse)
 {
     auto fbb = createNonReluPointwiseGraph();
-    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(fbb.GetBufferPointer(),
-                                                                     fbb.GetSize());
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(fbb.GetBufferPointer(),
+                                                                           fbb.GetSize());
     ASSERT_TRUE(graph.isValid());
     EXPECT_FALSE(_planBuilder->isApplicable(_handle, graph));
 }
@@ -61,8 +61,8 @@ TEST_F(ReluPlanBuilderTest, IsApplicable_NonReluPointwise_ReturnsFalse)
 TEST_F(ReluPlanBuilderTest, IsApplicable_MultiNodeGraph_ReturnsFalse)
 {
     auto fbb = createMultiNodeReluGraph();
-    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(fbb.GetBufferPointer(),
-                                                                     fbb.GetSize());
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(fbb.GetBufferPointer(),
+                                                                           fbb.GetSize());
     ASSERT_TRUE(graph.isValid());
     EXPECT_FALSE(_planBuilder->isApplicable(_handle, graph));
 }
@@ -70,8 +70,8 @@ TEST_F(ReluPlanBuilderTest, IsApplicable_MultiNodeGraph_ReturnsFalse)
 TEST_F(ReluPlanBuilderTest, IsApplicable_ConvFwdGraph_ReturnsFalse)
 {
     auto fbb = createConvFwdGraph();
-    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(fbb.GetBufferPointer(),
-                                                                     fbb.GetSize());
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(fbb.GetBufferPointer(),
+                                                                           fbb.GetSize());
     ASSERT_TRUE(graph.isValid());
     EXPECT_FALSE(_planBuilder->isApplicable(_handle, graph));
 }
@@ -79,8 +79,8 @@ TEST_F(ReluPlanBuilderTest, IsApplicable_ConvFwdGraph_ReturnsFalse)
 TEST_F(ReluPlanBuilderTest, GetMaxWorkspaceSize_ReturnsZero)
 {
     auto fbb = createReluFwdGraph();
-    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(fbb.GetBufferPointer(),
-                                                                     fbb.GetSize());
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(fbb.GetBufferPointer(),
+                                                                           fbb.GetSize());
     const ExampleProviderSettings settings;
     EXPECT_EQ(_planBuilder->getMaxWorkspaceSize(_handle, graph, settings), 0u);
 }
@@ -88,8 +88,8 @@ TEST_F(ReluPlanBuilderTest, GetMaxWorkspaceSize_ReturnsZero)
 TEST_F(ReluPlanBuilderTest, GetCustomKnobs_ReturnsNegativeSlopeKnob)
 {
     auto fbb = createReluFwdGraph();
-    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(fbb.GetBufferPointer(),
-                                                                     fbb.GetSize());
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(fbb.GetBufferPointer(),
+                                                                           fbb.GetSize());
     const auto knobs = _planBuilder->getCustomKnobs(_handle, graph);
     ASSERT_EQ(knobs.size(), 1u);
     EXPECT_EQ(knobs[0].knob_id, "example.relu.negative_slope");
@@ -98,8 +98,8 @@ TEST_F(ReluPlanBuilderTest, GetCustomKnobs_ReturnsNegativeSlopeKnob)
 TEST_F(ReluPlanBuilderTest, InitializeExecutionSettings_NegativeSlopeKnob_StoresInSettings)
 {
     auto graphFbb = createReluFwdGraph();
-    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(graphFbb.GetBufferPointer(),
-                                                                     graphFbb.GetSize());
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(
+        graphFbb.GetBufferPointer(), graphFbb.GetSize());
 
     auto configFbb = createEngineConfigWithFloatKnob(0, "example.relu.negative_slope", 0.5);
     const hipdnn_flatbuffers_sdk::flatbuffer_utilities::EngineConfigWrapper config(
@@ -114,8 +114,8 @@ TEST_F(ReluPlanBuilderTest, InitializeExecutionSettings_NegativeSlopeKnob_Stores
 TEST_F(ReluPlanBuilderTest, BuildPlan_SetsPlanOnContext)
 {
     auto graphFbb = createReluFwdGraph({1, 1, 4});
-    hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(graphFbb.GetBufferPointer(),
-                                                                     graphFbb.GetSize());
+    const hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper graph(
+        graphFbb.GetBufferPointer(), graphFbb.GetSize());
 
     auto configFbb = createEngineConfig(0);
     const hipdnn_flatbuffers_sdk::flatbuffer_utilities::EngineConfigWrapper config(


### PR DESCRIPTION
## Motivation

Following from https://github.com/ROCm/rocm-libraries/pull/6561; some additional clang-tidy fixes for the hipdnn example engine plugin.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
