### PR TITLE
[MIOpen] Guard new CK generic helpers when ComposableKernel is disabled

### DIFF
--- a/projects/miopen/src/ck_impl/implicitgemm_ck_util.hpp
+++ b/projects/miopen/src/ck_impl/implicitgemm_ck_util.hpp
@@ -239,6 +239,7 @@ template <template <typename, typename> class DeviceOpPtrs,
           typename ProblemDescriptionType = miopen::conv::ProblemDescription>
 std::vector<std::string> FillValidKernelsGeneric(const ProblemDescriptionType& problem)
 {
+#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
     switch(problem.GetInDataType())
     {
     case miopenHalf:
@@ -261,6 +262,10 @@ std::vector<std::string> FillValidKernelsGeneric(const ProblemDescriptionType& p
 
     default: return {};
     }
+#else
+    (void)problem;
+    return {};
+#endif
 }
 
 /**
@@ -344,6 +349,7 @@ template <template <typename, typename> class BilinearPtrs,
           typename ProblemDescriptionType = miopen::conv::ProblemDescription>
 std::vector<std::string> FillValidKernelsWithAlphaBetaGeneric(const ProblemDescriptionType& problem)
 {
+#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
     // Data type dispatch with TF32 support (C++17 compatible - uses helper function)
     switch(problem.GetInDataType())
     {
@@ -384,6 +390,10 @@ std::vector<std::string> FillValidKernelsWithAlphaBetaGeneric(const ProblemDescr
 
     default: return {};
     }
+#else
+    (void)problem;
+    return {};
+#endif
 }
 
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL


### PR DESCRIPTION
## Summary

Fixes ROCm/rocm-libraries#6832 — `miopen_gtest` build fails with `error: use of undeclared identifier 'ck'` in `projects/miopen/src/ck_impl/implicitgemm_ck_util.hpp` when MIOpen is built with `MIOPEN_USE_COMPOSABLEKERNEL=OFF`.

Observed in TheRock CI on:
- Linux `gfx110X-all` (RDNA3 — CK has no Navi3 instances, so CK is disabled)
- Windows `gfx94x` (Windows MIOpen builds disable CK)

### Root Cause

PR #6723 added three generic helpers to `implicitgemm_ck_util.hpp`. Two of them — `FillValidKernelsGeneric` (line 240) and `FillValidKernelsWithAlphaBetaGeneric` (line 345) — reference `ck::half_t`, `ck::bhalf_t`, and `ck::tf32_t` directly in their bodies. These are non-dependent names, so two-phase template name lookup resolves them at parse time even when the templates are never instantiated. With CK disabled, the CK headers at the top of the file are excluded and the build fails.

The third helper (`IsCKSplitKSupportedGeneric`, line 549) was already correctly guarded — only the two `FillValidKernels*` helpers were missing the guard.

### Fix

Wrap both helper bodies in `#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL ... #else (void)problem; return {}; #endif`, mirroring the established pattern used by `IsCKSplitKSupported` (line 508) and `IsCKSplitKSupportedGeneric` (line 549).

## Test plan

- [x] Reproduce locally: configure standalone MIOpen with `-DMIOPEN_USE_COMPOSABLEKERNEL=OFF -DMIOPEN_BACKEND=HIP -DMIOPEN_USE_MLIR=OFF` and build `test_unit_implicitgemm_ck_util` — pre-fix this fails with `use of undeclared identifier 'ck'`; post-fix it compiles and links cleanly.
- [x] CI: confirm TheRock `gfx110X-all` Linux and Windows `gfx94x` legs build successfully.
- [ ] CI: confirm CK-enabled targets (gfx90a/gfx942/gfx950) still build and existing CK behavior is unchanged (the `#if` branch is identical to the original code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)