### PR TITLE
[hipDNN] Add DVC to Docker image

### DIFF
--- a/projects/hipdnn/dockerfiles/Dockerfile.ubuntu24
+++ b/projects/hipdnn/dockerfiles/Dockerfile.ubuntu24
@@ -42,6 +42,15 @@ RUN apt-get update && apt-get install -y \
     gh \
     && rm -rf /var/lib/apt/lists/*
 
+# Install DVC
+RUN mkdir -p /etc/apt/keyrings && \
+    wget -qO - https://dvc.org/deb/iterative.asc | sudo gpg --dearmor -o /etc/apt/keyrings/packages.iterative.gpg && \
+    echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/packages.iterative.gpg] https://dvc.org/deb/ stable main" | sudo tee /etc/apt/sources.list.d/dvc.list && \
+    chmod 644 /etc/apt/keyrings/packages.iterative.gpg /etc/apt/sources.list.d/dvc.list && \
+    apt-get update && apt-get install -y dvc && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* 
+
 # ============================================================================
 # Prebuilt stage - downloads and extracts dev env prebuilt binaries tarball
 #

--- a/projects/hipdnn/dockerfiles/Dockerfile.ubuntu24
+++ b/projects/hipdnn/dockerfiles/Dockerfile.ubuntu24
@@ -42,15 +42,6 @@ RUN apt-get update && apt-get install -y \
     gh \
     && rm -rf /var/lib/apt/lists/*
 
-# Install DVC
-RUN mkdir -p /etc/apt/keyrings && \
-    wget -qO - https://dvc.org/deb/iterative.asc | sudo gpg --dearmor -o /etc/apt/keyrings/packages.iterative.gpg && \
-    echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/packages.iterative.gpg] https://dvc.org/deb/ stable main" | sudo tee /etc/apt/sources.list.d/dvc.list && \
-    chmod 644 /etc/apt/keyrings/packages.iterative.gpg /etc/apt/sources.list.d/dvc.list && \
-    apt-get update && apt-get install -y dvc && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* 
-
 # ============================================================================
 # Prebuilt stage - downloads and extracts dev env prebuilt binaries tarball
 #
@@ -280,6 +271,16 @@ RUN apt-get update && apt-get install -y \
     doxygen \
     llvm-20 \
     && rm -rf /var/lib/apt/lists/*
+
+
+# Install DVC
+RUN mkdir -p /etc/apt/keyrings && \
+    wget -qO - https://dvc.org/deb/iterative.asc | gpg --dearmor -o /etc/apt/keyrings/packages.iterative.gpg && \
+    echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/packages.iterative.gpg] https://dvc.org/deb/ stable main" | tee /etc/apt/sources.list.d/dvc.list && \
+    chmod 644 /etc/apt/keyrings/packages.iterative.gpg /etc/apt/sources.list.d/dvc.list && \
+    apt-get update && apt-get install -y dvc && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* 
 
 # Install flatc version 25.9.23
 RUN wget -q https://github.com/google/flatbuffers/releases/download/v25.9.23/Linux.flatc.binary.g++-13.zip -O /tmp/flatc.zip \

--- a/projects/hipdnn/dockerfiles/Dockerfile.ubuntu24
+++ b/projects/hipdnn/dockerfiles/Dockerfile.ubuntu24
@@ -280,7 +280,7 @@ RUN mkdir -p /etc/apt/keyrings && \
     chmod 644 /etc/apt/keyrings/packages.iterative.gpg /etc/apt/sources.list.d/dvc.list && \
     apt-get update && apt-get install -y dvc && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/* 
+    rm -rf /var/lib/apt/lists/*
 
 # Install flatc version 25.9.23
 RUN wget -q https://github.com/google/flatbuffers/releases/download/v25.9.23/Linux.flatc.binary.g++-13.zip -O /tmp/flatc.zip \


### PR DESCRIPTION
## Summary
- Installs DVC (Data Version Control) in `Dockerfile.ubuntu24` via the official iterative.ai apt repository
- Uses signed apt key and stable channel for reproducible installs
- Cleans up apt lists after install to keep image size minimal

## Test plan
- [x] Build the Docker image and verify `dvc --version` succeeds
- [x] Confirm apt lists are cleaned up (no leftover `/var/lib/apt/lists/*`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)