### PR TITLE
[hipDNN] Fix ADD_SQUARE pointwise mode doc comment

### DIFF
--- a/projects/hipdnn/backend/include/HipdnnPointwiseMode.h
+++ b/projects/hipdnn/backend/include/HipdnnPointwiseMode.h
@@ -26,7 +26,7 @@ typedef enum
 {
     HIPDNN_POINTWISE_ABS = 1, ///< Absolute value: |x|
     HIPDNN_POINTWISE_ADD = 2, ///< Addition: x + y
-    HIPDNN_POINTWISE_ADD_SQUARE = 3, ///< Add and square: (x + y)^2
+    HIPDNN_POINTWISE_ADD_SQUARE = 3, ///< Add and square: x + y^2
     HIPDNN_POINTWISE_BINARY_SELECT = 4, ///< Ternary select based on condition
     HIPDNN_POINTWISE_CEIL = 5, ///< Ceiling function
     HIPDNN_POINTWISE_CMP_EQ = 6, ///< Compare equal: x == y

--- a/projects/hipdnn/backend/include/HipdnnPointwiseMode.h
+++ b/projects/hipdnn/backend/include/HipdnnPointwiseMode.h
@@ -26,7 +26,7 @@ typedef enum
 {
     HIPDNN_POINTWISE_ABS = 1, ///< Absolute value: |x|
     HIPDNN_POINTWISE_ADD = 2, ///< Addition: x + y
-    HIPDNN_POINTWISE_ADD_SQUARE = 3, ///< Add and square: x + y^2
+    HIPDNN_POINTWISE_ADD_SQUARE = 3, ///< Add x to y squared: x + y^2
     HIPDNN_POINTWISE_BINARY_SELECT = 4, ///< Ternary select based on condition
     HIPDNN_POINTWISE_CEIL = 5, ///< Ceiling function
     HIPDNN_POINTWISE_CMP_EQ = 6, ///< Compare equal: x == y

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
@@ -78,7 +78,7 @@ enum class PointwiseMode
     NOT_SET = 0, ///< Mode not specified
     ABS = 1, ///< Absolute value: |x|
     ADD = 2, ///< Addition: x + y
-    ADD_SQUARE = 3, ///< Add and square: x + y²
+    ADD_SQUARE = 3, ///< Add x to y squared: x + y²
     BINARY_SELECT = 4, ///< Ternary select based on condition
     CEIL = 5, ///< Ceiling function
     CMP_EQ = 6, ///< Compare equal: x == y

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
@@ -78,7 +78,7 @@ enum class PointwiseMode
     NOT_SET = 0, ///< Mode not specified
     ABS = 1, ///< Absolute value: |x|
     ADD = 2, ///< Addition: x + y
-    ADD_SQUARE = 3, ///< Add and square: (x + y)²
+    ADD_SQUARE = 3, ///< Add and square: x + y²
     BINARY_SELECT = 4, ///< Ternary select based on condition
     CEIL = 5, ///< Ceiling function
     CMP_EQ = 6, ///< Compare equal: x == y

--- a/projects/hipdnn/tools/DescriptorGenerator/configs/pointwise.yaml
+++ b/projects/hipdnn/tools/DescriptorGenerator/configs/pointwise.yaml
@@ -105,7 +105,7 @@ operation:
           - { name: "NOT_SET", value: 0, sentinel: true }
           - { name: "ABS", value: 1, description: "Absolute value: |x|" }
           - { name: "ADD", value: 2, description: "Addition: x + y" }
-          - { name: "ADD_SQUARE", value: 3, description: "Add and square: x + y^2" }
+          - { name: "ADD_SQUARE", value: 3, description: "Add x to y squared: x + y^2" }
           - { name: "BINARY_SELECT", value: 4, description: "Ternary select based on condition" }
           - { name: "CEIL", value: 5, description: "Ceiling function" }
           - { name: "CMP_EQ", value: 6, description: "Compare equal: x == y" }

--- a/projects/hipdnn/tools/DescriptorGenerator/configs/pointwise.yaml
+++ b/projects/hipdnn/tools/DescriptorGenerator/configs/pointwise.yaml
@@ -105,7 +105,7 @@ operation:
           - { name: "NOT_SET", value: 0, sentinel: true }
           - { name: "ABS", value: 1, description: "Absolute value: |x|" }
           - { name: "ADD", value: 2, description: "Addition: x + y" }
-          - { name: "ADD_SQUARE", value: 3, description: "Add and square: (x + y)^2" }
+          - { name: "ADD_SQUARE", value: 3, description: "Add and square: x + y^2" }
           - { name: "BINARY_SELECT", value: 4, description: "Ternary select based on condition" }
           - { name: "CEIL", value: 5, description: "Ceiling function" }
           - { name: "CMP_EQ", value: 6, description: "Compare equal: x == y" }


### PR DESCRIPTION
## Summary

- Fixes the doc comment for `HIPDNN_POINTWISE_ADD_SQUARE` / `PointwiseMode::ADD_SQUARE`. 
- Updated in three places: backend C-API header (`HipdnnPointwiseMode.h`), frontend enum (`Types.hpp`), and the DescriptorGenerator YAML config (`pointwise.yaml`).

Fixes #6753.

## Test plan

- [x] `pre-commit` clean
- Doc-only change; no functional impact. `ADD_SQUARE` has no reference implementation or numerical test today (the `ReferencePointwiseBase::executeBinaryOperation()` switch throws `Unsupported binary pointwise operation` for it), so no test updates needed. Wiring up the ref impl + a numerical test is tracked as a follow-up in #6753.