### PR TITLE
[rocPRIM] Fix broken links to examples

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/device/device_merge_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_merge_sort.hpp
@@ -913,7 +913,7 @@ inline hipError_t merge_sort_impl(
 /// In this example a device-level ascending merge sort is performed on an array of
 /// \p float values.
 ///
-/// The full example is [on GitHub](https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocprim/example/rocprim/device/example_merge_sort.cpp).
+/// The full example is [on GitHub](https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocprim/example/rocprim/device/example_device_merge_sort.cpp).
 ///
 /// \code{.cpp}
 /// #include <rocprim/rocprim.hpp>

--- a/projects/rocprim/rocprim/include/rocprim/device/device_transform.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_transform.hpp
@@ -162,7 +162,7 @@ inline hipError_t transform_impl(InputIterator     input,
 /// In this example a device-level transform operation is performed on an array of
 /// integer values (<tt>short</tt>s are transformed into <tt>int</tt>s).
 ///
-/// The full example is [on GitHub](https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocprim/example/rocprim/device/example_device_search.cpp).
+/// The full example is [on GitHub](https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocprim/example/rocprim/device/example_device_transform.cpp).
 ///
 /// \code{.cpp}
 /// #include <rocprim/rocprim.hpp>


### PR DESCRIPTION
## Motivation

A few links to the examples are wrong.

## Technical Details

Fix the URLs to point to the correct location.

## Test Plan

Tried the links.  

## Test Result

They work.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
