### PR TITLE
[rocBLAS] Update test_categories.yaml for full runs

### DIFF
--- a/projects/rocblas/clients/gtest/test_categories.yaml
+++ b/projects/rocblas/clients/gtest/test_categories.yaml
@@ -38,8 +38,11 @@ test_categories:
   full:
     description: "Stress / weekly - same as Jenkins weekly (stress + HMM)"
     test_patterns:
-      - "*stress*"
-      - "*HMM*"
+    #  - "*stress*"
+    #  - "*HMM*"
+    # current CI use case currently does not match stress use case
+      - "*pre_checkin*"
+      - "*nightly*"
     exclude:
       - "*known_bug*"
     labels:


### PR DESCRIPTION
This pull request updates the `test_categories.yaml` configuration to better align the `full` test category with the current CI use cases. The main change is to adjust the test patterns for the `full` category so they match the purpose of CI runner.

Test pattern updates:

* Updated the `full` category in `test_categories.yaml` to comment out the previous `*stress*` and `*HMM*` patterns and add `*pre_checkin*` and `*nightly*` patterns instead, ensuring the test selection matches the current CI use case.