### PR TITLE
[rocblas] Docs: Add brief explanation for rocBLAS Dockerfiles

### DIFF
--- a/projects/rocblas/docs/install/Linux_Install_Guide.rst
+++ b/projects/rocblas/docs/install/Linux_Install_Guide.rst
@@ -299,3 +299,22 @@ one of these commands.
 
    "``./install.sh --clients-only``", "Build the rocBLAS clients and use the installed rocBLAS library at ``ROCM_PATH`` (defaults to ``/opt/rocm`` if not specified)."
    "``./install.sh --clients-only --library-path /path/to/rocBLAS``", "Build the rocBLAS clients and use the rocBLAS library at the specified location."
+
+Using the rocBLAS Docker images
+------------------------------------------
+
+The rocBLAS Docker images provide a reproducible, ready-to-use development environment to simplify
+the set-up process. The Dockerfiles install all system dependencies, such as Clang, LLVM,
+zstd, and the development libraries, schedule update alternatives, and configure the environment.
+Two Dockerfiles are available for Ubuntu 24.04:
+
+*  ``Dockerfile.ubuntu24.prebuilt``: Downloads a prebuilt ROCm nightly tarball from the `ROCm nightly builds <https://rocm.nightlies.amd.com>`_.
+   This solution is faster to build and suitable for most development work. It lets you configure the target ASIC,
+   nightly tag, tarball filename, and tarball source URL.
+*  ``Dockerfile.ubuntu24.fullbuild``: Clones `<https://github.com/ROCm/TheRock>`_ and builds ROCm from source.
+   It's the best choice for when a prebuilt tarball is unavailable or custom build options are required.
+   The configuration options include the target ASIC, specific commit hash, build type (release, debug, or preset), CMake presets,
+   and parallel job count.
+   
+For more information on how to download and use these images, see the
+`rocBLAS Docker documentation <https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocblas/docker/README.md>`_.


### PR DESCRIPTION
This pull request adds documentation to the Linux installation guide for rocBLAS, introducing guidance on using Docker images to simplify the development environment setup. The most important change is the addition of a new section describing the available Docker images and their use cases.

**New Docker-based installation instructions:**

* Added a section titled "Using the rocBLAS Docker images" to the `Linux_Install_Guide.rst`, explaining the benefits of Docker for reproducible and ready-to-use development environments.
* Provided details for two Dockerfiles (`Dockerfile.ubuntu24.prebuilt` and `Dockerfile.ubuntu24.fullbuild`), including their purposes, configuration options, and when to use each.
* Linked to the official rocBLAS Docker documentation for further instructions on downloading and using the images.
