### PR TITLE
 [MIOpen] Add Teams failure notifications and embed build info in CI images

### DIFF
--- a/projects/miopen/Jenkinsfile
+++ b/projects/miopen/Jenkinsfile
@@ -1081,7 +1081,6 @@ pipeline {
                         [name: 'Build',           template: "#${env.BUILD_NUMBER}"],
                         [name: 'Commit',          template: "${env.GIT_COMMIT?.take(7) ?: 'unknown'}"],
                         [name: 'TheRock hash',    template: "${env.THEROCK_PROMOTED_HASH ?: 'unknown'}"],
-                        [name: 'CK hash',         template: "${env.CK_GIT_HASH ?: 'unknown'}"],
                         [name: 'Duration',        template: "${currentBuild.durationString}"],
                         [name: 'Previous result', template: "${currentBuild.previousBuild?.result ?: 'N/A'}"],
                         [name: 'Build URL',       template: "${env.BUILD_URL}"]

--- a/projects/miopen/Jenkinsfile
+++ b/projects/miopen/Jenkinsfile
@@ -1060,34 +1060,19 @@ pipeline {
                          description: 'Some checks have failed'
             script {
                 if (params.BUILD_THEROCK_DOCKER) {
-                    withCredentials([string(credentialsId: 'TEAMS_WEBHOOK_URL', variable: 'TEAMS_WEBHOOK_URL')]) {
-                        def shortHash = env.THEROCK_SHORT_HASH ?: 'unknown'
-                        def payload = """
-                            {
-                                "@type": "MessageCard",
-                                "@context": "https://schema.org/extensions",
-                                "summary": "TheRock promotion failed",
-                                "themeColor": "FF0000",
-                                "title": "TheRock Docker Promotion Failed",
-                                "sections": [{
-                                    "facts": [
-                                        { "name": "Job", "value": "${env.JOB_NAME}" },
-                                        { "name": "Build", "value": "#${env.BUILD_NUMBER}" },
-                                        { "name": "TheRock hash", "value": "${shortHash}" }
-                                    ]
-                                }],
-                                "potentialAction": [{
-                                    "@type": "OpenUri",
-                                    "name": "View Build",
-                                    "targets": [{ "os": "default", "uri": "${env.BUILD_URL}" }]
-                                }]
-                            }
-                        """.stripIndent().trim()
-                        sh """curl -s -o /dev/null -w '%{http_code}' \
-                            -H 'Content-Type: application/json' \
-                            -d '${payload}' \
-                            "\${TEAMS_WEBHOOK_URL}" """
-                    }
+                    def shortHash = env.THEROCK_SHORT_HASH ?: 'unknown'
+                    office365ConnectorSend(
+                        webhookUrl: credentials('TEAMS_WEBHOOK_URL'),
+                        message: 'TheRock Docker Promotion Failed',
+                        status: 'Failure',
+                        color: '#FF0000',
+                        factDefinitions: [
+                            [name: 'Job',          template: "${env.JOB_NAME}"],
+                            [name: 'Build',        template: "#${env.BUILD_NUMBER}"],
+                            [name: 'TheRock hash', template: shortHash],
+                            [name: 'Build URL',    template: "${env.BUILD_URL}"]
+                        ]
+                    )
                 }
             }
         }

--- a/projects/miopen/Jenkinsfile
+++ b/projects/miopen/Jenkinsfile
@@ -1060,19 +1060,21 @@ pipeline {
                          description: 'Some checks have failed'
             script {
                 if (params.BUILD_THEROCK_DOCKER) {
-                    def shortHash = env.THEROCK_SHORT_HASH ?: 'unknown'
-                    office365ConnectorSend(
-                        webhookUrl: credentials('TEAMS_WEBHOOK_URL'),
-                        message: 'TheRock Docker Promotion Failed',
-                        status: 'Failure',
-                        color: '#FF0000',
-                        factDefinitions: [
-                            [name: 'Job',          template: "${env.JOB_NAME}"],
-                            [name: 'Build',        template: "#${env.BUILD_NUMBER}"],
-                            [name: 'TheRock hash', template: shortHash],
-                            [name: 'Build URL',    template: "${env.BUILD_URL}"]
-                        ]
-                    )
+                    withCredentials([string(credentialsId: 'TEAMS_WEBHOOK_URL', variable: 'TEAMS_WEBHOOK_URL')]) {
+                        def shortHash = env.THEROCK_SHORT_HASH ?: 'unknown'
+                        office365ConnectorSend(
+                            webhookUrl: TEAMS_WEBHOOK_URL,
+                            message: 'TheRock Docker Promotion Failed',
+                            status: 'Failure',
+                            color: '#FF0000',
+                            factDefinitions: [
+                                [name: 'Job',          template: "${env.JOB_NAME}"],
+                                [name: 'Build',        template: "#${env.BUILD_NUMBER}"],
+                                [name: 'TheRock hash', template: shortHash],
+                                [name: 'Build URL',    template: "${env.BUILD_URL}"]
+                            ]
+                        )
+                    }
                 }
             }
         }

--- a/projects/miopen/Jenkinsfile
+++ b/projects/miopen/Jenkinsfile
@@ -1069,6 +1069,7 @@ pipeline {
                     teamsFacts = [
                         [name: 'Build',           template: "#${env.BUILD_NUMBER}"],
                         [name: 'TheRock hash',    template: "${env.THEROCK_FULL_HASH ?: 'unknown'}"],
+                        [name: 'CK hash',         template: "${env.CK_GIT_HASH ?: 'unknown'}"],
                         [name: 'Duration',        template: "${currentBuild.durationString}"],
                         [name: 'Previous result', template: "${currentBuild.previousBuild?.result ?: 'N/A'}"],
                         [name: 'Build URL',       template: "${env.BUILD_URL}"]
@@ -1080,6 +1081,7 @@ pipeline {
                         [name: 'Build',           template: "#${env.BUILD_NUMBER}"],
                         [name: 'Commit',          template: "${env.GIT_COMMIT?.take(7) ?: 'unknown'}"],
                         [name: 'TheRock hash',    template: "${env.THEROCK_PROMOTED_HASH ?: 'unknown'}"],
+                        [name: 'CK hash',         template: "${env.CK_GIT_HASH ?: 'unknown'}"],
                         [name: 'Duration',        template: "${currentBuild.durationString}"],
                         [name: 'Previous result', template: "${currentBuild.previousBuild?.result ?: 'N/A'}"],
                         [name: 'Build URL',       template: "${env.BUILD_URL}"]

--- a/projects/miopen/Jenkinsfile
+++ b/projects/miopen/Jenkinsfile
@@ -1059,38 +1059,41 @@ pipeline {
                          status: 'FAILURE',
                          description: 'Some checks have failed'
             script {
+                def teamsMessage = null
+                def teamsColor = null
+                def teamsFacts = null
+
                 if (params.BUILD_THEROCK_DOCKER) {
-                    withCredentials([string(credentialsId: 'TEAMS_WEBHOOK_URL', variable: 'TEAMS_WEBHOOK_URL')]) {
-                        def shortHash = env.THEROCK_SHORT_HASH ?: 'unknown'
-                        office365ConnectorSend(
-                            webhookUrl: TEAMS_WEBHOOK_URL,
-                            message: 'TheRock Docker Promotion Failed',
-                            status: 'Failure',
-                            color: '#FF6600',
-                            factDefinitions: [
-                                [name: 'Job',             template: "${env.JOB_NAME}"],
-                                [name: 'Build',           template: "#${env.BUILD_NUMBER}"],
-                                [name: 'TheRock hash',    template: shortHash],
-                                [name: 'Duration',        template: "${currentBuild.durationString}"],
-                                [name: 'Previous result', template: "${currentBuild.previousBuild?.result ?: 'N/A'}"],
-                                [name: 'Build URL',       template: "${env.BUILD_URL}"]
-                            ]
-                        )
-                    }
+                    teamsMessage = 'TheRock Docker Promotion Failed'
+                    teamsColor = '#FF6600'
+                    teamsFacts = [
+                        [name: 'Build',           template: "#${env.BUILD_NUMBER}"],
+                        [name: 'TheRock hash',    template: "${env.THEROCK_FULL_HASH ?: 'unknown'}"],
+                        [name: 'Duration',        template: "${currentBuild.durationString}"],
+                        [name: 'Previous result', template: "${currentBuild.previousBuild?.result ?: 'N/A'}"],
+                        [name: 'Build URL',       template: "${env.BUILD_URL}"]
+                    ]
                 } else if (env.BRANCH_NAME == 'develop') {
+                    teamsMessage = 'MIOpen develop branch CI failed'
+                    teamsColor = '#FF0000'
+                    teamsFacts = [
+                        [name: 'Build',           template: "#${env.BUILD_NUMBER}"],
+                        [name: 'Commit',          template: "${env.GIT_COMMIT?.take(7) ?: 'unknown'}"],
+                        [name: 'TheRock hash',    template: "${env.THEROCK_PROMOTED_HASH ?: 'unknown'}"],
+                        [name: 'Duration',        template: "${currentBuild.durationString}"],
+                        [name: 'Previous result', template: "${currentBuild.previousBuild?.result ?: 'N/A'}"],
+                        [name: 'Build URL',       template: "${env.BUILD_URL}"]
+                    ]
+                }
+
+                if (teamsMessage) {
                     withCredentials([string(credentialsId: 'TEAMS_WEBHOOK_URL', variable: 'TEAMS_WEBHOOK_URL')]) {
                         office365ConnectorSend(
                             webhookUrl: TEAMS_WEBHOOK_URL,
-                            message: 'MIOpen develop branch CI failed',
+                            message: teamsMessage,
                             status: 'Failure',
-                            color: '#FF0000',
-                            factDefinitions: [
-                                [name: 'Build',           template: "#${env.BUILD_NUMBER}"],
-                                [name: 'Commit',          template: "${env.GIT_COMMIT?.take(7) ?: 'unknown'}"],
-                                [name: 'Duration',        template: "${currentBuild.durationString}"],
-                                [name: 'Previous result', template: "${currentBuild.previousBuild?.result ?: 'N/A'}"],
-                                [name: 'Build URL',       template: "${env.BUILD_URL}"]
-                            ]
+                            color: teamsColor,
+                            factDefinitions: teamsFacts
                         )
                     }
                 }

--- a/projects/miopen/Jenkinsfile
+++ b/projects/miopen/Jenkinsfile
@@ -1058,6 +1058,38 @@ pipeline {
             githubNotify context: 'Math CI Summary',
                          status: 'FAILURE',
                          description: 'Some checks have failed'
+            script {
+                if (params.BUILD_THEROCK_DOCKER) {
+                    withCredentials([string(credentialsId: 'TEAMS_WEBHOOK_URL', variable: 'TEAMS_WEBHOOK_URL')]) {
+                        def shortHash = env.THEROCK_SHORT_HASH ?: 'unknown'
+                        def payload = """
+                            {
+                                "@type": "MessageCard",
+                                "@context": "https://schema.org/extensions",
+                                "summary": "TheRock promotion failed",
+                                "themeColor": "FF0000",
+                                "title": "TheRock Docker Promotion Failed",
+                                "sections": [{
+                                    "facts": [
+                                        { "name": "Job", "value": "${env.JOB_NAME}" },
+                                        { "name": "Build", "value": "#${env.BUILD_NUMBER}" },
+                                        { "name": "TheRock hash", "value": "${shortHash}" }
+                                    ]
+                                }],
+                                "potentialAction": [{
+                                    "@type": "OpenUri",
+                                    "name": "View Build",
+                                    "targets": [{ "os": "default", "uri": "${env.BUILD_URL}" }]
+                                }]
+                            }
+                        """.stripIndent().trim()
+                        sh """curl -s -o /dev/null -w '%{http_code}' \
+                            -H 'Content-Type: application/json' \
+                            -d '${payload}' \
+                            "\${TEAMS_WEBHOOK_URL}" """
+                    }
+                }
+            }
         }
     }
 }

--- a/projects/miopen/Jenkinsfile
+++ b/projects/miopen/Jenkinsfile
@@ -1059,45 +1059,7 @@ pipeline {
                          status: 'FAILURE',
                          description: 'Some checks have failed'
             script {
-                def teamsMessage = null
-                def teamsColor = null
-                def teamsFacts = null
-
-                if (params.BUILD_THEROCK_DOCKER) {
-                    teamsMessage = 'TheRock Docker Promotion Failed'
-                    teamsColor = '#FF6600'
-                    teamsFacts = [
-                        [name: 'Build',           template: "#${env.BUILD_NUMBER}"],
-                        [name: 'TheRock hash',    template: "${env.THEROCK_FULL_HASH ?: 'unknown'}"],
-                        [name: 'CK hash',         template: "${env.CK_GIT_HASH ?: 'unknown'}"],
-                        [name: 'Duration',        template: "${currentBuild.durationString}"],
-                        [name: 'Previous result', template: "${currentBuild.previousBuild?.result ?: 'N/A'}"],
-                        [name: 'Build URL',       template: "${env.BUILD_URL}"]
-                    ]
-                } else if (env.BRANCH_NAME == 'develop') {
-                    teamsMessage = 'MIOpen develop branch CI failed'
-                    teamsColor = '#FF0000'
-                    teamsFacts = [
-                        [name: 'Build',           template: "#${env.BUILD_NUMBER}"],
-                        [name: 'Commit',          template: "${env.GIT_COMMIT?.take(7) ?: 'unknown'}"],
-                        [name: 'TheRock hash',    template: "${env.THEROCK_PROMOTED_HASH ?: 'unknown'}"],
-                        [name: 'Duration',        template: "${currentBuild.durationString}"],
-                        [name: 'Previous result', template: "${currentBuild.previousBuild?.result ?: 'N/A'}"],
-                        [name: 'Build URL',       template: "${env.BUILD_URL}"]
-                    ]
-                }
-
-                if (teamsMessage) {
-                    withCredentials([string(credentialsId: 'TEAMS_WEBHOOK_URL', variable: 'TEAMS_WEBHOOK_URL')]) {
-                        office365ConnectorSend(
-                            webhookUrl: TEAMS_WEBHOOK_URL,
-                            message: teamsMessage,
-                            status: 'Failure',
-                            color: teamsColor,
-                            factDefinitions: teamsFacts
-                        )
-                    }
-                }
+                utils.sendTeamsFailureNotification(buildTheRock: params.BUILD_THEROCK_DOCKER)
             }
         }
     }

--- a/projects/miopen/Jenkinsfile
+++ b/projects/miopen/Jenkinsfile
@@ -1066,12 +1066,30 @@ pipeline {
                             webhookUrl: TEAMS_WEBHOOK_URL,
                             message: 'TheRock Docker Promotion Failed',
                             status: 'Failure',
+                            color: '#FF6600',
+                            factDefinitions: [
+                                [name: 'Job',             template: "${env.JOB_NAME}"],
+                                [name: 'Build',           template: "#${env.BUILD_NUMBER}"],
+                                [name: 'TheRock hash',    template: shortHash],
+                                [name: 'Duration',        template: "${currentBuild.durationString}"],
+                                [name: 'Previous result', template: "${currentBuild.previousBuild?.result ?: 'N/A'}"],
+                                [name: 'Build URL',       template: "${env.BUILD_URL}"]
+                            ]
+                        )
+                    }
+                } else if (env.BRANCH_NAME == 'develop') {
+                    withCredentials([string(credentialsId: 'TEAMS_WEBHOOK_URL', variable: 'TEAMS_WEBHOOK_URL')]) {
+                        office365ConnectorSend(
+                            webhookUrl: TEAMS_WEBHOOK_URL,
+                            message: 'MIOpen develop branch CI failed',
+                            status: 'Failure',
                             color: '#FF0000',
                             factDefinitions: [
-                                [name: 'Job',          template: "${env.JOB_NAME}"],
-                                [name: 'Build',        template: "#${env.BUILD_NUMBER}"],
-                                [name: 'TheRock hash', template: shortHash],
-                                [name: 'Build URL',    template: "${env.BUILD_URL}"]
+                                [name: 'Build',           template: "#${env.BUILD_NUMBER}"],
+                                [name: 'Commit',          template: "${env.GIT_COMMIT?.take(7) ?: 'unknown'}"],
+                                [name: 'Duration',        template: "${currentBuild.durationString}"],
+                                [name: 'Previous result', template: "${currentBuild.previousBuild?.result ?: 'N/A'}"],
+                                [name: 'Build URL',       template: "${env.BUILD_URL}"]
                             ]
                         )
                     }

--- a/projects/miopen/vars/utils.groovy
+++ b/projects/miopen/vars/utils.groovy
@@ -484,20 +484,24 @@ def getDockerImage(Map conf=[:])
     dockerArgs = dockerArgs + " -f ${env.WORKSPACE}/${env.MIOPEN_DIR}/Dockerfile "
 
     // Carry the promoted TheRock hash forward into the CI image metadata.
-    withDockerRegistry([ credentialsId: "docker_test_cred", url: "" ]) {
-        sh "docker pull ${env.MIOPEN_DOCKER_IMAGE_URL}:therock > /dev/null 2>&1 || true"
-        def promotedHash = sh(
-            script: """
-                docker inspect --format '{{ index .Config.Labels "therock.git.hash" }}' \
-                    ${env.MIOPEN_DOCKER_IMAGE_URL}:therock 2>/dev/null || true
-            """.stripIndent(),
-            returnStdout: true
-        ).trim()
-        if (promotedHash) {
-            echo "Embedding TheRock hash into CI image metadata: ${promotedHash}"
-            dockerArgs = dockerArgs + "--label therock.git.hash=${promotedHash} "
-            env.THEROCK_PROMOTED_HASH = promotedHash
+    try {
+        withDockerRegistry([ credentialsId: "docker_test_cred", url: "" ]) {
+            sh "docker pull ${env.MIOPEN_DOCKER_IMAGE_URL}:therock > /dev/null 2>&1 || true"
+            def promotedHash = sh(
+                script: """
+                    docker inspect --format '{{ index .Config.Labels "therock.git.hash" }}' \
+                        ${env.MIOPEN_DOCKER_IMAGE_URL}:therock 2>/dev/null || true
+                """.stripIndent(),
+                returnStdout: true
+            ).trim()
+            if (promotedHash) {
+                echo "Embedding TheRock hash into CI image metadata: ${promotedHash}"
+                dockerArgs = dockerArgs + "--label therock.git.hash=${promotedHash} "
+                env.THEROCK_PROMOTED_HASH = promotedHash
+            }
         }
+    } catch (Exception e) {
+        echo "Could not read TheRock label from :therock image, skipping metadata embedding: ${e.message}"
     }
 
     // Embed the CK commit hash built into this image.

--- a/projects/miopen/vars/utils.groovy
+++ b/projects/miopen/vars/utils.groovy
@@ -778,4 +778,46 @@ def RunPerfTest(Map conf=[:]){
     }
 }
 
+def sendTeamsFailureNotification(Map conf=[:]) {
+    def teamsMessage = null
+    def teamsColor = null
+    def teamsFacts = null
+
+    if (conf.get("buildTheRock", false)) {
+        teamsMessage = 'TheRock Docker Promotion Failed'
+        teamsColor = '#FF6600'
+        teamsFacts = [
+            [name: 'Build',           template: "#${env.BUILD_NUMBER}"],
+            [name: 'TheRock hash',    template: "${env.THEROCK_FULL_HASH ?: 'unknown'}"],
+            [name: 'CK hash',         template: "${env.CK_GIT_HASH ?: 'unknown'}"],
+            [name: 'Duration',        template: "${currentBuild.durationString}"],
+            [name: 'Previous result', template: "${currentBuild.previousBuild?.result ?: 'N/A'}"],
+            [name: 'Build URL',       template: "${env.BUILD_URL}"]
+        ]
+    } else if (env.BRANCH_NAME == 'develop') {
+        teamsMessage = 'MIOpen develop branch CI failed'
+        teamsColor = '#FF0000'
+        teamsFacts = [
+            [name: 'Build',           template: "#${env.BUILD_NUMBER}"],
+            [name: 'Commit',          template: "${env.GIT_COMMIT?.take(7) ?: 'unknown'}"],
+            [name: 'TheRock hash',    template: "${env.THEROCK_PROMOTED_HASH ?: 'unknown'}"],
+            [name: 'Duration',        template: "${currentBuild.durationString}"],
+            [name: 'Previous result', template: "${currentBuild.previousBuild?.result ?: 'N/A'}"],
+            [name: 'Build URL',       template: "${env.BUILD_URL}"]
+        ]
+    }
+
+    if (teamsMessage) {
+        withCredentials([string(credentialsId: 'TEAMS_WEBHOOK_URL', variable: 'TEAMS_WEBHOOK_URL')]) {
+            office365ConnectorSend(
+                webhookUrl: TEAMS_WEBHOOK_URL,
+                message: teamsMessage,
+                status: 'Failure',
+                color: teamsColor,
+                factDefinitions: teamsFacts
+            )
+        }
+    }
+}
+
 return this

--- a/projects/miopen/vars/utils.groovy
+++ b/projects/miopen/vars/utils.groovy
@@ -500,6 +500,17 @@ def getDockerImage(Map conf=[:])
         }
     }
 
+    // Embed the CK commit hash built into this image.
+    def ckHash = sh(
+        script: "git -C ${env.WORKSPACE}/${env.CK_DIR} rev-parse HEAD",
+        returnStdout: true
+    ).trim()
+    if (ckHash) {
+        echo "Embedding CK hash into CI image metadata: ${ckHash}"
+        dockerArgs = dockerArgs + "--label ck.git.hash=${ckHash} "
+        env.CK_GIT_HASH = ckHash
+    }
+
     echo "Docker Args: ${dockerArgs}"
 
     def dockerImage
@@ -509,11 +520,15 @@ def getDockerImage(Map conf=[:])
         withDockerRegistry([ credentialsId: "docker_test_cred", url: "" ]) {
             dockerImage.pull()
         }
-        def embeddedHash = sh(
+        def embeddedTheRockHash = sh(
             script: "docker inspect --format '{{ index .Config.Labels \"therock.git.hash\" }}' ${image} 2>/dev/null || true",
             returnStdout: true
         ).trim()
-        echo "CI image TheRock hash: ${embeddedHash ?: 'not set'}"
+        def embeddedCkHash = sh(
+            script: "docker inspect --format '{{ index .Config.Labels \"ck.git.hash\" }}' ${image} 2>/dev/null || true",
+            returnStdout: true
+        ).trim()
+        echo "CI image TheRock hash: ${embeddedTheRockHash ?: 'not set'} | CK hash: ${embeddedCkHash ?: 'not set'}"
     }
     catch(org.jenkinsci.plugins.workflow.steps.FlowInterruptedException e){
         echo "The job was cancelled or aborted"

--- a/projects/miopen/vars/utils.groovy
+++ b/projects/miopen/vars/utils.groovy
@@ -482,6 +482,24 @@ def getDockerImage(Map conf=[:])
 
     // Append Dockerfile path after image name is generated to avoid affecting the hash.
     dockerArgs = dockerArgs + " -f ${env.WORKSPACE}/${env.MIOPEN_DIR}/Dockerfile "
+
+    // Carry the promoted TheRock hash forward into the CI image metadata.
+    withDockerRegistry([ credentialsId: "docker_test_cred", url: "" ]) {
+        sh "docker pull ${env.MIOPEN_DOCKER_IMAGE_URL}:therock > /dev/null 2>&1 || true"
+        def promotedHash = sh(
+            script: """
+                docker inspect --format '{{ index .Config.Labels "therock.git.hash" }}' \
+                    ${env.MIOPEN_DOCKER_IMAGE_URL}:therock 2>/dev/null || true
+            """.stripIndent(),
+            returnStdout: true
+        ).trim()
+        if (promotedHash) {
+            echo "Embedding TheRock hash into CI image metadata: ${promotedHash}"
+            dockerArgs = dockerArgs + "--label therock.git.hash=${promotedHash} "
+            env.THEROCK_PROMOTED_HASH = promotedHash
+        }
+    }
+
     echo "Docker Args: ${dockerArgs}"
 
     def dockerImage
@@ -491,6 +509,11 @@ def getDockerImage(Map conf=[:])
         withDockerRegistry([ credentialsId: "docker_test_cred", url: "" ]) {
             dockerImage.pull()
         }
+        def embeddedHash = sh(
+            script: "docker inspect --format '{{ index .Config.Labels \"therock.git.hash\" }}' ${image} 2>/dev/null || true",
+            returnStdout: true
+        ).trim()
+        echo "CI image TheRock hash: ${embeddedHash ?: 'not set'}"
     }
     catch(org.jenkinsci.plugins.workflow.steps.FlowInterruptedException e){
         echo "The job was cancelled or aborted"


### PR DESCRIPTION
## Motivation

There was no automated alerting when the nightly TheRock Docker promotion failed or when the develop branch CI broke. Failures were only discoverable by manually checking Jenkins. Additionally, CI Docker images carried no metadata about which TheRock or CK version they were built against, making it difficult to trace regressions back to a specific dependency version.

## Technical Details

### Teams notifications (`projects/miopen/Jenkinsfile`)

A `script` block is added to the top-level `post { failure }` section using the [Office 365 Connector plugin](https://plugins.jenkins.io/Office-365-Connector/) (`office365ConnectorSend`). 

Two mutually exclusive notification paths are implemented:

- **`BUILD_THEROCK_DOCKER=true`** — fires an orange (`#FF6600`) card titled *"TheRock Docker Promotion Failed"* with the full TheRock hash (`THEROCK_FULL_HASH`), CK hash (`CK_GIT_HASH`), build duration, previous result, and build URL.
- **`BRANCH_NAME == 'develop'`** (regular CI) — fires a red (`#FF0000`) card titled *"MIOpen develop branch CI failed"* with the triggering commit (short hash), the currently promoted TheRock hash (`THEROCK_PROMOTED_HASH`), build duration, previous result, and build URL.

### CI image build info labels (`projects/miopen/vars/utils.groovy`)

Two Docker labels are now embedded in every CI image built by `getDockerImage`:
- **`therock.git.hash`** — the full commit hash of the currently promoted `rocm/miopen:therock` image, read via `docker inspect` after pulling `:therock`. Wrapped in a `try/catch` so a registry failure does not abort the image build. The value is also exposed as `env.THEROCK_PROMOTED_HASH` for the post-block Teams notification.
- **`ck.git.hash`** — the HEAD commit of the `projects/composablekernel` submodule at build time, read via `git -C ${CK_DIR} rev-parse HEAD`. Exposed as `env.CK_GIT_HASH`.

Both labels are appended to `dockerArgs` **after** `getDockerImageName()` computes the image tag, so they do not affect the content-addressed tag. After a successful pull of a cached CI image, both labels are printed to the build log for easy inspection.

## Test Plan

- Triggered the pipeline with `BUILD_THEROCK_DOCKER=true` on a test branch to verify the orange Teams card fires on failure with the correct full TheRock hash and CK hash.
- Confirmed the `BRANCH_NAME == 'develop'` notification fires independently on a regular develop CI failure and does not double-fire during a TheRock nightly run.
- Confirmed `docker inspect` on a freshly built CI image shows both `therock.git.hash` and `ck.git.hash` labels.

## Test Result

- Teams notifications delivered correctly for both failure scenarios with all expected facts populated.
<img width="1067" height="703" alt="image" src="https://github.com/user-attachments/assets/ae712ed3-1e2b-400f-b0bf-49a13b2ad8c2" />

- `therock.git.hash` and `ck.git.hash` labels confirmed present on CI images via `docker inspect`.
- No changes to existing build stages, test execution, or image tagging logic.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
