### PR TITLE
[MIOpen] Fixing blacklisted ASan memory leaks and removing them from the list

### DIFF
--- a/projects/miopen/test/gtest/CMakeLists.txt
+++ b/projects/miopen/test/gtest/CMakeLists.txt
@@ -36,28 +36,8 @@ if(THEROCK_SANITIZER STREQUAL "ASAN")
     list(APPEND SKIP_TESTS bad_fusion_plan.cpp cba_find2_infer.cpp cba_infer.cpp ck_builder_shared.cpp ck_builder_xdl.cpp conv_activ_infer.cpp conv_ai_3d_kernel_tuning_utils.cpp conv_ck_igemm_fwd_v6r1_dlops_nchw.cpp conv_hip_igemm_xdlops.cpp conv_igemm_mlir_xdlops_bwd_wrw.cpp conv_igemm_mlir_xdlops_fwd.cpp find_2_conv.cpp find_db.cpp fused_conv_bias_res_add_activ.cpp graphapi_conv_bias_res_add_activ_fwd.cpp group_conv_deterministic_split_k.cpp group_conv2d_fwd.cpp group_conv2d_bwd.cpp group_conv2d_wrw.cpp group_conv3d_fwd.cpp group_conv3d_bwd.cpp group_conv3d_wrw.cpp find_mode_trust_verify.cpp kernel_tuning_net.cpp miopendriver_conv_immed.cpp miopendriver_conv2d_trans.cpp miopendriver_gemm.cpp miopendriver_regression_big_tensor.cpp miopendriver_regression_big_tensor.cpp miopendriver_regression_half_gfx9.cpp miopendriver_regression_half.cpp perf_config_HipImplicitGemm3DGroupFwdXdlops.cpp smoke_solver_ConvCkIgemmFwdV6r1DlopsNchw.cpp unit_conv_solver_ConvAsmImplicitGemmGTCDynamicBwdXdlops.cpp unit_conv_solver_ConvAsmImplicitGemmGTCDynamicFwdXdlops.cpp unit_conv_solver_ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC.cpp unit_conv_solver_ConvAsmImplicitGemmGTCDynamicWrwXdlops.cpp unit_conv_solver_ConvCkGroupedConvFwd.cpp unit_conv_solver_ConvHipImplicitGemm3DGroupBwdXdlops.cpp unit_conv_solver_ConvHipImplicitGemm3DGroupFwdXdlops.cpp unit_conv_solver_ConvHipImplicitGemm3DGroupWrwXdlops.cpp unit_conv_solver_ConvHipImplicitGemmBwdDataV1R1Xdlops.cpp unit_conv_solver_ConvHipImplicitGemmBwdDataV4R1Xdlops.cpp unit_conv_solver_ConvHipImplicitGemmFwdXdlops.cpp unit_conv_solver_ConvHipImplicitGemmGroupBwdXdlops.cpp unit_conv_solver_ConvHipImplicitGemmForwardV4R4Xdlops.cpp unit_conv_solver_ConvHipImplicitGemmForwardV4R5Xdlops.cpp unit_conv_solver_ConvHipImplicitGemmForwardV4R4Xdlops_Padded_Gemm.cpp unit_conv_solver_ConvHipImplicitGemmWrwV4R4Xdlops.cpp unit_conv_solver_ConvHipImplicitGemmWrwV4R4Xdlops_Padded_Gemm.cpp unit_conv_solver_ConvHipImplicitGemmBwdXdlops.cpp unit_conv_solver_ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC.cpp unit_conv_solver_ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC.cpp unit_conv_solver_ConvHipImplicitGemmGroupFwdXdlops.cpp unit_conv_solver_ConvHipImplicitGemmGroupWrwXdlops.cpp unit_implicitgemm_ck_util.cpp smoke_solver_ConvAsmImplicitGemmGTCDynamicXdlopsNHWC_fp32_fp16.cpp smoke_solver_ConvAsmImplicitGemmGTCDynamicXdlopsNHWC_bf16.cpp)
     # temporarily disable due to test failures
     list(APPEND SKIP_TESTS unit_conv_solver_ConvWinoRageRxS.cpp)
-    # Disable tests that leak memory when Address Sanitizer is enabled.  These tests need to be investigated and fixed.
-    list(APPEND SKIP_TESTS
-        gpu_mha_backward.cpp
-        gpu_mha_forward.cpp
-        graphapi_convolution.cpp
-        graphapi_enginecfg.cpp
-        graphapi_engineheur.cpp
-        graphapi_execution_plan.cpp
-        graphapi_matmul.cpp
-        graphapi_operationgraph_descriptor.cpp
-        graphapi_operation_reduction.cpp
-        graphapi_operation_reshape.cpp
-        graphapi_operation_matmul.cpp
-        graphapi_operation_pointwise.cpp
-        graphapi_operation_rng.cpp
-        graphapi_pointwise.cpp
-        graphapi_reduction.cpp
-        graphapi_rng.cpp
-        graphapi_tensor.cpp
-        graphapi_variant_pack.cpp
-        mha_find20.cpp
-        w_supertensor.cpp)
+    # Disable supertensor tests due to it running out of memory.  It is just a very memory intensive set of tests and ASan multiplying that pushes it over the edge.
+    list(APPEND SKIP_TESTS w_supertensor.cpp)
 endif()
 
 function(add_gtest_negative_filter NEGATIVE_FILTER_TO_ADD)

--- a/projects/miopen/test/gtest/gpu_mha_backward.cpp
+++ b/projects/miopen/test/gtest/gpu_mha_backward.cpp
@@ -376,6 +376,11 @@ protected:
             checkOutput(miopenTensorMhaDK, "tensor dK", dKDesc_ref);
             checkOutput(miopenTensorMhaDV, "tensor dV", dVDesc_ref);
         }
+
+        for(auto& solution : solutions)
+        {
+            ASSERT_EQ(miopenDestroySolution(solution), miopenStatusSuccess);
+        }
     }
 
     void TearDown() override

--- a/projects/miopen/test/gtest/gpu_mha_forward.cpp
+++ b/projects/miopen/test/gtest/gpu_mha_forward.cpp
@@ -294,6 +294,11 @@ protected:
 
             VerifyResults(handle);
         }
+
+        for(auto& solution : solutions)
+        {
+            ASSERT_EQ(miopenDestroySolution(solution), miopenStatusSuccess);
+        }
     }
 
     virtual void VerifyResults(const Handle& handle)

--- a/projects/miopen/test/gtest/mha_find20.cpp
+++ b/projects/miopen/test/gtest/mha_find20.cpp
@@ -666,6 +666,12 @@ TEST(GPU_TestMhaFind20_FP32, MhaForward)
     test.TestSolutionAttributes(solutions);
 
     test.TestRunSolutions(handle, solutions);
+
+    for(auto& solution : solutions)
+    {
+        EXPECT_EQUAL(miopenDestroySolution(solution), miopenStatusSuccess);
+    }
+
     test.Finalize();
 }
 
@@ -679,5 +685,11 @@ TEST(GPU_TestMhaFind20_FP32, MhaBackward)
     test.TestSolutionAttributes(solutions);
 
     test.TestRunSolutions(handle, solutions);
+
+    for(auto& solution : solutions)
+    {
+        EXPECT_EQUAL(miopenDestroySolution(solution), miopenStatusSuccess);
+    }
+
     test.Finalize();
 }

--- a/projects/miopen/test/gtest/w_supertensor.cpp
+++ b/projects/miopen/test/gtest/w_supertensor.cpp
@@ -31,6 +31,7 @@
 #include <miopen/miopen.h>
 
 #include "gtest_common.hpp"
+#include "gtest_desc_guard.hpp"
 #include "test_parameter_name_generator.hpp"
 #include "verify.hpp"
 
@@ -583,22 +584,9 @@ struct WSuperTensorTest : public testing::TestWithParam<TestCase>
         std::tie(
             seqLen, batch_size, num_layer, in_size, wei_hh, mode, biasMode, directionMode, inMode) =
             GetParam();
-
-        auto status = miopenCreateRNNDescriptor(&rnnDesc);
-        EXPECT_EQ(status, miopenStatusSuccess);
-
-        status = miopenCreateTensorDescriptor(&inputTensor);
-        EXPECT_EQ(status, miopenStatusSuccess);
-
-        status = miopenCreateTensorDescriptor(&weightTensor);
-        EXPECT_EQ(status, miopenStatusSuccess);
-
-        status = miopenCreateTensorDescriptor(&paramTensor);
-        EXPECT_EQ(status, miopenStatusSuccess);
-
-        status = miopenCreateTensorDescriptor(&biasTensor);
-        EXPECT_EQ(status, miopenStatusSuccess);
     }
+
+    void TearDown() override { DestroyDropoutDesc(); }
 
     void Run()
     {
@@ -608,6 +596,10 @@ struct WSuperTensorTest : public testing::TestWithParam<TestCase>
         }
 
         const std::array<int, 2> in_lens{{batch_size, in_size}};
+
+        // miopenSetRNNDescriptor overwrites the descriptor via copy assignment,
+        // leaking the internal DropoutDescriptor allocated by miopenCreateRNNDescriptor.
+        DestroyDropoutDesc();
 
         auto status = miopenSetRNNDescriptor(
             rnnDesc, wei_hh, num_layer, inMode, directionMode, mode, biasMode, algo, dataType);
@@ -621,6 +613,25 @@ struct WSuperTensorTest : public testing::TestWithParam<TestCase>
 
         Verify<verify_w_tensor_set>();
         Verify<verify_w_tensor_get>();
+    }
+
+    void DestroyDropoutDesc()
+    {
+        miopenDropoutDescriptor_t dropDesc = nullptr;
+        miopenGetRNNDescriptor_V2(rnnDesc,
+                                  nullptr,
+                                  nullptr,
+                                  &dropDesc,
+                                  nullptr,
+                                  nullptr,
+                                  nullptr,
+                                  nullptr,
+                                  nullptr,
+                                  nullptr);
+        if(dropDesc != nullptr)
+        {
+            miopenDestroyDropoutDescriptor(dropDesc);
+        }
     }
 
 private:
@@ -660,13 +671,13 @@ private:
     miopenRNNBiasMode_t biasMode{};
     miopenRNNDirectionMode_t directionMode{};
     miopenRNNInputMode_t inMode{};
-    miopenRNNDescriptor_t rnnDesc{};
+    RNNDescGuard rnnDesc;
     miopenRNNAlgo_t algo{miopenRNNdefault};
     miopenDataType_t dataType{miopenFloat};
-    miopenTensorDescriptor_t inputTensor{};
-    miopenTensorDescriptor_t weightTensor{};
-    miopenTensorDescriptor_t paramTensor{};
-    miopenTensorDescriptor_t biasTensor{};
+    TensorDescGuard inputTensor;
+    TensorDescGuard weightTensor;
+    TensorDescGuard paramTensor;
+    TensorDescGuard biasTensor;
 };
 
 struct TestNameGenerator


### PR DESCRIPTION


## Motivation

Tests were disabled due to hitting memory leaks when Address Sanitizer is used.  This PR fixes the leaks and re-enables the tests.

Several tests were removed since being added to the list, so those did not require any changes.

Exception being the supertensor tests, where the leak was fixed, but it hits an out of memory error due to ASan using significantly more memory.  It currently remains disabled.  I was able to get them running without the error, but those changes will be a separate discussion whether we want them in with these changes.

## Technical Details

| File | Status | Notes |
|------|--------|-------|
| gpu_mha_backward.cpp | DONE | Added miopenDestroySolution() cleanup for solutions returned by miopenFindSolutions() in TestBody() |
| gpu_mha_forward.cpp | DONE | Added miopenDestroySolution() cleanup for solutions returned by miopenFindSolutions() in TestBody() |
| graphapi_convolution.cpp | SKIP | File was deleted from codebase (GraphAPI dead code removal, commit 7c4b86cd0f) |
| graphapi_enginecfg.cpp | SKIP | File was deleted from codebase (GraphAPI dead code removal) |
| graphapi_engineheur.cpp | SKIP | File was deleted from codebase (GraphAPI dead code removal) |
| graphapi_execution_plan.cpp | SKIP | File was deleted from codebase (GraphAPI dead code removal) |
| graphapi_matmul.cpp | SKIP | File was deleted from codebase (GraphAPI dead code removal) |
| graphapi_operationgraph_descriptor.cpp | SKIP | File was deleted from codebase (GraphAPI dead code removal) |
| graphapi_operation_reduction.cpp | SKIP | File was deleted from codebase (GraphAPI dead code removal) |
| graphapi_operation_reshape.cpp | SKIP | File was deleted from codebase (GraphAPI dead code removal) |
| graphapi_operation_matmul.cpp | SKIP | File was deleted from codebase (GraphAPI dead code removal) |
| graphapi_operation_pointwise.cpp | SKIP | File was deleted from codebase (GraphAPI dead code removal) |
| graphapi_operation_rng.cpp | SKIP | File was deleted from codebase (GraphAPI dead code removal) |
| graphapi_pointwise.cpp | SKIP | File was deleted from codebase (GraphAPI dead code removal) |
| graphapi_reduction.cpp | SKIP | File was deleted from codebase (GraphAPI dead code removal) |
| graphapi_rng.cpp | SKIP | File was deleted from codebase (GraphAPI dead code removal) |
| graphapi_tensor.cpp | SKIP | File was deleted from codebase (GraphAPI dead code removal) |
| graphapi_variant_pack.cpp | SKIP | File was deleted from codebase (GraphAPI dead code removal) |
| mha_find20.cpp | DONE | Added miopenDestroySolution() cleanup in both MhaForward and MhaBackward tests |
| w_supertensor.cpp | DONE | Switched to use gtest_desc_guard and destroyed it on TearDown() |

## Test Plan

Execute the tests with ASan before changes to see the leak and then execute with ASan after to see a clean run.  The supertensor test output is showing only the leaking tests since it hits memory limits when ran as a full suite.

## Test Result

Supertensor tests before:

```
PRNG seed: 12345678
MIOpen(HIP): Info [get_device_name] Raw device name: gfx942:sramecc+:xnack+
MIOpen(HIP): Info [Handle] stream: 0, device_id: 0
Note: Google Test filter = *WSuperTensor*test_id_0:*WSuperTensor*test_id_1
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from Smoke/CPU_WSuperTensor_NONE
[ RUN      ] Smoke/CPU_WSuperTensor_NONE.WSuperTensorTest/seqLen_1_batch_size_2_num_layer_4_in_size_2_wei_hh_4_mode_miopenRNNRELU_directionMode_miopenRNNunidirection_inMode_miopenRNNskip_test_id_0
[       OK ] Smoke/CPU_WSuperTensor_NONE.WSuperTensorTest/seqLen_1_batch_size_2_num_layer_4_in_size_2_wei_hh_4_mode_miopenRNNRELU_directionMode_miopenRNNunidirection_inMode_miopenRNNskip_test_id_0 (0 ms)
[ RUN      ] Smoke/CPU_WSuperTensor_NONE.WSuperTensorTest/seqLen_1_batch_size_2_num_layer_4_in_size_2_wei_hh_4_mode_miopenRNNRELU_directionMode_miopenRNNunidirection_inMode_miopenRNNlinear_test_id_1
MIOpen(HIP): Info [IsNetworkedFilesystem] Filesystem type at '"/home/nhanna/.cache/miopen/3.5.1.2d83c4a060-dirty"' is: 0xef53 'EXT2/3/4_SUPER_MAGIC'
MIOpen(HIP): Info [KernDb] database not present
MIOpen(HIP): Info [KernDb] database not present
MIOpen(HIP): Info [KernDb] database not present
[       OK ] Smoke/CPU_WSuperTensor_NONE.WSuperTensorTest/seqLen_1_batch_size_2_num_layer_4_in_size_2_wei_hh_4_mode_miopenRNNRELU_directionMode_miopenRNNunidirection_inMode_miopenRNNlinear_test_id_1 (30 ms)
[----------] 2 tests from Smoke/CPU_WSuperTensor_NONE (30 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (39 ms total)
[  PASSED  ] 2 tests.

=================================================================
==494469==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 320 byte(s) in 2 object(s) allocated from:
    #0 0x7f2d5b31dd3d  (/data/nhanna/repos/TheRock/therock-build/lib/llvm/lib/clang/22/lib/linux/libclang_rt.asan-x86_64.so+0x162d3d)
    #1 0x7f2d5a7ab77c  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x2485e77c)
    #2 0x5573f72c1395  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x460c395)
    #3 0x5573f7381c98  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x46ccc98)

Direct leak of 320 byte(s) in 2 object(s) allocated from:
    #0 0x7f2d5b31dd3d  (/data/nhanna/repos/TheRock/therock-build/lib/llvm/lib/clang/22/lib/linux/libclang_rt.asan-x86_64.so+0x162d3d)
    #1 0x7f2d5a7ab77c  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x2485e77c)
    #2 0x5573f72c1087  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x460c087)
    #3 0x5573f7381c98  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x46ccc98)

Direct leak of 320 byte(s) in 2 object(s) allocated from:
    #0 0x7f2d5b31dd3d  (/data/nhanna/repos/TheRock/therock-build/lib/llvm/lib/clang/22/lib/linux/libclang_rt.asan-x86_64.so+0x162d3d)
    #1 0x7f2d5a7ab77c  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x2485e77c)
    #2 0x5573f72c0ef8  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x460bef8)
    #3 0x5573f7381c98  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x46ccc98)

Direct leak of 320 byte(s) in 2 object(s) allocated from:
    #0 0x7f2d5b31dd3d  (/data/nhanna/repos/TheRock/therock-build/lib/llvm/lib/clang/22/lib/linux/libclang_rt.asan-x86_64.so+0x162d3d)
    #1 0x7f2d5a7ab77c  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x2485e77c)
    #2 0x5573f72c120e  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x460c20e)
    #3 0x5573f7381c98  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x46ccc98)

Direct leak of 160 byte(s) in 2 object(s) allocated from:
    #0 0x7f2d5b31dd3d  (/data/nhanna/repos/TheRock/therock-build/lib/llvm/lib/clang/22/lib/linux/libclang_rt.asan-x86_64.so+0x162d3d)
    #1 0x7f2d59319a2c  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x233cca2c)
    #2 0x5573f72c0d74  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x460bd74)
    #3 0x5573f7381c98  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x46ccc98)

Direct leak of 48 byte(s) in 1 object(s) allocated from:
    #0 0x7f2d5b31dd3d  (/data/nhanna/repos/TheRock/therock-build/lib/llvm/lib/clang/22/lib/linux/libclang_rt.asan-x86_64.so+0x162d3d)
    #1 0x7f2d592ff029  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x233b2029)
    #2 0x7f2d59319a37  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x233cca37)
    #3 0x5573f72c0d74  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x460bd74)
    #4 0x5573f7381c98  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x46ccc98)

Indirect leak of 48 byte(s) in 1 object(s) allocated from:
    #0 0x7f2d5b31dd3d  (/data/nhanna/repos/TheRock/therock-build/lib/llvm/lib/clang/22/lib/linux/libclang_rt.asan-x86_64.so+0x162d3d)
    #1 0x7f2d592ff375  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x233b2375)
    #2 0x7f2d59322822  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x233d5822)
    #3 0x5573f72bb2c2  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x46062c2)
    #4 0x5573f7381c98  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x46ccc98)

Indirect leak of 48 byte(s) in 1 object(s) allocated from:
    #0 0x7f2d5b31dd3d  (/data/nhanna/repos/TheRock/therock-build/lib/llvm/lib/clang/22/lib/linux/libclang_rt.asan-x86_64.so+0x162d3d)
    #1 0x7f2d592ff029  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x233b2029)
    #2 0x7f2d59319a37  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x233cca37)
    #3 0x5573f72c0d74  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x460bd74)
    #4 0x5573f7381c98  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x46ccc98)

Indirect leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x7f2d5b31dd3d  (/data/nhanna/repos/TheRock/therock-build/lib/llvm/lib/clang/22/lib/linux/libclang_rt.asan-x86_64.so+0x162d3d)
    #1 0x7f2d5a788393  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x2483b393)
    #2 0x7f2d5a748962  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x247fb962)
    #3 0x7f2d5a74635e  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x247f935e)
    #4 0x7f2d5a745676  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x247f8676)
    #5 0x7f2d5a74a6d3  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x247fd6d3)
    #6 0x7f2d5a7cc2d7  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x2487f2d7)
    #7 0x5573f72bb4c4  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x46064c4)
    #8 0x5573f7381c98  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x46ccc98)

Indirect leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x7f2d5b31dd3d  (/data/nhanna/repos/TheRock/therock-build/lib/llvm/lib/clang/22/lib/linux/libclang_rt.asan-x86_64.so+0x162d3d)
    #1 0x7f2d5a788393  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x2483b393)
    #2 0x7f2d5a748962  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x247fb962)
    #3 0x7f2d5a74635e  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x247f935e)
    #4 0x7f2d5a745676  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x247f8676)
    #5 0x7f2d5930512e  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x233b812e)
    #6 0x7f2d59344459  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x233f7459)
    #7 0x5573f72bccf2  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x4607cf2)
    #8 0x5573f7381c98  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x46ccc98)

Indirect leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x7f2d5b31dd3d  (/data/nhanna/repos/TheRock/therock-build/lib/llvm/lib/clang/22/lib/linux/libclang_rt.asan-x86_64.so+0x162d3d)
    #1 0x7f2d5a745ae1  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x247f8ae1)
    #2 0x7f2d5a745649  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x247f8649)
    #3 0x7f2d5a74a6d3  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x247fd6d3)
    #4 0x7f2d5a7cc2d7  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x2487f2d7)
    #5 0x5573f72bb6b9  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x46066b9)
    #6 0x5573f7381c98  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x46ccc98)

Indirect leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x7f2d5b31dd3d  (/data/nhanna/repos/TheRock/therock-build/lib/llvm/lib/clang/22/lib/linux/libclang_rt.asan-x86_64.so+0x162d3d)
    #1 0x7f2d5a745ae1  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x247f8ae1)
    #2 0x7f2d5a745649  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x247f8649)
    #3 0x7f2d5930512e  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x233b812e)
    #4 0x7f2d59344459  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x233f7459)
    #5 0x5573f72bccf2  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x4607cf2)
    #6 0x5573f7381c98  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x46ccc98)

Indirect leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x7f2d5b31dd3d  (/data/nhanna/repos/TheRock/therock-build/lib/llvm/lib/clang/22/lib/linux/libclang_rt.asan-x86_64.so+0x162d3d)
    #1 0x7f2d5a745ae1  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x247f8ae1)
    #2 0x7f2d5a745649  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x247f8649)
    #3 0x7f2d5a74a6d3  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x247fd6d3)
    #4 0x7f2d5a7cc2d7  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x2487f2d7)
    #5 0x5573f72bb4c4  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x46064c4)
    #6 0x5573f7381c98  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x46ccc98)

Indirect leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x7f2d5b31dd3d  (/data/nhanna/repos/TheRock/therock-build/lib/llvm/lib/clang/22/lib/linux/libclang_rt.asan-x86_64.so+0x162d3d)
    #1 0x7f2d5a788393  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x2483b393)
    #2 0x7f2d5a748962  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x247fb962)
    #3 0x7f2d5a74635e  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x247f935e)
    #4 0x7f2d5a745676  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x247f8676)
    #5 0x7f2d5a74a6d3  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x247fd6d3)
    #6 0x7f2d5a7cc2d7  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x2487f2d7)
    #7 0x5573f72bb6b9  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x46066b9)
    #8 0x5573f7381c98  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x46ccc98)

Indirect leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x7f2d5b31dd3d  (/data/nhanna/repos/TheRock/therock-build/lib/llvm/lib/clang/22/lib/linux/libclang_rt.asan-x86_64.so+0x162d3d)
    #1 0x7f2d5a746651  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x247f9651)
    #2 0x7f2d593056fe  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x233b86fe)
    #3 0x7f2d59348259  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x233fb259)
    #4 0x5573f72bcfe7  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x4607fe7)
    #5 0x5573f7381c98  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x46ccc98)

Indirect leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x7f2d5b31dd3d  (/data/nhanna/repos/TheRock/therock-build/lib/llvm/lib/clang/22/lib/linux/libclang_rt.asan-x86_64.so+0x162d3d)
    #1 0x7f2d5a788393  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x2483b393)
    #2 0x7f2d5a748962  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x247fb962)
    #3 0x7f2d5a74635e  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x247f935e)
    #4 0x7f2d5a7466db  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x247f96db)
    #5 0x7f2d593056fe  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x233b86fe)
    #6 0x7f2d59348259  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/lib/libMIOpen.so.1+0x233fb259)
    #7 0x5573f72bcfe7  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x4607fe7)
    #8 0x5573f7381c98  (/data/nhanna/repos/rocm-libraries/projects/miopen/build/bin/miopen_gtest+0x46ccc98)

SUMMARY: AddressSanitizer: 1696 byte(s) leaked in 21 allocation(s).
```

Supertensor tests after:
```
PRNG seed: 12345678
MIOpen(HIP): Info [get_device_name] Raw device name: gfx942:sramecc+:xnack+
MIOpen(HIP): Info [Handle] stream: 0, device_id: 0
Note: Google Test filter = *WSuperTensor*test_id_0:*WSuperTensor*test_id_1
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from Smoke/CPU_WSuperTensor_NONE
[ RUN      ] Smoke/CPU_WSuperTensor_NONE.WSuperTensorTest/seqLen_1_batch_size_2_num_layer_4_in_size_2_wei_hh_4_mode_miopenRNNRELU_directionMode_miopenRNNunidirection_inMode_miopenRNNskip_test_id_0
[       OK ] Smoke/CPU_WSuperTensor_NONE.WSuperTensorTest/seqLen_1_batch_size_2_num_layer_4_in_size_2_wei_hh_4_mode_miopenRNNRELU_directionMode_miopenRNNunidirection_inMode_miopenRNNskip_test_id_0 (0 ms)
[ RUN      ] Smoke/CPU_WSuperTensor_NONE.WSuperTensorTest/seqLen_1_batch_size_2_num_layer_4_in_size_2_wei_hh_4_mode_miopenRNNRELU_directionMode_miopenRNNunidirection_inMode_miopenRNNlinear_test_id_1
MIOpen(HIP): Info [IsNetworkedFilesystem] Filesystem type at '"/home/nhanna/.cache/miopen/3.5.1.2d83c4a060-dirty"' is: 0xef53 'EXT2/3/4_SUPER_MAGIC'
MIOpen(HIP): Info [KernDb] database not present
MIOpen(HIP): Info [KernDb] database not present
MIOpen(HIP): Info [KernDb] database not present
[       OK ] Smoke/CPU_WSuperTensor_NONE.WSuperTensorTest/seqLen_1_batch_size_2_num_layer_4_in_size_2_wei_hh_4_mode_miopenRNNRELU_directionMode_miopenRNNunidirection_inMode_miopenRNNlinear_test_id_1 (15 ms)
[----------] 2 tests from Smoke/CPU_WSuperTensor_NONE (15 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (19 ms total)
[  PASSED  ] 2 tests.

```
