### PR TITLE
[CK] Fix zero k_batch_ in WMMA kernels

### DIFF
--- a/projects/composablekernel/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_multiple_d_wmma_cshuffle_v3.hpp
+++ b/projects/composablekernel/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_multiple_d_wmma_cshuffle_v3.hpp
@@ -653,7 +653,7 @@ struct DeviceGroupedConvBwdWeightMultipleD_Wmma_CShuffleV3
                 // Ensure that k_batch_ does not exceed the maximum value
                 // for the GEMM pipeline.
                 const auto k_batch_max = math::integer_divide_ceil(gemmK, KPerBlock);
-                k_batch_               = std::min(k_batch_, k_batch_max);
+                k_batch_               = max(std::min(k_batch_, k_batch_max), 1);
 
                 // Cap k_batch_ to 128 to avoid accuracy issues
                 k_batch_ = std::min(k_batch_, 128);

--- a/projects/composablekernel/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_two_stage_wmma_cshuffle_v3.hpp
+++ b/projects/composablekernel/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_two_stage_wmma_cshuffle_v3.hpp
@@ -597,7 +597,7 @@ struct DeviceGroupedConvBwdWeightTwoStage_Wmma_CShuffleV3
                 // Ensure that k_batch_ does not exceed the maximum value
                 // for the GEMM pipeline.
                 const auto k_batch_max = math::integer_divide_ceil(gemmK, KPerBlock);
-                k_batch_               = std::min(k_batch_, k_batch_max);
+                k_batch_               = max(std::min(k_batch_, k_batch_max), 1);
 
                 if(ck::EnvIsEnabled(CK_ENV(CK_LOGGING)))
                 {

--- a/projects/composablekernel/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_wmma_cshuffle_v3.hpp
+++ b/projects/composablekernel/include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_bwd_weight_wmma_cshuffle_v3.hpp
@@ -538,7 +538,7 @@ struct DeviceGroupedConvBwdWeight_Wmma_CShuffleV3
                 // Ensure that k_batch_ does not exceed the maximum value
                 // for the GEMM pipeline.
                 const auto k_batch_max = math::integer_divide_ceil(gemmK, KPerBlock);
-                k_batch_               = std::min(k_batch_, k_batch_max);
+                k_batch_               = max(std::min(k_batch_, k_batch_max), 1);
 
                 // Cap k_batch_ to 128 to avoid accuracy issues
                 k_batch_ = std::min(k_batch_, 128);


### PR DESCRIPTION
## Motivation

In certain edge cases (e.g. when `gemmK < KPerBlock`), `math::integer_divide_ceil(gemmK, KPerBlock)` returns 0, causing `k_batch_` to be clamped to 0 via `std::min`. A `k_batch_` of 0 is invalid for the GEMM split-K pipeline and leads to incorrect behavior or kernel failures. This PR ensures `k_batch_` is always at least 1.

Failure observed:
```
Unsupported stride / pad.
Unsupported BlockTransferSrcScalarPerVector.
Unsupported BlockTransferSrcScalarPerVector.
Unsupported BlockTransferSrcScalarPerVector.
Unsupported BlockTransferSrcScalarPerVector.
Unsupported BlockTransferSrcScalarPerVector.
Unsupported BlockTransferSrcScalarPerVector.
Unsupported BlockTransferSrcScalarPerVector.
Unsupported BlockTransferSrcScalarPerVector.
[SPLIT-K AUTODEDUCE] Max active thread blocks per CU for GEMM kernel:  12
[SPLIT-K AUTODEDUCE] Output grid size:  2
[SPLIT-K AUTODEDUCE] Optimal split-k value 1536
[SPLIT-K AUTODEDUCE] k_batch max value: 0
[SPLIT-K AUTODEDUCE] Final k_batch value: 0

Thread 258 "pt_autograd_0" received signal SIGFPE, Arithmetic exception.
[Switching to thread 258 (Thread 0x7fe9a4dff6c0 (LWP 26282))]

```

## Technical Details

The fix applies to three WMMA-based grouped convolution backward weight kernel implementations:

- `device_grouped_conv_bwd_weight_multiple_d_wmma_cshuffle_v3.hpp`
- `device_grouped_conv_bwd_weight_two_stage_wmma_cshuffle_v3.hpp`
- `device_grouped_conv_bwd_weight_wmma_cshuffle_v3.hpp`

In each file, the line that caps `k_batch_` to the pipeline maximum is changed from:

```cpp
k_batch_ = std::min(k_batch_, k_batch_max);
```

to:

```cpp
k_batch_ = max(std::min(k_batch_, k_batch_max), 1);
```

This wraps the existing upper-bound clamp with a `max(..., 1)` to enforce a lower bound of 1.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
