### PR TITLE
[Tensilelite] Fix latency hazard in SPMM SIA3 pack scheduler

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
@@ -2218,17 +2218,30 @@ class KernelWriter(metaclass=abc.ABCMeta):
               # when the number of inserted packs is >= the number of desired packs
               # check the last 2 inserted packs to see if we need to add extra instructions after the last inersted pack.
               remainLatency = len(instPackLast)
+              # Per-type pop counters: track how many packs of each type have been
+              # popped (= how many extras of that type have already been accounted for).
+              popCountA = popCountB = popCountM = 0
               while len(instPackLast):
                 instLast = instPackLast.pop()
+                # extraPackX <= popCountX means we've run out of the extras of type X
+                # and the current pack produces a register for the coming SMFMAC instruction.
+                # Hence, we need to insert an extra pack or s_nop between
+                # the current pack instruction and the coming SMFMAC instruction.
                 if instLast == "A":
-                  if numPackedA <= packAIdx:
+                  extraPackA = numPackedA - packAIdx
+                  if extraPackA <= popCountA:
                     break
+                  popCountA += 1
                 elif instLast == "M":
-                  if numPackedM <= packMIdx:
+                  extraPackM = numPackedM - packMIdx
+                  if extraPackM <= popCountM:
                     break
+                  popCountM += 1
                 elif instLast == "B":
-                  if numPackedB <= packBIdx:
+                  extraPackB = numPackedB - packBIdx
+                  if extraPackB <= popCountB:
                     break
+                  popCountB += 1
                 remainLatency -= 1
             instPackLast.clear()
 

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx94x/spmm_bf16_sb.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx94x/spmm_bf16_sb.yaml
@@ -83,3 +83,141 @@ BenchmarkProblems:
         - FactorDimArgs: [0,1]
         - ActivationArgs:
           - [Enum: none]
+
+  #######################################
+  # Test TransposeLDSMetadata=0
+  #######################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: B
+      DestDataType: B
+      ComputeDataType: S
+      HighPrecisionAccumulate: true
+      TransposeA: True
+      TransposeB: True
+      UseBeta: True
+      UseBias: 0
+      UseScaleAlphaVec: 0
+      Batched: True
+      Activation: True
+      ActivationType: all
+      Sparse: 2
+      SupportUserArgs: False
+      MetadataLayout: 0
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        #- EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 32, 1,  1,  9, 6,  2, 2 ]
+          - [16, 16, 32, 1,  1,  9, 4,  2, 2 ]
+        - 1LDSBuffer: [1]
+        - DepthU: [64]
+        - GlobalReadVectorWidthA: [8]
+        - GlobalReadVectorWidthB: [8]
+        - VectorWidthA: [1]
+        - VectorWidthB: [2]
+        - WaveSeparateGlobalReadA: [0]
+        - WaveSeparateGlobalReadB: [0]
+        - UnrollLoopSwapGlobalReadOrder: [0]
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - SourceSwap: [1]
+        - NonTemporalD: [4]
+        - StaggerU: [16]
+        - NumElementsPerBatchStore: [-1]
+        - WorkGroupMapping: [8]
+        - WorkGroupMappingXCC: [8]
+        - GlobalSplitU: [-1]
+        - GlobalSplitUAlgorithm: [MultipleBuffer]
+        - GlobalSplitUCoalesced: [true]
+        - GlobalSplitUWorkGroupMappingRoundRobin: [true]
+        - TransposeLDSMetadata: [0]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [16, 96, 1, 32] # classic format
+          - Exact: [16, 96, 1, 64] # classic format
+          - Exact: [16, 96, 1, 128] # classic format
+          - Exact: [16, 96, 1, 192] # classic format
+          - Exact: [16, 96, 1, 256] # classic format
+          - Exact: [16, 96, 1, 320] # classic format
+          - Exact: [16, 96, 1, 384] # classic format
+        - BiasTypeArgs: ["s"]
+        - FactorDimArgs: [1]
+        - ActivationArgs:
+          - [Enum: none]
+
+ #######################################
+  # Test TransposeLDSMetadata=0
+  #######################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: B
+      DestDataType: B
+      ComputeDataType: S
+      HighPrecisionAccumulate: true
+      TransposeA: True
+      TransposeB: True
+      UseBeta: True
+      UseBias: 0
+      UseScaleAlphaVec: 0
+      Batched: True
+      Activation: True
+      ActivationType: all
+      Sparse: 2
+      SupportUserArgs: False
+      MetadataLayout: 1
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        #- EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 32, 1,  1,  9, 6,  2, 2 ]
+          - [16, 16, 32, 1,  1,  9, 4,  2, 2 ]
+        - 1LDSBuffer: [1]
+        - DepthU: [64]
+        - GlobalReadVectorWidthA: [8]
+        - GlobalReadVectorWidthB: [8]
+        - VectorWidthA: [1]
+        - VectorWidthB: [2]
+        - WaveSeparateGlobalReadA: [0]
+        - WaveSeparateGlobalReadB: [0]
+        - UnrollLoopSwapGlobalReadOrder: [0]
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - SourceSwap: [1]
+        - NonTemporalD: [4]
+        - StaggerU: [16]
+        - NumElementsPerBatchStore: [-1]
+        - WorkGroupMapping: [8]
+        - WorkGroupMappingXCC: [8]
+        - GlobalSplitU: [-1]
+        - GlobalSplitUAlgorithm: [MultipleBuffer]
+        - GlobalSplitUCoalesced: [true]
+        - GlobalSplitUWorkGroupMappingRoundRobin: [true]
+        - TransposeLDSMetadata: [0]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [16, 96, 1, 32] # classic format
+          - Exact: [16, 96, 1, 64] # classic format
+          - Exact: [16, 96, 1, 128] # classic format
+          - Exact: [16, 96, 1, 192] # classic format
+          - Exact: [16, 96, 1, 256] # classic format
+          - Exact: [16, 96, 1, 320] # classic format
+          - Exact: [16, 96, 1, 384] # classic format
+        - BiasTypeArgs: ["s"]
+        - FactorDimArgs: [1]
+        - ActivationArgs:
+          - [Enum: none]


### PR DESCRIPTION
## Motivation

In sparse SMFMAC kernels using SIA3 scheduling with `TransposeLDSMetadata=0`,
when two consecutive extra B pack instructions appear immediately before a
`v_smfmac`, the pack scheduler incorrectly computed `remainLatency=0` and
inserted no gap instruction. This left only 1 instruction between the
`v_perm_b32` that produces a B input register and the `v_smfmac` that reads it,
violating the 2-instruction VALU-to-SMFMAC latency requirement on GFX942 and
producing incorrect results for sparse BF16 kernels when `K = 2×DepthU`
(LoopCounterL=2 bypass path).

## Technical Details

The root cause was in `KernelWriter.py`: the `elif curPackIdx >= numPack` branch
used a shared `(instPackLastLen - remainLatency)` as the pop index across all
pack types. For `instPackLast=['B','B']` where both B packs have
`numPackedB > packBIdx`, the original code decremented `remainLatency` twice to
0, inserting no gap instruction.

The fix replaces the shared index with per-type counters
(`popCountA`, `popCountB`, `popCountM`). The break condition
`extraPackX <= popCountX` correctly identifies when the first required pack of
each type is reached, independently of other types.

The table below shows `remainLatency` (= number of gap instructions to insert)
before and after the fix:

| `instPackLast` | `extraPackB` | `extraPackA` | Before | After |        |
|----------------|:------------:|:------------:|:------:|:-----:|--------|
| `['B','B']`    | 0 (required) | —            | 2      | 2     | ✓      |
| `['B','B']`    | 1 (1 extra)  | —            | **0**  | **1** | Fixed  |
| `['B','B']`    | 2 (all extra)| —            | 0      | 0     | ✓      |
| `['A','B']`    | 1            | 0 (required) | 1      | 1     | ✓      |
| `['A','B']`    | 1            | 1 (extra)    | 0      | 0     | ✓      |
| `['A','B']`    | 1            | 2 (all extra)| 0      | 0     | ✓      |

The critical bug row is `['B','B']` with `extraPackB=1`: one B perm produces a
register for the **current** SMFMAC (required) and one is pre-inserted for a
**future** SMFMAC (extra). The old code saw `numPackedB > packBIdx` for both
pops and decremented to 0. The new code correctly stops at the required pack and
keeps `remainLatency=1`, which triggers insertion of the next pending
`v_perm_b32` (e.g. `v[+7]`) before the SMFMAC, satisfying the 2-instruction gap.

## Test Plan

Added two new test groups to `spmm_bf16_sb.yaml` targeting
`TransposeLDSMetadata=0` with `MetadataLayout=[0,1]`, covering problem sizes
`K=32,64,128,192,256,320,384` with `DepthU=64`. The critical case is `K=128`
(=2×DepthU).

## Test Result

All added test cases pass with correct numerical results, including the
previously failing `K=128` case.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

## Related JIRA Ticket
https://amd-hub.atlassian.net/browse/AIHPBLAS-1993