### PR TITLE
[MIOpen] Skip CK tests when it's not available

### DIFF
--- a/projects/miopen/test/gtest/unit_conv_solver.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver.cpp
@@ -871,6 +871,14 @@ void UnitTestConvSolverBase::SetUpImpl(const UnitTestConvSolverParams& params)
     {
         GTEST_SKIP();
     }
+    else if(params.uses_ck_dynamic_lib)
+    {
+        const auto& loader = miopen::solver::CkImplLibLoader::Get(get_handle().GetDeviceName());
+        if(!loader.IsLoaded())
+        {
+            GTEST_SKIP() << "CK dynamic library not available for " << get_handle().GetDeviceName();
+        }
+    }
 }
 
 void UnitTestConvSolverBase::RunTestImpl(const miopen::solver::conv::ConvSolverInterface& solver,


### PR DESCRIPTION
Modifying the ConvSolverBase so that when uses_ck_dynamic_lib is true, but CK is not available (such as in the case where CK is not built), the test will be skipped.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
