### PR TITLE
[rocfft-bench] Remove check on brick equality for in-place multi-device benchmarking

### DIFF
--- a/projects/rocfft/clients/bench/bench.h
+++ b/projects/rocfft/clients/bench/bench.h
@@ -202,10 +202,6 @@ void alloc_bench_bricks(const Tparams&                            params,
     // bricks.  e.g. in-place real-complex
     if(params.placement == fft_placement_inplace)
     {
-        if(ibricks.size() != 1 && obricks.size() != 1 && ibricks != obricks)
-            throw std::runtime_error(
-                "in-place transform to different brick shapes only allowed for single bricks");
-
         // allocate the larger of the two bricks
         auto isize_bytes = compute_ptrdiff(ibricks.front().length(), ibricks.front().stride)
                            * var_size<size_t>(params.precision, params.itype);


### PR DESCRIPTION
## Motivation & details

The check prevents benchmarking for multi-device real in-place transforms and has no reason to be in that case.

## Test Plan

N/A.

## Test Result

N/A.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
