### PR TITLE
[MIOpen] -Wsign-compare warning enable

### DIFF
--- a/projects/miopen/cmake/EnableCompilerWarnings.cmake
+++ b/projects/miopen/cmake/EnableCompilerWarnings.cmake
@@ -39,7 +39,6 @@ set(__default_cxx_compile_options
     -Wuninitialized
     -Wunreachable-code
     -Wno-ignored-qualifiers
-    -Wno-sign-compare
 )
 
 set(__clang_cxx_compile_options


### PR DESCRIPTION
## Motivation

This PR is meant to enable back `-Wsign-compare` after merging those PRs:
https://github.com/ROCm/rocm-libraries/pull/6777
https://github.com/ROCm/rocm-libraries/pull/6778
https://github.com/ROCm/rocm-libraries/pull/6780
https://github.com/ROCm/rocm-libraries/pull/6781
https://github.com/ROCm/rocm-libraries/pull/6783
https://github.com/ROCm/rocm-libraries/pull/6784
https://github.com/ROCm/rocm-libraries/pull/6785
https://github.com/ROCm/rocm-libraries/pull/6786

Until all of those are merged, this PR's check will stay red and it shouldn't be merged.

## Technical Details

Everything is done in the mentioned PRs

## Test Plan

Once the checks are green, it's ready to be merged

## Test Result

Clean build without warnings

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
