### PR TITLE
[hipBLAS] version changelog updates

### DIFF
--- a/projects/hipblas/CHANGELOG.md
+++ b/projects/hipblas/CHANGELOG.md
@@ -3,6 +3,18 @@
 Documentation for hipBLAS is available at
 [https://rocm.docs.amd.com/projects/hipBLAS/en/latest/](https://rocm.docs.amd.com/projects/hipBLAS/en/latest/).
 
+## hipBLAS 3.4.0 
+ 
+### Added
+
+* gfx90c support to clients.
+* version and other properties to Windows `hipblas.dll`
+* support for `OpenBLAS` ILP64 based API usage in clients
+
+### Resolved issue
+
+* Restored fallback of using deprecated rocBLAS API `rocblas_set_device_memory_size` if allocations failing
+
 ## hipBLAS 3.3.0
 
 ### Added

--- a/projects/hipblas/CHANGELOG.md
+++ b/projects/hipblas/CHANGELOG.md
@@ -13,7 +13,7 @@ Documentation for hipBLAS is available at
 
 ### Resolved issue
 
-* Restored fallback of using deprecated rocBLAS API `rocblas_set_device_memory_size` if allocations failing
+* Restored fallback of using the deprecated rocBLAS API `rocblas_set_device_memory_size` if allocations are failing.
 
 ## hipBLAS 3.3.0
 

--- a/projects/hipblas/CHANGELOG.md
+++ b/projects/hipblas/CHANGELOG.md
@@ -8,8 +8,8 @@ Documentation for hipBLAS is available at
 ### Added
 
 * gfx90c support to clients.
-* version and other properties to Windows `hipblas.dll`
-* support for `OpenBLAS` ILP64 based API usage in clients
+* Version and other properties to Windows `hipblas.dll`.
+* Support for `OpenBLAS` ILP64-based API usage in clients.
 
 ### Resolved issue
 


### PR DESCRIPTION
This pull request updates the `CHANGELOG.md` file for `hipBLAS` to document the changes introduced in version 3.4.0. The update highlights new feature additions, improvements for Windows, expanded API support, and a resolved issue regarding device memory allocation.

Most important changes:

**Feature Additions:**
* Added support for `gfx90c` architecture in the hipBLAS clients.
* Included version and other property information in the Windows `hipblas.dll`.
* Enabled support for using the `OpenBLAS` ILP64-based API in clients.

**Bug Fixes / Resolved Issues:**
* Restored fallback to the deprecated rocBLAS API `rocblas_set_device_memory_size` when allocations fail, improving robustness.
