### PR TITLE
[hipDNN] Enable HIPDNN_ENABLE_SDPA in TheRock CI matrix

### DIFF
--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -63,6 +63,7 @@ project_map = {
         "cmake_options": [
             "-DTHEROCK_ENABLE_HIPKERNELPROVIDER=ON",
             "-DHIP_KERNEL_PROVIDER_ENABLE=ON",
+            "-DHIPDNN_ENABLE_SDPA=ON",
         ],
         "projects_to_test": ["hipkernelprovider"],
     },
@@ -95,6 +96,7 @@ additional_options = {
             "-DHIP_KERNEL_PROVIDER_ENABLE=ON",
             "-DTHEROCK_ENABLE_MIOPENPROVIDER=ON",
             "-DTHEROCK_ENABLE_HIPDNN_SAMPLES=ON",
+            "-DHIPDNN_ENABLE_SDPA=ON",
             "-DTHEROCK_ENABLE_COMPOSABLE_KERNEL=ON",
         ],
         "projects_to_test": [


### PR DESCRIPTION
## Summary

- Adds `-DHIPDNN_ENABLE_SDPA=ON` to the `hipdnn` omnibus entry in `.github/scripts/therock_matrix.py`, so the TheRock-driven hipDNN job (which builds hipDNN + miopen-provider + hipblaslt-provider + hip-kernel-provider together) exercises the SDPA frontend API and gtests.
- Adds `-DHIPDNN_ENABLE_SDPA=ON` to the standalone `hip-kernel-provider` entry, so the standalone provider job (triggered by changes confined to `dnn-providers/hip-kernel-provider/`) builds the ASM SDPA engine and its tests (gated on `HIPDNN_ENABLE_SDPA` via the exported `hipdnn_frontendConfig.cmake`).
- The CMake option default in `projects/hipdnn/CMakeLists.txt` stays `OFF`. This PR is opt-in via the CI matrix only; downstream consumers outside CI are unaffected.

Follows the matrix-flag pattern from #6649. SDPA frontend gating mechanism was added in #6647.

Providers like fusilli that have SDPA-conditional code but no current matrix entry are intentionally untouched here; they will pick up the flag automatically once they're wired into the matrix.

## Test plan

- [ ] TheRock-driven hipDNN job builds with SDPA on; SDPA-gated gtests in `projects/hipdnn/frontend/tests/TestGraph.cpp` (`SdpaFwdNodeCreation`, `SdpaFwdNodeCreationWithStats`) execute and pass.
- [ ] hip-kernel-provider standalone job builds with SDPA on; the `engines/asm_sdpa_engine` test target builds without the `HIPDNN_ENABLE_SDPA=OFF` FATAL_ERROR.
- [ ] No regressions in miopen-provider / hipblaslt-provider standalone jobs (no SDPA-conditional code paths there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)