### PR TITLE
[MIOpen] Fix ambiguous __habs/hsqrt/__hisnan in legacy CK reduction (rocm-systems#5430)

### DIFF
--- a/projects/miopen/src/legacy_composable_kernel/composable_kernel/include/utility/reduction_functions_binop.hpp
+++ b/projects/miopen/src/legacy_composable_kernel/composable_kernel/include/utility/reduction_functions_binop.hpp
@@ -34,7 +34,7 @@
 namespace ck {
 namespace detail {
 
-static inline __device__ bool isnan(half_t x) { return __hisnan(x); };
+static inline __device__ bool isnan(half_t x) { return ::isnan(static_cast<float>(x)); };
 
 template <NanPropagation_t nanPropaOpt, typename opReduce, typename compType>
 struct binop_with_nan_check;

--- a/projects/miopen/src/legacy_composable_kernel/composable_kernel/include/utility/reduction_operator.hpp
+++ b/projects/miopen/src/legacy_composable_kernel/composable_kernel/include/utility/reduction_operator.hpp
@@ -244,7 +244,10 @@ struct unary_abs<half_t, false>
 {
     __device__ unary_abs(const int divider = 1) { (void)divider; };
 
-    __device__ inline half_t operator()(half_t a) const { return static_cast<half_t>(fabsf(static_cast<float>(a))); };
+    __device__ inline half_t operator()(half_t a) const
+    {
+        return static_cast<half_t>(fabsf(static_cast<float>(a)));
+    };
 };
 
 template <class T>
@@ -260,7 +263,10 @@ struct unary_sqrt<half_t>
 {
     __device__ unary_sqrt(const int divider = 1) { (void)divider; };
 
-    __device__ inline half_t operator()(half_t a) const { return static_cast<half_t>(sqrtf(static_cast<float>(a))); };
+    __device__ inline half_t operator()(half_t a) const
+    {
+        return static_cast<half_t>(sqrtf(static_cast<float>(a)));
+    };
 };
 
 }; // end of namespace reduce

--- a/projects/miopen/src/legacy_composable_kernel/composable_kernel/include/utility/reduction_operator.hpp
+++ b/projects/miopen/src/legacy_composable_kernel/composable_kernel/include/utility/reduction_operator.hpp
@@ -231,7 +231,7 @@ struct unary_abs<half_t, hasDividing>
 
     __device__ inline half_t operator()(half_t a) const
     {
-        a = static_cast<half_t>(__habs(a));
+        a = static_cast<half_t>(fabsf(static_cast<float>(a)));
 
         return a * type_convert<half_t>{}(scaler);
     };
@@ -244,7 +244,7 @@ struct unary_abs<half_t, false>
 {
     __device__ unary_abs(const int divider = 1) { (void)divider; };
 
-    __device__ inline half_t operator()(half_t a) const { return static_cast<half_t>(__habs(a)); };
+    __device__ inline half_t operator()(half_t a) const { return static_cast<half_t>(fabsf(static_cast<float>(a))); };
 };
 
 template <class T>
@@ -260,7 +260,7 @@ struct unary_sqrt<half_t>
 {
     __device__ unary_sqrt(const int divider = 1) { (void)divider; };
 
-    __device__ inline half_t operator()(half_t a) const { return static_cast<half_t>(hsqrt(a)); };
+    __device__ inline half_t operator()(half_t a) const { return static_cast<half_t>(sqrtf(static_cast<float>(a))); };
 };
 
 }; // end of namespace reduce


### PR DESCRIPTION
## Summary

Fixes the HIPRTC compilation failures in MIOpen's legacy composable_kernel reduction kernels reported in [ROCm/rocm-systems#5430](https://github.com/ROCm/rocm-systems/issues/5430).

The bundled \`hiprtc_runtime.h\` shipped with newer rocm-systems builds now exposes overloads of \`__habs\`, \`hsqrt\`, and \`__hisnan\` for both \`__half\` and \`__hip_bfloat16\`. Calls passing legacy CK \`half_t\` — which is implicitly convertible to both — now fail HIPRTC compilation with *\"call is ambiguous\"*. The downstream symptom is ~142 reduction gtest failures on gfx942 dominated by:

- \`Smoke/GPU_Reduce_FP32\`
- \`Smoke/GPU_Reduce_FP16\`
- \`Full/GPU_reduce_custom_fp32_fp16_*\`

surfaced as \`hipoc_program.cpp:299\` *\"Code object build failed\"*.

## Fix

Replace each half-typed intrinsic with its float-typed counterpart, mirroring the prior pattern from #5235:

| Before | After |
|---|---|
| \`__habs(a)\` (a: half_t) | \`fabsf(static_cast<float>(a))\` |
| \`hsqrt(a)\` (a: half_t) | \`sqrtf(static_cast<float>(a))\` |
| \`__hisnan(x)\` (x: half_t) | \`::isnan(static_cast<float>(x))\` |

The surrounding \`static_cast<half_t>(...)\` is preserved so the public types of \`ck::reduce::unary_abs<half_t>\`, \`ck::reduce::unary_sqrt<half_t>\`, and \`ck::detail::isnan(half_t)\` are unchanged. The \`::\` qualifier on \`isnan\` is added defensively to make the call to the \`float\` overload unambiguous (the half_t overload's name lives in \`ck::detail\`).

## Files

- \`projects/miopen/src/legacy_composable_kernel/composable_kernel/include/utility/reduction_operator.hpp\` (lines 234, 247, 263)
- \`projects/miopen/src/legacy_composable_kernel/composable_kernel/include/utility/reduction_functions_binop.hpp\` (line 37)

## Scope

Narrow — only the four sites #5430 explicitly cites. Other \`__h*\` intrinsic uses in the tree (\`miopen_math.hpp\` \`hsin\`/\`hcos\`/\`__hfma\`, \`radix.hpp\` \`__hisnan\`) all take an explicit \`__half\` operand and are unambiguous; they are intentionally not touched here.

## Test plan

- [x] MIOpen standalone build (HIP backend) with the local ROCm clang
- [x] \`./bin/test_reduce\` on gfx90a (MI210)
- [x] \`./bin/test_reducecalculation\` on gfx90a
- [x] \`./bin/test_reduceextreme\` on gfx90a
- [x] CI: full reduce gtest matrix on gfx942 (the platform where  [ROCm/rocm-systems#5430](https://github.com/ROCm/rocm-systems/issues/5430) originally surfaced)

## Related

- Issue: ROCm/rocm-systems#5430
- Prior partial fix: #5235

🤖 Generated with [Claude Code](https://claude.com/claude-code)