### PR TITLE
Update auto-labeling behavior for stinkytofu

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -15,7 +15,6 @@
   - any-glob-to-any-file: 'projects/hipblaslt/**/*'
   - any-glob-to-any-file: 'shared/origami/**/*'
   - any-glob-to-any-file: 'shared/rocroller/**/*'
-  - any-glob-to-any-file: 'shared/stinkytofu/**/*'
 
 "project: hipblaslt-provider":
 - changed-files:
@@ -61,7 +60,8 @@
 - changed-files:
   - any-glob-to-any-file: 'projects/hipsparselt/**/*'
   - any-glob-to-any-file: 'projects/hipblaslt/tensilelite/**/*'
-
+  - any-glob-to-any-file: 'shared/stinkytofu/**/*'
+  
 "ci:hipsparselt-fast":
 - changed-files:
   - any-glob-to-any-file: 'projects/hipblaslt/tensilelite/**/*'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -61,7 +61,7 @@
   - any-glob-to-any-file: 'projects/hipsparselt/**/*'
   - any-glob-to-any-file: 'projects/hipblaslt/tensilelite/**/*'
   - any-glob-to-any-file: 'shared/stinkytofu/**/*'
-  
+
 "ci:hipsparselt-fast":
 - changed-files:
   - any-glob-to-any-file: 'projects/hipblaslt/tensilelite/**/*'


### PR DESCRIPTION
## Motivation

- Changes to StinkyTofu files will add `project:hipsparselt` label instead of `project:hipblaslt` label. 

## Technical Details

- math-ci reads labels to detect which project's tests to run. With this change, math-ci will not run hipsparselt tests instead of hipblaslt tests on PRs only affecting StinkyTofu files

## Test Plan

Can only be tested after merge

