### PR TITLE
[CK_TILE] Add tile_distribution_encoding tutorial series

### DIFF
--- a/projects/composablekernel/tutorial/ck_tile/CMakeLists.txt
+++ b/projects/composablekernel/tutorial/ck_tile/CMakeLists.txt
@@ -7,3 +7,4 @@ include_directories(AFTER
 
 add_subdirectory(00_copy_kernel)
 add_subdirectory(gemm)
+add_subdirectory(tile_distribution)

--- a/projects/composablekernel/tutorial/ck_tile/tile_distribution/CMakeLists.txt
+++ b/projects/composablekernel/tutorial/ck_tile/tile_distribution/CMakeLists.txt
@@ -1,0 +1,42 @@
+# Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
+
+set(TUTORIAL_NAME "tile_tutorial_tile_distribution")
+
+add_executable(${TUTORIAL_NAME} EXCLUDE_FROM_ALL tile_distribution.cpp)
+target_include_directories(${TUTORIAL_NAME} PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+target_compile_options(${TUTORIAL_NAME} PRIVATE
+  -Wno-undefined-func-template -Wno-float-equal -Wno-ctad-maybe-unsupported
+)
+
+add_dependencies(tutorials ${TUTORIAL_NAME})
+
+set(TUTORIAL_NAME_2 "tile_tutorial_tile_distribution_2")
+
+add_executable(${TUTORIAL_NAME_2} EXCLUDE_FROM_ALL tile_distribution_2.cpp)
+target_include_directories(${TUTORIAL_NAME_2} PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+target_compile_options(${TUTORIAL_NAME_2} PRIVATE
+  -Wno-undefined-func-template -Wno-float-equal -Wno-ctad-maybe-unsupported
+)
+
+add_dependencies(tutorials ${TUTORIAL_NAME_2})
+
+set(TUTORIAL_NAME_3 "tile_tutorial_tile_distribution_3")
+
+add_executable(${TUTORIAL_NAME_3} EXCLUDE_FROM_ALL tile_distribution_3.cpp)
+target_include_directories(${TUTORIAL_NAME_3} PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+target_compile_options(${TUTORIAL_NAME_3} PRIVATE
+  -Wno-undefined-func-template -Wno-float-equal -Wno-ctad-maybe-unsupported
+)
+
+add_dependencies(tutorials ${TUTORIAL_NAME_3})
+
+set(TUTORIAL_NAME_4 "tile_tutorial_tile_distribution_4")
+
+add_executable(${TUTORIAL_NAME_4} EXCLUDE_FROM_ALL tile_distribution_4.cpp)
+target_include_directories(${TUTORIAL_NAME_4} PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+target_compile_options(${TUTORIAL_NAME_4} PRIVATE
+  -Wno-undefined-func-template -Wno-float-equal -Wno-ctad-maybe-unsupported
+)
+
+add_dependencies(tutorials ${TUTORIAL_NAME_4})

--- a/projects/composablekernel/tutorial/ck_tile/tile_distribution/README.md
+++ b/projects/composablekernel/tutorial/ck_tile/tile_distribution/README.md
@@ -39,12 +39,13 @@ The recommended reading order is **1 → 3 → 2 → 4** (simple to complex):
 | `tile_distribution.cpp` | 1 | 32×8 | 128 (2 warps) | NDimP=1, basic P/Y split | MakeADramTileDistribution (simplified) |
 | `tile_distribution_3.cpp` | 3 | 128×8 | 128 (2 warps) | NDimP=2, lane→M only (small K) | MakeADramTileDistribution (RowMajor) |
 | `tile_distribution_2.cpp` | 2 | 64×32 | 128 (2 warps) | NDimP=2, lane→M+K (coalesced) | MakeADramTileDistribution (RowMajor) |
-| `tile_distribution_4.cpp` | 4 | 128×8 | 256 (4 warps) | NDimP=2 + R (inter-warp replicate) | MakeScaleADramTileDistribution |
+| `tile_distribution_4.cpp` | 4 | 128×8 | 256 (4 warps) | NDimP=2 + R (inter-warp replicate) | Tutorial replicate-pattern example |
 
 Scenarios 1-3 are from
 `include/ck_tile/ops/gemm/pipeline/gemm_pipeline_agmem_bgmem_creg_v1_default_policy.hpp`.
-Scenario 4 demonstrates the R (replicate) dimension pattern used in MX-GEMM scale-factor
-distributions.
+Scenario 4 demonstrates the R (replicate) dimension pattern used for scale-factor style
+distributions, but this tutorial does not currently point to a matching production helper in
+this repository.
 
 ## Building
 

--- a/projects/composablekernel/tutorial/ck_tile/tile_distribution/README.md
+++ b/projects/composablekernel/tutorial/ck_tile/tile_distribution/README.md
@@ -49,7 +49,7 @@ distributions.
 ## Building
 
 ```bash
-cd rocm-libraries-public/projects/composablekernel/build
+cd <repo-root>/projects/composablekernel/build
 
 # Build all tutorials:
 ninja tutorials

--- a/projects/composablekernel/tutorial/ck_tile/tile_distribution/README.md
+++ b/projects/composablekernel/tutorial/ck_tile/tile_distribution/README.md
@@ -1,0 +1,73 @@
+# CK Tile Distribution Encoding Tutorial
+
+## Overview
+
+Every `load_tile` and `store_tile` in CK needs to know **which thread reads which data element**.
+This mapping is defined by a `tile_distribution_encoding` — a compile-time struct with 6 template
+parameters:
+
+```cpp
+tile_distribution_encoding<Rs, Hs, Ps_major, Ps_minor, Ys_major, Ys_minor>
+```
+
+Every level of **Hs** (hierarchical dimensions) is assigned to exactly one role:
+
+| Role | Meaning |
+|------|---------|
+| **P** (parallel) | Thread ID selects which slice — different threads get different data |
+| **Y** (yield) | Each thread owns the entire range in its buffer |
+| **R** (replicate) | Identical data broadcast to multiple thread groups |
+
+This tutorial series makes these mappings concrete: each scenario loads a matrix using a
+production distribution and prints what each thread received, so you can trace the encoding
+by hand.
+
+No compute is performed. The tutorials are purely about data movement and thread-to-data mapping.
+
+**Architecture note:** All comments, ASCII art, and concrete values in these tutorials assume
+**CDNA (warp_size=64)**. On RDNA (warp_size=32), the thread-to-data mapping will differ:
+`lane_id` ranges 0–31 instead of 0–63, `BlockSize / warp_size` yields more warps, and
+production code derives different values for M0/M1/M2/K0/K1. The encodings will compile and
+run on both architectures, but the printed output will not match the comments on RDNA.
+
+## Tutorials
+
+The recommended reading order is **1 → 3 → 2 → 4** (simple to complex):
+
+| File | Scenario | Tile | Threads | Key Concept | Source |
+|------|----------|------|---------|-------------|--------|
+| `tile_distribution.cpp` | 1 | 32×8 | 128 (2 warps) | NDimP=1, basic P/Y split | MakeADramTileDistribution (simplified) |
+| `tile_distribution_3.cpp` | 3 | 128×8 | 128 (2 warps) | NDimP=2, lane→M only (small K) | MakeADramTileDistribution (RowMajor) |
+| `tile_distribution_2.cpp` | 2 | 64×32 | 128 (2 warps) | NDimP=2, lane→M+K (coalesced) | MakeADramTileDistribution (RowMajor) |
+| `tile_distribution_4.cpp` | 4 | 128×8 | 256 (4 warps) | NDimP=2 + R (inter-warp replicate) | MakeScaleADramTileDistribution |
+
+Scenarios 1-3 are from
+`include/ck_tile/ops/gemm/pipeline/gemm_pipeline_agmem_bgmem_creg_v1_default_policy.hpp`.
+Scenario 4 is from
+`include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_tdm_default_policy.hpp`.
+
+## Building
+
+```bash
+cd rocm-libraries-public/projects/composablekernel/build
+
+# Build all tutorials:
+ninja tutorials
+
+# Or build individually:
+ninja tile_tutorial_tile_distribution
+ninja tile_tutorial_tile_distribution_2
+ninja tile_tutorial_tile_distribution_3
+ninja tile_tutorial_tile_distribution_4
+```
+
+## Reference
+
+The distribution encoding is defined in:
+- `include/ck_tile/core/tensor/tile_distribution_encoding.hpp`
+- `include/ck_tile/core/tensor/tile_distribution.hpp` (line 98: NDimP → thread identity)
+- `include/ck_tile/core/algorithm/coordinate_transform.hpp` (merge_v3_division_mod: the modular decomposition)
+
+Production usage:
+- `include/ck_tile/ops/gemm/pipeline/gemm_pipeline_agmem_bgmem_creg_v1_default_policy.hpp`
+  (`MakeADramTileDistribution`, `MakeBDramTileDistribution`)

--- a/projects/composablekernel/tutorial/ck_tile/tile_distribution/README.md
+++ b/projects/composablekernel/tutorial/ck_tile/tile_distribution/README.md
@@ -43,8 +43,8 @@ The recommended reading order is **1 → 3 → 2 → 4** (simple to complex):
 
 Scenarios 1-3 are from
 `include/ck_tile/ops/gemm/pipeline/gemm_pipeline_agmem_bgmem_creg_v1_default_policy.hpp`.
-Scenario 4 is from
-`include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_comp_tdm_default_policy.hpp`.
+Scenario 4 demonstrates the R (replicate) dimension pattern used in MX-GEMM scale-factor
+distributions.
 
 ## Building
 

--- a/projects/composablekernel/tutorial/ck_tile/tile_distribution/tile_distribution.cpp
+++ b/projects/composablekernel/tutorial/ck_tile/tile_distribution/tile_distribution.cpp
@@ -1,0 +1,268 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+/*
+ * Tutorial: CK Tile Distribution Encoding
+ *
+ * Demonstrates how tile_distribution_encoding maps threads to data elements.
+ * Uses a simplified A-matrix DRAM tile distribution from the production GEMM pipeline.
+ * Source: gemm_pipeline_agmem_bgmem_creg_v1_default_policy.hpp
+ *         MakeADramTileDistribution(), RowMajor branch
+ *
+ * Host initialises A with sequential values 0, 1, 2, ... (row-major).
+ * A[m][k] = m * K + k, so the printed value directly gives the linear index.
+ * GPU kernel loads A using the distribution, then prints per-thread buffer
+ * contents so the reader can verify which elements each thread received.
+ *
+ * No compute is performed — this is purely about data movement.
+ *
+ * Note: Comments and values assume CDNA (warp_size=64). On RDNA (warp_size=32),
+ * the thread-to-data mapping will differ.
+ */
+
+#include "ck_tile/core.hpp"
+#include "ck_tile/host.hpp"
+#include <cstdio>
+
+using namespace ck_tile;
+
+// ============================================================================
+// THE GOAL
+// ============================================================================
+// We have a matrix A of size M=32 rows × K=8 columns stored in DRAM (row-major).
+// We want to load this entire tile into thread registers using 128 threads
+// (2 warps on CDNA, 4 warps on RDNA).
+//
+// The desired thread-to-data mapping is:
+//
+//   - Split the 32 M-rows into 2 equal halves (16 rows each).
+//   - Assign each half to a different group of threads.
+//   - Each thread in a group holds all 16 rows × 8 K-columns = 128 elements.
+//   - Multiple threads in the same group hold identical copies of the data.
+//     (This redundancy is intentional — in production GEMM, the data is
+//      written to LDS next, where each thread reads a different subset.)
+//
+//   Group 0 (even lanes: lane 0, 2, 4, ...):  M-rows  0..15, K-cols 0..7
+//   Group 1 (odd  lanes: lane 1, 3, 5, ...):  M-rows 16..31, K-cols 0..7
+//
+// Visually:
+//
+//       A matrix (32×8)                Thread assignment
+//       ────────────────               ─────────────────
+//       row  0: [  0   1  ...   7]  ─┐
+//       row  1: [  8   9  ...  15]   │  Group 0 (even lanes)
+//       ...                           │  128 elements per thread
+//       row 15: [120 121  ... 127]  ─┘
+//       row 16: [128 129  ... 135]  ─┐
+//       row 17: [136 137  ... 143]   │  Group 1 (odd lanes)
+//       ...                           │  128 elements per thread
+//       row 31: [248 249  ... 255]  ─┘
+//
+// Now try to write a tile_distribution_encoding that achieves this mapping
+// before reading the solution below!
+//
+// ============================================================================
+// THE SOLUTION: tile_distribution_encoding
+// ============================================================================
+// CK's tile_distribution_encoding has 6 template parameters:
+//
+//   tile_distribution_encoding<Rs, Hs, Ps_major, Ps_minor, Ys_major, Ys_minor>
+//
+// Every level of Hs is assigned to exactly one role:
+//   P = "parallel" — thread ID selects which slice
+//   Y = "yield"    — each thread owns the entire range in its buffer
+//   R = "replicate"— identical data broadcast to multiple thread groups
+//
+// Here is how we build it for our goal:
+//
+//   Step 1 — Hierarchical dimensions (Hs): factor each axis of the tile.
+//
+//      Hs[0] = sequence<2, 16>  → M = 2 groups × 16 rows/group = 32
+//      Hs[1] = sequence<8>      → K = 8 columns (kept flat)
+//
+//              Hs[0]              Hs[1]
+//           ┌────┴────┐            │
+//       level 0    level 1      level 0
+//        = 2        = 16          = 8
+//
+//   Step 2 — Parallel dimensions (Ps): which levels are selected by thread ID?
+//
+//      Ps_major = tuple<sequence<1>>   →  P0 points to Hs[0]  (1-indexed)
+//      Ps_minor = tuple<sequence<0>>   →  P0 points to level 0 of Hs[0] = the "2"
+//
+//      Mark it on the tree:
+//
+//              Hs[0]              Hs[1]
+//           ┌────┴────┐            │
+//          [P]       [?]          [?]
+//        = 2        = 16          = 8
+//
+//   Step 3 — Yield dimensions (Ys): what does each thread own?
+//
+//      Ys_major = sequence<1, 2>   →  Y0 → Hs[0],  Y1 → Hs[1]  (1-indexed)
+//      Ys_minor = sequence<1, 0>   →  Y0 → level 1, Y1 → level 0
+//
+//      Complete tree:
+//
+//              Hs[0]              Hs[1]
+//           ┌────┴────┐            │
+//          [P]       [Y0]         [Y1]
+//        = 2        = 16          = 8
+//       (group)   (rows/grp)    (columns)
+//
+//      Buffer size = Y0 × Y1 = 16 × 8 = 128 elements per thread.
+//
+//   Step 4 — Replicate (Rs): sequence<> — none.
+//
+// ============================================================================
+// HOW CK ASSIGNS THREADS TO P-GROUPS
+// ============================================================================
+// The number of P-dimensions = number of elements in the Ps_major tuple.
+//
+//   tuple<sequence<1>>              → 1 element  → NDimP = 1
+//   tuple<sequence<1>, sequence<2>> → 2 elements → NDimP = 2
+//
+// CK uses NDimP to decide what thread identity feeds P:
+//   NDimP == 1:  P0 = lane_id                   (0..63 on CDNA)
+//   NDimP == 2:  P0 = warp_id,  P1 = lane_id
+//
+// Our encoding has NDimP = 1, so P0 = lane_id.
+// P0 selects from Hs[0][0] which has size 2.
+// With 64 lanes mapping to 2 groups → lane_id % 2 picks the group:
+//
+//   lane  0 → 0 % 2 = 0 → group 0 (M=0..15)
+//   lane  1 → 1 % 2 = 1 → group 1 (M=16..31)
+//   lane  2 → 2 % 2 = 0 → group 0
+//   ...
+//   lane 63 → 63 % 2 = 1 → group 1
+//
+// 32 lanes per group, each holding identical 128-element buffers.
+// Both warps have lanes 0..63, so warp 0 and warp 1 hold identical data.
+// ============================================================================
+
+static constexpr index_t kM = 32;
+static constexpr index_t kK = 8;
+
+struct TileDistKernel1
+{
+    static constexpr index_t kBlockSize = 128;
+
+    CK_TILE_DEVICE void operator()(const int32_t* p_data) const
+    {
+        const auto a_tensor = make_naive_tensor_view<address_space_enum::global>(
+            p_data, make_tuple(kM, kK), make_tuple(kK, 1), number<1>{}, number<1>{});
+
+        constexpr auto distribution = make_static_tile_distribution(
+            tile_distribution_encoding<sequence<>,
+                                       tuple<sequence<2, 16>, sequence<8>>,
+                                       tuple<sequence<1>>,
+                                       tuple<sequence<0>>,
+                                       sequence<1, 2>,
+                                       sequence<1, 0>>{});
+
+        auto window = make_tile_window(
+            a_tensor, make_tuple(number<kM>{}, number<kK>{}), {0, 0}, distribution);
+
+        const auto tile = load_tile(window);
+
+        const auto& buf             = tile.get_thread_buffer();
+        constexpr index_t warp_size = get_warp_size();
+
+        constexpr index_t kBufSize       = 16 * 8; // 16 rows × 8 cols = 128
+        constexpr index_t kRowsPerThread = 16;
+        constexpr index_t kColsPerThread = 8;
+
+        // Copy compile-time-indexed buffer into a plain array for runtime printing
+        int32_t local_buf[kBufSize];
+        static_for<0, kBufSize, 1>{}([&](auto i) { local_buf[i] = static_cast<int32_t>(buf[i]); });
+
+        auto print_thread = [&](int tid) {
+            if(static_cast<int>(threadIdx.x) == tid)
+            {
+                printf("Thread %3d  (warp %d, lane %2d)  buf_size=%d  (%d rows x %d cols)\n",
+                       tid,
+                       tid / static_cast<int>(warp_size),
+                       tid % static_cast<int>(warp_size),
+                       static_cast<int>(kBufSize),
+                       static_cast<int>(kRowsPerThread),
+                       static_cast<int>(kColsPerThread));
+
+                for(index_t m = 0; m < kRowsPerThread; m++)
+                {
+                    int val0    = local_buf[m * kColsPerThread];
+                    int decoded = val0 / kColsPerThread;
+                    printf("  row %2d: (M=%2d) ", static_cast<int>(m), decoded);
+                    for(index_t k = 0; k < kColsPerThread; k++)
+                    {
+                        printf("%5d ", local_buf[m * kColsPerThread + k]);
+                    }
+                    printf("\n");
+                }
+                printf("\n");
+            }
+        };
+
+        if(blockIdx.x == 0)
+        {
+            if(threadIdx.x == 0)
+            {
+                printf("\n=== Tile Distribution: A-Matrix DRAM Load (RowMajor) ===\n");
+                printf("Tile: %d x %d,  BlockSize: %d,  WarpSize: %d\n",
+                       static_cast<int>(kM),
+                       static_cast<int>(kK),
+                       static_cast<int>(kBlockSize),
+                       static_cast<int>(warp_size));
+                printf("Each thread owns: 16 rows x 8 cols = 128 elements\n");
+                printf("NDimP=1 => P0 = lane_id. P0 maps to Hs[0][0] (size 2)\n");
+                printf("  => even lanes get M=0..15, odd lanes get M=16..31\n");
+                printf("  => warp 0 and warp 1 hold identical data (same lane IDs)\n\n");
+            }
+            __syncthreads();
+
+            // Warp 0, lane 0 (even → M=0..15)
+            print_thread(0);
+            __syncthreads();
+
+            // Warp 0, lane 1 (odd → M=16..31)
+            print_thread(1);
+            __syncthreads();
+
+            // Warp 1, lane 0 (even → M=0..15, same as T0)
+            print_thread(static_cast<int>(warp_size));
+            __syncthreads();
+
+            // Warp 1, lane 1 (odd → M=16..31, same as T1)
+            print_thread(static_cast<int>(warp_size) + 1);
+            __syncthreads();
+        }
+    }
+};
+
+int main()
+{
+    printf("=== CK Tile Distribution Tutorial ===\n\n");
+
+    HostTensor<int32_t> h_tensor({kM, kK});
+    for(int i = 0; i < kM * kK; i++)
+        h_tensor.mData[i] = i;
+
+    printf("Host matrix A[%d x %d], row-major, values 0..%d\n", kM, kK, kM * kK - 1);
+    printf("  A[0][0]=%d  A[0][7]=%d  A[1][0]=%d  A[31][7]=%d\n\n",
+           h_tensor(0, 0),
+           h_tensor(0, 7),
+           h_tensor(1, 0),
+           h_tensor(31, 7));
+
+    DeviceMem d_data(h_tensor);
+
+    launch_kernel(stream_config{},
+                  make_kernel<1>(TileDistKernel1{},
+                                 dim3(1),
+                                 dim3(TileDistKernel1::kBlockSize),
+                                 0,
+                                 static_cast<const int32_t*>(d_data.GetDeviceBuffer())));
+    hip_check_error(hipDeviceSynchronize());
+
+    printf("Done.\n");
+    return 0;
+}

--- a/projects/composablekernel/tutorial/ck_tile/tile_distribution/tile_distribution_2.cpp
+++ b/projects/composablekernel/tutorial/ck_tile/tile_distribution/tile_distribution_2.cpp
@@ -1,0 +1,250 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+/*
+ * Tutorial: CK Tile Distribution Encoding — Scenario 2
+ *
+ * Production GEMM: A-Matrix DRAM Load (RowMajor)
+ *
+ * Source: gemm_pipeline_agmem_bgmem_creg_v1_default_policy.hpp
+ *         MakeADramTileDistribution(), RowMajor branch
+ *
+ * Demonstrates how lane_id splits across BOTH M and K dimensions to ensure
+ * coalesced 128-bit reads along the contiguous K-dimension in row-major data.
+ *
+ * No compute is performed — this is purely about data movement.
+ *
+ * Note: Comments and values assume CDNA (warp_size=64). On RDNA (warp_size=32),
+ * the thread-to-data mapping will differ.
+ */
+
+#include "ck_tile/core.hpp"
+#include "ck_tile/host.hpp"
+#include <cstdio>
+
+using namespace ck_tile;
+
+// ============================================================================
+// THE GOAL
+// ============================================================================
+// We have a matrix A of size M=64 rows × K=32 columns stored in DRAM (row-major).
+// We want to load this entire tile into registers using 128 threads (2 warps).
+// Each thread should hold exactly 16 elements.
+//
+// For coalesced memory access, we want consecutive lanes to read consecutive
+// K-elements (since K is the contiguous dimension in row-major). Each lane
+// reads 8 contiguous K-values (128 bits for fp16), so 4 consecutive lanes
+// cover all 32 K-columns of one row:
+//
+//      lane 0: K=0..7    lane 1: K=8..15    lane 2: K=16..23    lane 3: K=24..31
+//      └──────────────── one row of 32 K-columns ──────────────────────────────┘
+//
+// The next group of 4 lanes handles the next M-row, and so on:
+//
+//      lanes  0- 3: row 0    (4 lanes × 8 K-values = 32 columns)
+//      lanes  4- 7: row 1
+//      lanes  8-11: row 2
+//      ...
+//      lanes 60-63: row 15
+//
+// So each warp (64 lanes) covers 16 M-rows × 32 K-columns.
+// With 2 warps: warp 0 → rows 0-15, warp 1 → rows 16-31.
+// That's only 32 rows, but we need 64. Each thread iterates twice (stride=32)
+// to cover the remaining rows:
+//
+//   Iteration 0: rows 0-31  (warp 0: 0-15,  warp 1: 16-31)
+//   Iteration 1: rows 32-63 (warp 0: 32-47, warp 1: 48-63)
+//
+// Per-thread buffer = 2 iterations × 8 K-values = 16 elements.
+//
+// Visually for warp 0:
+//
+//       A matrix (64×32)           lane_id decomposition
+//       ────────────────           ──────────────────────
+//       row  0: [ K=0..7 | 8..15 | 16..23 | 24..31 ]
+//                  L0       L1      L2       L3       ← iter 0
+//       row  1: [ K=0..7 | 8..15 | 16..23 | 24..31 ]
+//                  L4       L5      L6       L7
+//       ...
+//       row 15: [ K=0..7 | 8..15 | 16..23 | 24..31 ]
+//                  L60      L61     L62      L63
+//       ────── stride of 32 rows ──────
+//       row 32: [ K=0..7 | 8..15 | 16..23 | 24..31 ]
+//                  L0       L1      L2       L3       ← iter 1
+//       ...
+//       row 47: same lanes as iter 0
+//
+// ============================================================================
+// THE SOLUTION: tile_distribution_encoding
+// ============================================================================
+//
+//   Step 1 — Hierarchical dimensions (Hs): factor each axis.
+//
+//      Hs[0] = sequence<2, 2, 16>  → M = 2 × 2 × 16 = 64
+//      Hs[1] = sequence<4, 8>      → K = 4 × 8 = 32
+//
+//              Hs[0]                    Hs[1]
+//         ┌─────┼─────┐              ┌───┴───┐
+//      level 0  level 1  level 2   level 0  level 1
+//        = 2     = 2      = 16       = 4      = 8
+//
+//   Step 2 — Parallel dimensions (Ps): NDimP=2 (P0=warp_id, P1=lane_id).
+//
+//      P0 = warp_id  → Hs[0][1] = 2  (which warp → which M-group)
+//      P1 = lane_id  → Hs[0][2]=16 AND Hs[1][0]=4  (merged, total=64)
+//
+//      The merge transform decomposes lane_id:
+//        row_in_group = lane_id / 4   (0..15, outer)
+//        k_chunk      = lane_id % 4   (0..3,  inner → coalesced!)
+//
+//      Ps_major = tuple<sequence<1>, sequence<1, 2>>
+//      Ps_minor = tuple<sequence<1>, sequence<2, 0>>
+//
+//   Step 3 — Yield dimensions (Ys): what each thread owns.
+//
+//      Y0 = Hs[0][0] = 2  (M-iterations)
+//      Y1 = Hs[1][1] = 8  (vector load width)
+//
+//      Ys_major = sequence<1, 2>
+//      Ys_minor = sequence<0, 1>
+//
+//   Step 4 — Replicate: Rs = sequence<> (none).
+//
+//   Complete tree:
+//
+//              Hs[0]                    Hs[1]
+//         ┌─────┼─────┐              ┌───┴───┐
+//       [Y0]   [P0]  [P1]          [P1]     [Y1]
+//        = 2    = 2   = 16          = 4      = 8
+//      (iter) (warp) (row)        (K-chunk) (vec load)
+//
+//   Buffer size = Y0 × Y1 = 2 × 8 = 16 elements per thread.
+//
+// ============================================================================
+
+static constexpr index_t kM = 64;
+static constexpr index_t kK = 32;
+
+struct TileDistKernel2
+{
+    static constexpr index_t kBlockSize = 128;
+
+    CK_TILE_DEVICE void operator()(const int32_t* p_data) const
+    {
+        const auto a_tensor = make_naive_tensor_view<address_space_enum::global>(
+            p_data, make_tuple(kM, kK), make_tuple(kK, 1), number<1>{}, number<1>{});
+
+        constexpr auto distribution = make_static_tile_distribution(
+            tile_distribution_encoding<sequence<>,
+                                       tuple<sequence<2, 2, 16>, sequence<4, 8>>,
+                                       tuple<sequence<1>, sequence<1, 2>>,
+                                       tuple<sequence<1>, sequence<2, 0>>,
+                                       sequence<1, 2>,
+                                       sequence<0, 1>>{});
+
+        auto window = make_tile_window(
+            a_tensor, make_tuple(number<kM>{}, number<kK>{}), {0, 0}, distribution);
+
+        const auto tile = load_tile(window);
+
+        const auto& buf             = tile.get_thread_buffer();
+        constexpr index_t warp_size = get_warp_size();
+        constexpr index_t kBufSize  = 16; // 2 iterations × 8 K-values
+
+        int32_t local_buf[kBufSize];
+        static_for<0, kBufSize, 1>{}([&](auto i) { local_buf[i] = static_cast<int32_t>(buf[i]); });
+
+        auto print_thread = [&](int tid) {
+            if(static_cast<int>(threadIdx.x) == tid)
+            {
+                int lane       = tid % static_cast<int>(warp_size);
+                int warp       = tid / static_cast<int>(warp_size);
+                int row_in_grp = lane / 4;
+                int k_chunk    = lane % 4;
+
+                printf("Thread %3d  (warp %d, lane %2d)  row_in_grp=%2d  k_chunk=%d\n",
+                       tid,
+                       warp,
+                       lane,
+                       row_in_grp,
+                       k_chunk);
+
+                for(int iter = 0; iter < 2; iter++)
+                {
+                    int row = iter * 32 + warp * 16 + row_in_grp;
+                    int col = k_chunk * 8;
+                    printf("  iter %d: A[%2d][%2d..%2d] =", iter, row, col, col + 7);
+                    for(int k = 0; k < 8; k++)
+                        printf(" %4d", local_buf[iter * 8 + k]);
+                    printf("\n");
+                }
+            }
+        };
+
+        if(blockIdx.x == 0)
+        {
+            if(threadIdx.x == 0)
+            {
+                printf("\n=== Scenario 2: GEMM A-Matrix RowMajor DRAM Load ===\n");
+                printf("Source: MakeADramTileDistribution (RowMajor branch)\n");
+                printf("Tile: %dx%d  BlockSize: %d  WarpSize: %d  Warps: 2\n",
+                       kM,
+                       kK,
+                       kBlockSize,
+                       static_cast<int>(warp_size));
+                printf("Each thread: 2 iterations x 8 K-values = 16 elements\n\n");
+                printf("Coalescing: lanes 0-3 read K=0..31 of the same row\n");
+                printf("            (4 x 8 = 32 K-values = one full row)\n\n");
+            }
+            __syncthreads();
+
+            // Lane 0: row_in_grp=0, k_chunk=0 → rows {0, 32}, K=0..7
+            print_thread(0);
+            __syncthreads();
+            // Lane 1: row_in_grp=0, k_chunk=1 → rows {0, 32}, K=8..15 (coalesced!)
+            print_thread(1);
+            __syncthreads();
+            // Lane 4: row_in_grp=1, k_chunk=0 → rows {1, 33}, K=0..7 (next row)
+            print_thread(4);
+            __syncthreads();
+            // Lane 63: row_in_grp=15, k_chunk=3 → rows {15, 47}, K=24..31
+            print_thread(63);
+            __syncthreads();
+
+            if(threadIdx.x == 0)
+                printf("\n--- Warp 1 ---\n");
+            __syncthreads();
+            // Warp 1, Lane 0: rows {16, 48}, K=0..7
+            print_thread(64);
+            __syncthreads();
+            // Warp 1, Lane 63: rows {31, 63}, K=24..31
+            print_thread(127);
+            __syncthreads();
+        }
+    }
+};
+
+int main()
+{
+    printf("=== CK Tile Distribution Tutorial — Scenario 2 ===\n");
+    printf("=== Production GEMM A-Matrix RowMajor DRAM Load ===\n\n");
+
+    HostTensor<int32_t> h_tensor({kM, kK});
+    for(int i = 0; i < kM * kK; i++)
+        h_tensor.mData[i] = i;
+
+    printf("Host matrix A[%d x %d], row-major, A[m][k] = m*%d + k\n\n", kM, kK, kK);
+
+    DeviceMem d_data(h_tensor);
+
+    launch_kernel(stream_config{},
+                  make_kernel<1>(TileDistKernel2{},
+                                 dim3(1),
+                                 dim3(TileDistKernel2::kBlockSize),
+                                 0,
+                                 static_cast<const int32_t*>(d_data.GetDeviceBuffer())));
+    hip_check_error(hipDeviceSynchronize());
+
+    printf("Done.\n");
+    return 0;
+}

--- a/projects/composablekernel/tutorial/ck_tile/tile_distribution/tile_distribution_3.cpp
+++ b/projects/composablekernel/tutorial/ck_tile/tile_distribution/tile_distribution_3.cpp
@@ -1,0 +1,215 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+/*
+ * Tutorial: CK Tile Distribution Encoding — Scenario 3
+ *
+ * Production GEMM: A-Matrix DRAM Load (RowMajor, small K)
+ *
+ * Source: gemm_pipeline_agmem_bgmem_creg_v1_default_policy.hpp
+ *         MakeADramTileDistribution(), RowMajor branch
+ *
+ * Same function as Scenario 2, but with K=8 (small enough to fit in one
+ * vector load). This eliminates K-splitting — lane_id maps entirely to M.
+ * Serves as a stepping stone between the simple Scenario 1 and the
+ * coalesced Scenario 2.
+ *
+ * No compute is performed — this is purely about data movement.
+ *
+ * Note: Comments and values assume CDNA (warp_size=64). On RDNA (warp_size=32),
+ * the thread-to-data mapping will differ.
+ */
+
+#include "ck_tile/core.hpp"
+#include "ck_tile/host.hpp"
+#include <cstdio>
+
+using namespace ck_tile;
+
+// ============================================================================
+// THE GOAL
+// ============================================================================
+// Matrix A: M=128 rows × K=8 columns, stored in DRAM (row-major).
+// Load the entire tile using 128 threads (2 warps).
+// Each thread loads exactly 8 elements (one complete row).
+//
+// Since K=8 fits in a single 128-bit vector load (8 × fp16 = 16 bytes),
+// there is no need to split K across lanes. Each lane loads ALL K-columns
+// of its assigned row. lane_id selects only which M-row to load.
+//
+//       A matrix (128×8)              Thread assignment
+//       ────────────────              ─────────────────
+//       row   0: [  0   1  ...   7]   ← warp 0, lane  0
+//       row   1: [  8   9  ...  15]   ← warp 0, lane  1
+//       row   2: [ 16  17  ...  23]   ← warp 0, lane  2
+//       ...
+//       row  63: [504 505  ... 511]   ← warp 0, lane 63
+//       row  64: [512 513  ... 519]   ← warp 1, lane  0
+//       row  65: [520 521  ... 527]   ← warp 1, lane  1
+//       ...
+//       row 127: [1016 1017 .. 1023]  ← warp 1, lane 63
+//
+// This is the simplest NDimP=2 distribution:
+//   P0 = warp_id → which M-half  (2 warps)
+//   P1 = lane_id → which M-row within that half  (64 lanes)
+//   Y  = all 8 K-columns  (vector load, each thread owns the full row)
+//
+// Compare with Scenario 2 (K=32):
+//   When K grows beyond the vector load width, K must also be split across
+//   lanes for coalescing, making P1 map to both M and K. Here K is small
+//   enough that P1 maps only to M.
+//
+// ============================================================================
+// THE SOLUTION: tile_distribution_encoding
+// ============================================================================
+//
+//   Production code derives (fp16, BlockSize=128, MPerBlock=128, KPerBlock=8):
+//     K1 = 16/sizeof(fp16) = 8   → vector load = 8 K-values = entire K
+//     K0 = KPerBlock/K1 = 1      → only 1 K-chunk (no K-splitting!)
+//     M2 = warp_size/K0 = 64     → all 64 lanes go to M
+//     M1 = BlockSize/warp_size = 2
+//     M0 = MPerBlock/(M2*M1) = 1
+//
+//   We simplify by dropping trivial levels (M0=1, K0=1, Rs=1):
+//
+//   Step 1 — Hierarchical dimensions (Hs):
+//
+//      Hs[0] = sequence<2, 64>  → M = 2 × 64 = 128
+//      Hs[1] = sequence<8>      → K = 8
+//
+//              Hs[0]              Hs[1]
+//           ┌────┴────┐            │
+//         [P0]      [P1]         [Y0]
+//          = 2      = 64          = 8
+//        (warp)    (lane)      (vec load)
+//
+//   Step 2 — Parallel (Ps): NDimP=2.
+//
+//      P0 = warp_id → Hs[0][0] = 2
+//      P1 = lane_id → Hs[0][1] = 64  (maps only to M, no K-splitting)
+//
+//      Ps_major = tuple<sequence<1>, sequence<1>>
+//      Ps_minor = tuple<sequence<0>, sequence<1>>
+//
+//   Step 3 — Yield (Ys):
+//
+//      Y0 = Hs[1][0] = 8  (K-values, the vector load)
+//
+//      Ys_major = sequence<2>
+//      Ys_minor = sequence<0>
+//
+//   Step 4 — Replicate: Rs = sequence<> (none).
+//
+//   Buffer size = Y0 = 8 elements per thread.
+//
+// ============================================================================
+
+static constexpr index_t kM = 128;
+static constexpr index_t kK = 8;
+
+struct TileDistKernel3
+{
+    static constexpr index_t kBlockSize = 128;
+
+    CK_TILE_DEVICE void operator()(const int32_t* p_data) const
+    {
+        const auto a_tensor = make_naive_tensor_view<address_space_enum::global>(
+            p_data, make_tuple(kM, kK), make_tuple(kK, 1), number<1>{}, number<1>{});
+
+        constexpr auto distribution = make_static_tile_distribution(
+            tile_distribution_encoding<sequence<>,
+                                       tuple<sequence<2, 64>, sequence<8>>,
+                                       tuple<sequence<1>, sequence<1>>,
+                                       tuple<sequence<0>, sequence<1>>,
+                                       sequence<2>,
+                                       sequence<0>>{});
+
+        auto window = make_tile_window(
+            a_tensor, make_tuple(number<kM>{}, number<kK>{}), {0, 0}, distribution);
+
+        const auto tile = load_tile(window);
+
+        const auto& buf             = tile.get_thread_buffer();
+        constexpr index_t warp_size = get_warp_size();
+        constexpr index_t kBufSize  = 8;
+
+        int32_t local_buf[kBufSize];
+        static_for<0, kBufSize, 1>{}([&](auto i) { local_buf[i] = static_cast<int32_t>(buf[i]); });
+
+        auto print_thread = [&](int tid) {
+            if(static_cast<int>(threadIdx.x) == tid)
+            {
+                int lane = tid % static_cast<int>(warp_size);
+                int warp = tid / static_cast<int>(warp_size);
+                int row  = warp * 64 + lane;
+
+                printf("Thread %3d  (warp %d, lane %2d)  row=%3d  |", tid, warp, lane, row);
+                for(int k = 0; k < kBufSize; k++)
+                    printf(" %4d", local_buf[k]);
+                printf("\n");
+            }
+        };
+
+        if(blockIdx.x == 0)
+        {
+            if(threadIdx.x == 0)
+            {
+                printf("\n=== Scenario 3: GEMM A-Matrix RowMajor (Small K) ===\n");
+                printf("Source: MakeADramTileDistribution (RowMajor, K=%d)\n",
+                       static_cast<int>(kK));
+                printf("Tile: %dx%d  BlockSize: %d  WarpSize: %d  Warps: 2\n",
+                       kM,
+                       kK,
+                       kBlockSize,
+                       static_cast<int>(warp_size));
+                printf("K=%d fits in one vector load → no K-splitting\n", kK);
+                printf("P1=lane_id maps entirely to M (cf. Scenario 2: M+K)\n");
+                printf("Each thread: 1 row x %d cols = %d elements\n\n", kK, kBufSize);
+            }
+            __syncthreads();
+
+            if(threadIdx.x == 0)
+                printf("--- Warp 0 (rows 0-63) ---\n");
+            __syncthreads();
+            print_thread(0); // lane 0  → row 0
+            __syncthreads();
+            print_thread(1); // lane 1  → row 1
+            __syncthreads();
+            print_thread(63); // lane 63 → row 63
+            __syncthreads();
+
+            if(threadIdx.x == 0)
+                printf("\n--- Warp 1 (rows 64-127) ---\n");
+            __syncthreads();
+            print_thread(64); // lane 0  → row 64
+            __syncthreads();
+            print_thread(127); // lane 63 → row 127
+            __syncthreads();
+        }
+    }
+};
+
+int main()
+{
+    printf("=== CK Tile Distribution Tutorial — Scenario 3 ===\n");
+    printf("=== Production GEMM A-Matrix RowMajor (Small K) ===\n\n");
+
+    HostTensor<int32_t> h_tensor({kM, kK});
+    for(int i = 0; i < kM * kK; i++)
+        h_tensor.mData[i] = i;
+
+    printf("Host matrix A[%d x %d], row-major, A[m][k] = m*%d + k\n\n", kM, kK, kK);
+
+    DeviceMem d_data(h_tensor);
+
+    launch_kernel(stream_config{},
+                  make_kernel<1>(TileDistKernel3{},
+                                 dim3(1),
+                                 dim3(TileDistKernel3::kBlockSize),
+                                 0,
+                                 static_cast<const int32_t*>(d_data.GetDeviceBuffer())));
+    hip_check_error(hipDeviceSynchronize());
+
+    printf("Done.\n");
+    return 0;
+}

--- a/projects/composablekernel/tutorial/ck_tile/tile_distribution/tile_distribution_4.cpp
+++ b/projects/composablekernel/tutorial/ck_tile/tile_distribution/tile_distribution_4.cpp
@@ -1,0 +1,252 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+/*
+ * Tutorial: CK Tile Distribution Encoding — Scenario 4
+ *
+ * Demonstrates the R (replicate) dimension for inter-warp data replication.
+ *
+ * Matrix A: 128 rows × 8 columns, row-major.
+ * BlockSize: 256 threads (4 warps of 64 on CDNA).
+ * Each thread holds exactly 8 elements (one full row).
+ *
+ * The desired thread-to-data mapping is:
+ *
+ *   Warp 0 and Warp 1 load the SAME top half (rows 0-63):
+ *     T0   (warp 0, lane  0) → row   0     T64  (warp 1, lane  0) → row   0
+ *     T1   (warp 0, lane  1) → row   1     T65  (warp 1, lane  1) → row   1
+ *     ...                                   ...
+ *     T63  (warp 0, lane 63) → row  63     T127 (warp 1, lane 63) → row  63
+ *
+ *   Warp 2 and Warp 3 load the SAME bottom half (rows 64-127):
+ *     T128 (warp 2, lane  0) → row  64     T192 (warp 3, lane  0) → row  64
+ *     T129 (warp 2, lane  1) → row  65     T193 (warp 3, lane  1) → row  65
+ *     ...                                   ...
+ *     T191 (warp 2, lane 63) → row 127     T255 (warp 3, lane 63) → row 127
+ *
+ * Key insight: Ps_major can reference rh_major=0 to link the R dimension
+ * to a thread identity (warp_id). The warp_id is then decomposed across
+ * BOTH the H-partition and the R-replicate dimension via the merge transform.
+ *
+ * No compute is performed — this is purely about data movement.
+ *
+ * Note: Comments and values assume CDNA (warp_size=64). On RDNA (warp_size=32),
+ * the thread-to-data mapping will differ.
+ */
+
+#include "ck_tile/core.hpp"
+#include "ck_tile/host.hpp"
+#include <cstdio>
+
+using namespace ck_tile;
+
+// ============================================================================
+// THE GOAL
+// ============================================================================
+// Matrix A: M=128 rows × K=8 columns, 256 threads (4 warps).
+// We want 2 unique data partitions replicated across 2 warp pairs:
+//
+//   Warp 0 and Warp 1 both load rows 0-63 (identical data):
+//       row   0: [  0   1  ...   7]  ← warp 0 lane 0  AND  warp 1 lane 0
+//       row   1: [  8   9  ...  15]  ← warp 0 lane 1  AND  warp 1 lane 1
+//       ...
+//       row  63: [504 505  ... 511]  ← warp 0 lane 63 AND  warp 1 lane 63
+//
+//   Warp 2 and Warp 3 both load rows 64-127 (identical data):
+//       row  64: [512 513  ... 519]  ← warp 2 lane 0  AND  warp 3 lane 0
+//       ...
+//       row 127: [1016 1017 .. 1023] ← warp 2 lane 63 AND  warp 3 lane 63
+//
+// The key new concept is the R (replicate) dimension. To link R to warp_id,
+// Ps_major uses rh_major=0 (which references Rs, not Hs). The warp_id is
+// then decomposed across BOTH the H-partition and the R-replicate dimension.
+//
+// ============================================================================
+// THE SOLUTION: tile_distribution_encoding with R
+// ============================================================================
+//
+//   Hs[0] = sequence<2, 64>   → M = 2 × 64 = 128
+//   Hs[1] = sequence<8>       → K = 8
+//   Rs    = sequence<2>        → 2 replicate groups
+//
+//   P0 = warp_id maps to BOTH Hs[0][0]=2 AND Rs[0]=2:
+//
+//     Ps_major = tuple<sequence<1, 0>, sequence<1>>
+//                               ^  ^
+//                               |  └── rh_major=0 → Rs dimension (size 2)
+//                               └──── rh_major=1 → Hs[0] (1-indexed)
+//
+//     Ps_minor = tuple<sequence<0, 0>, sequence<1>>
+//                               ^  ^
+//                               |  └── Rs[0] (level 0)
+//                               └──── Hs[0][0] (level 0, size 2)
+//
+//   P0 total size = Hs[0][0] × Rs[0] = 2 × 2 = 4 → matches 4 warps.
+//
+//   The merge transform decomposes warp_id across [Hs[0][0]=2, Rs[0]=2]:
+//
+//     M_half = warp_id / 2   (outermost, first in sequence)
+//     R_idx  = warp_id % 2   (innermost, last in sequence)
+//
+//     warp 0: M_half=0, R=0  →  rows 0-63
+//     warp 1: M_half=0, R=1  →  rows 0-63   (replicate of warp 0)
+//     warp 2: M_half=1, R=0  →  rows 64-127
+//     warp 3: M_half=1, R=1  →  rows 64-127  (replicate of warp 2)
+//
+//   P1 = lane_id maps to Hs[0][1]=64 (one lane per row within the half).
+//
+//   Y0 = Hs[1][0] = 8 → each thread owns all 8 K-columns.
+//   Buffer size = 8 elements per thread.
+//
+// ============================================================================
+// GOLDEN RULE: Ordering in Ps_major controls which warps are replicates.
+// ============================================================================
+// The merge transform decomposes warp_id like a row-major flat index:
+//   - FIRST entry in the sequence = outermost (divided first, changes slowly)
+//   - LAST  entry in the sequence = innermost (modulo, changes every step)
+//
+// sequence<1, 0>  →  [H=2, R=2]  →  H outer, R inner
+//   warp 0: H=0, R=0   (rows 0-63)
+//   warp 1: H=0, R=1   (rows 0-63)     ← consecutive warps are replicates
+//   warp 2: H=1, R=0   (rows 64-127)
+//   warp 3: H=1, R=1   (rows 64-127)
+//
+// sequence<0, 1>  →  [R=2, H=2]  →  R outer, H inner
+//   warp 0: R=0, H=0   (rows 0-63)
+//   warp 1: R=0, H=1   (rows 64-127)   ← consecutive warps are DIFFERENT
+//   warp 2: R=1, H=0   (rows 0-63)
+//   warp 3: R=1, H=1   (rows 64-127)   ← alternating warps are replicates
+//
+// Rule: put the dimension you want to cycle fastest LAST in the sequence.
+// ============================================================================
+
+static constexpr index_t kM = 128;
+static constexpr index_t kK = 8;
+
+struct TileDistKernel4
+{
+    static constexpr index_t kBlockSize = 256;
+
+    CK_TILE_DEVICE void operator()(const int32_t* p_data) const
+    {
+        const auto a_tensor = make_naive_tensor_view<address_space_enum::global>(
+            p_data, make_tuple(kM, kK), make_tuple(kK, 1), number<1>{}, number<1>{});
+
+        constexpr auto distribution = make_static_tile_distribution(
+            tile_distribution_encoding<sequence<2>,
+                                       tuple<sequence<2, 64>, sequence<8>>,
+                                       tuple<sequence<1, 0>, sequence<1>>,
+                                       tuple<sequence<0, 0>, sequence<1>>,
+                                       sequence<2>,
+                                       sequence<0>>{});
+
+        auto window = make_tile_window(
+            a_tensor, make_tuple(number<kM>{}, number<kK>{}), {0, 0}, distribution);
+
+        const auto tile = load_tile(window);
+
+        const auto& buf             = tile.get_thread_buffer();
+        constexpr index_t warp_size = get_warp_size();
+        constexpr index_t kBufSize  = kK;
+
+        int32_t local_buf[kBufSize];
+        static_for<0, kBufSize, 1>{}([&](auto i) { local_buf[i] = static_cast<int32_t>(buf[i]); });
+
+        auto print_thread = [&](int tid) {
+            if(static_cast<int>(threadIdx.x) == tid)
+            {
+                int lane = tid % static_cast<int>(warp_size);
+                int warp = tid / static_cast<int>(warp_size);
+
+                printf("Thread %3d  (warp %d, lane %2d)  |", tid, warp, lane);
+
+                for(index_t k = 0; k < kBufSize; k++)
+                    printf(" %4d", local_buf[k]);
+                printf("\n");
+            }
+        };
+
+        if(blockIdx.x == 0)
+        {
+            if(threadIdx.x == 0)
+            {
+                printf(
+                    "\n=== Tile Distribution Scenario 4: R Dimension (Inter-Warp Replicate) ===\n");
+                printf("Tile: %d x %d,  BlockSize: %d,  WarpSize: %d,  Warps: 4\n",
+                       static_cast<int>(kM),
+                       static_cast<int>(kK),
+                       static_cast<int>(kBlockSize),
+                       static_cast<int>(warp_size));
+                printf("Each thread owns: 1 row x %d cols = %d elements\n",
+                       static_cast<int>(kK),
+                       static_cast<int>(kBufSize));
+                printf("R=2: warp0=warp1 (rows 0-63), warp2=warp3 (rows 64-127)\n\n");
+            }
+            __syncthreads();
+
+            // Warp 0 (M_half=0, R=0)
+            if(threadIdx.x == 0)
+                printf("--- Warp 0 (M_half=0, R=0) ---\n");
+            __syncthreads();
+            print_thread(0);
+            __syncthreads();
+            print_thread(63);
+            __syncthreads();
+
+            // Warp 1 (M_half=0, R=1) — should match Warp 0
+            if(threadIdx.x == 0)
+                printf("\n--- Warp 1 (M_half=0, R=1) — should match Warp 0 ---\n");
+            __syncthreads();
+            print_thread(64);
+            __syncthreads();
+            print_thread(127);
+            __syncthreads();
+
+            // Warp 2 (M_half=1, R=0)
+            if(threadIdx.x == 0)
+                printf("\n--- Warp 2 (M_half=1, R=0) ---\n");
+            __syncthreads();
+            print_thread(128);
+            __syncthreads();
+            print_thread(191);
+            __syncthreads();
+
+            // Warp 3 (M_half=1, R=1) — should match Warp 2
+            if(threadIdx.x == 0)
+                printf("\n--- Warp 3 (M_half=1, R=1) — should match Warp 2 ---\n");
+            __syncthreads();
+            print_thread(192);
+            __syncthreads();
+            print_thread(255);
+            __syncthreads();
+        }
+    }
+};
+
+int main()
+{
+    printf("=== CK Tile Distribution Tutorial — Scenario 4 (R Dimension) ===\n\n");
+
+    HostTensor<int32_t> h_tensor({kM, kK});
+    for(int i = 0; i < kM * kK; i++)
+        h_tensor.mData[i] = i;
+
+    printf("Host matrix A[%d x %d], row-major, values 0..%d\n", kM, kK, kM * kK - 1);
+    printf("  A[0][0..7]   = {0, 1, 2, 3, 4, 5, 6, 7}\n");
+    printf("  A[63][0..7]  = {504, 505, 506, 507, 508, 509, 510, 511}\n");
+    printf("  A[64][0..7]  = {512, 513, 514, 515, 516, 517, 518, 519}\n");
+    printf("  A[127][0..7] = {1016, 1017, 1018, 1019, 1020, 1021, 1022, 1023}\n\n");
+
+    DeviceMem d_data(h_tensor);
+
+    launch_kernel(stream_config{},
+                  make_kernel<1>(TileDistKernel4{},
+                                 dim3(1),
+                                 dim3(TileDistKernel4::kBlockSize),
+                                 0,
+                                 static_cast<const int32_t*>(d_data.GetDeviceBuffer())));
+    hip_check_error(hipDeviceSynchronize());
+
+    printf("Done.\n");
+    return 0;
+}

--- a/projects/composablekernel/tutorial/ck_tile/tile_distribution/tile_distribution_4.cpp
+++ b/projects/composablekernel/tutorial/ck_tile/tile_distribution/tile_distribution_4.cpp
@@ -172,11 +172,12 @@ struct TileDistKernel4
             {
                 printf(
                     "\n=== Tile Distribution Scenario 4: R Dimension (Inter-Warp Replicate) ===\n");
-                printf("Tile: %d x %d,  BlockSize: %d,  WarpSize: %d,  Warps: 4\n",
+                printf("Tile: %d x %d,  BlockSize: %d,  WarpSize: %d,  Warps: %d\n",
                        static_cast<int>(kM),
                        static_cast<int>(kK),
                        static_cast<int>(kBlockSize),
-                       static_cast<int>(warp_size));
+                       static_cast<int>(warp_size),
+                       static_cast<int>(kBlockSize / warp_size));
                 printf("Each thread owns: 1 row x %d cols = %d elements\n",
                        static_cast<int>(kK),
                        static_cast<int>(kBufSize));


### PR DESCRIPTION
## Summary
- Four progressive tutorials demonstrating how `tile_distribution_encoding` maps threads to data elements
- All encodings derived from production GEMM distributions (`MakeADramTileDistribution`, `MakeScaleADramTileDistribution`)
- Covers NDimP=1 (basic), NDimP=2 (warp+lane), coalesced K-splitting, and the R (replicate) dimension
- Each tutorial includes step-by-step encoding construction with ASCII art diagrams
- Comments note CDNA vs RDNA warp_size differences

| Scenario | Tile | Key Concept |
|----------|------|-------------|
| 1 | 32×8 | NDimP=1, basic P/Y split |
| 3 | 128×8 | NDimP=2, lane→M only (small K) |
| 2 | 64×32 | NDimP=2, lane→M+K (coalesced) |
| 4 | 128×8, 4 warps | NDimP=2 + R (inter-warp replicate) |

This work is based on prior work by @aghamari @ecamartins 